### PR TITLE
docs(simple-agent-poc): update architecture skill to match current ag…

### DIFF
--- a/projects/simple-agent-poc/.claude/skills/architecture/SKILL.md
+++ b/projects/simple-agent-poc/.claude/skills/architecture/SKILL.md
@@ -28,15 +28,17 @@ Layered architecture with clear separation of concerns:
 ## Types
 
 ```python
-Message: {role: "user" | "assistant", content: str}
+Message: {role: "system" | "user" | "assistant", content: str}
 LLMResponse: {content: str, usage: {prompt_tokens, completion_tokens, total_tokens}}
 ```
 
 ## Agent
 
 - Maintains conversation history (`list[Message]`)
-- Default model: `gpt-4.1-nano`
-- Injectable LLMClient for testing
+- Required constructor parameters:
+  - `system_prompt`: System prompt for the agent
+  - `model`: Model name to use
+- Optional `llm_client` for dependency injection (testing)
 
 ## Error Handling
 


### PR DESCRIPTION
## Summary                                                                                
  
  Updates the architecture skill documentation to reflect the current Agent implementation. 
  The skill was outdated regarding the Agent constructor parameters and Message type
  definition.                                                                               
                                                                                            
  ## Changes

  - Updated `Message` type to include `"system"` role
  - Replaced deprecated "Default model" description with required constructor parameters
  (`system_prompt`, `model`)
  - Documented optional `llm_client` parameter for dependency injection

  ## Checklist

  - [x] Skill documentation matches current `agent.py` implementation
  - [x] No functional code changes