### PR TITLE
fix: katex css import disabled

### DIFF
--- a/projects/portfolio/src/client/components/pages/Chat.tsx
+++ b/projects/portfolio/src/client/components/pages/Chat.tsx
@@ -33,7 +33,7 @@ import { SpinnerIcon } from '@/client/components/svg/SpinnerIcon'
 import { StopIcon } from '@/client/components/svg/StopIcon'
 import { UploadIcon } from '@/client/components/svg/UploadIcon'
 
-import 'katex/dist/katex.min.css'
+// import 'katex/dist/di.min.css' // hotfix: #148
 
 const client = hc<AppType>('/')
 


### PR DESCRIPTION
#148

hotfixによりLaTeX部分の CSS は適応されないが、ページ全体は崩れなくなった。
![image](https://github.com/user-attachments/assets/82106249-069c-456c-a95c-db1a2ef68246)

dist配下
![image](https://github.com/user-attachments/assets/f4e3b071-3e30-435f-82af-3bea2f939abe)