### PR TITLE
Fix/portfolio-diff-editor-responsive-height

### DIFF
--- a/projects/portfolio/src/client/pages/diff/index.tsx
+++ b/projects/portfolio/src/client/pages/diff/index.tsx
@@ -178,7 +178,7 @@ export function Diff() {
       </div>
       <div className='flex-1 min-h-0'>
         {mode === 'edit' ? (
-          <div className='grid grid-cols-1 md:grid-cols-2 gap-4 h-[calc(100vh-140px)] min-h-[400px] border rounded-xl border-gray-200 dark:border-gray-700 overflow-hidden'>
+          <div className='grid grid-cols-1 md:grid-cols-2 gap-4 h-[calc(100dvh-120px)] min-h-[200px] md:min-h-[300px] border rounded-xl border-gray-200 dark:border-gray-700 overflow-hidden'>
             <div className='flex flex-col h-full min-h-0 border-r border-gray-200 dark:border-gray-700'>
               <h3 className='text-lg font-semibold mb-2 dark:text-white px-4 pt-4'>Before</h3>
               <div className='flex-1 min-h-0 px-4 pb-4'>
@@ -205,7 +205,7 @@ export function Diff() {
             </div>
           </div>
         ) : (
-          <div className='h-[calc(100vh-140px)] min-h-[400px] border rounded-xl border-gray-200 dark:border-gray-700 overflow-y-auto'>
+          <div className='h-[calc(100dvh-120px)] min-h-[200px] md:min-h-[300px] border rounded-xl border-gray-200 dark:border-gray-700 overflow-y-auto'>
             <ReactDiffViewer
               key={isDarkTheme ? 'diff-dark' : 'diff-light'}
               oldValue={beforeCode}


### PR DESCRIPTION
 ## Summary                                  
                                                                                                       
  Fixes the diff editor height responsiveness on the portfolio diff page. The editor now properly fills
   the available viewport height without causing overflow issues on both desktop and mobile screens.   
                                                                                                       
  ## Changes                                                                                           
                                         
  - Changed container from `min-h-screen` to `h-screen` with `overflow-hidden` to prevent page-level   
  scrolling                                                                                            
  - Updated editor containers to use `h-[calc(100dvh-120px)]` for dynamic viewport height calculation
  - Added responsive min-height constraints (`min-h-[200px]` for mobile, `md:min-h-[300px]` for
  desktop) to ensure usability on small screens

  ## Checklist

  - [x] Editor displays correctly on desktop screens
  - [x] Editor displays correctly on mobile screens
  - [x] No layout overflow issues
  - [x] Minimum height constraints prevent editor collapse on small viewports