### PR TITLE
[simple-agent-poc] Refactor CLI into thin adapter

### DIFF
--- a/projects/simple-agent-poc/.claude/skills/architecture/SKILL.md
+++ b/projects/simple-agent-poc/.claude/skills/architecture/SKILL.md
@@ -14,11 +14,15 @@ entrypoint-specific concerns.
 Current files and responsibilities:
 
 - `src/simple_agent_poc/main.py`
-  - CLI entrypoint
+  - CLI entrypoint wiring
   - environment loading and logging setup
   - system prompt and model configuration
   - agent construction
-  - interactive loop and error handling
+- `src/simple_agent_poc/cli.py`
+  - CLI adapter for interactive execution
+  - stdin/stdout interaction loop
+  - CLI-specific exception handling and user-facing messaging
+  - delegation from terminal input to `RunAgentUseCase`
 - `src/simple_agent_poc/renderer.py`
   - CLI input/output only
   - loading indicator for synchronous terminal usage
@@ -33,9 +37,9 @@ Current files and responsibilities:
 - `src/simple_agent_poc/types.py`
   - shared DTO-like types and domain/application errors
 
-The main coupling that blocks multi-entry support today is that `main.py` directly owns the
-interactive flow and constructs `Agent` as the executable application flow. That keeps the CLI
-fast to iterate on, but it leaves no reusable use case boundary for an HTTP adapter.
+The current structure now separates entrypoint wiring from interactive CLI behavior. The next
+multi-entry steps can build on this by keeping new transport adapters thin and routing them
+through the same application use case boundary.
 
 ## Target layers
 
@@ -118,9 +122,12 @@ Migration guidance:
 - `agent.py` is the nearest precursor to the future core/application split.
   - conversation state should trend toward `core`
   - execution orchestration should trend toward `application`
+- `cli.py` is the current CLI adapter boundary
+  - interactive loop and terminal error handling live here
+  - it should remain transport-specific as HTTP support is added
 - `renderer.py` should remain CLI-specific and move under `adapters/cli`
 - `llm_client.py` should remain an adapter and move under `adapters/llm`
-- `main.py` should be split into an entrypoint and CLI adapter responsibilities
+- `main.py` is now the thin entrypoint and should stay focused on dependency wiring
 
 ## Non-goals
 

--- a/projects/simple-agent-poc/README.md
+++ b/projects/simple-agent-poc/README.md
@@ -36,6 +36,9 @@ The current boundary policy and migration direction are documented in
 The reusable execution contract currently lives in [src/simple_agent_poc/application.py](src/simple_agent_poc/application.py)
 as `RunAgentUseCase`, `RunAgentRequest`, and `RunAgentResponse`.
 
+The interactive CLI adapter now lives in [src/simple_agent_poc/cli.py](src/simple_agent_poc/cli.py),
+while [src/simple_agent_poc/main.py](src/simple_agent_poc/main.py) stays focused on production wiring.
+
 ## Development
 
 Format code:

--- a/projects/simple-agent-poc/src/simple_agent_poc/cli.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/cli.py
@@ -1,0 +1,77 @@
+"""CLI adapter for the application flow."""
+
+from collections.abc import Callable
+from typing import Protocol
+
+from simple_agent_poc.application import (
+    RunAgentRequest,
+    RunAgentResponse,
+    RunAgentUseCase,
+)
+from simple_agent_poc.renderer import (
+    get_user_input,
+    show_agent_response,
+    show_error,
+    show_exit_message,
+    show_welcome,
+    with_indicator,
+)
+
+
+class IndicatorRunner(Protocol):
+    """Wrap an operation with CLI-only progress feedback."""
+
+    def __call__(
+        self,
+        message: str,
+        operation: Callable[[], RunAgentResponse],
+    ) -> RunAgentResponse: ...
+
+
+class CLIAdapter:
+    """Thin stdin/stdout adapter around the shared agent use case."""
+
+    def __init__(
+        self,
+        run_agent: RunAgentUseCase,
+        *,
+        input_reader: Callable[[], str] = get_user_input,
+        response_renderer: Callable[[RunAgentResponse], None] = show_agent_response,
+        error_renderer: Callable[[Exception], None] = show_error,
+        welcome_renderer: Callable[[], None] = show_welcome,
+        exit_renderer: Callable[[], None] = show_exit_message,
+        indicator_runner: IndicatorRunner = with_indicator,
+    ) -> None:
+        self._run_agent = run_agent
+        self._input_reader = input_reader
+        self._response_renderer = response_renderer
+        self._error_renderer = error_renderer
+        self._welcome_renderer = welcome_renderer
+        self._exit_renderer = exit_renderer
+        self._indicator_runner = indicator_runner
+
+    def run(self) -> None:
+        """Start the interactive CLI loop."""
+        self._welcome_renderer()
+
+        while True:
+            try:
+                user_input = self._input_reader()
+                if not user_input.strip():
+                    continue
+
+                response = self._indicator_runner(
+                    "Thinking",
+                    lambda: self._run_agent.execute(
+                        RunAgentRequest(message=user_input)
+                    ),
+                )
+                self._response_renderer(response)
+            except KeyboardInterrupt:
+                self._exit_renderer()
+                break
+            except EOFError:
+                self._exit_renderer()
+                break
+            except Exception as error:
+                self._error_renderer(error)

--- a/projects/simple-agent-poc/src/simple_agent_poc/main.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/main.py
@@ -1,4 +1,4 @@
-"""Entry point for the CLI."""
+"""CLI entry point wiring."""
 
 import logging
 from datetime import datetime
@@ -6,15 +6,8 @@ from datetime import datetime
 from dotenv import load_dotenv
 
 from simple_agent_poc.agent import Agent
-from simple_agent_poc.application import RunAgentRequest, RunAgentUseCase
-from simple_agent_poc.renderer import (
-    get_user_input,
-    show_agent_response,
-    show_error,
-    show_exit_message,
-    show_welcome,
-    with_indicator,
-)
+from simple_agent_poc.application import RunAgentUseCase
+from simple_agent_poc.cli import CLIAdapter
 
 # Suppress LiteLLM logging to stderr
 logging.getLogger("litellm").setLevel(logging.CRITICAL)
@@ -37,12 +30,8 @@ Current datetime: {current_datetime}
 DEFAULT_MODEL = "gpt-4.1-nano"
 
 
-def main() -> None:
-    # UI layer: screen rendering
-    show_welcome()
-
-    # Business logic layer: initialize Agent
-    # Format system prompt with current datetime before passing to Agent
+def build_cli_adapter() -> CLIAdapter:
+    """Create the CLI adapter with production dependencies."""
     formatted_system_prompt = DEFAULT_SYSTEM_PROMPT.format(
         current_datetime=datetime.now().isoformat()
     )
@@ -50,35 +39,13 @@ def main() -> None:
         system_prompt=formatted_system_prompt,
         model=DEFAULT_MODEL,
     )
-    run_agent = RunAgentUseCase(agent)
+    return CLIAdapter(RunAgentUseCase(agent))
 
-    # CLI loop
-    while True:
-        try:
-            # UI layer: user input
-            user_input = get_user_input()
-            if not user_input.strip():
-                continue
 
-            # Business logic layer: process request
-            response = with_indicator(
-                "Thinking",
-                lambda: run_agent.execute(RunAgentRequest(message=user_input)),
-            )
-
-            # UI layer: display results
-            show_agent_response(response)
-
-        except KeyboardInterrupt:
-            show_exit_message()
-            break
-        except EOFError:
-            # Handle EOF (e.g., piped input, terminal closed)
-            show_exit_message()
-            break
-        except Exception as e:
-            # UI layer: display user-friendly error message
-            show_error(e)
+def main() -> None:
+    """Run the CLI entry point."""
+    adapter = build_cli_adapter()
+    adapter.run()
 
 
 if __name__ == "__main__":

--- a/projects/simple-agent-poc/tests/test_cli.py
+++ b/projects/simple-agent-poc/tests/test_cli.py
@@ -1,0 +1,124 @@
+"""Tests for the CLI adapter."""
+
+from collections.abc import Callable
+from unittest.mock import MagicMock
+
+import pytest
+
+from simple_agent_poc.application import RunAgentResponse
+from simple_agent_poc.cli import CLIAdapter
+
+
+def passthrough_indicator(
+    message: str,
+    operation: Callable[[], RunAgentResponse],
+) -> RunAgentResponse:
+    """Run the operation immediately for deterministic tests."""
+    assert message == "Thinking"
+    return operation()
+
+
+class TestCLIAdapter:
+    """Tests for the CLI adapter."""
+
+    def test_run_delegates_to_use_case_and_renders_response(self) -> None:
+        run_agent = MagicMock()
+        run_agent.execute.return_value = RunAgentResponse(
+            message="Hello, user!",
+            usage={
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "total_tokens": 15,
+            },
+            model="gpt-4o-mini",
+            response_time=0.85,
+        )
+        input_reader = MagicMock(side_effect=["Hello", EOFError()])
+        response_renderer = MagicMock()
+        welcome_renderer = MagicMock()
+        exit_renderer = MagicMock()
+
+        adapter = CLIAdapter(
+            run_agent,
+            input_reader=input_reader,
+            response_renderer=response_renderer,
+            welcome_renderer=welcome_renderer,
+            exit_renderer=exit_renderer,
+            indicator_runner=passthrough_indicator,
+        )
+
+        adapter.run()
+
+        welcome_renderer.assert_called_once_with()
+        run_agent.execute.assert_called_once()
+        request = run_agent.execute.call_args.args[0]
+        assert request.message == "Hello"
+        response_renderer.assert_called_once_with(run_agent.execute.return_value)
+        exit_renderer.assert_called_once_with()
+
+    def test_run_skips_blank_input(self) -> None:
+        run_agent = MagicMock()
+        input_reader = MagicMock(side_effect=["   ", "\t", EOFError()])
+
+        adapter = CLIAdapter(
+            run_agent,
+            input_reader=input_reader,
+            indicator_runner=passthrough_indicator,
+        )
+
+        adapter.run()
+
+        run_agent.execute.assert_not_called()
+
+    @pytest.mark.parametrize("interrupt", [KeyboardInterrupt(), EOFError()])
+    def test_run_exits_cleanly_on_terminal_interrupts(
+        self,
+        interrupt: BaseException,
+    ) -> None:
+        exit_renderer = MagicMock()
+        run_agent = MagicMock()
+        input_reader = MagicMock(side_effect=[interrupt])
+
+        adapter = CLIAdapter(
+            run_agent,
+            input_reader=input_reader,
+            exit_renderer=exit_renderer,
+            indicator_runner=passthrough_indicator,
+        )
+
+        adapter.run()
+
+        run_agent.execute.assert_not_called()
+        exit_renderer.assert_called_once_with()
+
+    def test_run_shows_errors_and_continues(self) -> None:
+        run_agent = MagicMock()
+        recovered_response = RunAgentResponse(
+            message="Recovered",
+            usage={
+                "prompt_tokens": 2,
+                "completion_tokens": 1,
+                "total_tokens": 3,
+            },
+            model="gpt-4o-mini",
+            response_time=0.25,
+        )
+        run_agent.execute.side_effect = [RuntimeError("boom"), recovered_response]
+        input_reader = MagicMock(side_effect=["Hello", "Retry", EOFError()])
+        error_renderer = MagicMock()
+        response_renderer = MagicMock()
+
+        adapter = CLIAdapter(
+            run_agent,
+            input_reader=input_reader,
+            error_renderer=error_renderer,
+            response_renderer=response_renderer,
+            indicator_runner=passthrough_indicator,
+        )
+
+        adapter.run()
+
+        error_renderer.assert_called_once()
+        assert isinstance(error_renderer.call_args.args[0], RuntimeError)
+        assert run_agent.execute.call_count == 2
+        response_renderer.assert_called_once_with(recovered_response)

--- a/projects/simple-agent-poc/tests/test_main.py
+++ b/projects/simple-agent-poc/tests/test_main.py
@@ -1,0 +1,44 @@
+"""Tests for CLI entry point wiring."""
+
+from unittest.mock import MagicMock, patch
+
+from simple_agent_poc.main import DEFAULT_MODEL, build_cli_adapter, main
+
+
+class TestBuildCLIAdapter:
+    """Tests for production CLI wiring."""
+
+    @patch("simple_agent_poc.main.CLIAdapter")
+    @patch("simple_agent_poc.main.RunAgentUseCase")
+    @patch("simple_agent_poc.main.Agent")
+    @patch("simple_agent_poc.main.datetime")
+    def test_build_cli_adapter_wires_dependencies(
+        self,
+        mock_datetime: MagicMock,
+        mock_agent: MagicMock,
+        mock_use_case: MagicMock,
+        mock_cli_adapter: MagicMock,
+    ) -> None:
+        mock_datetime.now.return_value.isoformat.return_value = "2026-03-09T12:00:00"
+
+        adapter = build_cli_adapter()
+
+        assert adapter is mock_cli_adapter.return_value
+        mock_agent.assert_called_once()
+        assert mock_agent.call_args.kwargs["model"] == DEFAULT_MODEL
+        assert "2026-03-09T12:00:00" in mock_agent.call_args.kwargs["system_prompt"]
+        mock_use_case.assert_called_once_with(mock_agent.return_value)
+        mock_cli_adapter.assert_called_once_with(mock_use_case.return_value)
+
+
+class TestMain:
+    """Tests for the CLI entry point."""
+
+    @patch("simple_agent_poc.main.build_cli_adapter")
+    def test_main_runs_built_adapter(self, mock_build_cli_adapter: MagicMock) -> None:
+        adapter = mock_build_cli_adapter.return_value
+
+        main()
+
+        mock_build_cli_adapter.assert_called_once_with()
+        adapter.run.assert_called_once_with()


### PR DESCRIPTION
## Issues

- Closes #683
- Related #680

## Why

`simple-agent-poc` の CLI は主要な開発入口として維持したい一方で、対話ループやエラーハンドリングまで `main.py` が持つと、今後 HTTP などの別 entrypoint を追加する際に責務が混ざります。

CLI 固有の入出力を adapter 境界に閉じ、共有の application flow を明示的に通す形へ寄せる必要がありました。

## Summary

CLI の対話ループを専用 adapter に分離し、`main.py` は依存配線だけを担うように整理しました。あわせて CLI の委譲と終了処理を確認するテストを追加し、アーキテクチャ資料と README を現状に合わせて更新しました。

## Changes

- `src/simple_agent_poc/cli.py` を追加して stdin/stdout の対話ループと CLI 向け例外処理を移設
- `src/simple_agent_poc/main.py` を thin entrypoint に整理し、`RunAgentUseCase` への委譲を明示化
- CLI adapter の振る舞いと entrypoint 配線を確認するテストを追加
- README と architecture skill の責務定義を今回の構成に更新

## Checklist

- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run ty check .`
- [x] `uv run pytest`
