### PR TITLE
feat(portfolio): add language selector to code block renderer (#559)

### DIFF
--- a/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
+++ b/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
@@ -111,24 +111,23 @@ export function CodeBlockRenderer({ className, children }: CodeBlockRendererProp
     setCopied(false)
   }
 
-  const headerBg = isDarkMode ? 'bg-[#282c34]' : 'bg-gray-100'
-  const textColor = isDarkMode ? 'text-gray-300' : 'text-gray-600'
-  const iconStroke = isDarkMode ? 'stroke-white' : 'stroke-gray-600'
-  const optionStyle = {
-    backgroundColor: isDarkMode ? '#282c34' : '#f3f4f6',
+  const selectOptionStyle = {
+    backgroundColor: isDarkMode ? '#282c34' : '#ffffff',
     color: isDarkMode ? '#d1d5db' : '#4b5563',
   }
 
   return (
     <>
-      <div className={`flex items-center justify-between px-2 py-1 ${headerBg}`}>
+      <div className='flex items-center justify-between'>
         <select
           value={selectedLanguage}
           onChange={(e) => setSelectedLanguage(e.target.value)}
-          className={`cursor-pointer rounded border-none text-xs ${headerBg} ${textColor}`}
+          className={`cursor-pointer rounded border-none text-xs ${
+            isDarkMode ? 'bg-[#282c34] text-gray-300' : 'bg-white text-gray-600'
+          }`}
         >
           {languageOptions.map((lang) => (
-            <option key={lang} value={lang} style={optionStyle}>
+            <option key={lang} value={lang} style={selectOptionStyle}>
               {lang}
             </option>
           ))}
@@ -141,13 +140,13 @@ export function CodeBlockRenderer({ className, children }: CodeBlockRendererProp
         >
           {copied ? (
             <>
-              <CheckIcon size={18} className={iconStroke} />
-              <span className={`text-xs ${textColor}`}>コピーしました</span>
+              <CheckIcon size={18} className='stroke-white' />
+              <span className='text-white text-xs'>コピーしました</span>
             </>
           ) : (
             <>
-              <CopyIcon size={18} className={iconStroke} />
-              <span className={`text-xs ${textColor}`}>コピーする</span>
+              <CopyIcon size={18} className='stroke-white' />
+              <span className='text-white text-xs'>コピーする</span>
             </>
           )}
         </button>

--- a/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
+++ b/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
@@ -1,4 +1,5 @@
 import { copyToClipboard } from '#/client/components/chat/copy-to-clipboard'
+import { useDarkMode } from '#/client/hooks/use-dark-mode'
 import { CheckIcon } from '#/client/components/svg/check-icon'
 import { CopyIcon } from '#/client/components/svg/copy-icon'
 import type { AnchorHTMLAttributes, HTMLAttributes, MouseEvent, ReactNode } from 'react'
@@ -78,7 +79,7 @@ type CodeBlockRendererProps = HTMLAttributes<HTMLElement> & {
 }
 
 export function CodeBlockRenderer({ className, children }: CodeBlockRendererProps) {
-  const isDarkMode = document.documentElement.classList.contains('dark')
+  const isDarkMode = useDarkMode()
   const [copied, setCopied] = useState(false)
 
   const code = typeof children === 'string' ? children : Array.isArray(children) ? children.join('') : ''

--- a/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
+++ b/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
@@ -111,16 +111,24 @@ export function CodeBlockRenderer({ className, children }: CodeBlockRendererProp
     setCopied(false)
   }
 
+  const headerBg = isDarkMode ? 'bg-[#282c34]' : 'bg-gray-100'
+  const textColor = isDarkMode ? 'text-gray-300' : 'text-gray-600'
+  const iconStroke = isDarkMode ? 'stroke-white' : 'stroke-gray-600'
+  const optionStyle = {
+    backgroundColor: isDarkMode ? '#282c34' : '#f3f4f6',
+    color: isDarkMode ? '#d1d5db' : '#4b5563',
+  }
+
   return (
     <>
-      <div className='flex items-center justify-between'>
+      <div className={`flex items-center justify-between px-2 py-1 ${headerBg}`}>
         <select
           value={selectedLanguage}
           onChange={(e) => setSelectedLanguage(e.target.value)}
-          className='cursor-pointer border-none bg-transparent text-xs text-white'
+          className={`cursor-pointer rounded border-none text-xs ${headerBg} ${textColor}`}
         >
           {languageOptions.map((lang) => (
-            <option key={lang} value={lang}>
+            <option key={lang} value={lang} style={optionStyle}>
               {lang}
             </option>
           ))}
@@ -133,13 +141,13 @@ export function CodeBlockRenderer({ className, children }: CodeBlockRendererProp
         >
           {copied ? (
             <>
-              <CheckIcon size={18} className='stroke-white' />
-              <span className='text-white text-xs'>コピーしました</span>
+              <CheckIcon size={18} className={iconStroke} />
+              <span className={`text-xs ${textColor}`}>コピーしました</span>
             </>
           ) : (
             <>
-              <CopyIcon size={18} className='stroke-white' />
-              <span className='text-white text-xs'>コピーする</span>
+              <CopyIcon size={18} className={iconStroke} />
+              <span className={`text-xs ${textColor}`}>コピーする</span>
             </>
           )}
         </button>

--- a/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
+++ b/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
@@ -28,6 +28,51 @@ export function MarkdownLink({ href, children }: MarkdownLinkProps) {
   )
 }
 
+const SUPPORTED_LANGUAGES = [
+  'plain',
+  'bash',
+  'c',
+  'cpp',
+  'csharp',
+  'css',
+  'dart',
+  'diff',
+  'docker',
+  'elixir',
+  'erlang',
+  'go',
+  'graphql',
+  'http',
+  'java',
+  'javascript',
+  'json',
+  'jsx',
+  'kotlin',
+  'lua',
+  'makefile',
+  'markup',
+  'markdown',
+  'nginx',
+  'objectivec',
+  'perl',
+  'php',
+  'powershell',
+  'python',
+  'r',
+  'ruby',
+  'rust',
+  'scala',
+  'scss',
+  'sql',
+  'swift',
+  'toml',
+  'tsx',
+  'typescript',
+  'vim',
+  'yaml',
+  'zig',
+]
+
 type CodeBlockRendererProps = HTMLAttributes<HTMLElement> & {
   children?: ReactNode | string
 }
@@ -35,12 +80,25 @@ type CodeBlockRendererProps = HTMLAttributes<HTMLElement> & {
 export function CodeBlockRenderer({ className, children }: CodeBlockRendererProps) {
   const isDarkMode = document.documentElement.classList.contains('dark')
   const [copied, setCopied] = useState(false)
-  const code = typeof children === 'string' ? children : Array.isArray(children) ? children.join('') : ''
-  const language = className?.split('-')[1]
 
-  if (typeof children !== 'string' || !language) {
-    return <code>{children}</code>
+  const code = typeof children === 'string' ? children : Array.isArray(children) ? children.join('') : ''
+  const detectedLanguage = className?.split('-')[1]
+  const initialLanguage = detectedLanguage ?? 'plain'
+
+  const [selectedLanguage, setSelectedLanguage] = useState(initialLanguage)
+
+  // Block code: has a language identifier OR children contains newlines
+  // (react-markdown adds a trailing \n to fenced code blocks)
+  const isBlock = detectedLanguage !== undefined || (typeof children === 'string' && code.includes('\n'))
+
+  if (!isBlock || typeof children !== 'string') {
+    return <code className={className}>{children}</code>
   }
+
+  // Include detected language in options even if not in the standard list
+  const languageOptions = SUPPORTED_LANGUAGES.includes(initialLanguage)
+    ? SUPPORTED_LANGUAGES
+    : [initialLanguage, ...SUPPORTED_LANGUAGES]
 
   const handleClickCopy = async () => {
     setCopied(true)
@@ -55,7 +113,18 @@ export function CodeBlockRenderer({ className, children }: CodeBlockRendererProp
 
   return (
     <>
-      <div className='flex justify-end'>
+      <div className='flex items-center justify-between'>
+        <select
+          value={selectedLanguage}
+          onChange={(e) => setSelectedLanguage(e.target.value)}
+          className='cursor-pointer border-none bg-transparent text-xs text-white'
+        >
+          {languageOptions.map((lang) => (
+            <option key={lang} value={lang}>
+              {lang}
+            </option>
+          ))}
+        </select>
         <button
           type='button'
           onClick={handleClickCopy}
@@ -75,7 +144,10 @@ export function CodeBlockRenderer({ className, children }: CodeBlockRendererProp
           )}
         </button>
       </div>
-      <SyntaxHighlighter style={isDarkMode ? atomDark : undefined} language={language}>
+      <SyntaxHighlighter
+        style={isDarkMode ? atomDark : undefined}
+        language={selectedLanguage === 'plain' ? undefined : selectedLanguage}
+      >
         {code}
       </SyntaxHighlighter>
     </>

--- a/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
+++ b/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
@@ -1,7 +1,7 @@
 import { copyToClipboard } from '#/client/components/chat/copy-to-clipboard'
-import { useDarkMode } from '#/client/hooks/use-dark-mode'
 import { CheckIcon } from '#/client/components/svg/check-icon'
 import { CopyIcon } from '#/client/components/svg/copy-icon'
+import { useDarkMode } from '#/client/hooks/use-dark-mode'
 import type { AnchorHTMLAttributes, HTMLAttributes, MouseEvent, ReactNode } from 'react'
 import { useState } from 'react'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'

--- a/projects/portfolio/src/client/hooks/use-dark-mode.ts
+++ b/projects/portfolio/src/client/hooks/use-dark-mode.ts
@@ -1,0 +1,14 @@
+import { useEffect, useState } from 'react'
+
+export function useDarkMode(): boolean {
+  const [isDark, setIsDark] = useState(() => document.documentElement.classList.contains('dark'))
+
+  useEffect(() => {
+    const sync = () => setIsDark(document.documentElement.classList.contains('dark'))
+    const observer = new MutationObserver(sync)
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] })
+    return () => observer.disconnect()
+  }, [])
+
+  return isDark
+}


### PR DESCRIPTION
## Issues

- Close #559

## Why

AIが言語指定なしのコードブロック（` ``` ` のみ）を返した場合、シンタックスハイライトが適用されずプレーンな `<code>` タグで表示される問題があった。また、AIが誤った言語を指定した場合にユーザー側で修正する手段がなかった。

## Summary

コードブロックのヘッダー部分に言語セレクターUI（ドロップダウン）を追加した。言語識別子なしのコードブロックは `"plain"` をデフォルト値とし、セレクターで変更するとリアルタイムにシンタックスハイライトが更新される。

<img width="963" height="367" alt="image" src="https://github.com/user-attachments/assets/9848d497-348b-441f-977c-61d3e03f70e0" />

<img width="184" height="659" alt="image" src="https://github.com/user-attachments/assets/8bb7684d-9e1e-48d9-9f3d-73d98896a8d9" />

## Changes

- `SUPPORTED_LANGUAGES` 定数を追加（`plain` を含む40種類の一般的な言語）
- コードブロックのヘッダーに `<select>` ドロップダウンを追加（左側に言語名、右側にコピーボタン）
- 言語識別子なしのフェンスコードブロックを `"plain"` デフォルトでフルUIレンダリングに変更
- インラインコードとブロックコードの判別を `code.includes('\n')` で実装
- `plain` 選択時は `SyntaxHighlighter` に `language={undefined}` を渡してハイライトなしで表示
- 検出した言語がサポートリストにない場合も動的にオプションへ追加

## Checklist

- [x] コードブロックのヘッダーに言語セレクターが表示される
- [x] 言語識別子付きコードブロックはその言語がセレクターの初期値になる
- [x] 言語識別子なしコードブロックは `"plain"` が初期値
- [x] セレクターで言語を変更するとシンタックスハイライトが即座に更新される
- [x] lint / format / test すべて通過
