### PR TITLE
test(portfolio): verify Docker test stage format failure

### DIFF
--- a/projects/portfolio/.gitignore
+++ b/projects/portfolio/.gitignore
@@ -4,3 +4,4 @@ dist/
 coverage/
 .env
 .tanstack
+.codex

--- a/projects/portfolio/Dockerfile
+++ b/projects/portfolio/Dockerfile
@@ -55,6 +55,7 @@ COPY --from=bun /usr/local/bin/bun /usr/local/bin/
 COPY . .
 
 RUN bun install --frozen-lockfile \
+  && bun run format:check \
   && bun run lint \
   && bun run test:coverage \
   && bun run typegen \

--- a/projects/portfolio/tests/setup.ts
+++ b/projects/portfolio/tests/setup.ts
@@ -1,6 +1,6 @@
 import { afterEach, vi } from 'vitest'
 
-afterEach(  () => {
+afterEach(() => {
   vi.restoreAllMocks()
   vi.unstubAllGlobals()
   vi.unstubAllEnvs()

--- a/projects/portfolio/tests/setup.ts
+++ b/projects/portfolio/tests/setup.ts
@@ -1,6 +1,6 @@
 import { afterEach, vi } from 'vitest'
 
-afterEach(() => {
+afterEach(  () => {
   vi.restoreAllMocks()
   vi.unstubAllGlobals()
   vi.unstubAllEnvs()


### PR DESCRIPTION
## Why

Docker の test ステージに `format:check` を追加したため、未整形コードがある PR で実際に fail することを確認したい。

## Summary

`Dockerfile` の test ステージで `bun run format:check` を実行するようにした。
あわせて `tests/setup.ts` に最小の未整形差分を入れ、CI が意図どおり失敗する状態を作った。

## Changes

- Docker test ステージに `bun run format:check` を追加
- `tests/setup.ts` に意図的なフォーマット崩れを追加

## Checklist

- [x] `bun run format:check` がローカルで失敗することを確認
- [ ] GitHub Actions / Docker test stage が失敗することを確認
