### PR TITLE
fix(file-server): show conflict errors in HTMX forms

### DIFF
--- a/projects/file-server/src/api/handlers.tsx
+++ b/projects/file-server/src/api/handlers.tsx
@@ -232,7 +232,7 @@ export async function mkdirHandler(c: Context<AppBindings>) {
           success: false,
           error: {
             name: "AlreadyExists",
-            message: "Directory already exists",
+            message: `"${folder}" already exists.`,
           },
         },
         400,
@@ -284,7 +284,7 @@ export async function createFileHandler(c: Context<AppBindings>) {
           success: false,
           error: {
             name: "AlreadyExists",
-            message: "File already exists",
+            message: `"${file}" already exists.`,
           },
         },
         400,
@@ -371,7 +371,7 @@ export async function renameHandler(c: Context<AppBindings>) {
         success: false,
         error: {
           name: "AlreadyExists",
-          message: "File or directory already exists",
+          message: `"${name}" already exists.`,
         },
       },
       400,

--- a/projects/file-server/src/components/FileList.tsx
+++ b/projects/file-server/src/components/FileList.tsx
@@ -19,6 +19,20 @@ interface FileListProps {
   requestPath: string
 }
 
+const formErrorClassName =
+  "hidden mt-3 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+
+function FormErrorMessage() {
+  return (
+    <p
+      data-form-error
+      role="alert"
+      aria-live="polite"
+      className={formErrorClassName}
+    ></p>
+  )
+}
+
 // パンくずリスト部分を生成
 function generateBreadcrumbs(requestPath: string) {
   const parts = requestPath.split("/").filter(Boolean)
@@ -145,6 +159,7 @@ export const FileList: FC<FileListProps> = ({ files, requestPath }) => {
       {/* New File フォーム（アコーディオン） */}
       <form
         id="new-file-form"
+        data-inline-error-form
         hx-post="/api/file"
         hx-target="#file-list-container"
         hx-swap="innerHTML"
@@ -164,11 +179,13 @@ export const FileList: FC<FileListProps> = ({ files, requestPath }) => {
         >
           Create File
         </button>
+        <FormErrorMessage />
       </form>
 
       {/* New Folder フォーム（アコーディオン） */}
       <form
         id="new-folder-form"
+        data-inline-error-form
         hx-post="/api/mkdir"
         hx-target="#file-list-container"
         hx-swap="innerHTML"
@@ -188,6 +205,7 @@ export const FileList: FC<FileListProps> = ({ files, requestPath }) => {
         >
           Create Folder
         </button>
+        <FormErrorMessage />
       </form>
 
       {/* ドラッグ＆ドロップ用隠しフォーム */}
@@ -351,6 +369,7 @@ export const FileList: FC<FileListProps> = ({ files, requestPath }) => {
                   <form
                     id={renameFormId}
                     data-rename-form
+                    data-inline-error-form
                     hx-post="/api/rename"
                     hx-target="#file-list-container"
                     hx-swap="innerHTML"
@@ -387,6 +406,7 @@ export const FileList: FC<FileListProps> = ({ files, requestPath }) => {
                         </button>
                       </div>
                     </div>
+                    <FormErrorMessage />
                   </form>
                 </li>
               )

--- a/projects/file-server/src/components/PageShell.tsx
+++ b/projects/file-server/src/components/PageShell.tsx
@@ -6,6 +6,88 @@ interface PageShellProps {
   user?: UserState
 }
 
+const inlineFormErrorScript = `
+  (() => {
+    const formEndpoints = new Set(["/api/file", "/api/mkdir", "/api/rename"]);
+
+    const getForm = (detail) => {
+      const source = detail?.elt instanceof Element ? detail.elt : null;
+      if (!source) {
+        return null;
+      }
+      return source.closest("form");
+    };
+
+    const getErrorNode = (form) => form?.querySelector("[data-form-error]") ?? null;
+
+    const clearFormError = (form) => {
+      const errorNode = getErrorNode(form);
+      if (!errorNode) {
+        return;
+      }
+      errorNode.textContent = "";
+      errorNode.classList.add("hidden");
+    };
+
+    const showFormError = (form, message) => {
+      const errorNode = getErrorNode(form);
+      if (!errorNode) {
+        return;
+      }
+      errorNode.textContent = message;
+      errorNode.classList.remove("hidden");
+    };
+
+    document.addEventListener("input", (event) => {
+      const target = event.target;
+      if (!(target instanceof Element)) {
+        return;
+      }
+      const form = target.closest("form[data-inline-error-form]");
+      if (form) {
+        clearFormError(form);
+      }
+    });
+
+    document.addEventListener("htmx:beforeRequest", (event) => {
+      const form = getForm(event.detail);
+      if (form?.matches("[data-inline-error-form]")) {
+        clearFormError(form);
+      }
+    });
+
+    document.addEventListener("htmx:responseError", (event) => {
+      const form = getForm(event.detail);
+      if (!form?.matches("[data-inline-error-form]")) {
+        return;
+      }
+
+      const xhr = event.detail?.xhr;
+      if (!xhr || xhr.status !== 400) {
+        return;
+      }
+
+      const action =
+        form.getAttribute("hx-post") || form.getAttribute("action") || "";
+      if (!formEndpoints.has(action)) {
+        return;
+      }
+
+      try {
+        const payload = JSON.parse(xhr.responseText);
+        if (
+          payload?.error?.name !== "AlreadyExists" ||
+          typeof payload?.error?.message !== "string"
+        ) {
+          return;
+        }
+        showFormError(form, payload.error.message);
+      } catch {
+      }
+    });
+  })();
+`
+
 export const PageShell: FC<PageShellProps> = ({ children, user }) => {
   return (
     <html lang="ja">
@@ -15,6 +97,7 @@ export const PageShell: FC<PageShellProps> = ({ children, user }) => {
         <title>File Server</title>
         <script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.8/dist/htmx.min.js"></script>
         <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+        <script dangerouslySetInnerHTML={{ __html: inlineFormErrorScript }} />
         <style>{`
           .image-viewer-img {
             height: -webkit-fill-available;

--- a/projects/file-server/tests/create-file.test.ts
+++ b/projects/file-server/tests/create-file.test.ts
@@ -63,6 +63,7 @@ describe("POST /api/file", () => {
     }
     expect(json.success).toBe(false)
     expect(json.error.name).toBe("AlreadyExists")
+    expect(json.error.message).toBe('"exist.txt" already exists.')
   })
 
   it("should return error when directory with same name exists", async () => {
@@ -81,6 +82,7 @@ describe("POST /api/file", () => {
     }
     expect(json.success).toBe(false)
     expect(json.error.name).toBe("AlreadyExists")
+    expect(json.error.message).toBe('"exist-dir" already exists.')
   })
 
   it("should return error for invalid path", async () => {
@@ -167,6 +169,7 @@ describe("POST /api/file", () => {
     expect(text).toContain("htmx-child.txt")
     expect(text).toContain("htmx-parent")
     expect(text).not.toContain("<html")
+    expect(text).toContain("data-form-error")
 
     const st = await stat(join(UPLOAD_DIR, "htmx-parent", "htmx-child.txt"))
     expect(st.isFile()).toBe(true)

--- a/projects/file-server/tests/mkdir.test.ts
+++ b/projects/file-server/tests/mkdir.test.ts
@@ -45,6 +45,7 @@ describe("POST /api/mkdir", () => {
     }
     expect(json.success).toBe(false)
     expect(json.error.name).toBe("AlreadyExists")
+    expect(json.error.message).toBe('"existdir" already exists.')
   })
 
   it("should return error for invalid path", async () => {
@@ -129,6 +130,7 @@ describe("POST /api/mkdir", () => {
     expect(text).toContain("htmx-child/") // 作成されたディレクトリ
     expect(text).toContain("htmx-parent") // パンくずリストに親ディレクトリが含まれる
     expect(text).not.toContain("<html")
+    expect(text).toContain("data-form-error")
 
     // Check if directory was actually created
     const st = await stat(join(UPLOAD_DIR, "htmx-parent", "htmx-child"))

--- a/projects/file-server/tests/rename.test.ts
+++ b/projects/file-server/tests/rename.test.ts
@@ -222,6 +222,7 @@ describe("POST /api/rename", () => {
     }
     expect(json.success).toBe(false)
     expect(json.error.name).toBe("AlreadyExists")
+    expect(json.error.message).toBe('"after.txt" already exists.')
   })
 
   it("returns updated HTML via htmx", async () => {
@@ -245,6 +246,7 @@ describe("POST /api/rename", () => {
     expect(text).toContain("after.txt")
     expect(text).not.toContain("before.txt")
     expect(text).toContain('hx-post="/api/rename"')
+    expect(text).toContain("data-form-error")
     expect(text).not.toContain("<html")
   })
 
@@ -285,6 +287,7 @@ describe("POST /api/rename", () => {
     expect(text).toContain('hx-post="/api/rename"')
     expect(text).toContain("Rename")
     expect(text).toContain('value="browse-test.txt"')
+    expect(text).toContain("data-form-error")
   })
 
   it("prevents authenticated users from renaming outside their scope", async () => {


### PR DESCRIPTION
## Issues

- Closes #672

## Why

When rename, empty file creation, or empty folder creation conflicts with an existing entry, the API returns `400 AlreadyExists` but the HTMX UI gave no visible feedback. That left the user without any indication of what happened or how to recover.
<img width="1086" height="965" alt="image" src="https://github.com/user-attachments/assets/fa6345ce-8428-4631-873f-c1608152ffa2" />

## Summary

Show inline form errors for name conflict responses in the HTMX UI and standardize the conflict messages returned by the API so they can be displayed directly.

## Changes

- add inline error placeholders to the create-file, create-folder, and rename forms
- handle HTMX `responseError` for `/api/file`, `/api/mkdir`, and `/api/rename` in `PageShell`
- clear inline errors on input changes and before resubmission
- update `AlreadyExists` API messages to include the conflicting target name
- extend tests to cover the updated API messages and rendered error placeholders

## Checklist

- [x] `bun run lint`
- [x] `bun test`
- [x] verified conflict errors render inline in the browser
