### PR TITLE
refactor(workflows): extract cleanup logic into composite action

### DIFF
--- a/.github/actions/build-docker-images/build-docker-images.sh
+++ b/.github/actions/build-docker-images/build-docker-images.sh
@@ -36,11 +36,12 @@ BUILD_PROJECTS=$(cat build_projects.txt)
 echo "Projects to build: $BUILD_PROJECTS"
 
 # カンマ区切りの場合とファイルの各行の場合の両方に対応
+# （環境変数経由とファイル直接読み込みの両方をサポート）
 if [[ "$BUILD_PROJECTS" == *","* ]]; then
-  # カンマ区切りの場合
+  # 環境変数BUILD_PROJECTからカンマ区切りで読み込んだ場合
   IFS=',' read -ra PROJECT_ARRAY <<< "$BUILD_PROJECTS"
 else
-  # 改行区切りの場合
+  # ファイルから改行区切りで読み込んだ場合
   mapfile -t PROJECT_ARRAY < build_projects.txt
 fi
 

--- a/.github/actions/cleanup-docker-images/action.yml
+++ b/.github/actions/cleanup-docker-images/action.yml
@@ -1,0 +1,29 @@
+name: Cleanup Docker Images
+description: Trigger repository dispatch to clean up old Docker images
+
+inputs:
+  token:
+    description: "GitHub token for repository dispatch"
+    required: true
+  repo-name:
+    description: "Target repository name for cleanup"
+    required: true
+  project-names-csv:
+    description: "Comma separated project names to clean up"
+    required: true
+  keep-count:
+    description: "Number of images to keep"
+    required: false
+    default: "3"
+
+runs:
+  using: composite
+  steps:
+    - name: Trigger Cleanup Workflow
+      shell: bash
+      run: |
+        ${{ github.action_path }}/cleanup-docker-images.sh \
+          "${{ inputs.token }}" \
+          "${{ inputs.repo-name }}" \
+          "${{ inputs.project-names-csv }}" \
+          "${{ inputs.keep-count }}"

--- a/.github/actions/cleanup-docker-images/cleanup-docker-images.sh
+++ b/.github/actions/cleanup-docker-images/cleanup-docker-images.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Dockerイメージのクリーンアップをトリガーするスクリプト
+# GitHub Actionsとローカルテストの両方で使用
+
+set -e
+
+# 引数を取得
+TOKEN="$1"
+REPO_NAME="$2"
+PROJECT_NAMES_CSV="$3"
+KEEP_COUNT="${4:-3}"
+
+# 引数のチェック
+if [[ -z "$TOKEN" ]]; then
+  echo "Error: GitHub token is required."
+  exit 1
+fi
+
+if [[ -z "$REPO_NAME" ]]; then
+  echo "Error: Repository name is required."
+  exit 1
+fi
+
+if [[ -z "$PROJECT_NAMES_CSV" ]]; then
+  echo "Warning: No projects specified for cleanup. Skipping."
+  exit 0
+fi
+
+echo "Triggering cleanup for projects: $PROJECT_NAMES_CSV"
+echo "Keeping $KEEP_COUNT most recent images"
+
+# リポジトリディスパッチイベントを発行
+curl -X POST \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer $TOKEN" \
+  "https://api.github.com/repos/u7chan/$REPO_NAME/dispatches" \
+  -d '{
+    "event_type": "deploy_trigger",
+    "client_payload": {
+      "target": "'"$PROJECT_NAMES_CSV"'",
+      "keep_count": "'"$KEEP_COUNT"'"
+    }
+  }'
+
+echo ""
+echo "Cleanup trigger sent successfully."

--- a/.github/actions/get-changed-directories/get-changed-dirs.sh
+++ b/.github/actions/get-changed-directories/get-changed-dirs.sh
@@ -6,7 +6,7 @@
 set -e
 
 # 対象ディレクトリを定義
-TARGET_DIRS=("projects", "packages")
+TARGET_DIRS=("projects" "packages")
 
 # 関数: diff_with_renames
 # 引数:

--- a/.github/actions/push-docker-images/push-docker-images.sh
+++ b/.github/actions/push-docker-images/push-docker-images.sh
@@ -13,7 +13,6 @@
 #   - ローカルテストでDockerが不要な場合に使用
 
 set -e
-# set -x  # デバッグ出力（必要に応じてコメントアウト）
 
 # モックモードの環境変数をチェック
 # MOCK_DOCKER_COMMANDS=true の場合、実際のDockerコマンドを実行せずにモックで動作
@@ -120,11 +119,12 @@ else
 fi
 
 # カンマ区切りの場合とファイルの各行の場合の両方に対応
+# （環境変数経由とファイル直接読み込みの両方をサポート）
 if [[ "$BUILD_PROJECTS" == *","* ]]; then
-  # カンマ区切りの場合
+  # 環境変数BUILD_PROJECTからカンマ区切りで読み込んだ場合
   IFS=',' read -ra PROJECT_ARRAY <<< "$BUILD_PROJECTS"
 else
-  # 改行区切りの場合（macOS互換）
+  # ファイルから改行区切りで読み込んだ場合（macOS互換）
   PROJECT_ARRAY=()
   while IFS= read -r line; do
     [[ -n "$line" ]] && PROJECT_ARRAY+=("$line")

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -8,13 +8,16 @@ on:
 
 jobs:
   docker-build-if-changes-detected:
-    runs-on: ubuntu-latest # Docker Command を使うので ubuntu-slim は利用できない
+    # Dockerコマンドを使用するため、ubuntu-slimでは利用できない
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2 # 最新の2つのコミットをフェッチ (PRからのマージコミットが取れれば良い)
+          # プッシュイベントでは直前のコミットとの差分で十分
+          # 2コミット分の履歴で変更検出が可能
+          fetch-depth: 2
 
       - name: Get Changed Directories
         uses: ./.github/actions/get-changed-directories
@@ -42,22 +45,10 @@ jobs:
           password: ${{ secrets.PRIVATE_REPO_TOKEN }}
 
       - name: Clean Up Docker Images
-        if: env.BUILD_PROJECT != ''
-        env:
-          GH_TOKEN: ${{ secrets.PRIVATE_REPO_TOKEN }}
-          REPO_NAME: ${{ secrets.PRIVATE_REPO_NAME }}
-          KEEP_COUNT: 3
-        run: |
-          export KEEP_COUNT="$KEEP_COUNT"
-          echo "project_names_csv = ${{ steps.push_images.outputs.project_names_csv }}"
-          curl -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer $GH_TOKEN" \
-            https://api.github.com/repos/u7chan/$REPO_NAME/dispatches \
-            -d '{
-              "event_type": "deploy_trigger",
-              "client_payload": {
-                "target": "${{ steps.push_images.outputs.project_names_csv }}",
-                "keep_count": "'"$KEEP_COUNT"'"
-              }
-            }'
+        if: steps.push_images.outputs.project_names_csv != ''
+        uses: ./.github/actions/cleanup-docker-images
+        with:
+          token: ${{ secrets.PRIVATE_REPO_TOKEN }}
+          repo-name: ${{ secrets.PRIVATE_REPO_NAME }}
+          project-names-csv: ${{ steps.push_images.outputs.project_names_csv }}
+          keep-count: 3

--- a/.github/workflows/pullrequest-check.yml
+++ b/.github/workflows/pullrequest-check.yml
@@ -8,13 +8,16 @@ on:
 
 jobs:
   pull-request-check-if-changes-detected:
-    runs-on: ubuntu-latest # Docker Command を使うので ubuntu-slim は利用できない
+    # Docker commands require ubuntu-latest, ubuntu-slim is not available
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 50 # プルリクエストの差分を取得するのに十分な履歴
+          # PRのベースブランチとの差分取得に必要な履歴深度
+          # 50コミットあれば通常のPRの変更はカバーできる
+          fetch-depth: 50
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Fetch base branch for comparison

--- a/docs/about-cicd.md
+++ b/docs/about-cicd.md
@@ -1,51 +1,170 @@
-# CICDについて
+# CI/CDについて
 
 ## 概要
 
-GitHub Actionsを使用したCI/CDパイプラインで、以下の処理を自動化します:
+GitHub Actionsを使用したCI/CDパイプラインです。変更のあったプロジェクトのみを検出して効率的にビルド・デプロイを行います。
 
-- mainブランチへのpush時: Dockerイメージをビルドし、GitHub Container Registry(GHCR)にプッシュ
-- pull request時: 変更プロジェクトを検出し、testステージでDockerイメージをビルド
+| トリガー | 実行内容 |
+|---------|---------|
+| **mainブランチへのpush** | Dockerイメージをビルド → GHCRにプッシュ → 古いイメージをクリーンアップ |
+| **mainブランチへのpull request** | 変更プロジェクトを検出 → testステージでビルド検証 |
 
-## トリガー条件
+## ワークフロー構成
 
-- mainブランチへのpush時
-- mainブランチへのpull request時
+### docker-build.yml (CD - 継続的デリバリー)
 
-## ワークフロー (docker-build.yml)
+mainブランチへのpush時に実行されます。
 
-1. コードのチェックアウト
-2. 変更ディレクトリの検出 (get-changed-directories)
-3. Dockerfileがある変更プロジェクトの特定 (get-changed-projects)
-4. Dockerイメージのビルド (build-docker-images)
-5. GHCRへのログイン
-6. Dockerイメージのプッシュ
-
-## ワークフロー (pullrequest-check.yml)
-
+```
 1. コードのチェックアウト (fetch-depth: 2)
+   └─ 直前のコミットとの差分検出に必要な最小限の履歴
+
 2. 変更ディレクトリの検出 (get-changed-directories)
-3. Dockerfileがある変更プロジェクトの特定 (get-changed-projects)
-4. Dockerイメージのビルド (build-docker-images) - testステージ指定
+   └─ projects/ および packages/ 配下の変更を検出
+
+3. 変更プロジェクトの特定 (get-changed-projects)
+   └─ Dockerfileがあるプロジェクトを絞り込み
+
+4. Dockerイメージのビルド (build-docker-images)
+   └─ finalステージを指定してビルド
+
+5. Dockerイメージのプッシュ (push-docker-images)
+   └─ GHCR (ghcr.io) へlatestタグでプッシュ
+
+6. 古いイメージのクリーンアップ (cleanup-docker-images)
+   └─ 別リポジトリのワークフローをトリガーして整理
+```
+
+### pullrequest-check.yml (CI - 継続的インテグレーション)
+
+mainブランチへのpull request時に実行されます。
+
+```
+1. コードのチェックアウト (fetch-depth: 50)
+   └─ PRのベースブランチとの差分検出に必要な履歴
+
+2. 変更ディレクトリの検出 (get-changed-directories)
+
+3. 変更プロジェクトの特定 (get-changed-projects)
+
+4. Dockerイメージのビルド (build-docker-images)
+   └─ testステージを指定してビルド（軽量な検証用）
+
 5. Dockerイメージの表示
+   └─ ビルド結果の確認
+```
 
 ## カスタムアクション詳細
 
 ### get-changed-directories
 
-- 最新コミットと1つ前のコミットの差分を取得
-- projects配下の変更ディレクトリを抽出
-- 重複排除してchanged_dirs.txtに出力
+変更のあったディレクトリを検出します。
+
+| 項目 | 内容 |
+|-----|------|
+| 入力 | `HEAD` とベースリファレンス（PR時: `origin/main`、Push時: `HEAD~1`）の差分 |
+| 対象 | `projects/`、`packages/` 配下のディレクトリ |
+| 出力 | `changed_dirs.txt`（改行区切りのディレクトリパス） |
+| 特徴 | リネーム（移動）されたファイルにも対応 |
 
 ### get-changed-projects
 
-- changed_dirs.txtからディレクトリを読み込み
-- 各ディレクトリにDockerfileが存在するか確認
-- DockerfileがあるプロジェクトをBUILD_PROJECT環境変数に設定
+Dockerfileがある変更プロジェクトを絞り込みます。
+
+| 項目 | 内容 |
+|-----|------|
+| 入力 | `changed_dirs.txt` |
+| 処理 | 各ディレクトリに `Dockerfile` が存在するか確認 |
+| 出力 | `build_projects.txt` + `BUILD_PROJECT` 環境変数（カンマ区切り） |
 
 ### build-docker-images
 
-- BUILD_PROJECT環境変数からビルド対象プロジェクトを取得
-- 各プロジェクトのDockerfileをビルド
-  - ステージ指定(--target)がある場合は使用
-- イメージはGHCRにlatestタグでビルド
+Dockerイメージをビルドします。
+
+| パラメータ | 必須 | 説明 |
+|-----------|------|------|
+| `stage` | ○ | ビルドステージ（`test` または `final`） |
+
+**ビルド仕様:**
+- `COMMIT_HASH` をビルド引数として渡す
+- 指定ステージが存在する場合: `--target` 指定でビルド
+- 存在しない場合: 通常ビルド（マルチステージ全体）
+- タグ: `ghcr.io/{リポジトリ名}/{プロジェクト名}:latest`
+
+**オプション機能:**
+- プロジェクト配下に `pre-docker-build.sh` があれば自動実行
+
+### push-docker-images
+
+GHCRへDockerイメージをプッシュします。
+
+| パラメータ | 必須 | 説明 |
+|-----------|------|------|
+| `registry` | × | レジストリURL（デフォルト: `ghcr.io`） |
+| `username` | ○ | レジストリのユーザー名 |
+| `password` | ○ | レジストリのパスワード（トークン） |
+
+**出力:**
+- `project_names_csv`: プッシュしたプロジェクト名（カンマ区切り）
+
+### cleanup-docker-images
+
+古いDockerイメージのクリーンアップを別リポジトリに依頼します。
+
+| パラメータ | 必須 | 説明 |
+|-----------|------|------|
+| `token` | ○ | GitHubトークン（`repo` スコープが必要） |
+| `repo-name` | ○ | クリーンアップ処理があるリポジトリ名 |
+| `project-names-csv` | ○ | 対象プロジェクト名（カンマ区切り） |
+| `keep-count` | × | 保持するイメージ数（デフォルト: `3`） |
+
+**動作:**
+- リポジトリディスパッチイベントを発行
+- 別リポジトリのワークフローをトリガー
+
+## ファイル間のデータ連携
+
+```
+┌─────────────────────────┐
+│ get-changed-directories │
+│    changed_dirs.txt     │
+└───────────┬─────────────┘
+            │
+            ▼
+┌─────────────────────────┐
+│  get-changed-projects   │
+│   build_projects.txt    │
+│    BUILD_PROJECT env    │
+└───────────┬─────────────┘
+            │
+    ┌───────┴───────┐
+    ▼               ▼
+┌─────────┐   ┌─────────┐
+│  build  │   │  push   │
+│docker-  │   │docker-  │
+│ images  │   │ images  │
+└─────────┘   └────┬────┘
+                   │
+                   ▼
+          ┌─────────────┐
+          │   cleanup   │
+          │docker-images│
+          └─────────────┘
+```
+
+## トラブルシューティング
+
+### 変更が検出されない
+
+- `fetch-depth` が十分か確認（PR時は50、Push時は2）
+- 対象ディレクトリ（`projects/`、`packages/`）配下の変更か確認
+
+### ビルドがスキップされる
+
+- `BUILD_PROJECT` 環境変数が設定されているか確認
+- Dockerfileがプロジェクトルートに存在するか確認
+
+### プッシュに失敗する
+
+- `PRIVATE_REPO_TOKEN` が正しく設定されているか確認
+- トークンに `write:packages` 権限があるか確認


### PR DESCRIPTION
## Summary                                                                                                                                                                                                      
                                                                                                                                                                                                                  
  CI/CDワークフローの保守性と可読性を向上させるため、Dockerイメージクリーンアップロジックを新規Composite Actionに抽出し、関連するバグ修正とドキュメント更新を行いました。                                         
                                                                                                                                                                                                                  
  ## Changes                                                                                                                                                                                                      
                                                                                                                                                                                                                  
  - **New Action**: `cleanup-docker-images` Composite Action を作成し、ワークフローから再利用可能に
  - **Bug Fix**: `get-changed-dirs.sh` の bash 配列定義構文エラーを修正（カンマを削除）                                                                                                                           
  - **Refactor**: `docker-build.yml` のインラインcurlスクリプトを新規アクションに置き換え                                                                                                                         
  - **Documentation**: `about-cicd.md` を更新し、新しいアクションとデータ連携フローを追記                                                                                                                         
  - **Polish**: シェルスクリプトとワークフローに説明コメントを追加

  ## Details

  ### 新規アクション: cleanup-docker-images
  - 入力: `token`, `repo-name`, `project-names-csv`, `keep-count`
  - 出力: 別リポジトリのワークフローを repository_dispatch でトリガー

  ### バグ修正
  `TARGET_DIRS=("projects", "packages")` → `("projects" "packages")`
  - bash配列ではカンマを含めると文字列として解釈されるため削除

  ## Checklist

  - [x] 新しいアクションを作成し、ワークフローから呼び出し
  - [x] bash配列の構文エラーを修正
  - [x] CI/CDドキュメントを更新
  - [x] 各スクリプトに処理理由のコメントを追加
  - [x] ローカルでテスト可能な構造を維持