### PR TITLE
fix(file-server): auto-create UPLOAD_DIR on server startup

### DIFF
--- a/projects/file-server/src/index.tsx
+++ b/projects/file-server/src/index.tsx
@@ -1,8 +1,13 @@
+import { mkdir } from "node:fs/promises"
 import { Hono } from "hono"
 import apiRoutes from "./routes/api"
 import browseRoutes from "./routes/browse"
 import fileRoutes from "./routes/file"
 import type { AppBindings } from "./types"
+
+// Ensure UPLOAD_DIR exists (default: ./tmp)
+const uploadDir = process.env.UPLOAD_DIR || "./tmp"
+await mkdir(uploadDir, { recursive: true })
 
 const app = new Hono<AppBindings>()
 


### PR DESCRIPTION
## 概要

ファイルサーバーで `./tmp` ディレクトリが存在しない場合、永続的なエラーレスポンスが返される問題を修正しました。

## 変更内容

- サーバー起動時に `UPLOAD_DIR` (デフォルト: `./tmp`) が存在しない場合は自動的に作成するようにしました
- `src/index.tsx` に `mkdir` のインポートとディレクトリ作成処理を追加

## 関連ファイル

- `src/index.tsx`

## 動作確認

1. `./tmp` ディレクトリを削除
2. サーバーを起動
3. ブラウザでアクセス → エラーなく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
