### PR TITLE
fix(portfolio): add timeout handling for model auto-fetch (#632)

### DIFF
--- a/projects/portfolio/src/client/components/chat/chat-settings/chat-settings-form.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-settings/chat-settings-form.tsx
@@ -10,6 +10,8 @@ import { TextInput } from './settings/text-input'
 interface Props {
   settings: Settings
   fetchedModels: string[]
+  isLoadingModels: boolean
+  fetchError: string | null
   temperature: number
   temperatureEnabled: boolean
   autoModel: boolean
@@ -39,6 +41,8 @@ interface Props {
 export function ChatSettingsForm({
   settings,
   fetchedModels,
+  isLoadingModels,
+  fetchError,
   temperature,
   temperatureEnabled,
   autoModel,
@@ -82,6 +86,8 @@ export function ChatSettingsForm({
               autoModel={autoModel}
               fakeMode={fakeMode}
               fetchedModels={fetchedModels}
+              isLoadingModels={isLoadingModels}
+              fetchError={fetchError}
               onChangeAutoModel={onChangeAutoModel}
               onChangeManualModel={onChangeManualModel}
             />

--- a/projects/portfolio/src/client/components/chat/chat-settings/chat-settings.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-settings/chat-settings.tsx
@@ -32,6 +32,8 @@ export function ChatSettings({
   const {
     settings,
     fetchedModels,
+    isLoadingModels,
+    fetchError,
     temperature,
     temperatureEnabled,
     autoModel,
@@ -102,6 +104,8 @@ export function ChatSettings({
         <ChatSettingsForm
           settings={settings}
           fetchedModels={fetchedModels}
+          isLoadingModels={isLoadingModels}
+          fetchError={fetchError}
           temperature={temperature}
           temperatureEnabled={temperatureEnabled}
           autoModel={autoModel}

--- a/projects/portfolio/src/client/components/chat/chat-settings/hooks/use-chat-settings.ts
+++ b/projects/portfolio/src/client/components/chat/chat-settings/hooks/use-chat-settings.ts
@@ -15,6 +15,8 @@ interface UseChatSettingsOptions {
 interface UseChatSettingsReturn {
   settings: Settings
   fetchedModels: string[]
+  isLoadingModels: boolean
+  fetchError: string | null
   temperature: number
   temperatureEnabled: boolean
   autoModel: boolean
@@ -39,23 +41,40 @@ interface UseChatSettingsReturn {
   handleToggleInteractiveMode: () => void
   handleToggleReasoningEffort: () => void
   handleChangeReasoningEffort: (event: ChangeEvent<HTMLSelectElement>) => void
+  refetchModels: () => void
 }
 
-async function fetchModels(baseURL: string, apiKey: string): Promise<string[]> {
+const FETCH_TIMEOUT_MS = 10000 // 10 seconds
+
+async function fetchModelsWithTimeout(
+  baseURL: string,
+  apiKey: string
+): Promise<{ models: string[]; error: string | null }> {
+  const fetchPromise = client.api['fetch-models'].$get({
+    header: {
+      'api-key': apiKey,
+      'base-url': baseURL,
+    },
+  })
+
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    setTimeout(() => reject(new Error('Timeout')), FETCH_TIMEOUT_MS)
+  })
+
   try {
-    const response = await client.api['fetch-models'].$get({
-      header: {
-        'api-key': apiKey,
-        'base-url': baseURL,
-      },
-    })
+    const response = await Promise.race([fetchPromise, timeoutPromise])
     if (response.ok) {
-      return await response.json()
+      const models = await response.json()
+      return { models, error: null }
     }
+    return { models: [], error: 'Failed to fetch models' }
   } catch (error) {
+    if (error instanceof Error && error.message === 'Timeout') {
+      return { models: [], error: 'Request timed out' }
+    }
     console.error('Failed to fetch models:', error)
+    return { models: [], error: 'Failed to fetch models' }
   }
-  return []
 }
 
 export function useChatSettings(options: UseChatSettingsOptions = {}): UseChatSettingsReturn {
@@ -71,6 +90,8 @@ export function useChatSettings(options: UseChatSettingsOptions = {}): UseChatSe
   const [temperatureEnabled, setTemperatureEnabled] = useState(defaultSettings?.temperatureEnabled ?? false)
   const [autoModel, setAutoModel] = useState(defaultSettings?.autoModel ?? false)
   const [fetchedModels, setFetchedModels] = useState<string[]>([])
+  const [isLoadingModels, setIsLoadingModels] = useState(false)
+  const [fetchError, setFetchError] = useState<string | null>(null)
   const [fakeMode, setFakeMode] = useState(defaultSettings?.fakeMode ?? false)
   const [markdownPreview, setMarkdownPreview] = useState(defaultSettings?.markdownPreview ?? true)
   const [streamMode, setStreamMode] = useState(defaultSettings?.streamMode ?? true)
@@ -83,9 +104,26 @@ export function useChatSettings(options: UseChatSettingsOptions = {}): UseChatSe
   // Fetch models when autoModel is enabled
   useEffect(() => {
     if (autoModel) {
+      setIsLoadingModels(true)
+      setFetchError(null)
       const { baseURL, apiKey } = readFromLocalStorage()
-      fetchModels(baseURL, apiKey).then((models) => {
+      fetchModelsWithTimeout(baseURL, apiKey).then(({ models, error }) => {
         setFetchedModels(models)
+        setFetchError(error)
+        setIsLoadingModels(false)
+      })
+    }
+  }, [autoModel])
+
+  const refetchModels = useCallback(() => {
+    if (autoModel) {
+      setIsLoadingModels(true)
+      setFetchError(null)
+      const { baseURL, apiKey } = readFromLocalStorage()
+      fetchModelsWithTimeout(baseURL, apiKey).then(({ models, error }) => {
+        setFetchedModels(models)
+        setFetchError(error)
+        setIsLoadingModels(false)
       })
     }
   }, [autoModel])
@@ -210,6 +248,8 @@ export function useChatSettings(options: UseChatSettingsOptions = {}): UseChatSe
   return {
     settings,
     fetchedModels,
+    isLoadingModels,
+    fetchError,
     temperature,
     temperatureEnabled,
     autoModel,
@@ -234,5 +274,6 @@ export function useChatSettings(options: UseChatSettingsOptions = {}): UseChatSe
     handleToggleInteractiveMode,
     handleToggleReasoningEffort,
     handleChangeReasoningEffort,
+    refetchModels,
   }
 }

--- a/projects/portfolio/src/client/components/chat/chat-settings/model-selector.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-settings/model-selector.tsx
@@ -5,6 +5,8 @@ interface Props {
   autoModel: boolean
   fakeMode: boolean
   fetchedModels: string[]
+  isLoadingModels: boolean
+  fetchError: string | null
   onChangeAutoModel: (event: ChangeEvent<HTMLSelectElement>) => void
   onChangeManualModel: (event: ChangeEvent<HTMLInputElement>) => void
 }
@@ -14,32 +16,45 @@ export function ModelSelector({
   autoModel,
   fakeMode,
   fetchedModels,
+  isLoadingModels,
+  fetchError,
   onChangeAutoModel,
   onChangeManualModel,
 }: Props) {
   if (autoModel) {
     return (
-      <select
-        name='model'
-        className={`w-full rounded-md border px-3 py-2 text-sm outline-none transition-all duration-200 ${
-          fakeMode
-            ? 'cursor-not-allowed border-gray-200 bg-gray-50 text-gray-400'
-            : 'border-gray-300 bg-white text-gray-900 hover:border-gray-400 focus:border-blue-500 focus:ring-2 focus:ring-blue-200 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:focus:ring-blue-800'
-        }`}
-        onChange={onChangeAutoModel}
-        disabled={fakeMode}
-        value={model}
-      >
-        {fetchedModels.length === 0 ? (
-          <option>Loading...</option>
-        ) : (
-          fetchedModels.map((modelName) => (
-            <option key={modelName} value={modelName}>
-              {modelName}
-            </option>
-          ))
+      <div className='space-y-1'>
+        <select
+          name='model'
+          className={`w-full rounded-md border px-3 py-2 text-sm outline-none transition-all duration-200 ${
+            fakeMode
+              ? 'cursor-not-allowed border-gray-200 bg-gray-50 text-gray-400'
+              : 'border-gray-300 bg-white text-gray-900 hover:border-gray-400 focus:border-blue-500 focus:ring-2 focus:ring-blue-200 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:focus:ring-blue-800'
+          }`}
+          onChange={onChangeAutoModel}
+          disabled={fakeMode || isLoadingModels || fetchedModels.length === 0}
+          value={model}
+        >
+          {isLoadingModels ? (
+            <option>Loading...</option>
+          ) : fetchError ? (
+            <option>Error: {fetchError}</option>
+          ) : fetchedModels.length === 0 ? (
+            <option>No models available</option>
+          ) : (
+            fetchedModels.map((modelName) => (
+              <option key={modelName} value={modelName}>
+                {modelName}
+              </option>
+            ))
+          )}
+        </select>
+        {fetchError && (
+          <p className='text-xs text-red-600 dark:text-red-400'>
+            {fetchError}. Please check your Base URL and API key.
+          </p>
         )}
-      </select>
+      </div>
     )
   }
 

--- a/projects/portfolio/src/server/app.tsx
+++ b/projects/portfolio/src/server/app.tsx
@@ -288,6 +288,7 @@ const app = new Hono<HonoEnv>()
             Authorization: `Bearer ${apiKey}`,
             'Content-Type': 'application/json',
           },
+          signal: AbortSignal.timeout(8000), // 8 seconds timeout
         })
         if (response.ok) {
           const data = await response.json()


### PR DESCRIPTION
## Issues

- Closes #632

## Why

モデル自動取得機能（Auto Model）使用時に、Endpointに障害がある場合、UIが永遠に「Loading...」のままになり、ユーザーは操作を継続できなくなる問題がありました。クライアント・サーバー双方でタイムアウト処理が不足していました。

## Summary

クライアント側とサーバー側の両方にタイムアウト処理を追加し、モデル自動取得時の無限ローディング問題を解消します。エラー発生時には適切なメッセージを表示し、ユーザーが状況を把握できるようにします。

## Changes

- **Client:** `Promise.race` を使用して10秒タイムアウトを実装
- **Server:** `AbortSignal.timeout(8000)` で外部API呼び出しに8秒タイムアウトを追加
- **State管理:** `isLoadingModels` と `fetchError` の状態を追加
- **UI改善:** 
  - ローディング/エラー/空状態を適切に表示
  - エラー時に赤文字でメッセージを表示（"Please check your Base URL and API key."）
  - ローディング中やエラー時はセレクトボックスを無効化

## Checklist

- [x] クライアント側に10秒タイムアウトを追加
- [x] サーバー側に8秒タイムアウトを追加
- [x] エラー状態をUIに反映
- [x] TypeScript型チェックが通過
- [x] Lintチェックが通過