### PR TITLE
feat: support manual debug image builds

### DIFF
--- a/.github/actions/build-docker-images/action.yml
+++ b/.github/actions/build-docker-images/action.yml
@@ -5,6 +5,10 @@ inputs:
   stage:
     description: "Docker build arguments --target option"
     required: true
+  image_tag:
+    description: "Docker image tag"
+    required: false
+    default: "latest"
 
 runs:
   using: composite
@@ -13,4 +17,4 @@ runs:
       shell: bash
       run: |
         # 共通スクリプトを実行
-        ${{ github.action_path }}/build-docker-images.sh "${{ inputs.stage }}"
+        ${{ github.action_path }}/build-docker-images.sh "${{ inputs.stage }}" "${{ inputs.image_tag }}"

--- a/.github/actions/build-docker-images/build-docker-images.sh
+++ b/.github/actions/build-docker-images/build-docker-images.sh
@@ -6,6 +6,7 @@
 set -e
 
 STAGE="$1"
+IMAGE_TAG="${2:-latest}"
 
 # ステージパラメータのチェック
 if [[ -z "$STAGE" ]]; then
@@ -13,7 +14,13 @@ if [[ -z "$STAGE" ]]; then
   exit 1
 fi
 
+if [[ -z "$IMAGE_TAG" ]]; then
+  echo "Error: Image tag parameter is required."
+  exit 1
+fi
+
 echo "> Building Docker images for stage: $STAGE"
+echo "> Docker image tag: $IMAGE_TAG"
 
 # build_projects.txt ファイルが存在するかチェック
 if [[ ! -f "build_projects.txt" ]]; then
@@ -54,7 +61,11 @@ for project in "${PROJECT_ARRAY[@]}"; do
   # プロジェクト名を取得（パスの最後の部分）
   project_name=$(basename "$project")
 
-  GHCR_URI="ghcr.io/$GITHUB_REPOSITORY/$project_name:latest"
+  if [[ -n "$GITHUB_REPOSITORY" ]]; then
+    GHCR_URI="ghcr.io/$GITHUB_REPOSITORY/$project_name:$IMAGE_TAG"
+  else
+    GHCR_URI="ghcr.io/test/$project_name:$IMAGE_TAG"
+  fi
   DOCKER_FILE="$project/Dockerfile"
   SEARCH_KEYWORD="AS $STAGE"
   PREBUILD_SCRIPT_NAME="pre-docker-build.sh"

--- a/.github/actions/cleanup-docker-images/action.yml
+++ b/.github/actions/cleanup-docker-images/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: "Number of images to keep"
     required: false
     default: "3"
+  cleanup-mode:
+    description: "Cleanup mode"
+    required: false
+    default: "normal"
 
 runs:
   using: composite
@@ -26,4 +30,5 @@ runs:
           "${{ inputs.token }}" \
           "${{ inputs.repo-name }}" \
           "${{ inputs.project-names-csv }}" \
-          "${{ inputs.keep-count }}"
+          "${{ inputs.keep-count }}" \
+          "${{ inputs.cleanup-mode }}"

--- a/.github/actions/cleanup-docker-images/cleanup-docker-images.sh
+++ b/.github/actions/cleanup-docker-images/cleanup-docker-images.sh
@@ -10,6 +10,7 @@ TOKEN="$1"
 REPO_NAME="$2"
 PROJECT_NAMES_CSV="$3"
 KEEP_COUNT="${4:-3}"
+CLEANUP_MODE="${5:-normal}"
 
 # 引数のチェック
 if [[ -z "$TOKEN" ]]; then
@@ -29,6 +30,7 @@ fi
 
 echo "Triggering cleanup for projects: $PROJECT_NAMES_CSV"
 echo "Keeping $KEEP_COUNT most recent images"
+echo "Cleanup mode: $CLEANUP_MODE"
 
 # リポジトリディスパッチイベントを発行
 curl -X POST \
@@ -39,7 +41,8 @@ curl -X POST \
     "event_type": "deploy_trigger",
     "client_payload": {
       "target": "'"$PROJECT_NAMES_CSV"'",
-      "keep_count": "'"$KEEP_COUNT"'"
+      "keep_count": "'"$KEEP_COUNT"'",
+      "cleanup_mode": "'"$CLEANUP_MODE"'"
     }
   }'
 

--- a/.github/actions/prepare-manual-build-inputs/action.yml
+++ b/.github/actions/prepare-manual-build-inputs/action.yml
@@ -1,0 +1,18 @@
+name: Prepare Manual Build Inputs
+description: Validate workflow_dispatch inputs and write build_projects.txt
+
+inputs:
+  projects:
+    description: "Comma separated project directories"
+    required: true
+  stage:
+    description: "Required Docker build stage"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Prepare Manual Build Inputs
+      shell: bash
+      run: |
+        ${{ github.action_path }}/prepare-manual-build-inputs.sh "${{ inputs.projects }}" "${{ inputs.stage }}"

--- a/.github/actions/prepare-manual-build-inputs/prepare-manual-build-inputs.sh
+++ b/.github/actions/prepare-manual-build-inputs/prepare-manual-build-inputs.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -e
+
+PROJECTS_INPUT="$1"
+STAGE_INPUT="$2"
+
+if [[ -z "$PROJECTS_INPUT" ]]; then
+  echo "Error: projects input is required."
+  exit 1
+fi
+
+if [[ -z "$STAGE_INPUT" ]]; then
+  echo "Error: stage input is required."
+  exit 1
+fi
+
+: > build_projects.txt
+IFS=',' read -ra PROJECT_ARRAY <<< "$PROJECTS_INPUT"
+for project in "${PROJECT_ARRAY[@]}"; do
+  project="$(echo "$project" | xargs)"
+  [[ -z "$project" ]] && continue
+
+  if [[ ! -f "$project/Dockerfile" ]]; then
+    echo "Error: Dockerfile not found at $project/Dockerfile"
+    exit 1
+  fi
+
+  if ! grep -qE "AS\\s+$STAGE_INPUT" "$project/Dockerfile"; then
+    echo "Error: Stage '$STAGE_INPUT' not found in $project/Dockerfile"
+    exit 1
+  fi
+
+  echo "$project" >> build_projects.txt
+done
+
+if [[ ! -s build_projects.txt ]]; then
+  echo "Error: no valid projects were provided."
+  exit 1
+fi
+
+if [[ -n "$GITHUB_ENV" ]]; then
+  echo "BUILD_PROJECT=$(paste -sd, build_projects.txt)" >> "$GITHUB_ENV"
+fi

--- a/.github/actions/push-docker-images/action.yml
+++ b/.github/actions/push-docker-images/action.yml
@@ -12,6 +12,10 @@ inputs:
   password:
     description: "Registry password"
     required: true
+  image_tag:
+    description: "Docker image tag"
+    required: false
+    default: "latest"
 
 outputs:
   project_names_csv:
@@ -25,4 +29,4 @@ runs:
       shell: bash
       run: |
         # 共通スクリプトを実行
-        ${{ github.action_path }}/push-docker-images.sh "${{ inputs.registry }}" "${{ inputs.username }}" "${{ inputs.password }}"
+        ${{ github.action_path }}/push-docker-images.sh "${{ inputs.registry }}" "${{ inputs.username }}" "${{ inputs.password }}" "${{ inputs.image_tag }}"

--- a/.github/actions/push-docker-images/push-docker-images.sh
+++ b/.github/actions/push-docker-images/push-docker-images.sh
@@ -66,6 +66,7 @@ execute_docker_push() {
 REGISTRY="$1"
 USERNAME="$2"
 PASSWORD="$3"
+IMAGE_TAG="${4:-latest}"
 
 # 引数のチェック
 if [[ -z "$REGISTRY" ]]; then
@@ -83,7 +84,13 @@ if [[ -z "$PASSWORD" ]]; then
   exit 1
 fi
 
+if [[ -z "$IMAGE_TAG" ]]; then
+  echo "Error: Image tag parameter is required."
+  exit 1
+fi
+
 echo "> Pushing Docker images to registry: $REGISTRY"
+echo "> Docker image tag: $IMAGE_TAG"
 
 # build_projects.txt ファイルが存在するかチェック
 if [[ ! -f "build_projects.txt" ]]; then
@@ -164,10 +171,10 @@ for project in "${PROJECT_ARRAY[@]}"; do
 
   # GitHub Container Registry URI を構築
   if [[ -n "$GITHUB_REPOSITORY" ]]; then
-    GHCR_URI="$REGISTRY/$GITHUB_REPOSITORY/$project_name:latest"
+    GHCR_URI="$REGISTRY/$GITHUB_REPOSITORY/$project_name:$IMAGE_TAG"
   else
     # ローカルテスト用のフォールバック
-    GHCR_URI="$REGISTRY/test/$project_name:latest"
+    GHCR_URI="$REGISTRY/test/$project_name:$IMAGE_TAG"
   fi
 
   echo ""

--- a/.github/actions/set-image-tag/action.yml
+++ b/.github/actions/set-image-tag/action.yml
@@ -1,0 +1,25 @@
+name: Set Image Tag
+description: Determine Docker image tag for push and manual builds
+
+inputs:
+  event_name:
+    description: "GitHub event name"
+    required: true
+  ref_input:
+    description: "workflow_dispatch ref input"
+    required: false
+    default: ""
+
+outputs:
+  image_tag:
+    description: "Docker image tag"
+    value: ${{ steps.set-image-tag.outputs.image_tag }}
+
+runs:
+  using: composite
+  steps:
+    - name: Set Image Tag
+      id: set-image-tag
+      shell: bash
+      run: |
+        ${{ github.action_path }}/set-image-tag.sh "${{ inputs.event_name }}" "${{ inputs.ref_input }}"

--- a/.github/actions/set-image-tag/set-image-tag.sh
+++ b/.github/actions/set-image-tag/set-image-tag.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e
+
+EVENT_NAME="$1"
+REF_INPUT="$2"
+
+if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+  SHORT_SHA="$(git rev-parse --short HEAD)"
+  SANITIZED_REF="$(printf '%s' "$REF_INPUT" | tr '[:upper:]' '[:lower:]' | sed -E 's#[^a-z0-9._-]+#-#g; s#-+#-#g; s#(^[-.]+|[-.]+$)##g')"
+
+  if [[ -z "$SANITIZED_REF" ]]; then
+    echo "Error: failed to sanitize ref input '$REF_INPUT'"
+    exit 1
+  fi
+
+  IMAGE_TAG="manual-${SANITIZED_REF}-${SHORT_SHA}"
+else
+  IMAGE_TAG="latest"
+fi
+
+echo "Using image tag: $IMAGE_TAG"
+
+if [[ -n "$GITHUB_OUTPUT" ]]; then
+  echo "image_tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+fi

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -5,6 +5,22 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Build target ref"
+        required: true
+      projects:
+        description: "Comma separated project directories"
+        required: true
+      stage:
+        description: "Docker build stage"
+        required: false
+        default: "final"
+      keep_count:
+        description: "Number of manual images to keep"
+        required: false
+        default: "3"
 
 jobs:
   docker-build-if-changes-detected:
@@ -15,23 +31,41 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
           # プッシュイベントでは直前のコミットとの差分で十分
           # 2コミット分の履歴で変更検出が可能
           fetch-depth: 2
 
       - name: Get Changed Directories
+        if: github.event_name == 'push'
         uses: ./.github/actions/get-changed-directories
 
       - name: Get Changed Projects
+        if: github.event_name == 'push'
         uses: ./.github/actions/get-changed-projects
         with:
           required-stage: final
+
+      - name: Prepare manual build inputs
+        if: github.event_name == 'workflow_dispatch'
+        uses: ./.github/actions/prepare-manual-build-inputs
+        with:
+          projects: ${{ github.event.inputs.projects }}
+          stage: ${{ github.event.inputs.stage || 'final' }}
+
+      - name: Set image tag
+        id: set-image-tag
+        uses: ./.github/actions/set-image-tag
+        with:
+          event_name: ${{ github.event_name }}
+          ref_input: ${{ github.event.inputs.ref }}
 
       - name: Build Docker Images
         if: env.BUILD_PROJECT != ''
         uses: ./.github/actions/build-docker-images
         with:
-          stage: final
+          stage: ${{ github.event.inputs.stage || 'final' }}
+          image_tag: ${{ steps.set-image-tag.outputs.image_tag }}
 
       - name: Show Docker Images
         if: env.BUILD_PROJECT != ''
@@ -45,6 +79,7 @@ jobs:
         with:
           username: ${{ github.actor }}
           password: ${{ secrets.PRIVATE_REPO_TOKEN }}
+          image_tag: ${{ steps.set-image-tag.outputs.image_tag }}
 
       - name: Clean Up Docker Images
         if: steps.push_images.outputs.project_names_csv != ''
@@ -53,4 +88,5 @@ jobs:
           token: ${{ secrets.PRIVATE_REPO_TOKEN }}
           repo-name: ${{ secrets.PRIVATE_REPO_NAME }}
           project-names-csv: ${{ steps.push_images.outputs.project_names_csv }}
-          keep-count: 3
+          keep-count: ${{ github.event.inputs.keep_count || '3' }}
+          cleanup-mode: ${{ github.event_name == 'workflow_dispatch' && 'manual' || 'normal' }}

--- a/deploy/abolished/chat-mcp-client.yml
+++ b/deploy/abolished/chat-mcp-client.yml
@@ -5,7 +5,7 @@ networks:
 services:
   chat-mcp-client:
     container_name: chat-mcp-client
-    image: ghcr.io/u7chan/monorepo/chat-mcp-client:latest
+    image: ghcr.io/u7chan/monorepo/chat-mcp-client:${PROJECT_IMAGE_TAG:-latest}
     restart: always
     ports:
       - 8003:3000

--- a/deploy/abolished/chatbot-ui.yml
+++ b/deploy/abolished/chatbot-ui.yml
@@ -5,7 +5,7 @@ networks:
 services:
   chatbot-ui:
     container_name: chatbot-ui
-    image: ghcr.io/u7chan/monorepo/chatbot-ui:latest
+    image: ghcr.io/u7chan/monorepo/chatbot-ui:${PROJECT_IMAGE_TAG:-latest}
     restart: always
     ports:
       - 8001:3000

--- a/deploy/abolished/fastapi-mcp-server.yml
+++ b/deploy/abolished/fastapi-mcp-server.yml
@@ -5,7 +5,7 @@ networks:
 services:
   fastapi-mcp-server:
     container_name: fastapi-mcp-server
-    image: ghcr.io/u7chan/monorepo/fastapi-mcp-server:latest
+    image: ghcr.io/u7chan/monorepo/fastapi-mcp-server:${PROJECT_IMAGE_TAG:-latest}
     restart: always
     ports:
       - 8004:8000

--- a/deploy/edit-vid.yml
+++ b/deploy/edit-vid.yml
@@ -5,7 +5,7 @@ networks:
 services:
   edit-vid:
     container_name: edit-vid
-    image: ghcr.io/u7chan/monorepo/edit-vid:latest
+    image: ghcr.io/u7chan/monorepo/edit-vid:${PROJECT_IMAGE_TAG:-latest}
     restart: always
     ports:
       - 8005:8000

--- a/deploy/file-server.yml
+++ b/deploy/file-server.yml
@@ -5,7 +5,7 @@ networks:
 services:
   file-server:
     container_name: file-server
-    image: ghcr.io/u7chan/monorepo/file-server:latest
+    image: ghcr.io/u7chan/monorepo/file-server:${PROJECT_IMAGE_TAG:-latest}
     restart: always
     ports:
       - 8010:3000

--- a/deploy/hono-mcp-server.yml
+++ b/deploy/hono-mcp-server.yml
@@ -5,7 +5,7 @@ networks:
 services:
   hono-mcp-server:
     container_name: hono-mcp-server
-    image: ghcr.io/u7chan/monorepo/hono-mcp-server:latest
+    image: ghcr.io/u7chan/monorepo/hono-mcp-server:${PROJECT_IMAGE_TAG:-latest}
     restart: always
     ports:
       - 8002:3000

--- a/deploy/portal.yml
+++ b/deploy/portal.yml
@@ -5,7 +5,7 @@ networks:
 services:
   portal:
     container_name: portal
-    image: ghcr.io/u7chan/monorepo/portal:latest
+    image: ghcr.io/u7chan/monorepo/portal:${PROJECT_IMAGE_TAG:-latest}
     restart: unless-stopped # 手動停止時は再起動しない
     ports:
       - 3000:3000

--- a/deploy/portfolio.yml
+++ b/deploy/portfolio.yml
@@ -5,7 +5,7 @@ networks:
 services:
   portfolio:
     container_name: portfolio
-    image: ghcr.io/u7chan/monorepo/portfolio:latest
+    image: ghcr.io/u7chan/monorepo/portfolio:${PROJECT_IMAGE_TAG:-latest}
     restart: always
     ports:
       - 8000:3000

--- a/deploy/u7agent.yml
+++ b/deploy/u7agent.yml
@@ -5,7 +5,7 @@ networks:
 services:
   u7agent:
     container_name: u7agent
-    image: ghcr.io/u7chan/monorepo/u7agent:latest
+    image: ghcr.io/u7chan/monorepo/u7agent:${PROJECT_IMAGE_TAG:-latest}
     restart: always
     ports:
       - 8012:3000

--- a/deploy/u7chat.yml
+++ b/deploy/u7chat.yml
@@ -5,7 +5,7 @@ networks:
 services:
   u7chat:
     container_name: u7chat
-    image: ghcr.io/u7chan/monorepo/u7chat:latest
+    image: ghcr.io/u7chan/monorepo/u7chat:${PROJECT_IMAGE_TAG:-latest}
     restart: always
     ports:
       - 8011:3000


### PR DESCRIPTION
## Issues

- https://github.com/u7chan/self-hosted-runner/issues/5

## Why

任意 ref の一時イメージを build して deploy できる経路がなく、デバッグ用イメージの運用と cleanup を分けて扱えませんでした。

## Summary

manual build 用の workflow_dispatch と custom image tag 対応を monorepo 側に追加します。deploy 定義も `PROJECT_IMAGE_TAG` で切り替えられるようにして、manual deploy の前提を整えます。

## Changes

- `docker-build.yml` に `workflow_dispatch` を追加
- build/push action に `image_tag` input を追加
- manual build 入力準備と image tag 決定を composite action に分離
- deploy 定義の monorepo image を `${PROJECT_IMAGE_TAG:-latest}` に変更
- cleanup dispatch に `cleanup_mode` を追加

## Checklist

- [x] 任意 ref と project 指定の manual build を追加
- [x] manual build で `latest` を更新しないようにした
- [x] manual deploy 用に image tag を deploy 定義へ渡せるようにした
- [x] manual cleanup 用の mode を dispatch payload に含めた
