### PR TITLE
chore(simple-agent-poc): set timezone in devcontainer config

### DIFF
--- a/projects/simple-agent-poc/.devcontainer/devcontainer.json
+++ b/projects/simple-agent-poc/.devcontainer/devcontainer.json
@@ -12,6 +12,9 @@
   },
   "remoteUser": "vscode",
   "updateRemoteUserUID": true,
+  "containerEnv": {
+    "TZ": "Asia/Tokyo"
+  },
   "customizations": {
     "vscode": {
       "extensions": [


### PR DESCRIPTION
  ## Summary     
                                                                                            
  Set the timezone to Asia/Tokyo in the devcontainer configuration to ensure consistent time
   handling across development environments.

  ## Changes

  - Add `TZ: Asia/Tokyo` environment variable to `.devcontainer/devcontainer.json`

  ## Test Results

  Verified the timezone configuration is working correctly:

  ```
  $ uv run dev
  ════════════════════════════════════════
    ✨  Welcome to Simple Agent POC  ✨
       (Press Ctrl+C to exit)
  ════════════════════════════════════════

  > what time?
  Agent: The current time is 22:26 (10:26 PM) on February 23, 2026.
  [Usage: Input=100, Output=23, Total=123 tokens]
  ```

  The agent now correctly reports the time in JST (Asia/Tokyo timezone).

  ## Checklist

  - [x] Devcontainer configuration updated
  - [x] Timezone functionality verified