### PR TITLE
refactor(simple-agent-poc): extract documentation to modular skill files

### DIFF
--- a/projects/simple-agent-poc/.claude/skills/architecture/SKILL.md
+++ b/projects/simple-agent-poc/.claude/skills/architecture/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: architecture
+description: Architecture guidance: Enforces 5-layer pattern for Python CLI apps.
+---
+
+## Architecture
+
+Layered architecture with clear separation of concerns:
+
+- **Application Layer**
+  - `main.py` - CLI loop, wiring, dependency injection
+- **UI Layer**
+  - `renderer.py` - Screen output (print), input handling, error display
+- **Business Logic Layer**
+  - `agent.py` - Conversation management, LLM interaction orchestration
+- **Infrastructure Layer**
+  - `llm_client.py` - LiteLLMClient implementation, error translation
+- **Contracts & Data Types**
+  - `interfaces.py` - LLMClient Protocol
+  - `types.py` - TypedDict definitions, custom exceptions
+
+## Key Rules
+
+1. **UI Layer Only**: All `print()` calls must be in `renderer.py`
+2. **No Print in Business Logic**: `agent.py` never prints; returns data only
+3. **Protocol-Based**: `LLMClient` is a Protocol for easy mocking/testing
+
+## Types
+
+```python
+Message: {role: "user" | "assistant", content: str}
+LLMResponse: {content: str, usage: {prompt_tokens, completion_tokens, total_tokens}}
+```
+
+## Agent
+
+- Maintains conversation history (`list[Message]`)
+- Default model: `gpt-4.1-nano`
+- Injectable LLMClient for testing
+
+## Error Handling
+
+- Custom exceptions in `types.py`: `AgentError` (base), `AuthenticationError`, `RateLimitError`, `LLMError`
+- LLM errors are caught in `llm_client.py` and converted to user-friendly messages
+- All errors are displayed via `renderer.show_error()`
+- LiteLLM logging is suppressed in `main.py`

--- a/projects/simple-agent-poc/.claude/skills/development/SKILL.md
+++ b/projects/simple-agent-poc/.claude/skills/development/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: development
+description: I will refer to this when I receive development instructions.
+---
+
+## Development
+
+### Development Tools
+- **uv**: Dependency management and virtual environments
+- **ruff**: Code formatting and linting
+- **pytest**: Unit and integration testing
+- **ty**: Type checker
+
+### Code Quality
+
+Format code:
+```bash
+uv run ruff format .
+```
+
+Check code:
+```bash
+uv run ruff check .
+```
+
+Type check:
+```bash
+uvx ty check
+```
+
+### Testing
+
+Run all tests:
+```bash
+uv run pytest
+```

--- a/projects/simple-agent-poc/.claude/skills/testing/SKILL.md
+++ b/projects/simple-agent-poc/.claude/skills/testing/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: testing
+description: I will refer to this when I receive testing instructions.
+---
+
+## Testing
+
+### Unit Tests
+- Located in `tests/` directory
+- Use `pytest` framework
+- Mock external dependencies (e.g., LiteLLM client)
+
+Command:
+```bash
+uv run pytest
+```
+
+### E2E Tests
+- The agent itself should debug using Bash.
+- Bash Command: `uv run dev`
+- Verify CLI interactions and LLM responses

--- a/projects/simple-agent-poc/.gitignore
+++ b/projects/simple-agent-poc/.gitignore
@@ -85,4 +85,7 @@ Thumbs.db
 *.tmp
 .cache/
 .ruff_cache/
-.claude/
+
+# Claude Code
+.claude/*
+!.claude/skills/

--- a/projects/simple-agent-poc/AGENTS.md
+++ b/projects/simple-agent-poc/AGENTS.md
@@ -1,113 +1,17 @@
-# Simple Agent POC - Specification
+# AGENTS.md
 
 ## Tech Stack
 
-### Core Technologies
-- **Python**: 3.14-slim (Lightweight Docker image)
-- **Package Manager**: uv (Fast Python package manager)
-- **Code Quality**: ruff (Linter and formatter)
-- **Testing**: pytest (Testing framework)
-
-### Development Tools
-- **uv**: Dependency management and virtual environments
-- **ruff**: Code formatting and linting
-- **pytest**: Unit and integration testing
-- **ty**: Type checker
-
-### Runtime Dependencies
-- **LiteLLM**: LLM provider integration
-- **python-dotenv**: Environment variable management
-- **Standard Library**: Minimal external dependencies
+- [CLAUDE.md](./CLAUDE.md)
 
 ## Architecture
 
-Layered architecture with clear separation of concerns:
-
-- **Application Layer**
-  - `main.py` - CLI loop, wiring, dependency injection
-- **UI Layer**
-  - `renderer.py` - Screen output (print), input handling, error display
-- **Business Logic Layer**
-  - `agent.py` - Conversation management, LLM interaction orchestration
-- **Infrastructure Layer**
-  - `llm_client.py` - LiteLLMClient implementation, error translation
-- **Contracts & Data Types**
-  - `interfaces.py` - LLMClient Protocol
-  - `types.py` - TypedDict definitions, custom exceptions
-
-## Key Rules
-
-1. **UI Layer Only**: All `print()` calls must be in `renderer.py`
-2. **No Print in Business Logic**: `agent.py` never prints; returns data only
-3. **Protocol-Based**: `LLMClient` is a Protocol for easy mocking/testing
-
-## Types
-
-```python
-Message: {role: "user" | "assistant", content: str}
-LLMResponse: {content: str, usage: {prompt_tokens, completion_tokens, total_tokens}}
-```
-
-## Agent
-
-- Maintains conversation history (`list[Message]`)
-- Default model: `gpt-4.1-nano`
-- Injectable LLMClient for testing
-
-## Error Handling
-
-- Custom exceptions in `types.py`: `AgentError` (base), `AuthenticationError`, `RateLimitError`, `LLMError`
-- LLM errors are caught in `llm_client.py` and converted to user-friendly messages
-- All errors are displayed via `renderer.show_error()`
-- LiteLLM logging is suppressed in `main.py`
+- [architecture/SKILL.md](.claude/skills/architecture/SKILL.md)
 
 ## Development
 
-### Code Quality
+- [development/SKILL.md](.claude/skills/development/SKILL.md)
 
-Format code:
-```bash
-uv run ruff format .
-```
+## Testing
 
-Check code:
-```bash
-uv run ruff check .
-```
-
-Type check:
-```bash
-uvx ty check
-```
-
-### Testing
-
-Run all tests:
-```bash
-uv run pytest
-```
-
-Run with coverage report:
-```bash
-uv run pytest --cov=simple_agent_poc --cov-report=term-missing
-```
-
-Generate HTML coverage report:
-```bash
-uv run pytest --cov=simple_agent_poc --cov-report=html
-```
-
-#### Test Structure
-
-- `tests/test_types.py` - Exception classes and TypedDict definitions
-- `tests/test_llm_client.py` - LLM client with mocked LiteLLM
-- `tests/test_agent.py` - Agent business logic with mocked client
-- `tests/test_renderer.py` - UI rendering functions
-- `tests/test_interfaces.py` - Protocol definitions
-
-#### Testing Guidelines
-
-- **Mock external dependencies**: LiteLLM client is always mocked
-- **Capture mutable arguments**: Lists passed to mocks are copied at call time
-- **Test error paths**: All custom exceptions have dedicated test cases
-- **UI tests use print mocking**: `builtins.print` is patched to verify output
+- [testing/SKILL.md](.claude/skills/testing/SKILL.md)

--- a/projects/simple-agent-poc/CLAUDE.md
+++ b/projects/simple-agent-poc/CLAUDE.md
@@ -1,0 +1,13 @@
+# CLAUDE.md
+
+## Tech Stack
+
+| Category | Tool | Purpose |
+| :--- | :--- | :--- |
+| **Core** | Python 3.14-slim | Lightweight Docker image |
+| **Package Manager** | uv | Fast package manager & virtual environments |
+| **Code Quality** | ruff | Linter & formatter |
+| **Testing** | pytest | Testing framework |
+| **Type Checking** | ty | Static type checking |
+| **LLM Integration** | LiteLLM | LLM provider integration |
+| **Environment** | python-dotenv | Environment variable management |


### PR DESCRIPTION
## Summary                                                                                                                                                                                                               
                                                                                                                                                                                                                           
  Refactors project documentation by extracting detailed sections from `AGENTS.md` into dedicated Claude Code skill files, enabling better modularity and reusability.                                                     
                                                                                                                                                                                                                           
  ## Changes                                                                                                                                                                                                               
                                                                                                                                                                                                                           
  - **Added** `CLAUDE.md` - Tech stack summary with table format
  - **Added** `.claude/skills/architecture/SKILL.md` - 5-layer architecture pattern                                                                                                                                        
  - **Added** `.claude/skills/development/SKILL.md` - Development tools and commands                                                                                                                                       
  - **Added** `.claude/skills/testing/SKILL.md` - Testing guidelines and commands                                                                                                                                          
  - **Updated** `AGENTS.md` - Simplified to reference skill files
  - **Updated** `.gitignore` - Allow `.claude/skills/` directory while ignoring other `.claude/` content

  ## Details

  This refactor adopts the Claude Code skill system for organizing project documentation. Each major concern (architecture, development, testing) now lives in its own skill file under `.claude/skills/`, making the
  documentation more modular and easier to maintain.

  ## Checklist

  - [x] Documentation restructured into skill files
  - [x] `AGENTS.md` updated with links to skill files
  - [x] `CLAUDE.md` created with tech stack overview
  - [x] `.gitignore` updated to allow skill files