### PR TITLE
feat(litellm-lab): add LiteLLM proxy research project

### DIFF
--- a/projects/litellm-proxy-lab/.env.example
+++ b/projects/litellm-proxy-lab/.env.example
@@ -1,0 +1,7 @@
+# litellm
+DATABASE_URL=postgresql://postgres:postgres@rdb:5432/postgres
+LITELLM_MASTER_KEY=test
+
+# rdb
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres

--- a/projects/litellm-proxy-lab/config/config.yaml
+++ b/projects/litellm-proxy-lab/config/config.yaml
@@ -1,0 +1,15 @@
+litellm_settings:
+  # drop_params:
+  #   True にすると、プロバイダー（OpenAI/Anthropic等）がサポートしていない
+  #   リクエストパラメータを自動的に削除し、エラーを防ぎます。
+  drop_params: true
+
+general_settings:
+  # store_prompts_in_spend_logs:
+  #   True にすると、リクエスト内容（プロンプト）とレスポンス内容（回答）をデータベースに保存します。
+  store_prompts_in_spend_logs: true
+
+  # store_model_in_db:
+  #   True にすると、使用されたモデル名をDBに記録します。
+  #   モデルごとの利用傾向やコスト分析に必須の設定です。
+  store_model_in_db: true

--- a/projects/litellm-proxy-lab/docker-compose.yaml
+++ b/projects/litellm-proxy-lab/docker-compose.yaml
@@ -1,0 +1,30 @@
+services:
+  litellm:
+    container_name: litellm
+    image: ghcr.io/berriai/litellm:main-latest
+    restart: always
+    ports:
+      - 4000:4000
+    volumes:
+      - ./config/config.yaml:/app/config/config.yaml
+    command: ["--config", "/app/config/config.yaml"]
+    env_file:
+      - .env
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    depends_on:
+      - rdb
+
+  rdb:
+    container_name: rdb
+    image: postgres:17-alpine
+    restart: always
+    ports:
+      - 4001:5432
+    env_file:
+      - .env
+    volumes:
+      - rdb-data:/var/lib/postgresql/data
+
+volumes:
+  rdb-data:


### PR DESCRIPTION
## Summary

LiteLLM Proxy を使用した LLM API 統合の研究用プロジェクトを追加します。
Docker Compose で簡単に環境を立ち上げられる構成で、複数の LLM プロバイダーを統一的に利用できるテスト環境を提供します。

## Changes

- `projects/litellm-proxy-lab/` に研究用プロジェクトを新規作成
- `docker-compose.yaml` - LiteLLM Proxy サービスの定義
- `config/config.yaml` - LiteLLM の設定ファイル（モデルルーティング設定）
- `.env.example` - 環境変数のテンプレート

## Details

LiteLLM Proxy を使用することで、OpenAI、Anthropic、Azure など複数の LLM プロバイダーを統一されたインターフェースで利用できます。
このプロジェクトは、モノレポ内での LLM 統合パターンの研究・検証を目的としています。

## Checklist

- [ ] `docker-compose.yaml` の動作確認
- [ ] `.env.example` に必要な環境変数が網羅されているか確認
- [ ] `config.yaml` のモデル設定が適切かレビュー
