### PR TITLE
fix(simple-agent-poc): remove colon from architecture skill description

### DIFF
--- a/projects/simple-agent-poc/.claude/skills/architecture/SKILL.md
+++ b/projects/simple-agent-poc/.claude/skills/architecture/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: architecture
-description: Architecture guidance: Enforces 5-layer pattern for Python CLI apps.
+description: Enforces 5-layer pattern for Python CLI apps.
 ---
 
 ## Architecture


### PR DESCRIPTION
## Summary

Fixes a YAML parsing error in the architecture skill file caused by a colon in the `description` field.

## Changes

- Removed colon from the `description` field in `.claude/skills/architecture/SKILL.md`
- Changed from "Architecture guidance: Enforces..." to "Enforces..."

## Details

YAML interprets unquoted colons as key-value separators, which caused the error:
`Error in user YAML: mapping values are not allowed in this context at line 2 column 35`

## Checklist

- [x] Fixed YAML syntax error in skill description
- [x] Verified description is concise and clear without the colon