### PR TITLE
refactor(simple-agent-poc): introduce reusable agent execution use case

### DIFF
--- a/projects/simple-agent-poc/README.md
+++ b/projects/simple-agent-poc/README.md
@@ -33,6 +33,9 @@ other adapters.
 The current boundary policy and migration direction are documented in
 `.claude/skills/architecture/SKILL.md`.
 
+The reusable execution contract currently lives in [src/simple_agent_poc/application.py](src/simple_agent_poc/application.py)
+as `RunAgentUseCase`, `RunAgentRequest`, and `RunAgentResponse`.
+
 ## Development
 
 Format code:

--- a/projects/simple-agent-poc/src/simple_agent_poc/application.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/application.py
@@ -1,0 +1,56 @@
+"""Application use cases and DTOs."""
+
+from dataclasses import dataclass
+
+from simple_agent_poc.agent import Agent
+from simple_agent_poc.types import LLMResponse, Usage
+
+
+@dataclass(frozen=True, slots=True)
+class RunAgentRequest:
+    """Request DTO for reusable agent execution."""
+
+    message: str
+    session_id: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class RunAgentResponse:
+    """Response DTO for reusable agent execution."""
+
+    message: str
+    usage: Usage
+    model: str
+    response_time: float
+    session_id: str | None = None
+
+    @classmethod
+    def from_llm_response(
+        cls,
+        response: LLMResponse,
+        *,
+        session_id: str | None = None,
+    ) -> "RunAgentResponse":
+        """Build the application DTO from a raw LLM response."""
+        return cls(
+            message=response["content"],
+            usage=response["usage"],
+            model=response["model"],
+            response_time=response["response_time"],
+            session_id=session_id,
+        )
+
+
+class RunAgentUseCase:
+    """Reusable execution path for agent interactions."""
+
+    def __init__(self, agent: Agent) -> None:
+        self._agent = agent
+
+    def execute(self, request: RunAgentRequest) -> RunAgentResponse:
+        """Run the agent for a single user message."""
+        response = self._agent.process_user_input(request.message)
+        return RunAgentResponse.from_llm_response(
+            response,
+            session_id=request.session_id,
+        )

--- a/projects/simple-agent-poc/src/simple_agent_poc/main.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/main.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from dotenv import load_dotenv
 
 from simple_agent_poc.agent import Agent
+from simple_agent_poc.application import RunAgentRequest, RunAgentUseCase
 from simple_agent_poc.renderer import (
     get_user_input,
     show_agent_response,
@@ -49,6 +50,7 @@ def main() -> None:
         system_prompt=formatted_system_prompt,
         model=DEFAULT_MODEL,
     )
+    run_agent = RunAgentUseCase(agent)
 
     # CLI loop
     while True:
@@ -61,7 +63,7 @@ def main() -> None:
             # Business logic layer: process request
             response = with_indicator(
                 "Thinking",
-                lambda: agent.process_user_input(user_input),
+                lambda: run_agent.execute(RunAgentRequest(message=user_input)),
             )
 
             # UI layer: display results

--- a/projects/simple-agent-poc/src/simple_agent_poc/renderer.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/renderer.py
@@ -5,7 +5,8 @@ import threading
 import time
 from typing import Callable
 
-from simple_agent_poc.types import AgentError, LLMResponse
+from simple_agent_poc.application import RunAgentResponse
+from simple_agent_poc.types import AgentError
 
 
 class LoadingIndicator:
@@ -90,24 +91,24 @@ def get_user_input() -> str:
     return input("> ")
 
 
-def show_agent_response(response: LLMResponse) -> None:
+def show_agent_response(response: RunAgentResponse) -> None:
     """Display the agent's response."""
-    print(f"Agent: {response['content']}")
+    print(f"Agent: {response.message}")
 
     # Format response time
-    elapsed = response["response_time"]
+    elapsed = response.response_time
     if elapsed < 1:
         time_str = f"{elapsed * 1000:.0f}ms"
     else:
         time_str = f"{elapsed:.2f}s"
 
     # Extract model name (remove provider prefix if exists)
-    model = response["model"]
+    model = response.model
     if "/" in model:
         model = model.split("/")[-1]
 
     # Build stats line
-    usage = response["usage"]
+    usage = response.usage
     stats = (
         f"Model: {model} │ "
         f"Time: {time_str} │ "

--- a/projects/simple-agent-poc/tests/test_application.py
+++ b/projects/simple-agent-poc/tests/test_application.py
@@ -1,0 +1,82 @@
+"""Tests for application use cases and DTOs."""
+
+from unittest.mock import MagicMock
+
+from simple_agent_poc.application import (
+    RunAgentRequest,
+    RunAgentResponse,
+    RunAgentUseCase,
+)
+from simple_agent_poc.types import LLMResponse
+
+
+class TestRunAgentRequest:
+    """Tests for request DTO."""
+
+    def test_defaults_session_id_to_none(self) -> None:
+        request = RunAgentRequest(message="Hello")
+
+        assert request.message == "Hello"
+        assert request.session_id is None
+
+
+class TestRunAgentResponse:
+    """Tests for response DTO."""
+
+    def test_from_llm_response(self) -> None:
+        llm_response: LLMResponse = {
+            "content": "Hello, user!",
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "total_tokens": 15,
+            },
+            "model": "gpt-4o-mini",
+            "response_time": 0.85,
+        }
+
+        response = RunAgentResponse.from_llm_response(
+            llm_response,
+            session_id="session-1",
+        )
+
+        assert response.message == "Hello, user!"
+        assert response.usage == llm_response["usage"]
+        assert response.model == "gpt-4o-mini"
+        assert response.response_time == 0.85
+        assert response.session_id == "session-1"
+
+
+class TestRunAgentUseCase:
+    """Tests for the reusable agent execution path."""
+
+    def test_execute_delegates_to_agent_and_returns_dto(self) -> None:
+        agent = MagicMock()
+        agent.process_user_input.return_value = {
+            "content": "Hello, user!",
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "total_tokens": 15,
+            },
+            "model": "gpt-4o-mini",
+            "response_time": 0.85,
+        }
+
+        use_case = RunAgentUseCase(agent)
+        response = use_case.execute(
+            RunAgentRequest(message="Hello", session_id="session-1")
+        )
+
+        agent.process_user_input.assert_called_once_with("Hello")
+        assert response == RunAgentResponse(
+            message="Hello, user!",
+            usage={
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "total_tokens": 15,
+            },
+            model="gpt-4o-mini",
+            response_time=0.85,
+            session_id="session-1",
+        )

--- a/projects/simple-agent-poc/tests/test_renderer.py
+++ b/projects/simple-agent-poc/tests/test_renderer.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from simple_agent_poc.application import RunAgentResponse
 from simple_agent_poc.renderer import (
     get_user_input,
     show_agent_response,
@@ -12,7 +13,7 @@ from simple_agent_poc.renderer import (
     show_welcome,
     with_indicator,
 )
-from simple_agent_poc.types import AgentError, AuthenticationError, LLMResponse
+from simple_agent_poc.types import AgentError, AuthenticationError
 
 
 class TestShowError:
@@ -95,16 +96,16 @@ class TestShowAgentResponse:
     @patch("builtins.print")
     def test_show_response(self, mock_print: MagicMock) -> None:
         """Test showing agent response."""
-        response: LLMResponse = {
-            "content": "Hello, user!",
-            "usage": {
+        response = RunAgentResponse(
+            message="Hello, user!",
+            usage={
                 "prompt_tokens": 10,
                 "completion_tokens": 5,
                 "total_tokens": 15,
             },
-            "model": "gpt-4o-mini",
-            "response_time": 0.85,
-        }
+            model="gpt-4o-mini",
+            response_time=0.85,
+        )
         show_agent_response(response)
 
         assert mock_print.call_count == 2


### PR DESCRIPTION
## Issues
- #682
- Parent: #680

## Why
The current simple-agent-poc flow invokes the agent directly from the CLI entrypoint, which makes it harder to reuse from future transports such as HTTP. This change introduces an explicit application boundary for execution while keeping the current CLI behavior intact.

## Summary
This PR adds a reusable agent execution use case with explicit request/response DTOs and routes the CLI through that contract. It also adds focused tests for the new execution path and updates contributor documentation.

## Changes
- add `RunAgentUseCase`, `RunAgentRequest`, and `RunAgentResponse`
- route the CLI execution path through the use case instead of direct agent invocation
- update renderer expectations to consume the application response DTO
- add unit tests for the new execution contract and adjust renderer tests
- document the reusable execution contract in `README.md`

## Checklist
- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run ty check .`
- [x] `uv run pytest`