### PR TITLE
refactor(deploy): add config path command argument

### DIFF
--- a/deploy/litellm.yml
+++ b/deploy/litellm.yml
@@ -11,6 +11,7 @@ services:
       - 4000:4000
     volumes:
       - ./config:/app/config:ro
+    command: ["--config", "/app/config/config.yaml"]
     env_file:
       - .env.secret
     extra_hosts:


### PR DESCRIPTION
## Summary

LiteLLMコンテナに `--config` コマンド引数を追加し、設定ファイルのパスを明示的に指定します。
これにより、設定ファイルの位置が確実に認識され、予期しないデフォルト値の使用を防ぎます。

## Changes

- `deploy/litellm.yml`: LiteLLMサービスに `command: ["--config", "/app/config/config.yaml"]` を追加

## Checklist

- [ ] Docker Composeでサービスが正常に起動することを確認
- [ ] LiteLLMが設定ファイルを正しく読み込むことを確認
