### PR TITLE
feat(portfolio): implement route-level code splitting with lazy loading

### DIFF
--- a/projects/portfolio/src/client/components/route-loading.tsx
+++ b/projects/portfolio/src/client/components/route-loading.tsx
@@ -1,0 +1,10 @@
+import { SpinnerIcon } from '#/client/components/svg/spinner-icon'
+
+export function RouteLoading() {
+  return (
+    <div className='flex min-h-[40vh] w-full flex-col items-center justify-center gap-3 text-slate-500'>
+      <SpinnerIcon />
+      <p className='text-sm'>Loading page...</p>
+    </div>
+  )
+}

--- a/projects/portfolio/src/client/routes/__root.tsx
+++ b/projects/portfolio/src/client/routes/__root.tsx
@@ -1,14 +1,15 @@
 import { AppLayout } from '#/client/components/app-layout'
+import { RouteLoading } from '#/client/components/route-loading'
 import { AboutIcon } from '#/client/components/svg/about-icon'
 import { ChatbotIcon } from '#/client/components/svg/chatbot-icon'
 import { DashboardIcon } from '#/client/components/svg/dashboard-icon'
 import { DiffIcon } from '#/client/components/svg/diff-icon'
 import { createRootRoute, Outlet } from '@tanstack/react-router'
-import React from 'react'
+import { Suspense, lazy } from 'react'
 
 const TanStackRouterDevtoolsPanel = import.meta.env.PROD
   ? () => null // Render nothing in production
-  : React.lazy(() =>
+  : lazy(() =>
       // Lazy load in development
       import('@tanstack/react-router-devtools').then((res) => ({
         default: res.TanStackRouterDevtools,
@@ -31,7 +32,9 @@ function Root() {
           { label: 'Chat', icon: <ChatbotIcon size={26} />, to: '/chat' },
         ]}
       >
-        <Outlet />
+        <Suspense fallback={<RouteLoading />}>
+          <Outlet />
+        </Suspense>
       </AppLayout>
       <TanStackRouterDevtoolsPanel position='bottom-right' />
     </>

--- a/projects/portfolio/src/client/routes/about.tsx
+++ b/projects/portfolio/src/client/routes/about.tsx
@@ -1,5 +1,7 @@
-import { About } from '#/client/pages/about'
 import { createFileRoute } from '@tanstack/react-router'
+import { lazy } from 'react'
+
+const About = lazy(() => import('#/client/pages/about').then((module) => ({ default: module.About })))
 
 export const Route = createFileRoute('/about')({
   component: RouteComponent,

--- a/projects/portfolio/src/client/routes/chat.tsx
+++ b/projects/portfolio/src/client/routes/chat.tsx
@@ -1,5 +1,7 @@
-import { Chat } from '#/client/pages/chat'
 import { createFileRoute } from '@tanstack/react-router'
+import { lazy } from 'react'
+
+const Chat = lazy(() => import('#/client/pages/chat').then((module) => ({ default: module.Chat })))
 
 export const Route = createFileRoute('/chat')({
   component: RouteComponent,

--- a/projects/portfolio/src/client/routes/diff.tsx
+++ b/projects/portfolio/src/client/routes/diff.tsx
@@ -1,5 +1,7 @@
-import { Diff } from '#/client/pages/diff'
 import { createFileRoute } from '@tanstack/react-router'
+import { lazy } from 'react'
+
+const Diff = lazy(() => import('#/client/pages/diff').then((module) => ({ default: module.Diff })))
 
 export const Route = createFileRoute('/diff')({
   component: RouteComponent,

--- a/projects/portfolio/src/client/routes/index.tsx
+++ b/projects/portfolio/src/client/routes/index.tsx
@@ -1,5 +1,7 @@
-import { Home } from '#/client/pages/home'
 import { createFileRoute } from '@tanstack/react-router'
+import { lazy } from 'react'
+
+const Home = lazy(() => import('#/client/pages/home').then((module) => ({ default: module.Home })))
 
 export const Route = createFileRoute('/')({
   component: RouteComponent,


### PR DESCRIPTION
## Summary
Implement route-level code splitting for the React SPA using TanStack Router to reduce initial bundle size and improve loading performance.

## Changes
- **Added RouteLoading component**: Global loading UI with spinner for route transitions
- **Wrapped Outlet in Suspense**: Added Suspense boundary in root route (`__root.tsx`) for centralized loading
- **Lazy-loaded page components**: Converted static imports to `React.lazy` in all routes (`/`, `/about`, `/diff`, `/chat`) to enable chunk splitting
- **Isolated heavy dependencies**: Monaco editor (in `/diff`) and chat UI are now in separate chunks

## Goals Achieved
- ✅ Initial JS bundle for `/` is smaller
- ✅ Heavy pages (`/diff`, `/chat`) load only when visited
- ✅ Client-side navigation works seamlessly
- ✅ Global loading UI appears during chunk loading
- ✅ Server routing unchanged (wildcard SPA shell)

## Testing
- **`bun run build`**: Confirm additional JS chunks exist in `dist/static`
- **`bun run dev`**:
  - Network tab: `/` doesn't load Monaco chunks
  - Navigate to `/diff`: Triggers chunk request + shows loader
- Direct navigation to `/diff` and `/chat` works (server returns SPA shell)

## Follow-ups
- Route prefetch on hover/focus for sidebar links
- Bundle visualizer to quantify improvements
- Maintain lazy loading if TanStack Router is replaced later

**Closes task:** `@tasks/2026-02-08-spa-route-code-splitting.md`