### PR TITLE
feat(cicd): add required-stage filter for CI-only projects

### DIFF
--- a/.github/actions/get-changed-projects/action.yml
+++ b/.github/actions/get-changed-projects/action.yml
@@ -1,6 +1,12 @@
 name: Get Changed Projects
 description: Get a list of projects with Dockerfile whose differences have been changed
 
+inputs:
+  required-stage:
+    description: "If specified, only include projects that have this stage in their Dockerfile"
+    required: false
+    default: ""
+
 runs:
   using: composite
   steps:
@@ -8,4 +14,4 @@ runs:
       shell: bash
       run: |
         # 共通スクリプトを実行
-        ${{ github.action_path }}/get-changed-projects.sh
+        ${{ github.action_path }}/get-changed-projects.sh "${{ inputs.required-stage }}"

--- a/.github/actions/get-changed-projects/get-changed-projects.sh
+++ b/.github/actions/get-changed-projects/get-changed-projects.sh
@@ -5,6 +5,9 @@
 
 set -e
 
+# パラメータから必須ステージを取得
+REQUIRED_STAGE="${1:-}"
+
 # 変更されたディレクトリファイルが存在するかチェック
 if [[ ! -f "changed_dirs.txt" ]]; then
   echo "Error: changed_dirs.txt not found. Please run get-changed-directories first."
@@ -12,6 +15,9 @@ if [[ ! -f "changed_dirs.txt" ]]; then
 fi
 
 echo "> checking projects with Dockerfile"
+if [[ -n "$REQUIRED_STAGE" ]]; then
+  echo "> required stage: $REQUIRED_STAGE"
+fi
 
 # 変更されたプロジェクトを確認し、Dockerfile が存在するかチェック
 BUILD_PROJECT=""
@@ -21,6 +27,17 @@ while read -r target; do
 
   if [[ -f "$target/Dockerfile" ]]; then
     echo "Dockerfile found: $target"
+
+    # 必須ステージが指定されている場合はチェック
+    if [[ -n "$REQUIRED_STAGE" ]]; then
+      if grep -qE "AS\s+$REQUIRED_STAGE" "$target/Dockerfile"; then
+        echo "  ✓ Stage '$REQUIRED_STAGE' found"
+      else
+        echo "  ✗ Stage '$REQUIRED_STAGE' not found, skipping"
+        continue
+      fi
+    fi
+
     if [ -z "$BUILD_PROJECT" ]; then
       BUILD_PROJECT="$target"
     else

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Get Changed Projects
         uses: ./.github/actions/get-changed-projects
+        with:
+          required-stage: final
 
       - name: Build Docker Images
         if: env.BUILD_PROJECT != ''

--- a/projects/cicd-ci-sample/Dockerfile
+++ b/projects/cicd-ci-sample/Dockerfile
@@ -1,6 +1,7 @@
 # -----------------------------------------------
-# CI用サンプル - testステージあり
+# CI専用サンプル - testステージのみ
 # PR時にCIが発火してビルド検証を行う
+# finalステージがないため、CD対象外となりイメージはビルドされない
 # -----------------------------------------------
 
 FROM alpine:3.21 AS base
@@ -22,18 +23,4 @@ RUN echo "=== Running tests (CI validation) ===" && \
     chmod +x scripts/test.sh && \
     ./scripts/test.sh
 
-# -----------------------------------------------
-# final stage
-# -----------------------------------------------
-FROM base AS final
-
-ARG COMMIT_HASH
-
-ENV APP_VERSION="${COMMIT_HASH}"
-
-COPY scripts/ scripts/
-
-RUN echo "=== CI Sample Build Complete ===" && \
-    echo "Version: ${APP_VERSION}"
-
-CMD ["echo", "CI sample - use --target=test for CI validation"]
+# finalステージはない - このプロジェクトはCI専用


### PR DESCRIPTION
## Summary

  `get-changed-projects` アクションに `required-stage` パラメータを追加し、`final`
  ステージを持たないプロジェクトをCDビルドから除外できるようにします。これにより、CI
  専用プロジェクト（テスト検証のみでイメージビルドが不要なプロジェクト）を自動的にス
  キップできます。

  ## Changes

  - `get-changed-projects` アクションに `required-stage` 入力パラメータを追加
  - `docker-build.yml` ワークフローで `final` ステージ必須を指定
  - `cicd-ci-sample` をCI専用プロジェクトに変更（`final` ステージを削除）
  - CI専用プロジェクトの仕様をドキュメントに追加

  ## Details

  ### 背景

  従来のワークフローでは、Dockerfileがある全てのプロジェクトがCDの対象となっていまし
  た。しかし、テスト実行や検証のみを目的としたCI専用プロジェクトでは、本番用イメージ
  （`final` ステージ）のビルドは不要です。

  ### 実装

  - `get-changed-projects` アクションに `required-stage` 入力を追加
  - 指定されたステージがDockerfile内に存在するかチェックするロジックを追加
  - 該当ステージがないプロジェクトはビルド対象から除外

  ### 使用例

  ```yaml
  - name: Get Changed Projects
    uses: ./.github/actions/get-changed-projects
    with:
      required-stage: final  # finalステージを持つプロジェクトのみ対象

  Checklist

  - get-changed-projects アクションに required-stage パラメータを追加
  - シェルスクリプトでステージ存在確認ロジックを実装
  - docker-build.yml で required-stage: final を設定
  - cicd-ci-sample の final ステージを削除してCI専用化
  - ドキュメントにCI専用プロジェクトの説明を追加