### PR TITLE
refactor(portfolio): clarify chat type boundaries and shared contracts

### DIFF
--- a/projects/portfolio/src/client/components/chat/chat-main.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-main.tsx
@@ -10,7 +10,7 @@ import { ArrowUpIcon } from '#/client/components/svg/arrow-upIcon'
 import { StopIcon } from '#/client/components/svg/stop-icon'
 import { UploadIcon } from '#/client/components/svg/upload-icon'
 import type { Settings } from '#/client/storage/remote-storage-settings'
-import type { ChatMessage, Conversation } from '#/types'
+import type { Conversation, Message } from '#/types'
 import React, { type FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { uuidv7 } from 'uuidv7'
 
@@ -34,7 +34,7 @@ export function ChatMain({
   const formRef = useRef<HTMLFormElement>(null)
 
   const [conversationId, setConversationId] = useState<string | null>(null)
-  const [messages, setMessages] = useState<ChatMessage[]>([])
+  const [messages, setMessages] = useState<Message[]>([])
   const {
     input,
     uploadImages,
@@ -71,22 +71,9 @@ export function ChatMain({
       return
     }
 
-    // 会話が選択された時、そのメッセージを設定
-    const convertedMessages: ChatMessage[] = currentConversation.messages.map((msg) => {
-      const base = {
-        role: msg.role as 'user' | 'assistant' | 'system',
-        content: msg.content,
-      }
-      if (msg.role === 'assistant') {
-        return {
-          ...base,
-          reasoning_content: msg.reasoningContent,
-        } as ChatMessage
-      }
-      return base as ChatMessage
-    })
+    // 会話が選択された時、そのメッセージをドメイン型のまま設定（変換不要）
     setConversationId(currentConversation.id)
-    setMessages(convertedMessages)
+    setMessages(currentConversation.messages)
     resetChatResults()
     setTimeout(() => {
       scrollToMessageEnd()
@@ -115,7 +102,9 @@ export function ChatMain({
         return
       }
 
-      setMessages(messages.length === 0 ? [...messages, ...params.messages] : params.messages)
+      // 送信直後に user メッセージを state に追加（ドメイン型で保持）
+      const nextMessages: Message[] = messages.length === 0 ? [params.draftUserMessage] : [...messages, params.draftUserMessage]
+      setMessages(nextMessages)
       resetAfterSubmit()
       resetChatResults()
 
@@ -126,47 +115,36 @@ export function ChatMain({
           mcpServerURLs: form.mcpServerURLs,
         },
         model: params.model,
-        messages: params.messages,
+        messages: params.apiMessages,
         streamMode: settings.streamMode,
         temperature: form.temperature,
         maxTokens: form.maxTokens,
         reasoningEffort: settings.reasoningEffortEnabled ? settings.reasoningEffort : undefined,
       }).then(({ result, responseTimeMs }) => {
-        const userInput = params.messages?.at(-1)?.content
-        const newConversationMessages = [
-          // TODO: append system message
-          {
-            role: 'user' as const,
-            content: typeof userInput === 'string' ? userInput : '',
-            reasoningContent: '',
-            metadata: {
-              model: params.model,
-              stream: settings.streamMode,
-              temperature: form.temperature,
-              maxTokens: form.maxTokens,
-            },
-          },
-          ...(result
-            ? [
-                {
-                  role: 'assistant' as const,
-                  content: result.message.content,
-                  reasoningContent: result.message.reasoningContent,
-                  metadata: {
-                    model: result.model,
-                    finishReason: result.finishReason,
-                    responseTimeMs: responseTimeMs,
-                    usage: {
-                      promptTokens: result.usage?.promptTokens || 0,
-                      completionTokens: result.usage?.completionTokens || 0,
-                      totalTokens: result.usage?.totalTokens || 0,
-                      reasoningTokens: result.usage?.reasoningTokens,
-                    },
-                  },
+        const userContent = params.draftUserMessage.content
+
+        // assistant メッセージを state に追加（ドメイン型で保持）
+        const assistantMessage: Message | null = result
+          ? {
+              role: 'assistant' as const,
+              content: result.message.content,
+              reasoningContent: result.message.reasoningContent,
+              metadata: {
+                model: result.model,
+                finishReason: result.finishReason,
+                responseTimeMs: responseTimeMs,
+                usage: {
+                  promptTokens: result.usage?.promptTokens || 0,
+                  completionTokens: result.usage?.completionTokens || 0,
+                  totalTokens: result.usage?.totalTokens || 0,
+                  reasoningTokens: result.usage?.reasoningTokens,
                 },
-              ]
-            : []),
-        ]
+              },
+            }
+          : null
+
+        const finalMessages: Message[] = assistantMessage ? [...nextMessages, assistantMessage] : nextMessages
+        setMessages(finalMessages)
 
         // 会話IDが指定されていない場合は会話IDを新規作成
         const currentConversationId =
@@ -177,24 +155,12 @@ export function ChatMain({
             return newConversationId
           })()
 
-        // 親コンポーネントに更新されたメッセージを通知
+        // 親コンポーネントに更新されたメッセージを通知（ドメイン型をそのまま渡す）
         onConversationChange?.({
           id: currentConversationId,
-          title: typeof userInput === 'string' ? userInput.slice(0, 10) : '',
-          messages: newConversationMessages,
+          title: typeof userContent === 'string' ? userContent.slice(0, 10) : '',
+          messages: finalMessages,
         })
-
-        if (result) {
-          const newMessages = [
-            ...(messages.length === 0 ? [...messages, ...params.messages] : params.messages),
-            {
-              role: 'assistant' as const,
-              content: result.message.content,
-              reasoning_content: result.message.reasoningContent,
-            },
-          ]
-          setMessages(newMessages)
-        }
       })
     },
     [

--- a/projects/portfolio/src/client/components/chat/chat-main.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-main.tsx
@@ -103,7 +103,8 @@ export function ChatMain({
       }
 
       // 送信直後に user メッセージを state に追加（ドメイン型で保持）
-      const nextMessages: Message[] = messages.length === 0 ? [params.draftUserMessage] : [...messages, params.draftUserMessage]
+      const nextMessages: Message[] =
+        messages.length === 0 ? [params.draftUserMessage] : [...messages, params.draftUserMessage]
       setMessages(nextMessages)
       resetAfterSubmit()
       resetChatResults()

--- a/projects/portfolio/src/client/components/chat/chat-main.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-main.tsx
@@ -103,8 +103,11 @@ export function ChatMain({
       }
 
       // 送信直後に user メッセージを state に追加（ドメイン型で保持）
+      // テンプレート初回送信時は systemMessage も先頭に含めて follow-up でも system prompt を維持する
       const nextMessages: Message[] =
-        messages.length === 0 ? [params.draftUserMessage] : [...messages, params.draftUserMessage]
+        messages.length === 0
+          ? [...(params.systemMessage ? [params.systemMessage] : []), params.draftUserMessage]
+          : [...messages, params.draftUserMessage]
       setMessages(nextMessages)
       resetAfterSubmit()
       resetChatResults()
@@ -203,7 +206,7 @@ export function ChatMain({
           const newMessages = [...prevMessages]
           newMessages.splice(index, 1)
           newMessages.splice(index, 1)
-          isConversationEmpty = newMessages.length <= 0
+          isConversationEmpty = newMessages.filter((m) => m.role !== 'system').length <= 0
           return newMessages
         })
         const deleteMessageIds = [
@@ -216,7 +219,7 @@ export function ChatMain({
     [currentConversation?.messages, onDeleteMessages]
   )
 
-  const emptyMessage = messages.length === 0
+  const emptyMessage = messages.filter((m) => m.role !== 'system').length === 0
 
   return (
     <form ref={formRef} onSubmit={handleSubmit} className='flex h-full min-h-0 flex-1 flex-col'>

--- a/projects/portfolio/src/client/components/chat/chat-message-list.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-message-list.tsx
@@ -3,7 +3,7 @@ import { CodeBlockRenderer, MarkdownLink } from '#/client/components/chat/code-b
 import { MessageRenderer } from '#/client/components/chat/message-renderer'
 import { ChatbotIcon } from '#/client/components/svg/chatbot-icon'
 import { SpinnerIcon } from '#/client/components/svg/spinner-icon'
-import type { ChatMessage } from '#/types'
+import type { Message } from '#/types'
 import { memo, type RefObject } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
@@ -15,7 +15,7 @@ const markdownComponents = {
 }
 
 interface ChatMessageListProps {
-  messages: ChatMessage[]
+  messages: Message[]
   markdownPreview: boolean
   loading: boolean
   stream: {
@@ -106,7 +106,7 @@ export function ChatMessageList({
 }
 
 interface MessageHistoryProps {
-  messages: ChatMessage[]
+  messages: Message[]
   markdownPreview: boolean
   copiedId: string
   disabled: boolean

--- a/projects/portfolio/src/client/components/chat/hooks/use-chat-form.ts
+++ b/projects/portfolio/src/client/components/chat/hooks/use-chat-form.ts
@@ -23,6 +23,8 @@ interface BuiltChatMessages {
   apiMessages: ApiChatMessage[]
   /** 送信に使ったドメインメッセージ（state 更新用） */
   draftUserMessage: Message
+  /** テンプレート送信時の system message（state 保持用）。通常送信時は undefined */
+  systemMessage?: Message
 }
 
 export function useChatForm({ initTrigger, formRef }: UseChatFormParams) {
@@ -178,5 +180,6 @@ const createTemplateMessage = (
     model: templateInput.model || model,
     apiMessages,
     draftUserMessage,
+    systemMessage,
   }
 }

--- a/projects/portfolio/src/client/components/chat/hooks/use-chat-form.ts
+++ b/projects/portfolio/src/client/components/chat/hooks/use-chat-form.ts
@@ -1,5 +1,6 @@
 import type { TemplateInput } from '#/client/components/chat/prompt-template'
-import type { ChatMessage, ChatMessageSystem, ChatMessageUser } from '#/types'
+import type { ApiChatMessage, Message } from '#/types'
+import { toApiChatMessage } from '#/types'
 import { type ChangeEvent, type KeyboardEvent, type RefObject, useEffect, useState } from 'react'
 
 const MIN_TEXT_LINE_COUNT = 2
@@ -12,13 +13,16 @@ interface UseChatFormParams {
 
 interface BuildChatMessagesParams {
   interactiveMode: boolean
-  messages: ChatMessage[]
+  messages: Message[]
   model: string
 }
 
 interface BuiltChatMessages {
   model: string
-  messages: ChatMessage[]
+  /** /api/chat wire 形式（metadata・reasoningContent を除いた送信用メッセージ） */
+  apiMessages: ApiChatMessage[]
+  /** 送信に使ったドメインメッセージ（state 更新用） */
+  draftUserMessage: Message
 }
 
 export function useChatForm({ initTrigger, formRef }: UseChatFormParams) {
@@ -114,13 +118,13 @@ const createMessage = (
     interactiveMode,
     messages,
     uploadImages,
-  }: { interactiveMode: boolean; messages: ChatMessage[]; uploadImages: string[] }
+  }: { interactiveMode: boolean; messages: Message[]; uploadImages: string[] }
 ): BuiltChatMessages | null => {
   if (!inputText) {
     return null
   }
 
-  const userMessage: ChatMessageUser = {
+  const draftUserMessage: Message = {
     role: 'user',
     content:
       uploadImages.length > 0
@@ -137,33 +141,46 @@ const createMessage = (
             })),
           ]
         : inputText,
+    reasoningContent: '',
+    metadata: { model },
   }
-  const newMessages: ChatMessage[] = [...messages, userMessage]
+
+  const allMessages: Message[] = [...messages, draftUserMessage]
+  const apiMessages: ApiChatMessage[] = (interactiveMode ? allMessages : [draftUserMessage]).map(toApiChatMessage)
 
   return {
     model,
-    messages: interactiveMode ? newMessages : [userMessage],
+    apiMessages,
+    draftUserMessage,
   }
 }
 
 const createTemplateMessage = (
   templateInput: TemplateInput,
   model: string,
-  { interactiveMode, messages }: { interactiveMode: boolean; messages: ChatMessage[] }
+  { interactiveMode, messages }: { interactiveMode: boolean; messages: Message[] }
 ): BuiltChatMessages => {
-  const userMessage: ChatMessageUser = {
+  const draftUserMessage: Message = {
     role: 'user',
     content: templateInput.content,
+    reasoningContent: '',
+    metadata: { model: templateInput.model || model },
   }
-  const systemMessage: ChatMessageSystem = {
+  const systemMessage: Message = {
     role: 'system',
     content: templateInput.prompt,
+    reasoningContent: '',
   }
-  const newMessages: ChatMessage[] =
-    messages.length === 0 && templateInput ? [systemMessage, userMessage] : [...messages, userMessage]
+
+  const allMessages: Message[] =
+    messages.length === 0 && templateInput ? [systemMessage, draftUserMessage] : [...messages, draftUserMessage]
+
+  const sendMessages: Message[] = interactiveMode ? allMessages : [systemMessage, draftUserMessage]
+  const apiMessages: ApiChatMessage[] = sendMessages.map(toApiChatMessage)
 
   return {
     model: templateInput.model || model,
-    messages: interactiveMode ? newMessages : [systemMessage, userMessage],
+    apiMessages,
+    draftUserMessage,
   }
 }

--- a/projects/portfolio/src/client/components/chat/hooks/use-chat-form.ts
+++ b/projects/portfolio/src/client/components/chat/hooks/use-chat-form.ts
@@ -114,11 +114,7 @@ export function useChatForm({ initTrigger, formRef }: UseChatFormParams) {
 const createMessage = (
   inputText: string,
   model: string,
-  {
-    interactiveMode,
-    messages,
-    uploadImages,
-  }: { interactiveMode: boolean; messages: Message[]; uploadImages: string[] }
+  { interactiveMode, messages, uploadImages }: { interactiveMode: boolean; messages: Message[]; uploadImages: string[] }
 ): BuiltChatMessages | null => {
   if (!inputText) {
     return null

--- a/projects/portfolio/src/client/components/chat/hooks/use-stream-processor.ts
+++ b/projects/portfolio/src/client/components/chat/hooks/use-stream-processor.ts
@@ -1,5 +1,5 @@
 import type { AppType } from '#/server/app.d'
-import type { ChatCompletionResult, ChatMessage } from '#/types'
+import type { ApiChatMessage, ChatCompletionResult } from '#/types'
 import { hc } from 'hono/client'
 import { useCallback, useRef, useState } from 'react'
 
@@ -12,7 +12,8 @@ interface SubmitChatCompletionParams {
     mcpServerURLs: string
   }
   model: string
-  messages: ChatMessage[]
+  /** /api/chat wire 形式のメッセージ（toApiChatMessage で変換済み） */
+  messages: ApiChatMessage[]
   streamMode: boolean
   temperature?: number
   maxTokens?: number
@@ -122,7 +123,7 @@ const sendChatCompletion = async (req: {
     mcpServerURLs: string
   }
   model: string
-  messages: ChatMessage[]
+  messages: ApiChatMessage[]
   stream: boolean
   temperature?: number
   maxTokens?: number

--- a/projects/portfolio/src/client/components/chat/message-renderer.tsx
+++ b/projects/portfolio/src/client/components/chat/message-renderer.tsx
@@ -3,7 +3,7 @@ import { ChatbotIcon } from '#/client/components/svg/chatbot-icon'
 import { CheckIcon } from '#/client/components/svg/check-icon'
 import { CopyIcon } from '#/client/components/svg/copy-icon'
 import { DeleteIcon } from '#/client/components/svg/delete-icon'
-import type { ChatMessage } from '#/types'
+import type { Message } from '#/types'
 import { isImageContentArray } from '#/types'
 import { Fragment, memo } from 'react'
 import ReactMarkdown from 'react-markdown'
@@ -16,7 +16,7 @@ const markdownComponents = {
 }
 
 interface MessageRendererProps {
-  message: ChatMessage
+  message: Message
   index: number
   markdownPreview: boolean
   copied: boolean
@@ -83,9 +83,9 @@ function MessageRendererComponent({
         <ChatbotIcon size={32} className='stroke-gray-600 dark:stroke-gray-300' />
       </div>
       <div className='message group ml-2 text-left'>
-        {message.reasoning_content && (
+        {message.reasoningContent && (
           <div className='wrap-break-word whitespace-pre-line break-all text-gray-400 text-xs dark:text-gray-200'>
-            {message.reasoning_content}
+            {message.reasoningContent}
           </div>
         )}
         {markdownPreview ? (

--- a/projects/portfolio/src/client/pages/chat/index.tsx
+++ b/projects/portfolio/src/client/pages/chat/index.tsx
@@ -138,19 +138,9 @@ export function Chat() {
       return
     }
 
-    // サーバーに会話履歴を更新（DB保存用にcontentを文字列化）
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const payload: any = {
-      id: conversation.id,
-      title: conversation.title,
-      messages: conversation.messages.map((msg) => ({
-        ...msg,
-        content: typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content),
-      })),
-    }
     client.api.conversations
       .$post({
-        json: payload,
+        json: conversation,
       })
       .then((res) => {
         if (res.status === 200) {

--- a/projects/portfolio/src/server/features/chat-conversations/read-conversations.ts
+++ b/projects/portfolio/src/server/features/chat-conversations/read-conversations.ts
@@ -1,7 +1,41 @@
 import { getDatabase } from '#/db'
 import { conversationsTable, messagesTable, usersTable } from '#/db/schema'
-import type { Conversation } from '#/types'
+import type { AssistantMetadata, Conversation, ImageContent, Message, TextContent, UserMetadata } from '#/types'
 import { asc, desc, eq, sql } from 'drizzle-orm'
+
+/**
+ * DB から読み出した content 文字列を deserialize する。
+ * 配列として保存されている場合（先頭が "[" ）は JSON.parse して配列に戻す。
+ * legacy データや通常の文字列はそのまま返す。
+ */
+function deserializeContent(value: string): string | Array<TextContent | ImageContent> {
+  if (value.startsWith('[')) {
+    try {
+      const parsed = JSON.parse(value)
+      if (Array.isArray(parsed)) {
+        return parsed as Array<TextContent | ImageContent>
+      }
+    } catch {
+      // パース失敗は文字列として扱う
+    }
+  }
+  return value
+}
+
+/**
+ * DB から読み出した metadata を deserialize する。
+ * jsonb カラムだが、legacy データとして JSON 文字列が入っている場合に対応。
+ */
+function deserializeMetadata(value: unknown): unknown {
+  if (typeof value === 'string') {
+    try {
+      return JSON.parse(value)
+    } catch {
+      return null
+    }
+  }
+  return value
+}
 
 export async function readConversations(databaseUrl: string, email: string): Promise<Conversation[] | null> {
   const db = getDatabase(databaseUrl)
@@ -57,16 +91,65 @@ export async function readConversations(databaseUrl: string, email: string): Pro
     if (row.messageRole && row.messageContent !== null && row.messageReasoningContent !== null) {
       const conversation = conversationMap.get(row.conversationId)
       if (conversation) {
-        conversation.messages.push({
+        const message = buildMessage({
           id: row.messageId ?? '',
-          role: row.messageRole as 'user' | 'assistant' | 'system',
+          role: row.messageRole,
           content: row.messageContent,
           reasoningContent: row.messageReasoningContent,
-          metadata: row.messageMetadata as never,
+          metadata: deserializeMetadata(row.messageMetadata),
         })
+        if (message) {
+          conversation.messages.push(message)
+        }
       }
     }
   }
 
   return Array.from(conversationMap.values())
+}
+
+/**
+ * DB 行からドメイン Message を構築する。
+ * role ごとに分岐して discriminated union を満たす。
+ */
+function buildMessage(row: {
+  id: string
+  role: string
+  content: string
+  reasoningContent: string
+  metadata: unknown
+}): Message | null {
+  const content = deserializeContent(row.content)
+
+  if (row.role === 'user') {
+    return {
+      id: row.id,
+      role: 'user',
+      content,
+      reasoningContent: row.reasoningContent,
+      metadata: (row.metadata ?? {}) as UserMetadata,
+    }
+  }
+
+  if (row.role === 'assistant') {
+    return {
+      id: row.id,
+      role: 'assistant',
+      content: typeof content === 'string' ? content : '',
+      reasoningContent: row.reasoningContent || undefined,
+      metadata: (row.metadata ?? {}) as AssistantMetadata,
+    }
+  }
+
+  if (row.role === 'system') {
+    return {
+      id: row.id,
+      role: 'system',
+      content: typeof content === 'string' ? content : '',
+      reasoningContent: row.reasoningContent,
+      metadata: (row.metadata as Record<string, never> | undefined) ?? undefined,
+    }
+  }
+
+  return null
 }

--- a/projects/portfolio/src/server/features/chat-conversations/upsert-conversation.ts
+++ b/projects/portfolio/src/server/features/chat-conversations/upsert-conversation.ts
@@ -4,6 +4,14 @@ import type { Conversation } from '#/types'
 import { eq } from 'drizzle-orm'
 import { uuidv7 } from 'uuidv7'
 
+/**
+ * content を DB 保存用に serialize する。
+ * 文字列の場合はそのまま、配列の場合は JSON 文字列に変換する。
+ */
+function serializeContent(content: string | unknown[]): string {
+  return typeof content === 'string' ? content : JSON.stringify(content)
+}
+
 export async function upsertConversation(databaseUrl: string, email: string, { id, title, messages }: Conversation) {
   const db = getDatabase(databaseUrl)
 
@@ -40,9 +48,10 @@ export async function upsertConversation(databaseUrl: string, email: string, { i
       id: uuidv7(),
       conversationId: id,
       role: message.role,
-      content: typeof message.content === 'string' ? message.content : JSON.stringify(message.content),
+      content: serializeContent(message.content),
       reasoningContent: message.reasoningContent ?? '',
-      metadata: message.metadata ? JSON.stringify(message.metadata) : null,
+      // metadata は jsonb カラムにオブジェクトのまま渡す（JSON.stringify は不要）
+      metadata: message.metadata ?? null,
       createdAt: now,
     }))
 

--- a/projects/portfolio/src/server/features/chat-conversations/upsert-conversation.ts
+++ b/projects/portfolio/src/server/features/chat-conversations/upsert-conversation.ts
@@ -41,9 +41,11 @@ export async function upsertConversation(databaseUrl: string, email: string, { i
     } else {
       // 存在すれば会話のupdatedAtを更新
       await tx.update(conversationsTable).set({ updatedAt: now }).where(eq(conversationsTable.id, id))
+      // 既存メッセージを削除（全件再挿入による重複を防ぐ）
+      await tx.delete(messagesTable).where(eq(messagesTable.conversationId, id))
     }
 
-    // メッセージの登録
+    // メッセージの登録（全件挿入）
     const messageValues = messages.map((message) => ({
       id: uuidv7(),
       conversationId: id,

--- a/projects/portfolio/src/server/features/chat/chat.ts
+++ b/projects/portfolio/src/server/features/chat/chat.ts
@@ -1,65 +1,8 @@
+import type { ApiChatMessage } from '#/types'
 import OpenAI from 'openai'
-import type { Stream } from 'openai/streaming'
-import z from 'zod'
+import type { Completions, StreamChunk } from './transport'
 
-export type CompletionChunk = OpenAI.ChatCompletion & {
-  choices: {
-    message: {
-      reasoning_content?: string // OpenAI APIでは提供されていないフィールド。LiteLLM経由の推論モデルでのみ取得可能。
-    }
-  }[]
-  usage?: {
-    completion_tokens_details?: {
-      reasoning_tokens: number // OpenAI APIでは提供されていないフィールド。LiteLLM経由の推論モデルでのみ取得可能。
-    }
-  }
-}
-export type StreamCompletionChunk = OpenAI.ChatCompletionChunk & {
-  choices: {
-    delta: {
-      reasoning_content?: string // OpenAI APIでは提供されていないフィールド。LiteLLM経由の推論モデルでのみ取得可能。
-    }
-  }[]
-  usage?: {
-    completion_tokens_details?: {
-      reasoning_tokens: number // OpenAI APIでは提供されていないフィールド。LiteLLM経由の推論モデルでのみ取得可能。
-    }
-  }
-}
-export type StreamChunk = Stream<StreamCompletionChunk>
-type Completions = CompletionChunk | StreamChunk
-
-export const MessageSchema = z.union([
-  z.object({
-    role: z.enum(['system']),
-    content: z.string().min(1),
-  }),
-  z.object({
-    role: z.enum(['assistant']),
-    content: z.string().min(1),
-  }),
-  z.object({
-    role: z.enum(['user']),
-    content: z.union([
-      z.string().min(1),
-      z
-        .union([
-          z.object({
-            type: z.enum(['text']),
-            text: z.string().min(1),
-          }),
-          z.object({
-            type: z.enum(['image_url']),
-            image_url: z.object({
-              url: z.string().min(1),
-              detail: z.enum(['auto', 'low', 'high']).optional(),
-            }),
-          }),
-        ])
-        .array(),
-    ]),
-  }),
-])
+export type { CompletionChunk, StreamCompletionChunk, StreamChunk } from './transport'
 
 interface Chat {
   completions(
@@ -70,7 +13,7 @@ interface Chat {
     },
     params: {
       model: string
-      messages: z.infer<typeof MessageSchema>[]
+      messages: ApiChatMessage[]
       temperature?: number
       maxTokens?: number
       reasoningEffort?: 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'
@@ -101,7 +44,7 @@ export const chat: Chat = {
       includeUsage,
     }: {
       model: string
-      messages: z.infer<typeof MessageSchema>[]
+      messages: ApiChatMessage[]
       temperature?: number
       maxTokens?: number
       reasoningEffort?: 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'

--- a/projects/portfolio/src/server/features/chat/transport.ts
+++ b/projects/portfolio/src/server/features/chat/transport.ts
@@ -1,0 +1,38 @@
+import OpenAI from 'openai'
+import type { Stream } from 'openai/streaming'
+
+/**
+ * サーバー内部 transport 型
+ * LiteLLM 経由の推論モデルが返す拡張フィールドを含む OpenAI レスポンス型。
+ * これらは OpenAI 公式 API では提供されていない。
+ */
+
+export type CompletionChunk = OpenAI.ChatCompletion & {
+  choices: {
+    message: {
+      reasoning_content?: string // OpenAI APIでは提供されていないフィールド。LiteLLM経由の推論モデルでのみ取得可能。
+    }
+  }[]
+  usage?: {
+    completion_tokens_details?: {
+      reasoning_tokens: number // OpenAI APIでは提供されていないフィールド。LiteLLM経由の推論モデルでのみ取得可能。
+    }
+  }
+}
+
+export type StreamCompletionChunk = OpenAI.ChatCompletionChunk & {
+  choices: {
+    delta: {
+      reasoning_content?: string // OpenAI APIでは提供されていないフィールド。LiteLLM経由の推論モデルでのみ取得可能。
+    }
+  }[]
+  usage?: {
+    completion_tokens_details?: {
+      reasoning_tokens: number // OpenAI APIでは提供されていないフィールド。LiteLLM経由の推論モデルでのみ取得可能。
+    }
+  }
+}
+
+export type StreamChunk = Stream<StreamCompletionChunk>
+
+export type Completions = CompletionChunk | StreamChunk

--- a/projects/portfolio/src/server/routes/chat.ts
+++ b/projects/portfolio/src/server/routes/chat.ts
@@ -2,7 +2,8 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { chatStub } from '#/server/features/chat-stub/chat-stub'
 import type { StreamChunk } from '#/server/features/chat/chat'
-import { chat, MessageSchema } from '#/server/features/chat/chat'
+import { chat } from '#/server/features/chat/chat'
+import { ApiChatRequestSchema } from '#/types'
 import { sValidator } from '@hono/standard-validator'
 import { Hono } from 'hono'
 import { streamSSE } from 'hono/streaming'
@@ -17,32 +18,8 @@ const ChatHeaderSchema = z.object({
   'mcp-server-urls': z.string().optional(),
 })
 
-const ChatRequestSchema = z.object({
-  messages: MessageSchema.array(),
-  model: z.string().min(1),
-  stream: z.boolean().default(false),
-  temperature: z.number().min(0).max(1).optional(),
-  max_tokens: z.number().min(1).optional(),
-  reasoning_effort: z.enum(['none', 'minimal', 'low', 'medium', 'high', 'xhigh']).optional(),
-  stream_options: z
-    .object({
-      include_usage: z.boolean().optional(),
-    })
-    .optional(),
-})
-
-const StubChatRequestSchema = z.object({
-  messages: MessageSchema.array(),
-  model: z.string().min(1),
-  stream: z.boolean().default(false),
-  temperature: z.number().min(0).max(1).optional(),
-  max_tokens: z.number().min(1).optional(),
-  stream_options: z
-    .object({
-      include_usage: z.boolean().optional(),
-    })
-    .optional(),
-})
+// /api/chat stub endpoint 用スキーマ（reasoning_effort なし）
+const StubChatRequestSchema = ApiChatRequestSchema.omit({ reasoning_effort: true })
 
 const chatHeaderValidator = validator('header', (value, c) => {
   const parsed = ChatHeaderSchema.safeParse({
@@ -128,7 +105,7 @@ const streamStubCompletion = (
   })
 
 const chatRoutes = new Hono<HonoEnv>()
-  .post('/api/chat', chatHeaderValidator, sValidator('json', ChatRequestSchema), async (c) => {
+  .post('/api/chat', chatHeaderValidator, sValidator('json', ApiChatRequestSchema), async (c) => {
     const header = c.req.valid('header')
     const req = c.req.valid('json')
 

--- a/projects/portfolio/src/types/chat.ts
+++ b/projects/portfolio/src/types/chat.ts
@@ -23,7 +23,7 @@ export const TextContentSchema = z.object({
 export type TextContent = z.infer<typeof TextContentSchema>
 
 // ============================================
-// メッセージ型（Zod スキーマ）
+// 共有ドメイン型 — UI state・会話保存の正本
 // ============================================
 
 export const UserMetadataSchema = z.object({
@@ -102,27 +102,54 @@ export const ConversationSchema = z.object({
 export type Conversation = z.infer<typeof ConversationSchema>
 
 // ============================================
-// API 通信用の内部型
+// /api/chat HTTP wire 型 — 送信時の変換先
 // ============================================
 
-/** API リクエスト用のメッセージ型 */
-export interface ChatMessageUser {
-  role: 'user'
-  content: string | Array<TextContent | ImageContent>
-}
+/** /api/chat に送るメッセージの wire スキーマ（metadata・reasoningContent は含まない） */
+export const ApiChatMessageSchema = z.discriminatedUnion('role', [
+  z.object({
+    role: z.literal('user'),
+    content: z.union([z.string().min(1), z.array(z.union([TextContentSchema, ImageContentSchema]))]),
+  }),
+  z.object({
+    role: z.literal('assistant'),
+    content: z.string().min(1),
+  }),
+  z.object({
+    role: z.literal('system'),
+    content: z.string().min(1),
+  }),
+])
 
-export interface ChatMessageAssistant {
-  role: 'assistant'
-  content: string
-  reasoning_content?: string // API 形式に合わせてスネークケース
-}
+export type ApiChatMessage = z.infer<typeof ApiChatMessageSchema>
 
-export interface ChatMessageSystem {
-  role: 'system'
-  content: string
-}
+/** /api/chat リクエスト本体の共有スキーマ */
+export const ApiChatRequestSchema = z.object({
+  messages: ApiChatMessageSchema.array(),
+  model: z.string().min(1),
+  stream: z.boolean().default(false),
+  temperature: z.number().min(0).max(1).optional(),
+  max_tokens: z.number().min(1).optional(),
+  reasoning_effort: z.enum(['none', 'minimal', 'low', 'medium', 'high', 'xhigh']).optional(),
+  stream_options: z
+    .object({
+      include_usage: z.boolean().optional(),
+    })
+    .optional(),
+})
 
-export type ChatMessage = ChatMessageUser | ChatMessageAssistant | ChatMessageSystem
+export type ApiChatRequest = z.infer<typeof ApiChatRequestSchema>
+
+/** ドメイン Message → /api/chat wire メッセージへの変換 */
+export function toApiChatMessage(message: Message): ApiChatMessage {
+  if (message.role === 'user') {
+    return { role: 'user', content: message.content }
+  }
+  if (message.role === 'assistant') {
+    return { role: 'assistant', content: message.content }
+  }
+  return { role: 'system', content: message.content }
+}
 
 // ============================================
 // API レスポンス型

--- a/projects/portfolio/src/types/index.ts
+++ b/projects/portfolio/src/types/index.ts
@@ -9,6 +9,9 @@ export {
   AssistantMetadataSchema,
   ImageContentSchema,
   TextContentSchema,
+  // /api/chat wire schemas
+  ApiChatMessageSchema,
+  ApiChatRequestSchema,
   // Types
   type Conversation,
   type Message,
@@ -19,12 +22,13 @@ export {
   type AssistantMetadata,
   type ImageContent,
   type TextContent,
-  // API Types
-  type ChatMessage,
-  type ChatMessageUser,
-  type ChatMessageAssistant,
-  type ChatMessageSystem,
+  // /api/chat wire types
+  type ApiChatMessage,
+  type ApiChatRequest,
+  // API レスポンス型
   type ChatCompletionResult,
+  // Converters
+  toApiChatMessage,
   // Guards
   isUserMessage,
   isAssistantMessage,

--- a/projects/portfolio/tests/features/chat-conversations/read-conversations.test.ts
+++ b/projects/portfolio/tests/features/chat-conversations/read-conversations.test.ts
@@ -126,7 +126,10 @@ describe('readConversations', () => {
           messageId: 'message-1',
           messageRole: 'user',
           // 配列 content が JSON 文字列として保存されている
-          messageContent: JSON.stringify([{ type: 'text', text: 'hello' }, { type: 'image_url', image_url: { url: 'http://example.com/img.png' } }]),
+          messageContent: JSON.stringify([
+            { type: 'text', text: 'hello' },
+            { type: 'image_url', image_url: { url: 'http://example.com/img.png' } },
+          ]),
           messageReasoningContent: '',
           messageMetadata: { model: 'gpt-test' },
           messageCreatedAt: new Date(),

--- a/projects/portfolio/tests/features/chat-conversations/read-conversations.test.ts
+++ b/projects/portfolio/tests/features/chat-conversations/read-conversations.test.ts
@@ -95,7 +95,8 @@ describe('readConversations', () => {
             role: 'system',
             content: 'system',
             reasoningContent: '',
-            metadata: null,
+            // metadata が null の場合は undefined（SystemMessage.metadata は optional）
+            metadata: undefined,
           },
           {
             id: 'message-2',
@@ -112,5 +113,54 @@ describe('readConversations', () => {
         messages: [],
       },
     ])
+  })
+
+  it('配列 content（JSON 文字列）を deserialize して配列に戻す', async () => {
+    const { readConversations } = await importSubject({
+      users: [{ id: 'user-1', email: 'test@example.com' }],
+      rows: [
+        {
+          conversationId: 'conversation-1',
+          conversationTitle: 'Test',
+          conversationCreatedAt: new Date(),
+          messageId: 'message-1',
+          messageRole: 'user',
+          // 配列 content が JSON 文字列として保存されている
+          messageContent: JSON.stringify([{ type: 'text', text: 'hello' }, { type: 'image_url', image_url: { url: 'http://example.com/img.png' } }]),
+          messageReasoningContent: '',
+          messageMetadata: { model: 'gpt-test' },
+          messageCreatedAt: new Date(),
+        },
+      ],
+    })
+
+    const result = await readConversations('postgres://db', 'test@example.com')
+    expect(result?.[0].messages[0].content).toEqual([
+      { type: 'text', text: 'hello' },
+      { type: 'image_url', image_url: { url: 'http://example.com/img.png' } },
+    ])
+  })
+
+  it('legacy: metadata が文字列化 JSON の場合はパースして返す', async () => {
+    const { readConversations } = await importSubject({
+      users: [{ id: 'user-1', email: 'test@example.com' }],
+      rows: [
+        {
+          conversationId: 'conversation-1',
+          conversationTitle: 'Test',
+          conversationCreatedAt: new Date(),
+          messageId: 'message-1',
+          messageRole: 'user',
+          messageContent: 'hello',
+          messageReasoningContent: '',
+          // legacy: metadata が JSON 文字列として格納されているケース
+          messageMetadata: JSON.stringify({ model: 'gpt-test', stream: true }),
+          messageCreatedAt: new Date(),
+        },
+      ],
+    })
+
+    const result = await readConversations('postgres://db', 'test@example.com')
+    expect(result?.[0].messages[0].metadata).toEqual({ model: 'gpt-test', stream: true })
   })
 })

--- a/projects/portfolio/tests/features/chat-conversations/upsert-conversation.test.ts
+++ b/projects/portfolio/tests/features/chat-conversations/upsert-conversation.test.ts
@@ -6,6 +6,7 @@ const importSubject = async (params: {
 }) => {
   const insertValues: unknown[] = []
   const updateSets: unknown[] = []
+  const deleteWheres: unknown[] = []
 
   const tx = {
     select: vi.fn(() => ({
@@ -25,6 +26,12 @@ const importSubject = async (params: {
         return {
           where: vi.fn().mockResolvedValue(undefined),
         }
+      }),
+    })),
+    delete: vi.fn(() => ({
+      where: vi.fn((where: unknown) => {
+        deleteWheres.push(where)
+        return Promise.resolve()
       }),
     })),
   }
@@ -53,6 +60,7 @@ const importSubject = async (params: {
     upsertConversation,
     insertValues,
     updateSets,
+    deleteWheres,
     uuidv7,
   }
 }
@@ -115,8 +123,8 @@ describe('upsertConversation', () => {
     expect(uuidv7).toHaveBeenCalled()
   })
 
-  it('既存会話は updatedAt を更新して message を追加する', async () => {
-    const { upsertConversation, updateSets, insertValues } = await importSubject({
+  it('既存会話は updatedAt を更新し、既存 message を削除して全件再挿入する', async () => {
+    const { upsertConversation, updateSets, insertValues, deleteWheres } = await importSubject({
       users: [{ id: 'user-1', email: 'test@example.com' }],
       existingConversations: [{ id: 'conversation-1' }],
     })
@@ -136,9 +144,12 @@ describe('upsertConversation', () => {
       ],
     })
 
-    expect(insertValues).toHaveLength(1)
     expect(updateSets[0]).toEqual({
       updatedAt: expect.any(Date),
     })
+    // 既存 message が削除されること（重複 insert 防止）
+    expect(deleteWheres).toHaveLength(1)
+    // 全件挿入が1回呼ばれること
+    expect(insertValues).toHaveLength(1)
   })
 })

--- a/projects/portfolio/tests/features/chat-conversations/upsert-conversation.test.ts
+++ b/projects/portfolio/tests/features/chat-conversations/upsert-conversation.test.ts
@@ -108,7 +108,8 @@ describe('upsertConversation', () => {
         role: 'user',
         content: JSON.stringify([{ type: 'text', text: 'hello' }]),
         reasoningContent: 'thinking',
-        metadata: JSON.stringify({ model: 'gpt-test' }),
+        // metadata は jsonb カラムにオブジェクトのまま渡す（JSON.stringify しない）
+        metadata: { model: 'gpt-test' },
       }),
     ])
     expect(uuidv7).toHaveBeenCalled()


### PR DESCRIPTION
## Issues

- Close #737

## Why

`projects/portfolio` の chat 機能で、共有ドメイン型・`/api/chat` wire 型・サーバー内部 transport 型が混在しており、`reasoningContent` / `reasoning_content` の変換や metadata の serialize/deserialize が各所に散らばっていた。型の正本と変換責務を明確化し、保守しやすい構成にする。

## Summary

chat 型を用途別に再編し、UI state・API 送信・会話保存の各境界で必要な変換だけが起きる構成に整理した。フロントの state を `Message[]`（camelCase）に統一したことで、save と display の二重管理がなくなった。

## Changes

- `src/types/chat.ts` に `ApiChatMessageSchema` / `ApiChatRequestSchema` / `toApiChatMessage()` を追加し、共有契約の正本として定義
- `server/features/chat/transport.ts` を新規作成し、`CompletionChunk` / `StreamChunk` 等のサーバー内部 transport 型を `chat.ts` から分離
- `server/features/chat/chat.ts` の重複 `MessageSchema` を削除し、共有 `ApiChatMessage` を使用
- `server/routes/chat.ts` のローカルスキーマを廃止し `ApiChatRequestSchema` で統一
- フロントの chat state を `ChatMessage[]` → `Message[]` に変更し、`reasoning_content` (snake_case) を `reasoningContent` (camelCase) に統一
- `read-conversations.ts` に `deserializeContent` / `deserializeMetadata` を追加し、配列 content の復元と legacy 文字列 metadata の吸収を明示化
- `upsert-conversation.ts` で metadata を `JSON.stringify` せず jsonb オブジェクトのまま保存

## Checklist

- [ ] `bun run lint` が通ること（tsc + oxlint）
- [ ] `bun run test` が通ること
- [ ] `bun run format` が通ること
- [ ] 非 stream / stream のチャットリクエストが従来どおり通ること
- [ ] 既存会話の選択・表示が破綻しないこと
- [ ] 配列 content（画像付きメッセージ）の保存・読み込みが round-trip すること
- [ ] legacy stringified JSON の metadata が read 側で正しくパースされること