### PR TITLE
CI: update GitHub Actions workflows for Node 24

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -14,14 +14,22 @@ on:
         description: "Comma separated project directories"
         required: true
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
+
 jobs:
   docker-build-if-changes-detected:
     # Dockerコマンドを使用するため、ubuntu-slimでは利用できない
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.ref || github.ref }}
           # プッシュイベントでは直前のコミットとの差分で十分

--- a/.github/workflows/pullrequest-check.yml
+++ b/.github/workflows/pullrequest-check.yml
@@ -6,14 +6,22 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pull-request-check-if-changes-detected:
     # Docker commands require ubuntu-latest, ubuntu-slim is not available
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # PRのベースブランチとの差分取得に必要な履歴深度
           # 50コミットあれば通常のPRの変更はカバーできる


### PR DESCRIPTION
## Issues
- Close #735

## Why
GitHub Actions で `actions/checkout@v4` に対する Node.js 20 deprecation warning が出ており、2026-06-02 以降の runner 変更前に workflow を追随させる必要がありました。

## Summary
CI/CD workflow の `actions/checkout` を Node.js 24 対応の v6 に更新しました。
あわせて `permissions`、`concurrency`、`timeout-minutes` を追加し、重複実行とハングに強い設定へ整えました。

## Changes
- `.github/workflows/pullrequest-check.yml` の `actions/checkout` を `v6` に更新
- `.github/workflows/docker-build.yml` の `actions/checkout` を `v6` に更新
- 両 workflow に `permissions: contents: read` を追加
- PR workflow に `concurrency` と `timeout-minutes: 20` を追加
- CD workflow に `concurrency` と `timeout-minutes: 45` を追加

## Checklist
- [x] `actions/checkout@v4` を Node.js 24 対応版へ更新
- [x] workflow 権限を最小権限へ明示
- [x] PR と push の重複実行制御を追加
- [x] job timeout を追加
- [x] `git diff --check` を実行
- [x] Python で workflow YAML のパース確認を実行

## Details
- `workflow_dispatch` 実行は自動 cancel されないようにし、手動実行を潰さない設定にしています。
- ローカルの composite action は Node runtime 非依存のため今回の変更対象に含めていません。
