### PR TITLE
fix(deploy): make litellm config path configurable via env var

### DIFF
--- a/deploy/litellm.yml
+++ b/deploy/litellm.yml
@@ -10,7 +10,7 @@ services:
     ports:
       - 4000:4000
     volumes:
-      - ./config:/app/config:ro
+      - ${CONFIG_PATH:-./config}:/app/config:ro
     command: ["--config", "/app/config/config.yaml"]
     env_file:
       - .env.secret


### PR DESCRIPTION
## Issues

- Closes #635

## Why

現在の `deploy/litellm.yml` では、設定ディレクトリのパスが `./config` に固定されています。
このままでは CI/CD 環境で実行した際に、ワークスペースディレクトリがバインドマウントされてしまい、期待する永続的な設定ディレクトリ（`~/configs/litellm/` など）がマウントされません。

## Summary

`CONFIG_PATH` 環境変数を使用して設定ディレクトリのパスを柔軟に指定できるように変更しました。
未設定時は `./config` がデフォルト値として使用されるため、後方互換性を維持しています。

## Changes

- `deploy/litellm.yml`: volumes セクションのパスを `${CONFIG_PATH:-./config}` に変更

## Checklist

- [ ] `CONFIG_PATH` 環境変数を設定して `docker compose up` を実行
- [ ] `docker inspect` でバインドマウントの Source が `CONFIG_PATH` で指定したパスになっていることを確認