### PR TITLE
fix: use the usage of the last chunk

### DIFF
--- a/projects/portfolio/src/client/components/Chat.tsx
+++ b/projects/portfolio/src/client/components/Chat.tsx
@@ -336,8 +336,9 @@ export const Chat: FC = () => {
               .map((x) => JSON.parse(x))
             // Append chunk to result
             result += chunkJSONs.map((x) => x.choices.at(0)?.delta?.content).join('')
-            if (!usage) {
-              usage = chunkJSONs.find((x) => x.usage)?.usage ?? null
+            const newUsage = chunkJSONs.find((x) => x.usage)?.usage ?? null
+            if (newUsage) {
+              usage = newUsage
             }
             setStream(`${result}●`)
           }


### PR DESCRIPTION
Bugfix: Geminiの場合、usageがすべてのチャンクに付与されていて、
最初に参照できたusageを使う実装になっていたため、期待通りに表示されていなかった。

![image](https://github.com/user-attachments/assets/afe3fcd1-c9cd-4edf-a2a2-2a40e9ba717b)
