### PR TITLE
feat(portfolio): Chat Response Time Measurement and Display (#574)

### DIFF
--- a/projects/portfolio/src/client/components/chat/chat-main.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-main.tsx
@@ -159,6 +159,7 @@ export function ChatMain({
   const [chatResults, setChatResults] = useState<{
     model?: string
     finish_reason: string
+    responseTimeMs?: number
     usage?: {
       promptTokens: number
       completionTokens: number
@@ -299,6 +300,7 @@ export function ChatMain({
     }
 
     setLoading(true)
+    const requestStartTime = Date.now()
     setMessages(messages.length === 0 ? [...messages, ...params.messages] : params.messages)
     setInput('')
     setTemplateInput(null)
@@ -326,6 +328,7 @@ export function ChatMain({
         setStream(stream)
       },
     }).then((result) => {
+      const responseTimeMs = Date.now() - requestStartTime
       const userInput = params.messages?.at(-1)?.content
       const newConversationMessages = [
         // TODO: append system message
@@ -349,6 +352,7 @@ export function ChatMain({
                 metadata: {
                   model: result.model,
                   finishReason: result.finishReason,
+                  responseTimeMs: responseTimeMs,
                   usage: {
                     promptTokens: result.usage?.promptTokens || 0,
                     completionTokens: result.usage?.completionTokens || 0,
@@ -390,6 +394,7 @@ export function ChatMain({
         setChatResults({
           model: result.model,
           finish_reason: result.finishReason,
+          responseTimeMs: responseTimeMs,
           usage: result.usage,
         })
       }
@@ -679,6 +684,7 @@ export function ChatMain({
                 <ChatResults
                   model={chatResults.model}
                   finishReason={chatResults.finish_reason}
+                  responseTimeMs={chatResults.responseTimeMs}
                   usage={chatResults.usage}
                 />
               )}
@@ -1009,6 +1015,7 @@ const sendChatCompletion = async (req: {
       content: result.content,
       reasoningContent: result.reasoning_content,
     },
+    responseTimeMs: 0,
     usage: usage
       ? {
           promptTokens: usage.prompt_tokens,

--- a/projects/portfolio/src/client/components/chat/chat-results.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-results.tsx
@@ -1,13 +1,21 @@
 interface ChatResultsProps {
   model?: string
   finishReason?: string
+  responseTimeMs?: number
   usage?: {
     promptTokens?: number
     completionTokens?: number
   } | null
 }
 
-export function ChatResults({ model, finishReason, usage }: ChatResultsProps) {
+function formatResponseTime(ms: number): string {
+  if (ms < 1000) {
+    return `${ms}ms`
+  }
+  return `${(ms / 1000).toFixed(1)}s`
+}
+
+export function ChatResults({ model, finishReason, responseTimeMs, usage }: ChatResultsProps) {
   return (
     <div className='mt-2 flex flex-wrap justify-end gap-1'>
       <div className='flex items-center rounded-md bg-gray-100 px-2 py-1 text-xs dark:bg-gray-700 dark:text-gray-300'>
@@ -18,6 +26,12 @@ export function ChatResults({ model, finishReason, usage }: ChatResultsProps) {
         <div className='flex items-center rounded-md bg-gray-100 px-2 py-1 text-xs dark:bg-gray-700 dark:text-gray-300'>
           <span className='mr-1'>finish_reason:</span>
           <span>{finishReason}</span>
+        </div>
+      )}
+      {responseTimeMs !== undefined && (
+        <div className='flex items-center rounded-md bg-gray-100 px-2 py-1 text-xs dark:bg-gray-700 dark:text-gray-300'>
+          <span className='mr-1'>time:</span>
+          <span>{formatResponseTime(responseTimeMs)}</span>
         </div>
       )}
       <div className='flex items-center rounded-md bg-gray-100 px-2 py-1 text-xs dark:bg-gray-700 dark:text-gray-300'>

--- a/projects/portfolio/src/types/chat.ts
+++ b/projects/portfolio/src/types/chat.ts
@@ -49,6 +49,7 @@ export type UserMessage = z.infer<typeof UserMessageSchema>
 export const AssistantMetadataSchema = z.object({
   model: z.string(),
   finishReason: z.string().optional(),
+  responseTimeMs: z.number().optional(),
   usage: z.object({
     completionTokens: z.number().optional(),
     promptTokens: z.number().optional(),
@@ -134,6 +135,7 @@ export interface ChatCompletionResult {
     content: string
     reasoningContent: string
   }
+  responseTimeMs: number
   usage: {
     promptTokens: number
     completionTokens: number


### PR DESCRIPTION
## Summary

ポートフォリオプロジェクトのChatBot機能に、API応答時間（レスポンスタイム）を表示する機能を追加しました。

Closes #574

## Changes

- **型定義の更新** (`src/types/chat.ts`)
  - `AssistantMetadataSchema` に `responseTimeMs` を追加
  - `ChatCompletionResult` インターフェースに `responseTimeMs` を追加

- **タイミング計算の実装** (`src/client/components/chat/chat-main.tsx`)
  - リクエスト開始時に `Date.now()` で時刻を記録
  - ストリーミングレスポンス完了時に経過時間を計算
  - 会話履歴のメタデータに `responseTimeMs` を永続化

- **UI表示の追加** (`src/client/components/chat/chat-results.tsx`)
  - `responseTimeMs` prop を追加
  - フォーマット関数を実装（1秒未満: \"450ms\", 1秒以上: \"1.2s\"）
  - `finish_reason` の後、`usage` の前に表示

## Test Plan

- [x] チャットにメッセージを送信し、レスポンス完了後に `time: XXXms` または `time: X.Xs` が表示されること
- [x] 異なる応答時間が正しく表示されること
- [ ] 会話履歴から復元時に応答時間が保持されること

🤖 Generated with Claude Code