### PR TITLE
chore(skills): add codex symlink and fastapi reference skill

### DIFF
--- a/.claude/skills/fastapi/SKILL.md
+++ b/.claude/skills/fastapi/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: fastapi
+description: This will be referenced when creating a project with FastAPI.
+---
+
+[reference](https://raw.githubusercontent.com/fastapi/fastapi/master/fastapi/.agents/skills/fastapi/SKILL.md)

--- a/.codex/skills
+++ b/.codex/skills
@@ -1,0 +1,1 @@
+../.claude/skills


### PR DESCRIPTION
## Issues

- N/A

## Why

FastAPIのベストプラクティス追従のため、FastAPI Skillはローカル固定手順ではなく本家スキル参照のみを保持したい。
加えて、Codexから同じskillsを参照できるようにシンボリックリンクを追加する。

## Summary

`.claude/skills/fastapi/SKILL.md` を upstream 参照のみの構成で追加し、
`.codex/skills` から `.claude/skills` を参照する symlink を追加した。

## Changes

- Add `.claude/skills/fastapi/SKILL.md` with a reference-only definition
- Add symlink `.codex/skills -> ../.claude/skills`

## Checklist

- [x] FastAPI skill is reference-only
- [x] `.codex/skills` symlink resolves to `.claude/skills`
- [x] Changes are committed on feature branch
