### PR TITLE
docs(simple-agent-poc): simplify agent entry docs

### DIFF
--- a/projects/simple-agent-poc/.claude/skills/README.md
+++ b/projects/simple-agent-poc/.claude/skills/README.md
@@ -1,0 +1,27 @@
+# Skills README
+
+This file is a human-facing index for navigating project skills and references.
+Do not treat it as a required one-shot load target for agents; open only the specific linked files you need.
+
+## Tech Stack
+
+- [CLAUDE.md](../../CLAUDE.md)
+
+## Architecture
+
+- [architecture/SKILL.md](./architecture/SKILL.md)
+
+### Multi-entry boundary policy
+
+- Keep CLI input/output concerns in adapters, not in reusable application flows.
+- Add shared execution logic under application use cases with explicit DTOs.
+- Keep entrypoints thin and focused on wiring.
+- Use `./architecture/SKILL.md` as the reference for follow-up refactors.
+
+## Development
+
+- [development/SKILL.md](./development/SKILL.md)
+
+## Testing
+
+- [testing/SKILL.md](./testing/SKILL.md)

--- a/projects/simple-agent-poc/AGENTS.md
+++ b/projects/simple-agent-poc/AGENTS.md
@@ -2,23 +2,12 @@
 
 ## Tech Stack
 
-- [CLAUDE.md](./CLAUDE.md)
-
-## Architecture
-
-- [architecture/SKILL.md](.claude/skills/architecture/SKILL.md)
-
-### Multi-entry boundary policy
-
-- Keep CLI input/output concerns in adapters, not in reusable application flows.
-- Add shared execution logic under application use cases with explicit DTOs.
-- Keep entrypoints thin and focused on wiring.
-- Use `.claude/skills/architecture/SKILL.md` as the reference for follow-up refactors.
-
-## Development
-
-- [development/SKILL.md](.claude/skills/development/SKILL.md)
-
-## Testing
-
-- [testing/SKILL.md](.claude/skills/testing/SKILL.md)
+| Category | Tool | Purpose |
+| :--- | :--- | :--- |
+| **Core** | Python 3.14-slim | Lightweight Docker image |
+| **Package Manager** | uv | Fast package manager & virtual environments |
+| **Code Quality** | ruff | Linter & formatter |
+| **Testing** | pytest | Testing framework |
+| **Type Checking** | ty | Static type checking |
+| **LLM Integration** | LiteLLM | LLM provider integration |
+| **Environment** | python-dotenv | Environment variable management |

--- a/projects/simple-agent-poc/CLAUDE.md
+++ b/projects/simple-agent-poc/CLAUDE.md
@@ -1,13 +1,3 @@
 # CLAUDE.md
 
-## Tech Stack
-
-| Category | Tool | Purpose |
-| :--- | :--- | :--- |
-| **Core** | Python 3.14-slim | Lightweight Docker image |
-| **Package Manager** | uv | Fast package manager & virtual environments |
-| **Code Quality** | ruff | Linter & formatter |
-| **Testing** | pytest | Testing framework |
-| **Type Checking** | ty | Static type checking |
-| **LLM Integration** | LiteLLM | LLM provider integration |
-| **Environment** | python-dotenv | Environment variable management |
+See [AGENTS.md](./AGENTS.md).


### PR DESCRIPTION
## Issues

- None

## Why

AGENTS.md was acting as a human-oriented index and encouraged agents to load too much context at once. This change keeps the agent entry document lightweight and moves the navigational index into a dedicated human-facing README under `.claude/skills`.

## Summary

Simplify the project entry docs for agents and relocate the human-facing skill index. Keep `CLAUDE.md` as a pointer to `AGENTS.md`.

## Changes

- replace `AGENTS.md` contents with the lightweight project tech-stack summary
- change `CLAUDE.md` into a reference to `AGENTS.md`
- add `.claude/skills/README.md` as the human-facing skills index with a note not to bulk-load it for agents

## Checklist

- [x] Documentation paths updated
- [x] Human-facing index moved under `.claude/skills`
- [x] No code or runtime behavior changed
