### PR TITLE
feat(simple-agent-poc): add model and response time to usage display

### DIFF
--- a/projects/simple-agent-poc/src/simple_agent_poc/llm_client.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/llm_client.py
@@ -1,5 +1,7 @@
 """LLM client implementation."""
 
+import time
+
 from litellm import completion
 from litellm.exceptions import (
     AuthenticationError as LiteLLMAuthError,
@@ -23,6 +25,7 @@ class LiteLLMClient(LLMClient):
         self.model = model
 
     def complete(self, messages: list[Message]) -> LLMResponse:
+        start_time = time.perf_counter()
         try:
             response = completion(
                 model=self.model,
@@ -55,6 +58,7 @@ class LiteLLMClient(LLMClient):
                 display_message=f"An error occurred while communicating with the LLM: {e}",
             ) from e
 
+        elapsed = time.perf_counter() - start_time
         return {
             "content": response.choices[0].message.content,
             "usage": {
@@ -62,4 +66,6 @@ class LiteLLMClient(LLMClient):
                 "completion_tokens": response.usage.completion_tokens,
                 "total_tokens": response.usage.total_tokens,
             },
+            "model": self.model,
+            "response_time": elapsed,
         }

--- a/projects/simple-agent-poc/src/simple_agent_poc/renderer.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/renderer.py
@@ -93,11 +93,29 @@ def get_user_input() -> str:
 def show_agent_response(response: LLMResponse) -> None:
     """Display the agent's response."""
     print(f"Agent: {response['content']}")
-    print(
-        f"[Usage: Input={response['usage']['prompt_tokens']}, "
-        f"Output={response['usage']['completion_tokens']}, "
-        f"Total={response['usage']['total_tokens']} tokens]"
+
+    # Format response time
+    elapsed = response["response_time"]
+    if elapsed < 1:
+        time_str = f"{elapsed * 1000:.0f}ms"
+    else:
+        time_str = f"{elapsed:.2f}s"
+
+    # Extract model name (remove provider prefix if exists)
+    model = response["model"]
+    if "/" in model:
+        model = model.split("/")[-1]
+
+    # Build stats line
+    usage = response["usage"]
+    stats = (
+        f"Model: {model} │ "
+        f"Time: {time_str} │ "
+        f"Tokens: {usage['prompt_tokens']} → {usage['completion_tokens']} "
+        f"(total: {usage['total_tokens']})"
     )
+
+    print(f"  └─ {stats}")
 
 
 def show_exit_message() -> None:

--- a/projects/simple-agent-poc/src/simple_agent_poc/types.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/types.py
@@ -52,3 +52,5 @@ class Usage(TypedDict):
 class LLMResponse(TypedDict):
     content: str
     usage: Usage
+    model: str
+    response_time: float

--- a/projects/simple-agent-poc/tests/test_agent.py
+++ b/projects/simple-agent-poc/tests/test_agent.py
@@ -103,6 +103,8 @@ class TestAgent:
                 "completion_tokens": 5,
                 "total_tokens": 15,
             },
+            "model": "gpt-4o-mini",
+            "response_time": 0.85,
         }
         mock_client.complete.return_value = mock_response
 

--- a/projects/simple-agent-poc/tests/test_renderer.py
+++ b/projects/simple-agent-poc/tests/test_renderer.py
@@ -102,15 +102,18 @@ class TestShowAgentResponse:
                 "completion_tokens": 5,
                 "total_tokens": 15,
             },
+            "model": "gpt-4o-mini",
+            "response_time": 0.85,
         }
         show_agent_response(response)
 
         assert mock_print.call_count == 2
         calls = [call.args[0] for call in mock_print.call_args_list]
         assert calls[0] == "Agent: Hello, user!"
-        assert "Input=10" in calls[1]
-        assert "Output=5" in calls[1]
-        assert "Total=15" in calls[1]
+        assert "gpt-4o-mini" in calls[1]
+        assert "850ms" in calls[1] or "0.85s" in calls[1]
+        assert "10 → 5" in calls[1]
+        assert "total: 15" in calls[1]
 
 
 class TestShowExitMessage:


### PR DESCRIPTION
## Summary

Enhance the agent response display to include model name and response time alongside token usage, providing better visibility into LLM performance and costs.

## Changes

- Add `model` and `response_time` fields to `LLMResponse` type
- Measure response time using `time.perf_counter()` in the LLM client
- Redesign usage display with tree-style layout showing:
  - Model name (provider prefix stripped for brevity)
  - Response time (ms for <1s, seconds otherwise)
  - Token usage in `input → output (total)` format
- Update tests to verify new display format

## Example Output

```
════════════════════════════════════════
  ✨  Welcome to Simple Agent POC  ✨
     (Press Ctrl+C to exit)
════════════════════════════════════════

> Hey
Agent: Hello! How can I assist you today?
  └─ Model: gpt-4.1-nano │ Time: 1.50s │ Tokens: 98 → 9 (total: 107)
```

## Checklist

- [x] Type definitions updated (`LLMResponse`)
- [x] LLM client updated to capture timing and model info
- [x] Renderer updated with new display format
- [x] Tests updated and passing
- [x] Linting passes