### PR TITLE
feat(simple-agent-poc): add loading indicator for LLM calls

### DIFF
--- a/projects/simple-agent-poc/src/simple_agent_poc/main.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/main.py
@@ -12,6 +12,7 @@ from simple_agent_poc.renderer import (
     show_error,
     show_exit_message,
     show_welcome,
+    with_indicator,
 )
 
 # Suppress LiteLLM logging to stderr
@@ -58,12 +59,19 @@ def main() -> None:
                 continue
 
             # Business logic layer: process request
-            response = agent.process_user_input(user_input)
+            response = with_indicator(
+                "Thinking",
+                lambda: agent.process_user_input(user_input),
+            )
 
             # UI layer: display results
             show_agent_response(response)
 
         except KeyboardInterrupt:
+            show_exit_message()
+            break
+        except EOFError:
+            # Handle EOF (e.g., piped input, terminal closed)
             show_exit_message()
             break
         except Exception as e:

--- a/projects/simple-agent-poc/src/simple_agent_poc/renderer.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/renderer.py
@@ -1,6 +1,64 @@
 """UI rendering functions for CLI output."""
 
+import sys
+import threading
+import time
+from typing import Callable
+
 from simple_agent_poc.types import AgentError, LLMResponse
+
+
+class LoadingIndicator:
+    """Async loading indicator for CLI."""
+
+    def __init__(self, message: str = "Thinking") -> None:
+        self.message = message
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._spinner_chars = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
+
+    def _run(self) -> None:
+        """Run the spinner animation."""
+        idx = 0
+        while not self._stop_event.is_set():
+            char = self._spinner_chars[idx % len(self._spinner_chars)]
+            sys.stdout.write(f"\r{char} {self.message}...")
+            sys.stdout.flush()
+            idx += 1
+            time.sleep(0.08)
+        # Clear the line when stopped
+        sys.stdout.write("\r" + " " * (len(self.message) + 10) + "\r")
+        sys.stdout.flush()
+
+    def start(self) -> None:
+        """Start the loading indicator."""
+        self._stop_event.clear()
+        self._thread = threading.Thread(target=self._run)
+        self._thread.start()
+
+    def stop(self) -> None:
+        """Stop the loading indicator."""
+        self._stop_event.set()
+        if self._thread:
+            self._thread.join()
+
+
+def with_indicator[T](message: str, operation: Callable[[], T]) -> T:
+    """Execute an operation with a loading indicator.
+
+    Args:
+        message: The message to display next to the spinner.
+        operation: The function to execute while showing the indicator.
+
+    Returns:
+        The result of the operation.
+    """
+    indicator = LoadingIndicator(message)
+    indicator.start()
+    try:
+        return operation()
+    finally:
+        indicator.stop()
 
 
 def show_error(error: Exception) -> None:

--- a/projects/simple-agent-poc/tests/test_renderer.py
+++ b/projects/simple-agent-poc/tests/test_renderer.py
@@ -2,12 +2,15 @@
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from simple_agent_poc.renderer import (
     get_user_input,
     show_agent_response,
     show_error,
     show_exit_message,
     show_welcome,
+    with_indicator,
 )
 from simple_agent_poc.types import AgentError, AuthenticationError, LLMResponse
 
@@ -119,3 +122,25 @@ class TestShowExitMessage:
         show_exit_message()
 
         mock_print.assert_called_once_with("\nExiting...")
+
+
+class TestWithIndicator:
+    """Tests for with_indicator function."""
+
+    def test_executes_operation_and_returns_result(self) -> None:
+        """Test that operation is executed and result is returned."""
+        mock_op = MagicMock(return_value="test_result")
+
+        result = with_indicator("Loading", mock_op)
+
+        assert result == "test_result"
+        mock_op.assert_called_once()
+
+    def test_propagates_exception_and_stops_indicator(self) -> None:
+        """Test that exceptions are propagated and indicator stops cleanly."""
+        mock_op = MagicMock(side_effect=ValueError("test error"))
+
+        with pytest.raises(ValueError, match="test error"):
+            with_indicator("Loading", mock_op)
+
+        mock_op.assert_called_once()


### PR DESCRIPTION
  ## Summary                                                                                      
                                                                                                  
  LLMリクエスト中にスピナーインジケーターを表示する機能を追加しました。Claude
  CodeのようなAIエージェントCLIのUXに近づけるための改善です。                                     
                                                                                                  
  ## Changes

  - `renderer.py`: `LoadingIndicator` クラスと `with_indicator()` ヘルパーを追加
  - `main.py`: LLM呼び出し時にインジケーターを表示するよう統合
  - `main.py`: `EOFError` ハンドリングを追加（パイプ入力時の無限ループ防止）
  - `test_renderer.py`: `with_indicator` の基本動作テストを追加

  ## Details

  ### アーキテクチャ準拠
  - UIレイヤー (`renderer.py`) にインジケーター表示ロジックを集中
  - ビジネスロジックレイヤー (`agent.py`) は変更なし
  - 非同期スピナーは別スレッドで動作し、メインスレッドでLLM処理を実行

  ### 実装ポイント
  - ブロックdotsスピナー（⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏）を使用
  - 処理完了後はインジケーター行を自動クリア
  - 例外発生時も `finally` で確実にインジケーターを停止

  ## Checklist

  - [x] インジケーター機能をUIレイヤーに実装
  - [x] アーキテクチャの責務分離を維持
  - [x] EOFErrorハンドリングで無限ループを防止
  - [x] 最低限のテストを追加
  - [x] ruffチェックパス
  - [x] tyチェックパス