### PR TITLE
feat(file-server): add rename support

### DIFF
--- a/projects/file-server/src/api/handlers.tsx
+++ b/projects/file-server/src/api/handlers.tsx
@@ -3,6 +3,7 @@ import {
   mkdir,
   readdir,
   readFile,
+  rename,
   rm,
   unlink,
   writeFile,
@@ -298,6 +299,102 @@ export async function createFileHandler(c: Context<AppBindings>) {
   }
 
   return c.redirect(`/?path=${encodeURIComponent(dirPathParam || "")}`, 301)
+}
+
+export async function renameHandler(c: Context<AppBindings>) {
+  const validatedData = c.req.valid("form" as never) as {
+    path: string
+    name: string
+  }
+  const { path: currentPathParam, name } = validatedData
+  const uploadDir = getUploadDir(c)
+
+  if (isInvalidPath(currentPathParam) || isInvalidNodeName(name)) {
+    return c.json(
+      {
+        success: false,
+        error: { name: "PathError", message: "Invalid path" },
+      },
+      400,
+    )
+  }
+
+  const parentPath = path.dirname(currentPathParam)
+  const normalizedParentPath =
+    parentPath === "." ? "" : parentPath.replace(/\\/g, "/")
+  const currentName = path.basename(currentPathParam)
+
+  if (currentName === name) {
+    if (isHtmxRequest(c)) {
+      const files = await getFileList(uploadDir, normalizedParentPath)
+      return c.html(
+        <FileList files={files} requestPath={normalizedParentPath} />,
+      )
+    }
+
+    return c.redirect(`/?path=${encodeURIComponent(normalizedParentPath)}`, 301)
+  }
+
+  const sourcePath = path.join(uploadDir, currentPathParam)
+  const destinationRelativePath = normalizedParentPath
+    ? path.join(normalizedParentPath, name)
+    : name
+  const destinationPath = path.join(uploadDir, destinationRelativePath)
+
+  try {
+    await fsStat(sourcePath)
+  } catch (err: unknown) {
+    if (
+      typeof err === "object" &&
+      err !== null &&
+      "code" in err &&
+      (err as { code?: string }).code === "ENOENT"
+    ) {
+      return c.json(
+        {
+          success: false,
+          error: {
+            name: "FileNotFound",
+            message: "File or directory does not exist",
+          },
+        },
+        400,
+      )
+    }
+    throw err
+  }
+
+  try {
+    await fsStat(destinationPath)
+    return c.json(
+      {
+        success: false,
+        error: {
+          name: "AlreadyExists",
+          message: "File or directory already exists",
+        },
+      },
+      400,
+    )
+  } catch (err: unknown) {
+    if (
+      typeof err === "object" &&
+      err !== null &&
+      "code" in err &&
+      (err as { code?: string }).code !== "ENOENT"
+    ) {
+      throw err
+    }
+  }
+
+  await rename(sourcePath, destinationPath)
+
+  if (isHtmxRequest(c)) {
+    const files = await getFileList(uploadDir, normalizedParentPath)
+    return c.html(<FileList files={files} requestPath={normalizedParentPath} />)
+  }
+
+  return c.redirect(`/?path=${encodeURIComponent(normalizedParentPath)}`, 301)
 }
 
 export async function updateFileHandler(c: Context<AppBindings>) {

--- a/projects/file-server/src/components/FileList.tsx
+++ b/projects/file-server/src/components/FileList.tsx
@@ -245,11 +245,13 @@ export const FileList: FC<FileListProps> = ({ files, requestPath }) => {
             {sortedFiles.map((file) => {
               const filePath = path.join(requestPath, file.name)
               const encodedPath = encodeURIComponent(filePath)
+              const renameFormId = `rename-form-${encodedPath}`
+              const renameInputId = `rename-input-${encodedPath}`
 
               return (
                 <li
                   key={file.name}
-                  className="flex justify-between items-center py-3 px-4 mb-2 rounded-xl border-2 border-transparent hover:border-indigo-300 hover:bg-gradient-to-r hover:from-indigo-50 hover:to-purple-50 cursor-pointer transition-all duration-200"
+                  className="py-3 px-4 mb-2 rounded-xl border-2 border-transparent hover:border-indigo-300 hover:bg-gradient-to-r hover:from-indigo-50 hover:to-purple-50 cursor-pointer transition-all duration-200"
                   hx-get={
                     file.type === "dir"
                       ? `/browse?path=${encodedPath}`
@@ -266,59 +268,126 @@ export const FileList: FC<FileListProps> = ({ files, requestPath }) => {
                       : `/file?path=${encodedPath}`
                   }
                 >
-                  {/* ファイル/ディレクトリ名リンク */}
-                  <span className="flex items-center gap-2 text-indigo-700 font-medium hover:text-purple-600 transition-colors overflow-hidden min-w-0">
-                    {file.type === "dir" ? (
-                      <>
-                        <span className="flex-shrink-0">
-                          <FolderIcon />
-                        </span>
-                        <span className="break-all min-w-0">{file.name}/</span>
-                      </>
-                    ) : (
-                      <>
-                        <span className="flex-shrink-0">
-                          <FileIcon />
-                        </span>
-                        <span className="break-all min-w-0">{file.name}</span>
-                      </>
-                    )}
-                  </span>
+                  <div className="flex justify-between items-center gap-4">
+                    {/* ファイル/ディレクトリ名リンク */}
+                    <span className="flex items-center gap-2 text-indigo-700 font-medium hover:text-purple-600 transition-colors overflow-hidden min-w-0">
+                      {file.type === "dir" ? (
+                        <>
+                          <span className="flex-shrink-0">
+                            <FolderIcon />
+                          </span>
+                          <span className="break-all min-w-0">
+                            {file.name}/
+                          </span>
+                        </>
+                      ) : (
+                        <>
+                          <span className="flex-shrink-0">
+                            <FileIcon />
+                          </span>
+                          <span className="break-all min-w-0">{file.name}</span>
+                        </>
+                      )}
+                    </span>
 
-                  <div className="flex gap-4 items-center">
-                    {/* ファイルサイズ表示（ファイルのみ） */}
-                    {file.type === "file" && (
-                      <div className="hidden sm:block sm:w-30 text-right">
-                        {formatFileSize(file.size || 0)}
+                    <div className="flex gap-4 items-center">
+                      {/* ファイルサイズ表示（ファイルのみ） */}
+                      {file.type === "file" && (
+                        <div className="hidden sm:block sm:w-30 text-right">
+                          {formatFileSize(file.size || 0)}
+                        </div>
+                      )}
+                      {/* タイムスタンプ表示 */}
+                      <div className="hidden sm:block sm:w-45 text-right text-gray-600 text-sm">
+                        {file.mtime && formatTimestamp(new Date(file.mtime))}
                       </div>
-                    )}
-                    {/* タイムスタンプ表示 */}
-                    <div className="hidden sm:block sm:w-45 text-right text-gray-600 text-sm">
-                      {file.mtime && formatTimestamp(new Date(file.mtime))}
-                    </div>
-                    {/* 削除ボタン */}
-                    <div
-                      className="flex justify-end"
-                      hx-on:click="event.stopPropagation()"
-                    >
-                      <form
-                        hx-post="/api/delete"
-                        hx-target="#file-list-container"
-                        hx-swap="innerHTML"
-                        hx-confirm={`Are you sure you want to delete ${file.name}?`}
+                      <div
+                        className="flex gap-2 justify-end"
+                        hx-on:click="event.stopPropagation()"
                       >
-                        <input type="hidden" name="path" value={filePath} />
                         <button
-                          type="submit"
-                          title="Delete"
-                          aria-label="Delete"
-                          className="w-8 h-8 flex items-center justify-center bg-gradient-to-r from-red-500 to-pink-500 text-white font-semibold border-none rounded-lg cursor-pointer hover:from-red-600 hover:to-pink-600 transition-all transform hover:scale-105"
+                          type="button"
+                          title="Rename"
+                          aria-label="Rename"
+                          data-rename-button
+                          className="px-3 h-8 flex items-center justify-center bg-white text-indigo-700 font-semibold border-2 border-indigo-200 rounded-lg cursor-pointer hover:border-purple-400 hover:text-purple-700 hover:bg-purple-50 transition-all"
+                          hx-on:click={`
+                            event.stopPropagation();
+                            const form = document.getElementById('${renameFormId}');
+                            const input = document.getElementById('${renameInputId}');
+                            const container = document.getElementById('file-list-container');
+                            const shouldOpen = form.classList.contains('hidden');
+                            container.querySelectorAll('[data-rename-form]').forEach((el) => el.classList.add('hidden'));
+                            container.querySelectorAll('[data-rename-button]').forEach((el) => el.classList.remove('ring-2', 'ring-purple-400'));
+                            if (shouldOpen) {
+                              form.classList.remove('hidden');
+                              this.classList.add('ring-2', 'ring-purple-400');
+                              input.focus();
+                              input.select();
+                            }
+                          `}
                         >
-                          <DeleteIcon />
+                          Rename
                         </button>
-                      </form>
+                        <form
+                          hx-post="/api/delete"
+                          hx-target="#file-list-container"
+                          hx-swap="innerHTML"
+                          hx-confirm={`Are you sure you want to delete ${file.name}?`}
+                        >
+                          <input type="hidden" name="path" value={filePath} />
+                          <button
+                            type="submit"
+                            title="Delete"
+                            aria-label="Delete"
+                            className="w-8 h-8 flex items-center justify-center bg-gradient-to-r from-red-500 to-pink-500 text-white font-semibold border-none rounded-lg cursor-pointer hover:from-red-600 hover:to-pink-600 transition-all transform hover:scale-105"
+                          >
+                            <DeleteIcon />
+                          </button>
+                        </form>
+                      </div>
                     </div>
                   </div>
+                  <form
+                    id={renameFormId}
+                    data-rename-form
+                    hx-post="/api/rename"
+                    hx-target="#file-list-container"
+                    hx-swap="innerHTML"
+                    className="hidden mt-3 pt-3 border-t border-indigo-100"
+                    hx-on:click="event.stopPropagation()"
+                  >
+                    <input type="hidden" name="path" value={filePath} />
+                    <div className="flex flex-col sm:flex-row gap-2">
+                      <input
+                        id={renameInputId}
+                        type="text"
+                        name="name"
+                        value={file.name}
+                        required
+                        className="px-4 py-2 border-2 border-indigo-300 rounded-lg focus:outline-none focus:border-purple-500 transition-colors"
+                      />
+                      <div className="flex gap-2">
+                        <button
+                          type="submit"
+                          className="px-4 py-2 bg-white text-indigo-700 font-semibold border-2 border-indigo-200 rounded-lg cursor-pointer hover:border-purple-400 hover:text-purple-700 hover:bg-purple-50 transition-all"
+                        >
+                          Save
+                        </button>
+                        <button
+                          type="button"
+                          className="px-4 py-2 bg-gray-100 text-gray-700 font-semibold border border-gray-200 rounded-lg cursor-pointer hover:bg-gray-200 transition-colors"
+                          hx-on:click={`
+                            event.stopPropagation();
+                            document.getElementById('${renameFormId}').classList.add('hidden');
+                            document.querySelectorAll('[data-rename-button]').forEach((el) => el.classList.remove('ring-2', 'ring-purple-400'));
+                          `}
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    </div>
+                  </form>
                 </li>
               )
             })}

--- a/projects/file-server/src/routes/api.ts
+++ b/projects/file-server/src/routes/api.ts
@@ -6,6 +6,7 @@ import {
   deleteFileHandler,
   listFilesHandler,
   mkdirHandler,
+  renameHandler,
   updateFileHandler,
   uploadFileHandler,
 } from "../api/handlers"
@@ -71,6 +72,18 @@ apiRoutes.post(
 )
 
 // ファイル内容更新API
+apiRoutes.post(
+  "/rename",
+  zValidator(
+    "form",
+    z.object({
+      path: z.string(),
+      name: z.string(),
+    }),
+  ),
+  renameHandler,
+)
+
 apiRoutes.post(
   "/update",
   zValidator(

--- a/projects/file-server/tests/rename.test.ts
+++ b/projects/file-server/tests/rename.test.ts
@@ -1,0 +1,350 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { mkdir, readFile, rm, stat, writeFile } from "node:fs/promises"
+import path from "node:path"
+import app from "../src/index"
+import { resetUsersCacheForTests } from "../src/utils/userConfigCache"
+import { createTestSession } from "./helpers/auth"
+
+const UPLOAD_DIR = "./tmp-test-rename"
+const USERS_FILE = path.join(UPLOAD_DIR, "users.json")
+const SESSION_SECRET = "0123456789abcdef0123456789abcdef"
+
+type PlainUser = {
+  username: string
+  password: string
+  role?: "admin" | "user"
+}
+
+async function writeUsers(users: PlainUser[]) {
+  const userConfigs = await Promise.all(
+    users.map(async (user) => ({
+      username: user.username,
+      passwordHash: await Bun.password.hash(user.password, {
+        algorithm: "bcrypt",
+        cost: 4,
+      }),
+      role: user.role ?? "user",
+    })),
+  )
+  await writeFile(USERS_FILE, JSON.stringify(userConfigs), "utf-8")
+}
+
+describe("POST /api/rename", () => {
+  beforeEach(async () => {
+    await rm(UPLOAD_DIR, { recursive: true, force: true })
+    await mkdir(UPLOAD_DIR, { recursive: true })
+    process.env.UPLOAD_DIR = UPLOAD_DIR
+    delete process.env.USERS_FILE
+    delete process.env.SESSION_SECRET
+    resetUsersCacheForTests()
+  })
+
+  afterEach(async () => {
+    await rm(UPLOAD_DIR, { recursive: true, force: true })
+    delete process.env.USERS_FILE
+    delete process.env.SESSION_SECRET
+    resetUsersCacheForTests()
+  })
+
+  it("renames a file in the root directory", async () => {
+    await writeFile(path.join(UPLOAD_DIR, "before.txt"), "content")
+
+    const body = new URLSearchParams({ path: "before.txt", name: "after.txt" })
+    const res = await app.request(
+      new Request("http://localhost/api/rename", {
+        method: "POST",
+        body,
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+      }),
+    )
+
+    expect(res.status).toBe(301)
+    expect(res.headers.get("location")).toBe("/?path=")
+    expect(await readFile(path.join(UPLOAD_DIR, "after.txt"), "utf-8")).toBe(
+      "content",
+    )
+    expect(
+      Bun.file(path.join(UPLOAD_DIR, "before.txt")).text(),
+    ).rejects.toThrow()
+  })
+
+  it("renames a file in a subdirectory", async () => {
+    await mkdir(path.join(UPLOAD_DIR, "parent"), { recursive: true })
+    await writeFile(path.join(UPLOAD_DIR, "parent", "before.txt"), "nested")
+
+    const body = new URLSearchParams({
+      path: "parent/before.txt",
+      name: "after.txt",
+    })
+    const res = await app.request(
+      new Request("http://localhost/api/rename", {
+        method: "POST",
+        body,
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+      }),
+    )
+
+    expect(res.status).toBe(301)
+    expect(res.headers.get("location")).toBe("/?path=parent")
+    expect(
+      await readFile(path.join(UPLOAD_DIR, "parent", "after.txt"), "utf-8"),
+    ).toBe("nested")
+  })
+
+  it("renames a directory and keeps its contents", async () => {
+    await mkdir(path.join(UPLOAD_DIR, "before-dir"), { recursive: true })
+    await writeFile(
+      path.join(UPLOAD_DIR, "before-dir", "inside.txt"),
+      "inside-content",
+    )
+
+    const body = new URLSearchParams({
+      path: "before-dir",
+      name: "after-dir",
+    })
+    const res = await app.request(
+      new Request("http://localhost/api/rename", {
+        method: "POST",
+        body,
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+      }),
+    )
+
+    expect(res.status).toBe(301)
+    expect(res.headers.get("location")).toBe("/?path=")
+    expect(await stat(path.join(UPLOAD_DIR, "after-dir"))).toMatchObject({
+      isDirectory: expect.any(Function),
+    })
+    expect(
+      await readFile(path.join(UPLOAD_DIR, "after-dir", "inside.txt"), "utf-8"),
+    ).toBe("inside-content")
+  })
+
+  it("treats same-name rename as a success no-op", async () => {
+    await writeFile(path.join(UPLOAD_DIR, "same.txt"), "same-content")
+
+    const body = new URLSearchParams({ path: "same.txt", name: "same.txt" })
+    const res = await app.request(
+      new Request("http://localhost/api/rename", {
+        method: "POST",
+        body,
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+      }),
+    )
+
+    expect(res.status).toBe(301)
+    expect(res.headers.get("location")).toBe("/?path=")
+    expect(await readFile(path.join(UPLOAD_DIR, "same.txt"), "utf-8")).toBe(
+      "same-content",
+    )
+  })
+
+  it("rejects invalid source paths", async () => {
+    const body = new URLSearchParams({ path: "../bad", name: "after.txt" })
+    const res = await app.request(
+      new Request("http://localhost/api/rename", {
+        method: "POST",
+        body,
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+      }),
+    )
+
+    expect(res.status).toBe(400)
+    const json = (await res.json()) as {
+      success: boolean
+      error: { name: string; message: string }
+    }
+    expect(json.success).toBe(false)
+    expect(json.error.name).toBe("PathError")
+  })
+
+  it("rejects invalid target names", async () => {
+    await writeFile(path.join(UPLOAD_DIR, "before.txt"), "content")
+
+    for (const name of ["", ".", "..", "a/b", "a\\b"]) {
+      const body = new URLSearchParams({ path: "before.txt", name })
+      const res = await app.request(
+        new Request("http://localhost/api/rename", {
+          method: "POST",
+          body,
+          headers: {
+            "content-type": "application/x-www-form-urlencoded",
+          },
+        }),
+      )
+
+      expect(res.status).toBe(400)
+      const json = (await res.json()) as {
+        success: boolean
+        error: { name: string; message: string }
+      }
+      expect(json.success).toBe(false)
+      expect(json.error.name).toBe("PathError")
+    }
+  })
+
+  it("returns FileNotFound when the source does not exist", async () => {
+    const body = new URLSearchParams({ path: "missing.txt", name: "after.txt" })
+    const res = await app.request(
+      new Request("http://localhost/api/rename", {
+        method: "POST",
+        body,
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+      }),
+    )
+
+    expect(res.status).toBe(400)
+    const json = (await res.json()) as {
+      success: boolean
+      error: { name: string; message: string }
+    }
+    expect(json.success).toBe(false)
+    expect(json.error.name).toBe("FileNotFound")
+  })
+
+  it("returns AlreadyExists when the destination already exists", async () => {
+    await writeFile(path.join(UPLOAD_DIR, "before.txt"), "content")
+    await writeFile(path.join(UPLOAD_DIR, "after.txt"), "existing")
+
+    const body = new URLSearchParams({ path: "before.txt", name: "after.txt" })
+    const res = await app.request(
+      new Request("http://localhost/api/rename", {
+        method: "POST",
+        body,
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+      }),
+    )
+
+    expect(res.status).toBe(400)
+    const json = (await res.json()) as {
+      success: boolean
+      error: { name: string; message: string }
+    }
+    expect(json.success).toBe(false)
+    expect(json.error.name).toBe("AlreadyExists")
+  })
+
+  it("returns updated HTML via htmx", async () => {
+    await writeFile(path.join(UPLOAD_DIR, "before.txt"), "content")
+
+    const body = new URLSearchParams({ path: "before.txt", name: "after.txt" })
+    const res = await app.request(
+      new Request("http://localhost/api/rename", {
+        method: "POST",
+        body,
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          "HX-Request": "true",
+        },
+      }),
+    )
+
+    expect(res.status).toBe(200)
+    const text = await res.text()
+    expect(text).toContain('id="file-list-container"')
+    expect(text).toContain("after.txt")
+    expect(text).not.toContain("before.txt")
+    expect(text).toContain('hx-post="/api/rename"')
+    expect(text).not.toContain("<html")
+  })
+
+  it("keeps the parent breadcrumb in nested htmx renames", async () => {
+    await mkdir(path.join(UPLOAD_DIR, "foo"), { recursive: true })
+    await writeFile(path.join(UPLOAD_DIR, "foo", "before.txt"), "content")
+
+    const body = new URLSearchParams({
+      path: "foo/before.txt",
+      name: "after.txt",
+    })
+    const res = await app.request(
+      new Request("http://localhost/api/rename", {
+        method: "POST",
+        body,
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          "HX-Request": "true",
+        },
+      }),
+    )
+
+    expect(res.status).toBe(200)
+    const text = await res.text()
+    expect(text).toContain('id="file-list-container"')
+    expect(text).toContain("foo")
+    expect(text).toContain("after.txt")
+    expect(text).not.toContain("before.txt")
+  })
+
+  it("pre-renders rename controls in the browse view", async () => {
+    await writeFile(path.join(UPLOAD_DIR, "browse-test.txt"), "content")
+
+    const res = await app.request(new Request("http://localhost/?path="))
+
+    expect(res.status).toBe(200)
+    const text = await res.text()
+    expect(text).toContain('hx-post="/api/rename"')
+    expect(text).toContain("Rename")
+    expect(text).toContain('value="browse-test.txt"')
+  })
+
+  it("prevents authenticated users from renaming outside their scope", async () => {
+    process.env.USERS_FILE = USERS_FILE
+    process.env.SESSION_SECRET = SESSION_SECRET
+    await writeUsers([{ username: "alice", password: "password1" }])
+    await mkdir(path.join(UPLOAD_DIR, "alice"), { recursive: true })
+
+    const session = await createTestSession("alice", SESSION_SECRET)
+    const body = new URLSearchParams({ path: "../bob/file.txt", name: "x.txt" })
+    const res = await app.request(
+      new Request("http://localhost/api/rename", {
+        method: "POST",
+        body,
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          cookie: session.cookie,
+        },
+      }),
+    )
+
+    expect(res.status).toBe(400)
+    const json = (await res.json()) as {
+      success: boolean
+      error: { name: string; message: string }
+    }
+    expect(json.success).toBe(false)
+    expect(json.error.name).toBe("PathError")
+  })
+
+  it("allows admins to rename items under the upload root", async () => {
+    process.env.USERS_FILE = USERS_FILE
+    process.env.SESSION_SECRET = SESSION_SECRET
+    await writeUsers([
+      { username: "admin", password: "password1", role: "admin" },
+      { username: "alice", password: "password2", role: "user" },
+    ])
+    await mkdir(path.join(UPLOAD_DIR, "alice"), { recursive: true })
+    await writeFile(path.join(UPLOAD_DIR, "alice", "before.txt"), "content")
+
+    const session = await createTestSession("admin", SESSION_SECRET)
+    const body = new URLSearchParams({
+      path: "alice/before.txt",
+      name: "after.txt",
+    })
+    const res = await app.request(
+      new Request("http://localhost/api/rename", {
+        method: "POST",
+        body,
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          cookie: session.cookie,
+        },
+      }),
+    )
+
+    expect(res.status).toBe(301)
+    expect(res.headers.get("location")).toBe("/?path=alice")
+    expect(
+      await readFile(path.join(UPLOAD_DIR, "alice", "after.txt"), "utf-8"),
+    ).toBe("content")
+  })
+})


### PR DESCRIPTION
## Issues

- Closes #662

## Why

Web UI からファイルやフォルダ名を変更できず、作成し直しや再アップロードが必要でした。
一覧画面から安全に basename を変更できる導線を追加して、既存のパス検証と認証スコープを維持したままリネームできるようにします。
<img width="1067" height="856" alt="image" src="https://github.com/user-attachments/assets/dbbf6293-af1b-48d2-b62e-a058c7d2ec87" />

## Summary

ファイル・フォルダのリネーム API と、一覧画面のインライン rename UI を追加しました。
通常リクエスト、HTMX 更新、認証スコープを含む rename テストも追加しています。

## Changes

- `POST /api/rename` を追加し、同一親ディレクトリ内での basename リネームを実装
- `PathError`、`FileNotFound`、`AlreadyExists`、same-name no-op を既存 API と同じパターンで処理
- `FileList` の各行に inline rename フォームを追加し、1件だけ開ける UI に変更
- `tests/rename.test.ts` を追加して通常系、HTMX、認証スコープを検証

## Checklist

- [x] rename API を追加
- [x] 一覧 UI から rename できる
- [x] HTMX 更新を確認
- [x] `bun run lint`
- [x] `bun test`
