### PR TITLE
fix(file-server): fix file upload on iOS mobile browsers

### DIFF
--- a/projects/file-server/src/components/file-list/DropUploadForm.tsx
+++ b/projects/file-server/src/components/file-list/DropUploadForm.tsx
@@ -1,19 +1,31 @@
+import { fileInputChangeScript } from "./clientActions"
+
 interface DropUploadFormProps {
-	requestPath: string
+  requestPath: string
 }
 
 export function DropUploadForm({ requestPath }: DropUploadFormProps) {
-	return (
-		<form
-			id="drop-upload-form"
-			hx-post="/api/upload"
-			hx-target="#file-list-container"
-			hx-swap="innerHTML"
-			hx-encoding="multipart/form-data"
-			className="hidden"
-		>
-			<input type="hidden" name="path" value={requestPath} />
-			<input type="file" name="files" id="drop-upload-input" multiple />
-		</form>
-	)
+  return (
+    <>
+      <form
+        id="drop-upload-form"
+        hx-post="/api/upload"
+        hx-target="#file-list-container"
+        hx-swap="innerHTML"
+        hx-encoding="multipart/form-data"
+        className="hidden"
+      >
+        <input type="hidden" name="path" value={requestPath} />
+      </form>
+      <input
+        type="file"
+        name="files"
+        id="drop-upload-input"
+        multiple
+        form="drop-upload-form"
+        className="absolute opacity-0 w-px h-px overflow-hidden"
+        hx-on:change={fileInputChangeScript}
+      />
+    </>
+  )
 }

--- a/projects/file-server/src/components/file-list/clientActions.ts
+++ b/projects/file-server/src/components/file-list/clientActions.ts
@@ -1,10 +1,10 @@
 const ACTIVE_TOGGLE_CLASSES =
-	"'ring-2', 'ring-purple-400', 'bg-purple-50', 'border-purple-300', 'text-purple-700'"
+  "'ring-2', 'ring-purple-400', 'bg-purple-50', 'border-purple-300', 'text-purple-700'"
 
 export const toggleCreateFormScript = (
-	formId: string,
-	otherFormId: string,
-	otherButtonId: string,
+  formId: string,
+  otherFormId: string,
+  otherButtonId: string,
 ) => `
 	const form = document.getElementById('${formId}');
 	const otherForm = document.getElementById('${otherFormId}');
@@ -49,11 +49,17 @@ export const dropZoneDropScript = `
 `
 
 export const openUploadDialogScript =
-	"document.getElementById('drop-upload-input').click()"
+  "document.getElementById('drop-upload-input').click()"
+
+export const fileInputChangeScript =
+  "if (this.files.length > 0) htmx.trigger(document.getElementById('drop-upload-form'), 'submit')"
 
 export const stopPropagationScript = "event.stopPropagation()"
 
-export const renameButtonScript = (renameFormId: string, renameInputId: string) => `
+export const renameButtonScript = (
+  renameFormId: string,
+  renameInputId: string,
+) => `
 	event.stopPropagation();
 	const form = document.getElementById('${renameFormId}');
 	const input = document.getElementById('${renameInputId}');


### PR DESCRIPTION
## Summary

- iOSのモバイルブラウザ（Safari / Chrome）でファイルアップロードが空うちになる問題を修正
- `display: none` な要素内の `<input type="file">` に対して `.click()` を呼び出しても、iOS WebKit はファイルピッカーを開かない
- ファイル選択後にフォームを submit するハンドラが存在しなかった問題も同時に修正

## Changes

- `DropUploadForm.tsx`: file input をフォーム外に移し `form="drop-upload-form"` で関連付け。`display: none` を回避するため `absolute opacity-0 w-px h-px` でvisual-onlyに非表示化
- `clientActions.ts`: `fileInputChangeScript` を追加 — ファイル選択後に `htmx.trigger` でフォームを submit

## Test plan

- [ ] iPhone の Chrome / Safari でページを開き、アップロードアイコンをタップ → ファイルピッカーが開く
- [ ] ファイルを選択 → アップロードが実行されファイルリストに表示される
- [ ] デスクトップで drag-and-drop / クリックアップロードが引き続き動作する
- [ ] `bun test` が通る (103 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)