### PR TITLE
[simple-agent-poc] Support Session-Id header transport for chat API

### DIFF
--- a/projects/simple-agent-poc/README.md
+++ b/projects/simple-agent-poc/README.md
@@ -45,9 +45,14 @@ Continue the same conversation by sending back the returned `session_id`:
 
 ```bash
 curl -X POST http://127.0.0.1:8000/api/chat \
+  -H "Session-Id: <session-id>" \
   -H "Content-Type: application/json" \
-  -d '{"message":"Continue","session_id":"<session-id>"}'
+  -d '{"message":"Continue"}'
 ```
+
+`/api/chat` uses the `Session-Id` request header as the primary session transport.
+For compatibility, the JSON body still accepts an optional `session_id` for now. If both are
+sent, they must match; otherwise the API returns `400`.
 
 ## Architecture Direction
 
@@ -71,7 +76,8 @@ The process entrypoints live under `src/simple_agent_poc/entrypoints/`.
 ## Session Model
 
 - CLI keeps one in-process conversation and forwards the active `session_id` internally.
-- HTTP accepts an optional `session_id` and returns the effective `session_id` on every response.
+- HTTP accepts `Session-Id` as the primary session transport and returns the effective `session_id` on every response.
+- HTTP request-body `session_id` remains temporarily supported for compatibility, but it must match `Session-Id` when both are present.
 - The initial implementation uses an in-memory `SessionStore`; durable persistence is a later step.
 
 ## Development

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/api.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/api.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from typing import Annotated
 
-from fastapi import Depends, FastAPI, HTTPException
+from fastapi import Depends, FastAPI, Header, HTTPException
 from pydantic import BaseModel, ConfigDict, field_validator
 
 from simple_agent_poc.application.dto import RunAgentRequest, RunAgentResponse
@@ -50,6 +50,27 @@ class ChatResponse(BaseModel):
         )
 
 
+def resolve_session_id(
+    *,
+    header_session_id: str | None,
+    body_session_id: str | None,
+) -> str | None:
+    """Resolve the effective session ID across supported HTTP transports."""
+    if header_session_id is None:
+        return body_session_id
+
+    if body_session_id is None or body_session_id == header_session_id:
+        return header_session_id
+
+    raise HTTPException(
+        status_code=400,
+        detail=(
+            "Conflicting session_id values were provided in the Session-Id header "
+            "and request body."
+        ),
+    )
+
+
 def create_app(
     *,
     use_case_factory: Callable[[], RunAgentUseCase] | None = None,
@@ -65,12 +86,20 @@ def create_app(
     def chat(
         request: ChatRequest,
         run_agent: Annotated[RunAgentUseCase, Depends(get_run_agent_use_case)],
+        *,
+        session_id_header: Annotated[
+            str | None,
+            Header(alias="Session-Id"),
+        ] = None,
     ) -> ChatResponse:
         try:
             response = run_agent.execute(
                 RunAgentRequest(
                     message=request.message,
-                    session_id=request.session_id,
+                    session_id=resolve_session_id(
+                        header_session_id=session_id_header,
+                        body_session_id=request.session_id,
+                    ),
                 )
             )
         except SessionNotFoundError as error:

--- a/projects/simple-agent-poc/tests/test_api.py
+++ b/projects/simple-agent-poc/tests/test_api.py
@@ -87,7 +87,8 @@ class TestAPI:
         session_id = first_response.json()["session_id"]
         second_response = client.post(
             "/api/chat",
-            json={"message": "Again", "session_id": session_id},
+            headers={"Session-Id": session_id},
+            json={"message": "Again"},
         )
 
         assert first_response.status_code == 200
@@ -100,7 +101,33 @@ class TestAPI:
             {"role": "user", "content": "Again"},
         ]
 
-    def test_chat_returns_404_for_unknown_session(self) -> None:
+    def test_chat_accepts_body_session_id_for_compatibility(self) -> None:
+        store = InMemorySessionStore()
+        first_llm = StubLLMClient(reply="First")
+        second_llm = StubLLMClient(reply="Second")
+        llm_clients = iter([first_llm, second_llm])
+
+        app = create_app(
+            use_case_factory=lambda: RunAgentUseCase(
+                llm_client=next(llm_clients),
+                session_store=store,
+                system_prompt="System prompt",
+            )
+        )
+        client = TestClient(app)
+
+        first_response = client.post("/api/chat", json={"message": "Hello"})
+        session_id = first_response.json()["session_id"]
+        second_response = client.post(
+            "/api/chat",
+            json={"message": "Again", "session_id": session_id},
+        )
+
+        assert first_response.status_code == 200
+        assert second_response.status_code == 200
+        assert second_response.json()["message"] == "Second"
+
+    def test_chat_returns_404_for_unknown_session_header(self) -> None:
         app = create_app(
             use_case_factory=lambda: RunAgentUseCase(
                 llm_client=StubLLMClient(reply="unused"),
@@ -112,8 +139,33 @@ class TestAPI:
 
         response = client.post(
             "/api/chat",
-            json={"message": "Hello", "session_id": "missing-session"},
+            headers={"Session-Id": "missing-session"},
+            json={"message": "Hello"},
         )
 
         assert response.status_code == 404
         assert response.json() == {"detail": "Session not found."}
+
+    def test_chat_returns_400_for_conflicting_session_transports(self) -> None:
+        app = create_app(
+            use_case_factory=lambda: RunAgentUseCase(
+                llm_client=StubLLMClient(reply="unused"),
+                session_store=InMemorySessionStore(),
+                system_prompt="System prompt",
+            )
+        )
+        client = TestClient(app)
+
+        response = client.post(
+            "/api/chat",
+            headers={"Session-Id": "header-session"},
+            json={"message": "Hello", "session_id": "body-session"},
+        )
+
+        assert response.status_code == 400
+        assert response.json() == {
+            "detail": (
+                "Conflicting session_id values were provided in the "
+                "Session-Id header and request body."
+            )
+        }


### PR DESCRIPTION
## Issues
- Closes #699

## Why
HTTP chat API の session transport を body の `session_id` 依存から切り離し、今後の streaming 対応でも扱いやすい契約を先に明確化するためです。

## Summary
`/api/chat` で `Session-Id` ヘッダを受け付けるようにしました。互換のため request body の `session_id` は暫定サポートし、不一致時は `400` を返します。

## Changes
- HTTP アダプタで `Session-Id` ヘッダを読み取り、body と統合する解決ロジックを追加
- header 継続、body 互換、未知セッション、transport 競合の API テストを追加
- README を header ベースの契約と競合ルールに更新

## Checklist
- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run ty check .`
- [x] `uv run pytest`
