### PR TITLE
feat(simple-agent-poc): add Dockerfile for CI-only testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
+# Ignore files that track recently changed directories and build projects
 changed_dirs.txt
 build_projects.txt
+
+# Ignore local settings for Claude
+.claude/settings.local.json

--- a/projects/simple-agent-poc/Dockerfile
+++ b/projects/simple-agent-poc/Dockerfile
@@ -1,0 +1,39 @@
+# CI-only project - test stage only
+FROM python:3.14-slim AS base
+
+ARG COMMIT_HASH=""
+ENV COMMIT_HASH=${COMMIT_HASH}
+
+WORKDIR /app
+
+# Install uv
+RUN pip install --no-cache-dir uv
+
+# Copy dependency files
+COPY pyproject.toml uv.lock ./
+COPY README.md ./
+
+# Install dependencies
+RUN uv sync --frozen --no-install-project
+
+# ---- test stage (REQUIRED for CI) ----
+FROM base AS test
+
+ARG COMMIT_HASH=""
+ENV COMMIT_HASH=${COMMIT_HASH}
+
+# Copy source code and tests
+COPY src/ src/
+COPY tests/ tests/
+
+# Install project
+RUN uv sync --frozen
+
+# Log commit hash and run tests
+RUN echo "Building with commit: ${COMMIT_HASH}" && \
+    uv run ruff format --check . && \
+    uv run ruff check . && \
+    uv run ty check . && \
+    uv run pytest -v
+
+# No final stage - CI only

--- a/projects/simple-agent-poc/tests/test_agent.py
+++ b/projects/simple-agent-poc/tests/test_agent.py
@@ -24,7 +24,11 @@ class TestAgent:
     def test_init_with_custom_client(self) -> None:
         """Test agent initialization with custom client."""
         mock_client = MagicMock()
-        agent = Agent(system_prompt=DEFAULT_SYSTEM_PROMPT, model=DEFAULT_MODEL, llm_client=mock_client)
+        agent = Agent(
+            system_prompt=DEFAULT_SYSTEM_PROMPT,
+            model=DEFAULT_MODEL,
+            llm_client=mock_client,
+        )
         assert agent._client is mock_client
         assert len(agent._messages) == 1
         assert agent._messages[0]["role"] == "system"
@@ -69,7 +73,11 @@ class TestAgent:
             "usage": {"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8},
         }
 
-        agent = Agent(system_prompt=DEFAULT_SYSTEM_PROMPT, model=DEFAULT_MODEL, llm_client=mock_client)
+        agent = Agent(
+            system_prompt=DEFAULT_SYSTEM_PROMPT,
+            model=DEFAULT_MODEL,
+            llm_client=mock_client,
+        )
         agent.process_user_input("Hello")
 
         # System message should be first, then user message
@@ -98,7 +106,11 @@ class TestAgent:
         }
         mock_client.complete.return_value = mock_response
 
-        agent = Agent(system_prompt=DEFAULT_SYSTEM_PROMPT, model=DEFAULT_MODEL, llm_client=mock_client)
+        agent = Agent(
+            system_prompt=DEFAULT_SYSTEM_PROMPT,
+            model=DEFAULT_MODEL,
+            llm_client=mock_client,
+        )
         response = agent.process_user_input("Hello")
 
         assert response == mock_response
@@ -136,7 +148,11 @@ class TestAgent:
         mock_client = MagicMock()
         mock_client.complete.side_effect = capture_and_return
 
-        agent = Agent(system_prompt=DEFAULT_SYSTEM_PROMPT, model=DEFAULT_MODEL, llm_client=mock_client)
+        agent = Agent(
+            system_prompt=DEFAULT_SYSTEM_PROMPT,
+            model=DEFAULT_MODEL,
+            llm_client=mock_client,
+        )
 
         # First message (system + user + assistant = 3)
         agent.process_user_input("First")
@@ -177,7 +193,11 @@ class TestAgent:
         mock_client = MagicMock()
         mock_client.complete.side_effect = capture_and_return
 
-        agent = Agent(system_prompt=DEFAULT_SYSTEM_PROMPT, model=DEFAULT_MODEL, llm_client=mock_client)
+        agent = Agent(
+            system_prompt=DEFAULT_SYSTEM_PROMPT,
+            model=DEFAULT_MODEL,
+            llm_client=mock_client,
+        )
         agent.process_user_input("Test")
 
         # Check the messages passed to complete() at call time


### PR DESCRIPTION
## Summary                                                                                                                                                  
                                                                                                                                                              
  Add a multi-stage Dockerfile to `simple-agent-poc` for CI-only testing. This enables the project to be validated through the monorepo's CI pipeline without 
  producing deployable artifacts.
                                                                                                                                                              
  ## Changes                                                                                                                                                  

  - Add `Dockerfile` with `base` and `test` stages
  - Use Python 3.14-slim as the base image
  - Install `uv` package manager for fast dependency resolution
  - Configure test stage to run linting (ruff), type checking (ty), and tests (pytest)
  - Log `COMMIT_HASH` during build for traceability

  ## Details

  This is a CI-only project (no `final` stage), meaning:
  - CI will build and test on PRs
  - CD will skip this project (no image push to GHCR)

  ## Checklist

  - [x] Dockerfile has `test` stage with `AS test`
  - [x] `COMMIT_HASH` build argument is accepted
  - [x] Tests pass in local Docker build