### PR TITLE
Feat/add test stage

### DIFF
--- a/projects/chatbot-ui/Dockerfile
+++ b/projects/chatbot-ui/Dockerfile
@@ -1,14 +1,26 @@
+# -----------------------------------------------
+# base stage
+# -----------------------------------------------
 FROM node:22-alpine AS base
 
 WORKDIR /app
 
-FROM base AS builder
-
-ENV PATH="/root/.bun/bin:${PATH}"
+# -----------------------------------------------
+# setup stage
+# -----------------------------------------------
+FROM base AS setup
 
 RUN apk add --no-cache bash curl \
     && curl -fsSL https://bun.sh/install -sSf | bash
 
+# -----------------------------------------------
+# builder stage
+# -----------------------------------------------
+FROM base AS builder
+
+ENV PATH="/root/.bun/bin:${PATH}"
+
+COPY --from=setup /root/.bun/bin/bun /root/.bun/bin/
 COPY . .
 
 RUN bun install --frozen-lockfile \
@@ -20,6 +32,9 @@ COPY package.json bun.lock ./temp/prod/
 RUN cd ./temp/prod \
     && bun install --frozen-lockfile --production
 
+# -----------------------------------------------
+# final stage
+# -----------------------------------------------
 FROM base AS final
 
 ENV NODE_ENV=production

--- a/projects/chatbot-ui/Dockerfile
+++ b/projects/chatbot-ui/Dockerfile
@@ -14,21 +14,33 @@ RUN apk add --no-cache bash curl \
     && curl -fsSL https://bun.sh/install -sSf | bash
 
 # -----------------------------------------------
+# test stage
+#  > example: `docker build -t test_image . --target=test --progress plain --no-cache`
+# -----------------------------------------------
+FROM base AS test
+
+ENV PATH="/root/.bun/bin:${PATH}"
+COPY --from=setup /root/.bun/bin/bun /root/.bun/bin/
+
+COPY . .
+RUN bun install --frozen-lockfile \
+    && bun run lint \
+    && bun run build
+
+# -----------------------------------------------
 # builder stage
 # -----------------------------------------------
 FROM base AS builder
 
 ENV PATH="/root/.bun/bin:${PATH}"
-
 COPY --from=setup /root/.bun/bin/bun /root/.bun/bin/
-COPY . .
 
+COPY . .
 RUN bun install --frozen-lockfile \
     && bun run build \
     && mkdir -p ./temp/prod
 
 COPY package.json bun.lock ./temp/prod/
-
 RUN cd ./temp/prod \
     && bun install --frozen-lockfile --production
 
@@ -42,11 +54,10 @@ ENV NODE_ENV=production
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/temp/prod/node_modules ./node_modules
 
-RUN apk --no-cache add tzdata && \
-    cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime && \
-    apk del tzdata
-
-RUN adduser -D -s /bin/sh u7chan
+RUN apk --no-cache add tzdata \
+    && cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime \
+    && apk del tzdata \
+    && adduser -D -s /bin/sh u7chan
 
 USER u7chan
 EXPOSE 3000


### PR DESCRIPTION
### Overview:
CI/CD用にDockerファイルにテストステージの定義を追加

### Check:
ローカルでわざとエラーを出すコードを追加して、Dockerコマンドを実行
```
$ docker build -t test_image . --target=test --progress plain --no-cache
```
```
#0 building with "desktop-linux" instance using docker driver

#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 1.75kB 0.0s done
#1 DONE 0.0s

#2 [internal] load metadata for docker.io/library/node:22-alpine
#2 DONE 0.0s

#3 [internal] load .dockerignore
#3 transferring context: 94B done
#3 DONE 0.0s

#4 [internal] load build context
#4 DONE 0.0s

#5 [base 1/2] FROM docker.io/library/node:22-alpine@sha256:9bef0ef1e268f60627da9ba7d7605e8831d5b56ad07487d24d1aa386336d1944
#5 resolve docker.io/library/node:22-alpine@sha256:9bef0ef1e268f60627da9ba7d7605e8831d5b56ad07487d24d1aa386336d1944 0.0s done
#5 DONE 0.0s

#6 [base 2/2] WORKDIR /app
#6 CACHED

#4 [internal] load build context
#4 transferring context: 2.70kB 0.0s done
#4 DONE 0.0s

#7 [setup 1/1] RUN apk add --no-cache bash curl     && curl -fsSL https://bun.sh/install -sSf | bash
#7 0.295 fetch https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz
#7 0.491 fetch https://dl-cdn.alpinelinux.org/alpine/v3.21/community/x86_64/APKINDEX.tar.gz
#7 1.039 (1/13) Installing ncurses-terminfo-base (6.5_p20241006-r3)
#7 1.057 (2/13) Installing libncursesw (6.5_p20241006-r3)
#7 1.078 (3/13) Installing readline (8.2.13-r0)
#7 1.091 (4/13) Installing bash (5.2.37-r0)
#7 1.130 Executing bash-5.2.37-r0.post-install
#7 1.140 (5/13) Installing brotli-libs (1.1.0-r2)
#7 1.178 (6/13) Installing c-ares (1.34.3-r0)
#7 1.195 (7/13) Installing libunistring (1.2-r0)
#7 1.241 (8/13) Installing libidn2 (2.3.7-r0)
#7 1.265 (9/13) Installing nghttp2-libs (1.64.0-r0)
#7 1.273 (10/13) Installing libpsl (0.21.5-r3)
#7 1.282 (11/13) Installing zstd-libs (1.5.6-r2)
#7 1.304 (12/13) Installing libcurl (8.12.1-r1)
#7 1.326 (13/13) Installing curl (8.12.1-r1)
#7 1.340 Executing busybox-1.37.0-r12.trigger
#7 1.351 OK: 16 MiB in 30 packages
######################################################################## 100.0%
#7 3.834 bun was installed successfully to ~/.bun/bin/bun 
#7 3.836 
#7 3.841 Manually add the directory to ~/.bashrc (or similar):
#7 3.841   export BUN_INSTALL="$HOME/.bun" 
#7 3.841   export PATH="$BUN_INSTALL/bin:$PATH" 
#7 3.841 
#7 3.841 To get started, run: 
#7 3.841 
#7 3.841   bun --help 
#7 DONE 4.5s

#8 [test 1/3] COPY --from=setup /root/.bun/bin/bun /root/.bun/bin/
#8 DONE 0.2s

#9 [test 2/3] COPY . .
#9 DONE 0.1s

#10 [test 3/3] RUN bun install --frozen-lockfile     && bun run lint     && bun run build
#10 0.227 bun install v1.2.8 (adab0f64)
#10 1.988 
#10 1.988 + @biomejs/biome@1.9.4
#10 1.988 + @hono/vite-build@1.5.0
#10 1.988 + @hono/vite-dev-server@0.19.0
#10 1.988 + @types/node@22.14.0
#10 1.988 + typescript@5.8.2
#10 1.988 + vite@6.2.5
#10 1.988 + hono@4.7.5
#10 1.988 
#10 1.988 27 packages installed [1.76s]
#10 2.011 $ tsc && biome lint --error-on-warnings ./src
#10 6.936 src/app.ts(10,7): error TS1155: 'const' declarations must be initialized.
#10 6.936 src/app.ts(10,7): error TS7005: Variable 'aaa' implicitly has an 'any' type.
#10 6.936 src/app.ts(11,1): error TS2304: Cannot find name 'aa'.
#10 ERROR: process "/bin/sh -c bun install --frozen-lockfile     && bun run lint     && bun run build" did not complete successfully: exit code: 2
------
 > [test 3/3] RUN bun install --frozen-lockfile     && bun run lint     && bun run build:
1.988 + @types/node@22.14.0
1.988 + typescript@5.8.2
1.988 + vite@6.2.5
1.988 + hono@4.7.5
1.988 
1.988 27 packages installed [1.76s]
2.011 $ tsc && biome lint --error-on-warnings ./src
6.936 src/app.ts(10,7): error TS1155: 'const' declarations must be initialized.
6.936 src/app.ts(10,7): error TS7005: Variable 'aaa' implicitly has an 'any' type.
6.936 src/app.ts(11,1): error TS2304: Cannot find name 'aa'.
------
Dockerfile:27
--------------------
  26 |     
  27 | >>> RUN bun install --frozen-lockfile \
  28 | >>>     && bun run lint \
  29 | >>>     && bun run build
  30 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c bun install --frozen-lockfile     && bun run lint     && bun run build" did not complete successfully: exit code: 2
```

tsc でエラーが検出されていることを確認 ... ✅

```
2.011 $ tsc && biome lint --error-on-warnings ./src
6.936 src/app.ts(10,7): error TS1155: 'const' declarations must be initialized.
6.936 src/app.ts(10,7): error TS7005: Variable 'aaa' implicitly has an 'any' type.
6.936 src/app.ts(11,1): error TS2304: Cannot find name 'aa'.
```

### CIパイプライン
LinterとBuildが動いていることを確認 ... ✅
![image](https://github.com/user-attachments/assets/d5450c72-dc93-4c3c-b9d3-3e0a78ff828a)
