### PR TITLE
refactor(portfolio): extract chat magic numbers into named constants

### DIFF
--- a/projects/portfolio/src/client/components/chat/chat-main.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-main.tsx
@@ -12,6 +12,8 @@ import { UploadIcon } from '#/client/components/svg/upload-icon'
 import type { Settings } from '#/client/storage/remote-storage-settings'
 import type { Conversation, Message } from '#/types'
 import React, { type FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+const CONVERSATION_TITLE_MAX_LENGTH = 10
 import { uuidv7 } from 'uuidv7'
 
 interface Props {
@@ -162,7 +164,7 @@ export function ChatMain({
         // 親コンポーネントに更新されたメッセージを通知（ドメイン型をそのまま渡す）
         onConversationChange?.({
           id: currentConversationId,
-          title: typeof userContent === 'string' ? userContent.slice(0, 10) : '',
+          title: typeof userContent === 'string' ? userContent.slice(0, CONVERSATION_TITLE_MAX_LENGTH) : '',
           messages: finalMessages,
         })
       })

--- a/projects/portfolio/src/server/features/chat-stub/chat-stub.ts
+++ b/projects/portfolio/src/server/features/chat-stub/chat-stub.ts
@@ -15,6 +15,9 @@ interface ChatStub {
   }): Promise<void>
 }
 
+const STREAM_CHUNK_SIZE = 5
+const STUB_REPEAT_COUNT = 3
+
 export const chatStub: ChatStub = {
   async completions(model: string, content: string): Promise<CompletionChunk> {
     return {
@@ -75,16 +78,14 @@ export const chatStub: ChatStub = {
       ],
       usage: null,
     }
-    const chunkSize = 5
-    const repeatCount = 3
     const contentList = [
-      `これからストリームで返すデータは ${repeatCount} 回繰り返します 🚀`,
+      `これからストリームで返すデータは ${STUB_REPEAT_COUNT} 回繰り返します 🚀`,
       '\n\n',
-      ...splitByLength(content.repeat(repeatCount), chunkSize),
+      ...splitByLength(content.repeat(STUB_REPEAT_COUNT), STREAM_CHUNK_SIZE),
       'ストリームの終端です 🚀',
     ]
     const chunkList = [
-      ...splitByLength(reasoningContent, chunkSize).map((text) => ({
+      ...splitByLength(reasoningContent, STREAM_CHUNK_SIZE).map((text) => ({
         content: undefined,
         reasoning_content: text,
       })),


### PR DESCRIPTION
## Issues

- Close #671

## Why

チャット関連ファイルに散在するマジックナンバーが、値の意味や変更時の影響範囲を分かりにくくしていた。名前付き定数に置き換えることで可読性と保守性を向上させる。

## Summary

`chat-stub.ts` と `chat-main.tsx` のインラインリテラルを、目的を示す定数名に抽出した。動作の変更はなく、既存テストはすべて通過している。

## Changes

- `chat-stub.ts`: `chunkSize = 5` → `STREAM_CHUNK_SIZE`、`repeatCount = 3` → `STUB_REPEAT_COUNT` をモジュールレベル定数として定義
- `chat-main.tsx`: タイトル切り出し文字数 `10` → `CONVERSATION_TITLE_MAX_LENGTH` として定義

## Checklist

- [x] lint 通過 (`bun run lint`)
- [x] テスト通過 (`bun run test`: 53 tests passed)
- [x] フォーマット適用 (`bun run format`)
- [x] 動作変更なし（定数値は元のリテラルと同一）
