### PR TITLE
fix(file-server): add text mode fallback to default viewer

### DIFF
--- a/projects/file-server/src/components/file-viewer/DefaultViewer.tsx
+++ b/projects/file-server/src/components/file-viewer/DefaultViewer.tsx
@@ -1,11 +1,29 @@
 import type { FC } from "hono/jsx"
+import { secondaryButtonClassName } from "../buttonStyles"
 
-export const DefaultViewer: FC = () => {
-  return (
-    <div className="flex-1 overflow-auto flex justify-center items-center">
-      <p className="mb-6 text-gray-600 text-lg text-center">
-        This file type cannot be displayed in the browser.
-      </p>
-    </div>
-  )
+interface DefaultViewerProps {
+	path?: string
+}
+
+export const DefaultViewer: FC<DefaultViewerProps> = ({ path }) => {
+	const encodedPath = path ? encodeURIComponent(path) : ""
+
+	return (
+		<div className="flex flex-1 flex-col items-center justify-center gap-6 overflow-auto rounded-xl border-2 border-dashed border-purple-200 bg-gradient-to-br from-purple-50 to-pink-50 p-8 text-center">
+			<p className="text-lg text-gray-600">
+				This file type cannot be displayed in the browser.
+			</p>
+			{path ? (
+				<button
+					type="button"
+					hx-get={`/file?path=${encodedPath}&view=text`}
+					hx-target="#file-viewer-container"
+					hx-swap="outerHTML"
+					className={secondaryButtonClassName}
+				>
+					Open as text
+				</button>
+			) : null}
+		</div>
+	)
 }

--- a/projects/file-server/src/components/file-viewer/index.tsx
+++ b/projects/file-server/src/components/file-viewer/index.tsx
@@ -13,6 +13,7 @@ interface FileViewerProps {
   fileName?: string
   path?: string
   isEditing?: boolean
+  allowEdit?: boolean
 }
 
 export const FileViewer: FC<FileViewerProps> = ({
@@ -21,6 +22,7 @@ export const FileViewer: FC<FileViewerProps> = ({
   fileName,
   path,
   isEditing = false,
+  allowEdit = true,
 }) => {
   const encodedPath = path ? encodeURIComponent(path) : ""
   const fileUrl = `/file/raw?path=${encodedPath}`
@@ -34,22 +36,22 @@ export const FileViewer: FC<FileViewerProps> = ({
           path={path}
           borderColor="indigo-300"
           isEditing={true}
-          showEdit={true}
+          showEdit={allowEdit}
         >
           <TextEditor content={content} path={path} />
         </FileViewerModal>
       )
     }
     return (
-      <FileViewerModal
-        fileName={fileName}
-        path={path}
-        borderColor="indigo-300"
-        showEdit={true}
-      >
-        <TextViewer content={content} />
-      </FileViewerModal>
-    )
+        <FileViewerModal
+          fileName={fileName}
+          path={path}
+          borderColor="indigo-300"
+          showEdit={allowEdit}
+        >
+          <TextViewer content={content} />
+        </FileViewerModal>
+      )
   }
 
   // バイナリファイルの場合
@@ -99,7 +101,7 @@ export const FileViewer: FC<FileViewerProps> = ({
       borderColor="purple-300"
       animation="animate-[slideIn_0.2s_ease-out]"
     >
-      <DefaultViewer />
+      <DefaultViewer path={path} />
     </FileViewerModal>
   )
 }

--- a/projects/file-server/src/routes/file.tsx
+++ b/projects/file-server/src/routes/file.tsx
@@ -129,6 +129,7 @@ fileRoutes.get("/", async (c) => {
 
   const mimeType = mime.lookup(resolvedFile) || "application/octet-stream"
   const isText = isTextMime(mimeType)
+  const forceTextView = c.req.query("view") === "text"
   const isHtmx = isHtmxRequest(c)
 
   // htmxリクエストでない場合（リロード時）は親ディレクトリにリダイレクト
@@ -139,9 +140,9 @@ fileRoutes.get("/", async (c) => {
     return c.redirect(redirectPath)
   }
 
-  if (isText) {
+  if (isText || forceTextView) {
     const content = await readFile(resolvedFile, "utf-8")
-    const isEditing = c.req.query("edit") === "true"
+    const isEditing = !forceTextView && c.req.query("edit") === "true"
     return renderWithShell(
       c,
       <FileViewer
@@ -149,6 +150,7 @@ fileRoutes.get("/", async (c) => {
         fileName={path.basename(resolvedFile)}
         path={requestPath}
         isEditing={isEditing}
+        allowEdit={!forceTextView}
       />,
     )
   }

--- a/projects/file-server/tests/read.test.ts
+++ b/projects/file-server/tests/read.test.ts
@@ -361,6 +361,48 @@ describe("file endpoint /file", () => {
     expect(text).not.toContain("edit=true")
   })
 
+  it("should offer text view toggle for unsupported file types", async () => {
+    await Bun.write(
+      path.join(UPLOAD_DIR, "config.custom"),
+      JSON.stringify({ hello: "world" }),
+    )
+    const req = new Request("http://localhost/file?path=config.custom", {
+      method: "GET",
+      headers: { "HX-Request": "true" },
+    })
+
+    const res = await app.request(req)
+
+    expect(res.status).toBe(200)
+    const text = await res.text()
+    expect(text).toContain("This file type cannot be displayed in the browser.")
+    expect(text).toContain('hx-get="/file?path=config.custom&amp;view=text"')
+    expect(text).toContain("Open as text")
+  })
+
+  it("should render unsupported file types as text when text view is requested", async () => {
+    await Bun.write(
+      path.join(UPLOAD_DIR, "config.custom"),
+      JSON.stringify({ hello: "world" }),
+    )
+    const req = new Request(
+      "http://localhost/file?path=config.custom&view=text",
+      {
+        method: "GET",
+        headers: { "HX-Request": "true" },
+      },
+    )
+
+    const res = await app.request(req)
+
+    expect(res.status).toBe(200)
+    const text = await res.text()
+    expect(text).toContain('{&quot;hello&quot;:&quot;world&quot;}')
+    expect(text).toMatch(/<pre[^>]*>/)
+    expect(text).not.toContain("Open as text")
+    expect(text).not.toContain("edit=true")
+  })
+
   it("should render a placeholder for empty text files in edit mode", async () => {
     await Bun.write(path.join(UPLOAD_DIR, "empty-edit.txt"), "")
     const req = new Request(


### PR DESCRIPTION
## Issues

- None

## Why

DefaultViewer で開かれる未対応ファイルでも、実体がテキストなら内容を確認したいケースがあります。MIME 判定だけで閲覧不能にすると、中身が読めず運用上困るため、明示的にテキスト表示へ切り替えられる導線を追加します。

## Summary

DefaultViewer に `Open as text` ボタンを追加し、`view=text` クエリで強制的にテキスト表示できるようにしました。強制テキスト表示時は既存の編集導線を出さず、閲覧専用にしています。

## Changes

- DefaultViewer にテキスト表示切り替えボタンを追加
- `/file` で `view=text` を受け取り、未対応 MIME でも UTF-8 として読み込む処理を追加
- 強制テキスト表示時は `Edit` ボタンを表示しないように調整
- read テストに切り替え導線と表示結果の検証を追加

## Checklist

- [x] `bun test tests/read.test.ts`
- [x] `bun run lint`

## Test
<img width="1399" height="581" alt="image" src="https://github.com/user-attachments/assets/58cac67b-0b00-41c1-8395-904f1ad7b181" />
<img width="1236" height="415" alt="image" src="https://github.com/user-attachments/assets/3337b206-ae1d-4286-8d74-f27b61dd2591" />
