### PR TITLE
fix: warning

### DIFF
--- a/projects/portfolio/vite.config.ts
+++ b/projects/portfolio/vite.config.ts
@@ -69,6 +69,12 @@ export default defineConfig(({ mode }) => {
               entryFileNames: 'client.js',
               assetFileNames: '[name].[ext]',
             },
+            onwarn(warning, warn) {
+              if (warning.code === "MODULE_LEVEL_DIRECTIVE") {
+                return;
+              }
+              warn(warning);
+            },
           },
         },
       }


### PR DESCRIPTION
#310 

対策後の`bun run build`ログ

```
vscode@1d38202e3de5:/workspaces/monorepo/projects/portfolio$ bun run build
$ vite build
vite v7.0.0 building for production...
(node:24090) ExperimentalWarning: Type Stripping is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
Generated route tree in 133ms
✓ 1537 modules transformed.
dist/static/main.css      37.03 kB │ gzip:   7.11 kB
dist/static/client.js  1,218.16 kB │ gzip: 419.20 kB

(!) Some chunks are larger than 500 kB after minification. Consider:
- Using dynamic import() to code-split the application
- Use build.rollupOptions.output.manualChunks to improve chunking: https://rollupjs.org/configuration-options/#output-manualchunks
- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.
✓ built in 9.57s
```

### 参考:

`https://github.com/TanStack/query/issues/5175#issuecomment-2039457794`
