### PR TITLE
chore(file-server): add project design skill

### DIFF
--- a/projects/file-server/.claude/skills/file-server-design/SKILL.md
+++ b/projects/file-server/.claude/skills/file-server-design/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: file-server-design
+description: >
+  Use this when working on UI or UX changes in the file-server project, especially for
+  buttons, colors, dialogs, empty states, and visual consistency across Hono JSX + HTMX screens.
+  It captures the project's design direction so future design edits stay aligned.
+---
+
+# File Server Design
+
+## Overview
+
+Use this skill for UI-facing changes in `projects/file-server`.
+It keeps visual changes aligned with the current product direction instead of making one-off styling decisions.
+
+## When to Use This Skill
+
+- When changing button styles, accent colors, gradients, or action hierarchy
+- When editing dialogs, file viewer UI, list actions, or inline forms
+- When adding or revising empty states, placeholders, helper text, or feedback copy
+- When reviewing whether a UI change matches the existing visual language
+
+## What the Agent Does
+
+1. Inspect the affected UI and identify the action roles involved.
+2. Read `references/design-guidelines.md` before proposing or implementing visual changes.
+3. Reuse the existing visual language unless there is an explicit request to change it.
+4. Keep color semantics consistent across list views, dialogs, and editor states.
+5. Preserve HTMX behavior, auth behavior, and path-safety constraints while changing presentation.
+6. Add or update tests when UI output changes in a way the current test suite asserts.
+
+## Input and Output
+
+**Input:**
+- A UI or UX change request in `projects/file-server`
+- Existing Hono JSX components and HTML-based tests
+
+**Output:**
+- Consistent design decisions for the changed UI
+- Updated components and tests that reflect the project design rules
+
+## Step Details
+
+### Step 1: Read the Design Reference
+
+Open `references/design-guidelines.md`.
+Use it as the source of truth for button roles, color semantics, empty states, and scope boundaries.
+
+### Step 2: Map Actions to Roles
+
+For each changed control, decide whether it is:
+- `primary`
+- `secondary`
+- `danger`
+- `dismiss`
+
+Do not assign styles by feature name alone.
+Assign them by user intent and risk level.
+
+### Step 3: Preserve the Product Shape
+
+Keep the current visual language:
+- soft indigo/purple/pink page palette
+- rounded containers and controls
+- gradients used selectively, not everywhere
+- strong distinction between destructive and non-destructive actions
+
+Avoid introducing a new palette or a competing button system unless the user explicitly asks for a redesign.
+
+### Step 4: Handle Empty States Explicitly
+
+When content can be empty, show that emptiness intentionally.
+Do not leave bordered panels, editors, or dialogs looking broken or unfinished.
+
+### Step 5: Protect Non-Visual Behavior
+
+Do not break:
+- HTMX targets, swaps, and push-url behavior
+- file/path validation rules
+- auth scope behavior
+- current routes and API contracts
+
+### Step 6: Update Tests
+
+If HTML output or copy changes, update or add tests in `tests/` so the intended UX is locked in.
+
+## Quality Check
+
+- [ ] The changed UI follows the role-based button rules in the reference
+- [ ] Destructive actions are not visually confused with close/cancel actions
+- [ ] Empty content states are explicit, not silent blanks
+- [ ] Existing HTMX and file-server behavior is preserved
+- [ ] Tests cover new visible behavior when relevant
+
+## References
+
+- `references/design-guidelines.md`
+- `src/components/FileList.tsx`
+- `src/components/file-viewer/`

--- a/projects/file-server/.claude/skills/file-server-design/references/design-guidelines.md
+++ b/projects/file-server/.claude/skills/file-server-design/references/design-guidelines.md
@@ -1,0 +1,119 @@
+# File Server Design Guidelines
+
+## Purpose
+
+These guidelines define the current design direction for `projects/file-server`.
+Use them when making UI changes so the interface evolves coherently.
+
+## Visual Direction
+
+- Keep the existing soft indigo, purple, and pink palette used by the page shell.
+- Keep rounded corners and lightly elevated containers.
+- Use gradients as accents, not as the default style for every action.
+- Prefer a calm base UI with a few intentional highlights.
+
+## Button Semantics
+
+Map every action to one of these roles before choosing styles.
+
+### Primary
+
+Use for the main commit action in the current context.
+
+Style direction:
+- indigo-to-purple gradient
+- white text
+- stronger visual weight than surrounding controls
+
+Typical examples:
+- `Create File`
+- `Create Folder`
+- editor `Save`
+
+Rule:
+- In a single local action group, avoid multiple primary buttons unless they are truly equivalent submit actions.
+
+### Secondary
+
+Use for non-destructive utility actions and entry points.
+
+Style direction:
+- white or lightly tinted surface
+- indigo border/text
+- hover tint instead of a full gradient
+
+Typical examples:
+- `New File`
+- `New Folder`
+- `Download Zip`
+- modal `Download`
+- modal `Edit`
+- list `Rename`
+
+Rule:
+- A feature should not become primary only because it is new or visually prominent.
+
+### Danger
+
+Use only for destructive actions.
+
+Style direction:
+- red or rose treatment
+- must be clearly distinguishable from close/cancel
+
+Typical examples:
+- `Delete`
+
+Rule:
+- Do not use danger styling for navigation, dismissal, or non-destructive exits.
+
+### Dismiss
+
+Use for leaving or backing out of the current state without destructive effect.
+
+Style direction:
+- neutral gray or other low-emphasis treatment
+- visually quieter than primary and danger
+
+Typical examples:
+- modal `Close`
+- rename `Cancel`
+- editor `Cancel`
+
+Rule:
+- Close and cancel must never look like delete.
+
+## Active and Toggle States
+
+- For accordion triggers or toggleable utility buttons, show active state with ring, border, or tint changes.
+- Do not give one toggle a permanent primary treatment if it is only one of several peer actions.
+- When toggling between forms, use the same active-state language for both options.
+
+## Dialog and Viewer Rules
+
+- Modal toolbar buttons must use the same role semantics as list actions.
+- Keep title styling and container treatment aligned with the page shell palette.
+- Avoid mixing unrelated accent colors for peer actions in the same toolbar.
+
+## Empty States
+
+- Empty content should look intentional.
+- In read mode, show a short empty-state message inside the viewer instead of an empty framed box.
+- In edit mode, use a placeholder when the editable text is empty.
+- Empty-state copy should be short, calm, and in English unless the product language changes.
+
+Suggested phrasing:
+- `This file is empty.`
+- `This file is empty. Start typing...`
+
+## Scope Boundaries
+
+- These rules apply to the file browsing and file viewer experience first.
+- Auth pages can remain simpler unless a task explicitly includes them.
+- Preserve current HTMX structure and server-side rendering patterns while adjusting presentation.
+
+## Implementation Notes
+
+- Prefer a lightweight shared class helper or style constant when multiple controls share the same role.
+- Avoid large design-system abstractions unless the task clearly justifies them.
+- If tests assert HTML output, update them alongside the UI change.

--- a/projects/file-server/.codex/skills
+++ b/projects/file-server/.codex/skills
@@ -1,0 +1,1 @@
+../.claude/skills


### PR DESCRIPTION
## Issues

- None

## Why

The file-server project now has a project-specific design direction for UI work, but that guidance should be reusable by both Claude Code and Codex. Keeping the design rules in a project skill reduces one-off styling decisions and makes future UI changes more consistent.

## Summary

Add a file-server design skill and link the Codex skills path to the Claude skills directory so the same project skill can be reused from both environments.

## Changes

- add a project-local `file-server-design` skill under `.claude/skills`
- add `design-guidelines.md` with button-role, color, dialog, and empty-state guidance
- add `.codex/skills` symlink pointing at `../.claude/skills`

## Checklist

- [x] Added the file-server design skill
- [x] Added the project design reference document
- [x] Verified `.codex/skills` resolves to the project `.claude/skills` directory

## Details

This PR intentionally excludes the experimental `claude-to-codex-skills-link` helper skill and the unstaged `AGENTS.md` change.
