### PR TITLE
fix(portfolio): correct SVG path arc flag syntax

### DIFF
--- a/projects/portfolio/src/client/pages/diff/index.tsx
+++ b/projects/portfolio/src/client/pages/diff/index.tsx
@@ -153,7 +153,7 @@ export function Diff() {
         >
           {mode === 'view' ? (
             <svg className='w-4 h-4' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
-              <path strokeWidth='2.5' d='M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 2-2v-7'></path>
+              <path strokeWidth='2.5' d='M11 4H4a2 2 0 0 0 -2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2 -2v-7'></path>
               <path strokeWidth='2.5' d='m18.5 2.5 3 3L12 15l-4 1 1-4 9.5-9.5z'></path>
             </svg>
           ) : (


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                        
  
  Fix SVG path syntax error in the diff editor page by adding missing spaces between arc flag values and coordinates. This resolves the browser console error: `<path> attribute d: Expected arc flag ('0' or '1')`.                
                 
  ## Changes                                                                                                                                                                                                                        
                                                                                                                                                                                                                                    
  - Add spaces between arc flag values and negative coordinates in SVG path `d` attribute

  ## Details

  The SVG path data attribute was missing spaces between the sweep flag (`0`) and the x-radius coordinate (`-2`), causing the browser to parse `0 0 2-2` as an invalid token. Added proper spacing to ensure correct SVG rendering.

  ## Checklist

  - [x] Fix SVG path syntax in diff page
  - [x] Verify browser console no longer shows arc flag error