### PR TITLE
[file-server] Improve PDF viewer preview usability in modal

### DIFF
--- a/projects/file-server/src/components/PageShell.tsx
+++ b/projects/file-server/src/components/PageShell.tsx
@@ -104,6 +104,15 @@ export const PageShell: FC<PageShellProps> = ({ children, user }) => {
             height: -moz-available;
             height: stretch;
           }
+
+          .pdf-viewer-shell {
+            min-height: 0;
+          }
+
+          .pdf-viewer-frame {
+            display: block;
+            min-height: min(72vh, 56rem);
+          }
         `}</style>
       </head>
       <body className="box-border min-h-screen bg-gradient-to-br from-indigo-50 via-purple-50 to-pink-50 font-sans">

--- a/projects/file-server/src/components/file-viewer/FileViewerModal.tsx
+++ b/projects/file-server/src/components/file-viewer/FileViewerModal.tsx
@@ -14,6 +14,7 @@ interface FileViewerModalProps {
   animation?: string
   isEditing?: boolean
   showEdit?: boolean
+  layout?: "default" | "pdf"
   children: Child
 }
 
@@ -24,6 +25,7 @@ export const FileViewerModal: FC<FileViewerModalProps> = ({
   animation,
   isEditing = false,
   showEdit = false,
+  layout = "default",
   children,
 }) => {
   const encodedPath = path ? encodeURIComponent(path) : ""
@@ -63,6 +65,11 @@ export const FileViewerModal: FC<FileViewerModalProps> = ({
     </button>
   )
 
+  const panelClassName =
+    layout === "pdf"
+      ? `bg-white p-4 sm:p-6 rounded-[1.5rem] w-full max-w-6xl h-[92vh] max-h-[92vh] overflow-hidden flex flex-col border-4 border-${borderColor} ${animation || ""}`
+      : `bg-white p-6 rounded-2xl max-w-4xl w-full max-h-[80vh] overflow-hidden flex flex-col border-4 border-${borderColor} ${animation || ""}`
+
   return (
     <div id="file-viewer-container">
       <script
@@ -75,7 +82,7 @@ export const FileViewerModal: FC<FileViewerModalProps> = ({
         hx-on:click={closeScript}
       >
         <div
-          className={`bg-white p-6 rounded-2xl max-w-4xl w-full max-h-[80vh] overflow-hidden flex flex-col border-4 border-${borderColor} ${animation || ""}`}
+          className={panelClassName}
           hx-on:click="event.stopPropagation();"
         >
           <div className="flex justify-between items-center mb-4 pb-4 border-b-2 border-indigo-200 flex-shrink-0">

--- a/projects/file-server/src/components/file-viewer/PdfViewer.tsx
+++ b/projects/file-server/src/components/file-viewer/PdfViewer.tsx
@@ -7,10 +7,10 @@ interface PdfViewerProps {
 
 export const PdfViewer: FC<PdfViewerProps> = ({ fileUrl, fileName }) => {
   return (
-    <div className="flex-1 overflow-auto flex justify-center items-center">
+    <div className="pdf-viewer-shell flex-1 min-h-0">
       <iframe
         src={fileUrl}
-        className="w-full h-full border-2 border-indigo-200 rounded-xl"
+        className="pdf-viewer-frame h-full w-full rounded-xl border-2 border-indigo-200 bg-white"
         title={fileName || "PDF Viewer"}
       ></iframe>
     </div>

--- a/projects/file-server/src/components/file-viewer/index.tsx
+++ b/projects/file-server/src/components/file-viewer/index.tsx
@@ -83,6 +83,7 @@ export const FileViewer: FC<FileViewerProps> = ({
           fileName={fileName}
           path={path}
           borderColor="indigo-300"
+          layout="pdf"
         >
           <PdfViewer fileUrl={fileUrl} fileName={fileName} />
         </FileViewerModal>

--- a/projects/file-server/tests/read.test.ts
+++ b/projects/file-server/tests/read.test.ts
@@ -342,6 +342,25 @@ describe("file endpoint /file", () => {
     expect(text).not.toMatch(/<pre[^>]*>/)
   })
 
+  it("should render pdf viewer with pdf-specific modal layout", async () => {
+    await Bun.write(path.join(UPLOAD_DIR, "preview.pdf"), "fake pdf content")
+    const req = new Request("http://localhost/file?path=preview.pdf", {
+      method: "GET",
+      headers: { "HX-Request": "true" },
+    })
+
+    const res = await app.request(req)
+
+    expect(res.status).toBe(200)
+    const text = await res.text()
+    expect(text).toContain('src="/file/raw?path=preview.pdf"')
+    expect(text).toContain("max-w-6xl")
+    expect(text).toContain("h-[92vh] max-h-[92vh]")
+    expect(text).toContain("pdf-viewer-shell")
+    expect(text).toContain("pdf-viewer-frame")
+    expect(text).not.toContain("edit=true")
+  })
+
   it("should render a placeholder for empty text files in edit mode", async () => {
     await Bun.write(path.join(UPLOAD_DIR, "empty-edit.txt"), "")
     const req = new Request(


### PR DESCRIPTION
## Issues

- Closes #705

## Why

The PDF preview modal opened with an unstable visible area, so long documents could appear as only a thin slice on initial open. That made in-modal previewing hard to use and pushed users toward repeated scrolling or external viewing.

## Summary

This PR improves the shared file viewer modal for PDFs without changing the existing modal workflow. PDF previews now open in a larger, explicit-height layout with stable iframe sizing, while other viewer types remain unchanged.

## Changes

- add a PDF-specific layout variant to the shared file viewer modal
- give the PDF iframe container explicit height hooks so initial preview area is larger and more stable
- keep existing download, close, raw file URL, and auth/path validation flows unchanged
- add HTML test coverage for the PDF-specific modal layout hooks

## Checklist

- [x] `bun test`
- [x] `bun run lint`
- [x] Manual verification completed for the updated PDF modal behavior

## Test
<img width="1916" height="966" alt="image" src="https://github.com/user-attachments/assets/e099ac20-626d-4eb0-b465-a9661b0b5011" />

