### PR TITLE
docs(portfolio): add policy sections to AGENTS.md

### DIFF
--- a/projects/portfolio/AGENTS.md
+++ b/projects/portfolio/AGENTS.md
@@ -34,3 +34,27 @@
 
 - **Test**: `bun run test`
 - **Test Coverage**: `bun run test:coverage`
+
+## Why / What / Constraints First
+
+Before implementation, clarify the following concisely as needed.
+
+- **Why**: Why it is needed
+- **What**: What must be satisfied
+- **Constraints**: Assumptions and constraints to follow
+
+**How** refers to the implementation itself and is intentionally excluded here.  
+Express How through design and code.
+
+## Test Policy
+
+- Design test cases as living documentation (specifications).
+- Each test file has a top-level `describe` naming the module, command, or use case.
+- Use `it()` for test cases; names should not repeat context already in `describe` — lead with the expected result or failure condition.
+- 1–3 tests with a single responsibility: one level of `describe`.
+- 4+ tests or multiple responsibilities: use nested `describe` to separate concerns; headings alone should convey the boundary.
+- Nested `describe` splits by public function, responsibility, or user-facing behavior — not by implementation detail.
+
+## Review Policy
+
+- Always review in Japanese.

--- a/projects/portfolio/CLAUDE.md
+++ b/projects/portfolio/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Why

AGENTS.md にプロジェクト共通のポリシーが不足しており、実装・テスト・レビューの方針が暗黙知になっていた。また Claude Code 向けの設定ファイル（CLAUDE.md）が存在しなかった。

## Summary

AGENTS.md にポリシーセクションを追加し、Claude Code が読み込む CLAUDE.md を新規追加した。CLAUDE.md は `@AGENTS.md` で参照する形式とし、Claude Code でも AGENTS.md の内容が自動的にコンテキストに組み込まれることを確認済み。

## Changes

- Add `## Why / What / Constraints First` section to AGENTS.md
- Add `## Test Policy` section with `it()` and `describe` conventions to AGENTS.md
- Add `## Review Policy` section to AGENTS.md
- Add `CLAUDE.md` referencing AGENTS.md via `@AGENTS.md`

## Checklist

- [x] 英語で統一
- [x] 箇条書きスタイルを既存セクションに合わせた
- [x] `it()` 表記をテストポリシーに明記
- [x] CLAUDE.md を追加し Claude Code での動作確認済み