### PR TITLE
Migrate to dev server from node-server to vite

### DIFF
--- a/projects/chatbot-ui/bun.lock
+++ b/projects/chatbot-ui/bun.lock
@@ -10,6 +10,7 @@
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
         "@hono/vite-build": "^1.5.0",
+        "@hono/vite-dev-server": "^0.19.0",
         "@types/node": "^22.14.0",
         "tsx": "^4.19.3",
         "typescript": "^5.8.2",
@@ -90,6 +91,8 @@
 
     "@hono/vite-build": ["@hono/vite-build@1.5.0", "", { "peerDependencies": { "hono": "*" } }, "sha512-aPQwcRp1j6Av+mI8cPoSSUNHwp+VGAm1uF6KqJGY4ZlCLtu13OgMt/+X5kZpLLlo2wBJqkO1POX/LfjKvc2jBg=="],
 
+    "@hono/vite-dev-server": ["@hono/vite-dev-server@0.19.0", "", { "dependencies": { "@hono/node-server": "^1.12.0", "minimatch": "^9.0.3" }, "peerDependencies": { "hono": "*", "miniflare": "*", "wrangler": "*" }, "optionalPeers": ["miniflare", "wrangler"] }, "sha512-myMc4Nm0nFQSPaeE6I/a1ODyDR5KpQ4EHodX4Tu/7qlB31GfUemhUH/WsO91HJjDEpRRpsT4Zbg+PleMlpTljw=="],
+
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.39.0", "", { "os": "android", "cpu": "arm" }, "sha512-lGVys55Qb00Wvh8DMAocp5kIcaNzEFTmGhfFd88LfaogYTRKrdxgtlO5H6S49v2Nd8R2C6wLOal0qv6/kCkOwA=="],
 
     "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.39.0", "", { "os": "android", "cpu": "arm64" }, "sha512-It9+M1zE31KWfqh/0cJLrrsCPiF72PoJjIChLX+rEcujVRCb4NLQ5QzFkzIZW8Kn8FTbvGQBY5TkKBau3S8cCQ=="],
@@ -134,6 +137,10 @@
 
     "@types/node": ["@types/node@22.14.0", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA=="],
 
+    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "brace-expansion": ["brace-expansion@2.0.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA=="],
+
     "esbuild": ["esbuild@0.25.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.2", "@esbuild/android-arm": "0.25.2", "@esbuild/android-arm64": "0.25.2", "@esbuild/android-x64": "0.25.2", "@esbuild/darwin-arm64": "0.25.2", "@esbuild/darwin-x64": "0.25.2", "@esbuild/freebsd-arm64": "0.25.2", "@esbuild/freebsd-x64": "0.25.2", "@esbuild/linux-arm": "0.25.2", "@esbuild/linux-arm64": "0.25.2", "@esbuild/linux-ia32": "0.25.2", "@esbuild/linux-loong64": "0.25.2", "@esbuild/linux-mips64el": "0.25.2", "@esbuild/linux-ppc64": "0.25.2", "@esbuild/linux-riscv64": "0.25.2", "@esbuild/linux-s390x": "0.25.2", "@esbuild/linux-x64": "0.25.2", "@esbuild/netbsd-arm64": "0.25.2", "@esbuild/netbsd-x64": "0.25.2", "@esbuild/openbsd-arm64": "0.25.2", "@esbuild/openbsd-x64": "0.25.2", "@esbuild/sunos-x64": "0.25.2", "@esbuild/win32-arm64": "0.25.2", "@esbuild/win32-ia32": "0.25.2", "@esbuild/win32-x64": "0.25.2" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-16854zccKPnC+toMywC+uKNeYSv+/eXkevRAfwRD/G9Cleq66m8XFIrigkbvauLLlCfDL45Q2cWegSg53gGBnQ=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
@@ -141,6 +148,8 @@
     "get-tsconfig": ["get-tsconfig@4.10.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-kGzZ3LWWQcGIAmg6iWvXn0ei6WDtV26wzHRMwDSzmAbcXrTEXxHy6IehI6/4eT6VRKyMP1eF1VqwrVUmE/LR7A=="],
 
     "hono": ["hono@4.7.5", "", {}, "sha512-fDOK5W2C1vZACsgLONigdZTRZxuBqFtcKh7bUQ5cVSbwI2RWjloJDcgFOVzbQrlI6pCmhlTsVYZ7zpLj4m4qMQ=="],
+
+    "minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 

--- a/projects/chatbot-ui/bun.lock
+++ b/projects/chatbot-ui/bun.lock
@@ -4,7 +4,6 @@
     "": {
       "name": "chatbot-ui",
       "dependencies": {
-        "@hono/node-server": "^1.14.0",
         "hono": "^4.7.5",
       },
       "devDependencies": {
@@ -12,7 +11,6 @@
         "@hono/vite-build": "^1.5.0",
         "@hono/vite-dev-server": "^0.19.0",
         "@types/node": "^22.14.0",
-        "tsx": "^4.19.3",
         "typescript": "^5.8.2",
         "vite": "^6.2.5",
       },

--- a/projects/chatbot-ui/package.json
+++ b/projects/chatbot-ui/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
     "@hono/vite-build": "^1.5.0",
+    "@hono/vite-dev-server": "^0.19.0",
     "@types/node": "^22.14.0",
     "tsx": "^4.19.3",
     "typescript": "^5.8.2",

--- a/projects/chatbot-ui/package.json
+++ b/projects/chatbot-ui/package.json
@@ -9,7 +9,6 @@
     "format": "biome check --write ./src"
   },
   "dependencies": {
-    "@hono/node-server": "^1.14.0",
     "hono": "^4.7.5"
   },
   "devDependencies": {
@@ -17,7 +16,6 @@
     "@hono/vite-build": "^1.5.0",
     "@hono/vite-dev-server": "^0.19.0",
     "@types/node": "^22.14.0",
-    "tsx": "^4.19.3",
     "typescript": "^5.8.2",
     "vite": "^6.2.5"
   }

--- a/projects/chatbot-ui/package.json
+++ b/projects/chatbot-ui/package.json
@@ -2,7 +2,7 @@
   "name": "chatbot-ui",
   "type": "module",
   "scripts": {
-    "dev": "tsx watch src/dev-serve.ts",
+    "dev": "vite",
     "build": "vite build",
     "start": "node dist/index.js",
     "lint": "tsc && biome lint --error-on-warnings ./src",

--- a/projects/chatbot-ui/src/dev-serve.ts
+++ b/projects/chatbot-ui/src/dev-serve.ts
@@ -1,7 +1,0 @@
-import { serve } from '@hono/node-server'
-
-import app from './app'
-
-serve({ fetch: app.fetch, port: 3000 }, (info) => {
-  console.log(`Dev Server is running on http://localhost:${info.port}`)
-})

--- a/projects/chatbot-ui/vite.config.ts
+++ b/projects/chatbot-ui/vite.config.ts
@@ -1,11 +1,17 @@
 import build from '@hono/vite-build/node'
+import devServer from '@hono/vite-dev-server'
 import { defineConfig } from 'vite'
 
-export default defineConfig({
-  plugins: [
-    build({
-      entry: './src/app.ts',
-      port: 3000,
-    }),
-  ],
-})
+const port = 3000
+const entry = './src/app.ts'
+
+export default defineConfig(({ command }) =>
+  command === 'build'
+    ? {
+        plugins: [build({ entry, port })],
+      }
+    : {
+        plugins: [devServer({ entry })],
+        server: { port, host: true },
+      },
+)


### PR DESCRIPTION
### Overview
Migrate to dev server from `@hono/node-server` to `@hono/vite-dev-server`

### Check:
`bun run dev` ... ✅

```
  VITE v6.2.5  ready in 389 ms

  ➜  Local:   http://localhost:3000/
  ➜  Network: http://172.17.0.2:3000/
  ➜  press h + enter to show help
```

`bun run build` ... ✅

```
$ vite build
vite v6.2.5 building SSR bundle for production...
✓ 26 modules transformed.
dist/index.js  30.37 kB
✓ built in 628ms
```

`bun run start` ... ✅

```
$ node dist/index.js
```