### PR TITLE
[portfolio] Improve chat page state and typing

### DIFF
--- a/projects/portfolio/src/client/components/chat/chat-main.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-main.tsx
@@ -11,10 +11,10 @@ import { StopIcon } from '#/client/components/svg/stop-icon'
 import { UploadIcon } from '#/client/components/svg/upload-icon'
 import type { Settings } from '#/client/storage/remote-storage-settings'
 import type { Conversation, Message } from '#/types'
-import React, { type FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { type FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { uuidv7 } from 'uuidv7'
 
 const CONVERSATION_TITLE_MAX_LENGTH = 10
-import { uuidv7 } from 'uuidv7'
 
 interface Props {
   initTrigger?: number
@@ -65,7 +65,7 @@ export function ChatMain({
     setMessages([])
     setConversationId(null)
     resetChatResults()
-  }, [initTrigger])
+  }, [initTrigger, resetChatResults])
 
   // 選択された会話のメッセージを設定
   useEffect(() => {

--- a/projects/portfolio/src/client/components/chat/chat-message-list.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-message-list.tsx
@@ -3,7 +3,7 @@ import { CodeBlockRenderer, MarkdownLink } from '#/client/components/chat/code-b
 import { MessageRenderer } from '#/client/components/chat/message-renderer'
 import { ChatbotIcon } from '#/client/components/svg/chatbot-icon'
 import { SpinnerIcon } from '#/client/components/svg/spinner-icon'
-import type { Message } from '#/types'
+import type { ChatResultSummary, ChatStreamState, Message } from '#/types'
 import { memo, type RefObject } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
@@ -18,20 +18,8 @@ interface ChatMessageListProps {
   messages: Message[]
   markdownPreview: boolean
   loading: boolean
-  stream: {
-    content: string
-    reasoning_content?: string
-  } | null
-  chatResults: {
-    model?: string
-    finish_reason: string
-    responseTimeMs?: number
-    usage?: {
-      promptTokens: number
-      completionTokens: number
-      totalTokens: number
-    } | null
-  } | null
+  stream: ChatStreamState | null
+  chatResults: ChatResultSummary | null
   copiedId: string
   messageEndRef: RefObject<HTMLDivElement | null>
   onCopyMessage: (message: string, index: number) => void

--- a/projects/portfolio/src/client/components/chat/chat-results.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-results.tsx
@@ -1,13 +1,11 @@
+import type { ChatResultSummary } from '#/types'
 import { memo } from 'react'
 
 interface ChatResultsProps {
-  model?: string
+  model?: ChatResultSummary['model']
   finishReason?: string
-  responseTimeMs?: number
-  usage?: {
-    promptTokens?: number
-    completionTokens?: number
-  } | null
+  responseTimeMs?: ChatResultSummary['responseTimeMs']
+  usage?: ChatResultSummary['usage']
 }
 
 function formatResponseTime(ms: number): string {

--- a/projects/portfolio/src/client/components/chat/hooks/chat-response.ts
+++ b/projects/portfolio/src/client/components/chat/hooks/chat-response.ts
@@ -1,0 +1,89 @@
+import {
+  ChatCompletionResponseSchema,
+  ChatCompletionStreamChunkSchema,
+  type ChatCompletionResponse,
+  type ChatCompletionResult,
+  type ChatCompletionStreamChunk,
+  type ChatResultSummary,
+  type ChatStreamState,
+} from '#/types'
+
+type ApiUsage = ChatCompletionResponse['usage'] | ChatCompletionStreamChunk['usage']
+
+export function parseChatCompletionResponse(value: unknown): ChatCompletionResponse {
+  return ChatCompletionResponseSchema.parse(value)
+}
+
+export function parseChatCompletionStreamChunk(value: string): ChatCompletionStreamChunk {
+  return ChatCompletionStreamChunkSchema.parse(JSON.parse(value))
+}
+
+export function updateChatStream(
+  stream: ChatStreamState,
+  chunk: ChatCompletionStreamChunk
+): {
+  stream: ChatStreamState
+  finishReason: string
+  model?: string
+  usage: ChatResultSummary['usage']
+} {
+  const choice = chunk.choices.at(0)
+  const nextStream = {
+    content: stream.content + (choice?.delta.content ?? ''),
+    reasoning_content: (stream.reasoning_content ?? '') + (choice?.delta.reasoning_content ?? ''),
+  }
+
+  return {
+    stream: nextStream,
+    finishReason: choice?.finish_reason ?? '',
+    model: chunk.model,
+    usage: normalizeUsage(chunk.usage),
+  }
+}
+
+export function toChatCompletionResult(response: ChatCompletionResponse): ChatCompletionResult | null {
+  const choice = response.choices.at(0)
+  const content = choice?.message.content ?? ''
+
+  if (!content) {
+    return null
+  }
+
+  return {
+    model: response.model ?? 'N/A',
+    finishReason: choice?.finish_reason ?? '',
+    message: {
+      content,
+      reasoningContent: choice?.message.reasoning_content ?? '',
+    },
+    responseTimeMs: 0,
+    usage: normalizeUsage(response.usage),
+  }
+}
+
+export function toChatResultSummary(params: {
+  model?: string
+  finishReason: string
+  responseTimeMs?: number
+  usage: ApiUsage
+}): ChatResultSummary {
+  return {
+    model: params.model,
+    finish_reason: params.finishReason,
+    responseTimeMs: params.responseTimeMs,
+    usage: normalizeUsage(params.usage),
+  }
+}
+
+function normalizeUsage(usage: ApiUsage): ChatResultSummary['usage'] {
+  if (!usage) {
+    return null
+  }
+
+  return {
+    promptTokens: usage.prompt_tokens,
+    completionTokens: usage.completion_tokens,
+    totalTokens: usage.total_tokens,
+    reasoningTokens: usage.reasoning_tokens ?? usage.completion_tokens_details?.reasoning_tokens,
+  }
+}

--- a/projects/portfolio/src/client/components/chat/hooks/use-message-scroll.ts
+++ b/projects/portfolio/src/client/components/chat/hooks/use-message-scroll.ts
@@ -1,22 +1,11 @@
+import type { ChatResultSummary, ChatStreamState } from '#/types'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 interface UseMessageScrollParams {
   loading: boolean
   streamMode: boolean
-  stream: {
-    content: string
-    reasoning_content?: string
-  } | null
-  chatResults: {
-    model?: string
-    finish_reason: string
-    responseTimeMs?: number
-    usage?: {
-      promptTokens: number
-      completionTokens: number
-      totalTokens: number
-    } | null
-  } | null
+  stream: ChatStreamState | null
+  chatResults: ChatResultSummary | null
 }
 
 export function useMessageScroll({ loading, streamMode, stream, chatResults }: UseMessageScrollParams) {

--- a/projects/portfolio/src/client/components/chat/hooks/use-stream-processor.ts
+++ b/projects/portfolio/src/client/components/chat/hooks/use-stream-processor.ts
@@ -1,7 +1,14 @@
 import type { AppType } from '#/server/app.d'
-import type { ApiChatMessage, ChatCompletionResult } from '#/types'
+import type { ApiChatMessage, ChatCompletionResult, ChatResultSummary, ChatStreamState } from '#/types'
 import { hc } from 'hono/client'
 import { useCallback, useRef, useState } from 'react'
+import {
+  parseChatCompletionResponse,
+  parseChatCompletionStreamChunk,
+  toChatCompletionResult,
+  toChatResultSummary,
+  updateChatStream,
+} from './chat-response'
 
 const client = hc<AppType>('/')
 
@@ -27,20 +34,8 @@ interface UseStreamProcessorParams {
 export function useStreamProcessor({ onSubmitting }: UseStreamProcessorParams = {}) {
   const abortControllerRef = useRef<AbortController | null>(null)
   const [loading, setLoading] = useState(false)
-  const [stream, setStream] = useState<{
-    content: string
-    reasoning_content?: string
-  } | null>(null)
-  const [chatResults, setChatResults] = useState<{
-    model?: string
-    finish_reason: string
-    responseTimeMs?: number
-    usage?: {
-      promptTokens: number
-      completionTokens: number
-      totalTokens: number
-    } | null
-  } | null>(null)
+  const [stream, setStream] = useState<ChatStreamState | null>(null)
+  const [chatResults, setChatResults] = useState<ChatResultSummary | null>(null)
 
   const cancelStream = useCallback(() => {
     if (abortControllerRef.current) {
@@ -86,12 +81,21 @@ export function useStreamProcessor({ onSubmitting }: UseStreamProcessorParams = 
         const responseTimeMs = Date.now() - requestStartTime
 
         if (result) {
-          setChatResults({
-            model: result.model,
-            finish_reason: result.finishReason,
-            responseTimeMs,
-            usage: result.usage,
-          })
+          setChatResults(
+            toChatResultSummary({
+              model: result.model,
+              finishReason: result.finishReason,
+              responseTimeMs,
+              usage: result.usage
+                ? {
+                    prompt_tokens: result.usage.promptTokens,
+                    completion_tokens: result.usage.completionTokens,
+                    total_tokens: result.usage.totalTokens,
+                    reasoning_tokens: result.usage.reasoningTokens,
+                  }
+                : null,
+            })
+          )
         }
 
         return { result, responseTimeMs }
@@ -128,21 +132,14 @@ const sendChatCompletion = async (req: {
   temperature?: number
   maxTokens?: number
   reasoningEffort?: 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'
-  onStream?: (stream: { content: string; reasoning_content: string }) => void
+  onStream?: (stream: ChatStreamState) => void
 }): Promise<ChatCompletionResult | null> => {
-  const result = {
+  let result: ChatStreamState = {
     content: '',
     reasoning_content: '',
   }
   let finish_reason = ''
-  let usage: {
-    prompt_tokens: number
-    completion_tokens: number
-    total_tokens: number
-    completion_tokens_details?: {
-      reasoning_tokens?: number
-    }
-  } | null = null
+  let usage: ChatResultSummary['usage'] = null
   let responseModel = 'N/A'
 
   try {
@@ -173,24 +170,16 @@ const sendChatCompletion = async (req: {
       const error = (await res.json()) as { message?: string }
       result.content = error?.message || JSON.stringify(error)
     } else {
-      const nonStream = res.headers.get('Content-Type') === 'application/json'
+      const nonStream = res.headers.get('Content-Type')?.includes('application/json') ?? false
       if (nonStream) {
-        const data = (await res.json()) as {
-          choices: {
-            message: { content: string; reasoning_content?: string }
-          }[]
-          model?: string
-          usage?: {
-            prompt_tokens: number
-            completion_tokens: number
-            total_tokens: number
-            reasoning_tokens: number
-          }
+        const data = parseChatCompletionResponse(await res.json())
+        const completion = toChatCompletionResult(data)
+
+        if (!completion) {
+          return null
         }
-        result.reasoning_content = data.choices[0].message?.reasoning_content || ''
-        result.content = data.choices[0].message.content
-        responseModel = data?.model || 'N/A'
-        usage = data?.usage ?? null
+
+        return completion
       } else {
         const reader = res.body?.getReader()
         if (!reader) {
@@ -219,36 +208,22 @@ const sendChatCompletion = async (req: {
               break
             }
             try {
-              const parsedChunk = JSON.parse(jsonStr) as {
-                choices: {
-                  delta: { content: string; reasoning_content?: string }
-                  finish_reason: string
-                }[]
-                model?: string
-                usage?: {
-                  prompt_tokens: number
-                  completion_tokens: number
-                  total_tokens: number
-                  completion_tokens_details?: {
-                    reasoning_tokens?: number
-                  }
-                }
+              const parsedChunk = parseChatCompletionStreamChunk(jsonStr)
+              const next = updateChatStream(result, parsedChunk)
+
+              result = next.stream
+              if (next.finishReason) {
+                finish_reason = next.finishReason
               }
-              result.reasoning_content += parsedChunk.choices.at(0)?.delta?.reasoning_content || ''
-              result.content += parsedChunk.choices.at(0)?.delta?.content || ''
-              const chunkFinishReason = parsedChunk.choices.at(0)?.finish_reason || ''
-              if (chunkFinishReason) {
-                finish_reason = chunkFinishReason
+              if (next.model) {
+                responseModel = next.model
               }
-              if (parsedChunk?.model) {
-                responseModel = parsedChunk.model
-              }
-              if (parsedChunk?.usage) {
-                usage = parsedChunk.usage
+              if (next.usage) {
+                usage = next.usage
               }
               req.onStream?.({
-                content: result.content ? `${result.content}` : '',
-                reasoning_content: result.reasoning_content,
+                content: result.content,
+                reasoning_content: result.reasoning_content ?? '',
               })
             } catch (error) {
               console.error('JSON parse error:', error)
@@ -274,16 +249,9 @@ const sendChatCompletion = async (req: {
     finishReason: finish_reason,
     message: {
       content: result.content,
-      reasoningContent: result.reasoning_content,
+      reasoningContent: result.reasoning_content ?? '',
     },
     responseTimeMs: 0,
-    usage: usage
-      ? {
-          promptTokens: usage.prompt_tokens,
-          completionTokens: usage.completion_tokens,
-          totalTokens: usage.total_tokens,
-          reasoningTokens: usage?.completion_tokens_details?.reasoning_tokens,
-        }
-      : null,
+    usage,
   }
 }

--- a/projects/portfolio/src/client/pages/chat/index.tsx
+++ b/projects/portfolio/src/client/pages/chat/index.tsx
@@ -2,10 +2,10 @@ import { ChatLayout } from '#/client/components/chat/chat-layout'
 import { ChatMain } from '#/client/components/chat/chat-main'
 import { ChatSettings } from '#/client/components/chat/chat-settings'
 import { ConversationHistory } from '#/client/components/chat/conversation-history'
+import { useChatPageState } from '#/client/pages/chat/use-chat-page-state'
 import { useMetaProps } from '#/client/pages/home'
-import { readFromLocalStorage, type Settings } from '#/client/storage/remote-storage-settings'
 import type { AppType } from '#/server/app.d'
-import type { Conversation } from '#/types'
+import { ConversationListResponseSchema, type Conversation } from '#/types'
 import { useQuery } from '@tanstack/react-query'
 import { hc } from 'hono/client'
 import { useState } from 'react'
@@ -14,22 +14,19 @@ const client = hc<AppType>('/')
 
 export function Chat() {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false)
-
-  const [viewModel, setViewModel] = useState<{
-    showSettingsActions: boolean
-    showSettingsPopup: boolean
-    newChatTrigger: number
-    conversationId: string | null
-    conversations: Conversation[]
-    settings: Settings
-  }>({
-    showSettingsActions: true,
-    showSettingsPopup: false,
-    newChatTrigger: Date.now(),
-    conversationId: null,
-    conversations: [],
-    settings: readFromLocalStorage(),
-  })
+  const {
+    selectedConversationId,
+    isSettingsPopupOpen,
+    newChatTrigger,
+    settings,
+    showSettingsActions,
+    startNewConversation,
+    toggleSettingsPopup,
+    closeSettingsPopup,
+    selectConversation,
+    setSubmitting,
+    updateSettings,
+  } = useChatPageState()
 
   const { email } = useMetaProps()
 
@@ -37,39 +34,13 @@ export function Chat() {
     queryKey: ['conversations'],
     queryFn: async () => {
       const res = await client.api.conversations.$get()
-      const { data } = await res.json()
-      setViewModel((p) => ({ ...p, conversations: data }))
-      return data
+      const data = ConversationListResponseSchema.parse(await res.json())
+      return data.data
     },
   })
 
-  const handleNewChat = () => {
-    setViewModel((p) => ({
-      ...p,
-      newChatTrigger: Date.now(),
-      showSettingsPopup: false,
-    }))
-  }
-
-  const handleShowMenu = () => {
-    setViewModel((p) => ({ ...p, showSettingsPopup: !p.showSettingsPopup }))
-  }
-
-  const handleChangeSettings = (settings: Settings) => {
-    setViewModel((p) => ({ ...p, settings }))
-  }
-
-  const handleChatClickOutside = () => {
-    setViewModel((p) => ({ ...p, showSettingsPopup: false }))
-  }
-
-  const handleChatSubmitting = (submitting: boolean) => {
-    setViewModel((p) => ({ ...p, showSettingsActions: !submitting }))
-  }
-
-  const handleSelectConversation = (conversationId: string) => {
-    setViewModel((p) => ({ ...p, conversationId }))
-  }
+  const conversations = query.data ?? []
+  const currentConversation = conversations.find(({ id }) => id === selectedConversationId) || null
 
   const handleDeleteConversation = (conversationId: string) => {
     if (!email) {
@@ -86,8 +57,8 @@ export function Chat() {
           query.refetch()
 
           // カレントの会話が削除された場合、新しい会話を開始
-          if (conversationId === viewModel.conversationId) {
-            handleNewConversation()
+          if (conversationId === selectedConversationId) {
+            startNewConversation()
           }
         }
       })
@@ -112,7 +83,7 @@ export function Chat() {
 
           // カレントの会話が削除された場合、新しい会話を開始
           if (isConversationEmpty) {
-            handleNewConversation()
+            startNewConversation()
           }
         }
       })
@@ -121,18 +92,9 @@ export function Chat() {
       })
   }
 
-  const handleNewConversation = () => {
-    setViewModel((p) => ({
-      ...p,
-      newChatTrigger: Date.now(),
-      showSettingsPopup: false,
-      conversationId: null,
-    }))
-  }
-
   const handleConversationChange = (conversation: Conversation) => {
     // カレントの会話IDを更新
-    setViewModel((p) => ({ ...p, conversationId: conversation.id }))
+    selectConversation(conversation.id)
 
     if (!email) {
       return
@@ -160,34 +122,34 @@ export function Chat() {
       conversations={
         query.isLoading
           ? 'Loading...'
-          : viewModel.conversations.length > 0 && (
+          : conversations.length > 0 && (
               <ConversationHistory
-                conversations={viewModel.conversations}
-                currentConversationId={viewModel.conversationId}
-                disabled={!viewModel.showSettingsActions}
-                onSelectConversation={handleSelectConversation}
+                conversations={conversations}
+                currentConversationId={selectedConversationId}
+                disabled={!showSettingsActions}
+                onSelectConversation={selectConversation}
                 onDeleteConversation={handleDeleteConversation}
-                onNewConversation={handleNewConversation}
+                onNewConversation={startNewConversation}
               />
             )
       }
     >
       <ChatSettings
-        showActions={viewModel.showSettingsActions}
-        showNewChat={viewModel.conversations.length <= 0}
-        showPopup={viewModel.showSettingsPopup}
+        showActions={showSettingsActions}
+        showNewChat={conversations.length <= 0}
+        showPopup={isSettingsPopupOpen}
         showSidebarToggle={!!email}
-        onNewChat={handleNewChat}
-        onShowMenu={handleShowMenu}
+        onNewChat={startNewConversation}
+        onShowMenu={toggleSettingsPopup}
         onToggleSidebar={() => setIsSidebarOpen(!isSidebarOpen)}
-        onChange={handleChangeSettings}
-        onHidePopup={handleChatClickOutside}
+        onChange={updateSettings}
+        onHidePopup={closeSettingsPopup}
       />
       <ChatMain
-        initTrigger={viewModel.newChatTrigger}
-        settings={viewModel.settings}
-        onSubmitting={handleChatSubmitting}
-        currentConversation={viewModel.conversations.find(({ id }) => id === viewModel.conversationId) || null}
+        initTrigger={newChatTrigger}
+        settings={settings}
+        onSubmitting={setSubmitting}
+        currentConversation={currentConversation}
         onConversationChange={handleConversationChange}
         onDeleteMessages={handleDeleteConversationMessage}
       />

--- a/projects/portfolio/src/client/pages/chat/use-chat-page-state.ts
+++ b/projects/portfolio/src/client/pages/chat/use-chat-page-state.ts
@@ -1,0 +1,51 @@
+import { readFromLocalStorage, type Settings } from '#/client/storage/remote-storage-settings'
+import { useCallback, useState } from 'react'
+
+export function useChatPageState() {
+  const [selectedConversationId, setSelectedConversationId] = useState<string | null>(null)
+  const [isSettingsPopupOpen, setIsSettingsPopupOpen] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [newChatTrigger, setNewChatTrigger] = useState(Date.now())
+  const [settings, setSettings] = useState<Settings>(() => readFromLocalStorage())
+
+  const startNewConversation = useCallback(() => {
+    setSelectedConversationId(null)
+    setIsSettingsPopupOpen(false)
+    setNewChatTrigger(Date.now())
+  }, [])
+
+  const toggleSettingsPopup = useCallback(() => {
+    setIsSettingsPopupOpen((current) => !current)
+  }, [])
+
+  const closeSettingsPopup = useCallback(() => {
+    setIsSettingsPopupOpen(false)
+  }, [])
+
+  const selectConversation = useCallback((conversationId: string) => {
+    setSelectedConversationId(conversationId)
+  }, [])
+
+  const setSubmitting = useCallback((submitting: boolean) => {
+    setIsSubmitting(submitting)
+  }, [])
+
+  const updateSettings = useCallback((nextSettings: Settings) => {
+    setSettings(nextSettings)
+  }, [])
+
+  return {
+    selectedConversationId,
+    isSettingsPopupOpen,
+    isSubmitting,
+    newChatTrigger,
+    settings,
+    showSettingsActions: !isSubmitting,
+    startNewConversation,
+    toggleSettingsPopup,
+    closeSettingsPopup,
+    selectConversation,
+    setSubmitting,
+    updateSettings,
+  }
+}

--- a/projects/portfolio/src/types/chat.ts
+++ b/projects/portfolio/src/types/chat.ts
@@ -101,6 +101,12 @@ export const ConversationSchema = z.object({
 
 export type Conversation = z.infer<typeof ConversationSchema>
 
+export const ConversationListResponseSchema = z.object({
+  data: z.array(ConversationSchema),
+})
+
+export type ConversationListResponse = z.infer<typeof ConversationListResponseSchema>
+
 // ============================================
 // /api/chat HTTP wire 型 — 送信時の変換先
 // ============================================
@@ -154,6 +160,69 @@ export function toApiChatMessage(message: Message): ApiChatMessage {
 // ============================================
 // API レスポンス型
 // ============================================
+
+const ApiUsageSchema = z
+  .object({
+    prompt_tokens: z.number(),
+    completion_tokens: z.number(),
+    total_tokens: z.number(),
+    reasoning_tokens: z.number().optional(),
+    completion_tokens_details: z
+      .object({
+        reasoning_tokens: z.number().optional(),
+      })
+      .optional(),
+  })
+  .nullable()
+
+export const ChatCompletionResponseSchema = z.object({
+  choices: z.array(
+    z.object({
+      message: z.object({
+        content: z.string(),
+        reasoning_content: z.string().optional(),
+      }),
+      finish_reason: z.string().nullable().optional(),
+    })
+  ),
+  model: z.string().optional(),
+  usage: ApiUsageSchema.optional(),
+})
+
+export type ChatCompletionResponse = z.infer<typeof ChatCompletionResponseSchema>
+
+export const ChatCompletionStreamChunkSchema = z.object({
+  choices: z.array(
+    z.object({
+      delta: z.object({
+        content: z.string().optional(),
+        reasoning_content: z.string().optional(),
+      }),
+      finish_reason: z.string().nullable().optional(),
+    })
+  ),
+  model: z.string().optional(),
+  usage: ApiUsageSchema.optional(),
+})
+
+export type ChatCompletionStreamChunk = z.infer<typeof ChatCompletionStreamChunkSchema>
+
+export interface ChatStreamState {
+  content: string
+  reasoning_content?: string
+}
+
+export interface ChatResultSummary {
+  model?: string
+  finish_reason: string
+  responseTimeMs?: number
+  usage: {
+    promptTokens: number
+    completionTokens: number
+    totalTokens: number
+    reasoningTokens?: number
+  } | null
+}
 
 export interface ChatCompletionResult {
   model: string

--- a/projects/portfolio/src/types/chat.ts
+++ b/projects/portfolio/src/types/chat.ts
@@ -26,12 +26,14 @@ export type TextContent = z.infer<typeof TextContentSchema>
 // 共有ドメイン型 — UI state・会話保存の正本
 // ============================================
 
-export const UserMetadataSchema = z.object({
-  model: z.string().catch(''),
-  stream: z.boolean().optional(),
-  temperature: z.number().optional(),
-  maxTokens: z.number().optional(),
-}).catch({ model: '' })
+export const UserMetadataSchema = z
+  .object({
+    model: z.string().catch(''),
+    stream: z.boolean().optional(),
+    temperature: z.number().optional(),
+    maxTokens: z.number().optional(),
+  })
+  .catch({ model: '' })
 
 export type UserMetadata = z.infer<typeof UserMetadataSchema>
 
@@ -46,19 +48,21 @@ export const UserMessageSchema = z.object({
 
 export type UserMessage = z.infer<typeof UserMessageSchema>
 
-export const AssistantMetadataSchema = z.object({
-  model: z.string().catch(''),
-  finishReason: z.string().optional(),
-  responseTimeMs: z.number().optional(),
-  usage: z
-    .object({
-      completionTokens: z.number().optional(),
-      promptTokens: z.number().optional(),
-      totalTokens: z.number().optional(),
-      reasoningTokens: z.number().optional(),
-    })
-    .catch({}),
-}).catch({ model: '', usage: {} })
+export const AssistantMetadataSchema = z
+  .object({
+    model: z.string().catch(''),
+    finishReason: z.string().optional(),
+    responseTimeMs: z.number().optional(),
+    usage: z
+      .object({
+        completionTokens: z.number().optional(),
+        promptTokens: z.number().optional(),
+        totalTokens: z.number().optional(),
+        reasoningTokens: z.number().optional(),
+      })
+      .catch({}),
+  })
+  .catch({ model: '', usage: {} })
 
 export type AssistantMetadata = z.infer<typeof AssistantMetadataSchema>
 

--- a/projects/portfolio/src/types/chat.ts
+++ b/projects/portfolio/src/types/chat.ts
@@ -27,11 +27,11 @@ export type TextContent = z.infer<typeof TextContentSchema>
 // ============================================
 
 export const UserMetadataSchema = z.object({
-  model: z.string(),
+  model: z.string().catch(''),
   stream: z.boolean().optional(),
   temperature: z.number().optional(),
   maxTokens: z.number().optional(),
-})
+}).catch({ model: '' })
 
 export type UserMetadata = z.infer<typeof UserMetadataSchema>
 
@@ -47,16 +47,18 @@ export const UserMessageSchema = z.object({
 export type UserMessage = z.infer<typeof UserMessageSchema>
 
 export const AssistantMetadataSchema = z.object({
-  model: z.string(),
+  model: z.string().catch(''),
   finishReason: z.string().optional(),
   responseTimeMs: z.number().optional(),
-  usage: z.object({
-    completionTokens: z.number().optional(),
-    promptTokens: z.number().optional(),
-    totalTokens: z.number().optional(),
-    reasoningTokens: z.number().optional(),
-  }),
-})
+  usage: z
+    .object({
+      completionTokens: z.number().optional(),
+      promptTokens: z.number().optional(),
+      totalTokens: z.number().optional(),
+      reasoningTokens: z.number().optional(),
+    })
+    .catch({}),
+}).catch({ model: '', usage: {} })
 
 export type AssistantMetadata = z.infer<typeof AssistantMetadataSchema>
 
@@ -179,7 +181,7 @@ export const ChatCompletionResponseSchema = z.object({
   choices: z.array(
     z.object({
       message: z.object({
-        content: z.string(),
+        content: z.string().nullable(),
         reasoning_content: z.string().optional(),
       }),
       finish_reason: z.string().nullable().optional(),

--- a/projects/portfolio/src/types/index.ts
+++ b/projects/portfolio/src/types/index.ts
@@ -1,6 +1,7 @@
 export {
   // Schemas
   ConversationSchema,
+  ConversationListResponseSchema,
   MessageSchema,
   UserMessageSchema,
   AssistantMessageSchema,
@@ -12,8 +13,11 @@ export {
   // /api/chat wire schemas
   ApiChatMessageSchema,
   ApiChatRequestSchema,
+  ChatCompletionResponseSchema,
+  ChatCompletionStreamChunkSchema,
   // Types
   type Conversation,
+  type ConversationListResponse,
   type Message,
   type UserMessage,
   type AssistantMessage,
@@ -25,7 +29,11 @@ export {
   // /api/chat wire types
   type ApiChatMessage,
   type ApiChatRequest,
+  type ChatCompletionResponse,
+  type ChatCompletionStreamChunk,
   // API レスポンス型
+  type ChatStreamState,
+  type ChatResultSummary,
   type ChatCompletionResult,
   // Converters
   toApiChatMessage,

--- a/projects/portfolio/tests/client/hooks/chat-response.test.ts
+++ b/projects/portfolio/tests/client/hooks/chat-response.test.ts
@@ -1,0 +1,123 @@
+import {
+  parseChatCompletionResponse,
+  parseChatCompletionStreamChunk,
+  toChatCompletionResult,
+  toChatResultSummary,
+  updateChatStream,
+} from '#/client/components/chat/hooks/chat-response'
+import { describe, expect, it } from 'vitest'
+
+describe('chat-response helpers', () => {
+  it('non-stream response を共有型で正規化できる', () => {
+    const response = parseChatCompletionResponse({
+      model: 'gpt-test',
+      choices: [
+        {
+          message: {
+            content: 'assistant answer',
+            reasoning_content: 'thinking',
+          },
+          finish_reason: 'stop',
+        },
+      ],
+      usage: {
+        prompt_tokens: 10,
+        completion_tokens: 20,
+        total_tokens: 30,
+        reasoning_tokens: 5,
+      },
+    })
+
+    expect(toChatCompletionResult(response)).toEqual({
+      model: 'gpt-test',
+      finishReason: 'stop',
+      message: {
+        content: 'assistant answer',
+        reasoningContent: 'thinking',
+      },
+      responseTimeMs: 0,
+      usage: {
+        promptTokens: 10,
+        completionTokens: 20,
+        totalTokens: 30,
+        reasoningTokens: 5,
+      },
+    })
+
+    expect(
+      toChatResultSummary({
+        model: response.model,
+        finishReason: response.choices[0]?.finish_reason ?? '',
+        responseTimeMs: 1234,
+        usage: response.usage,
+      })
+    ).toEqual({
+      model: 'gpt-test',
+      finish_reason: 'stop',
+      responseTimeMs: 1234,
+      usage: {
+        promptTokens: 10,
+        completionTokens: 20,
+        totalTokens: 30,
+        reasoningTokens: 5,
+      },
+    })
+  })
+
+  it('stream chunk を蓄積して finish reason と usage を取り出せる', () => {
+    const firstChunk = parseChatCompletionStreamChunk(
+      JSON.stringify({
+        model: 'gpt-stream',
+        choices: [
+          {
+            delta: {
+              reasoning_content: 'thinking',
+            },
+            finish_reason: null,
+          },
+        ],
+      })
+    )
+    const secondChunk = parseChatCompletionStreamChunk(
+      JSON.stringify({
+        model: 'gpt-stream',
+        choices: [
+          {
+            delta: {
+              content: 'answer',
+            },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: {
+          prompt_tokens: 11,
+          completion_tokens: 22,
+          total_tokens: 33,
+          completion_tokens_details: {
+            reasoning_tokens: 7,
+          },
+        },
+      })
+    )
+
+    const accumulated = updateChatStream({ content: '', reasoning_content: '' }, firstChunk)
+    const completed = updateChatStream(accumulated.stream, secondChunk)
+
+    expect(accumulated.stream).toEqual({
+      content: '',
+      reasoning_content: 'thinking',
+    })
+    expect(completed.stream).toEqual({
+      content: 'answer',
+      reasoning_content: 'thinking',
+    })
+    expect(completed.finishReason).toBe('stop')
+    expect(completed.model).toBe('gpt-stream')
+    expect(completed.usage).toEqual({
+      promptTokens: 11,
+      completionTokens: 22,
+      totalTokens: 33,
+      reasoningTokens: 7,
+    })
+  })
+})

--- a/projects/portfolio/tests/client/hooks/chat-response.test.ts
+++ b/projects/portfolio/tests/client/hooks/chat-response.test.ts
@@ -64,6 +64,23 @@ describe('chat-response helpers', () => {
     })
   })
 
+  it('non-stream response の content=null を結果なしとして扱える', () => {
+    const response = parseChatCompletionResponse({
+      model: 'gpt-test',
+      choices: [
+        {
+          message: {
+            content: null,
+          },
+          finish_reason: 'tool_calls',
+        },
+      ],
+      usage: null,
+    })
+
+    expect(toChatCompletionResult(response)).toBeNull()
+  })
+
   it('stream chunk を蓄積して finish reason と usage を取り出せる', () => {
     const firstChunk = parseChatCompletionStreamChunk(
       JSON.stringify({

--- a/projects/portfolio/tests/client/hooks/use-chat-page-state.test.ts
+++ b/projects/portfolio/tests/client/hooks/use-chat-page-state.test.ts
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('crypto-js', () => ({
+  default: {
+    AES: {
+      encrypt: (value: string) => ({ toString: () => value }),
+      decrypt: (value: string) => ({ toString: () => value }),
+    },
+    enc: { Utf8: 'utf8' },
+  },
+}))
+
+const STORAGE_KEY = 'portfolio.chat-settings'
+
+const defaultSettings = {
+  schemaVersion: '1.0.0',
+  model: 'gpt-4.1-mini',
+  baseURL: '',
+  apiKey: '',
+  mcpServerURLs: '',
+  temperature: 0.7,
+  temperatureEnabled: false,
+  maxTokens: undefined,
+  reasoningEffort: 'medium',
+  reasoningEffortEnabled: false,
+  fakeMode: false,
+  autoModel: false,
+  markdownPreview: true,
+  streamMode: true,
+  interactiveMode: true,
+  templateModels: {},
+}
+
+const createLocalStorageMock = (initialEntries: Record<string, string> = {}) => {
+  const store = new Map(Object.entries(initialEntries))
+
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value)
+    },
+    removeItem: (key: string) => {
+      store.delete(key)
+    },
+    clear: () => {
+      store.clear()
+    },
+  }
+}
+
+describe('useChatPageState', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'localStorage',
+      createLocalStorageMock({
+        [STORAGE_KEY]: JSON.stringify(defaultSettings),
+      })
+    )
+    vi.resetModules()
+  })
+
+  const importHook = async () => {
+    const mod = await import('#/client/pages/chat/use-chat-page-state')
+    return mod.useChatPageState
+  }
+
+  it('startNewConversation で選択中会話を解除し popup を閉じて trigger を更新する', async () => {
+    const useChatPageState = await importHook()
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(100)
+
+    const { result } = renderHook(() => useChatPageState())
+
+    act(() => {
+      result.current.selectConversation('conversation-1')
+      result.current.toggleSettingsPopup()
+    })
+
+    expect(result.current.selectedConversationId).toBe('conversation-1')
+    expect(result.current.isSettingsPopupOpen).toBe(true)
+    expect(result.current.newChatTrigger).toBe(100)
+
+    nowSpy.mockReturnValue(200)
+    act(() => {
+      result.current.startNewConversation()
+    })
+
+    expect(result.current.selectedConversationId).toBeNull()
+    expect(result.current.isSettingsPopupOpen).toBe(false)
+    expect(result.current.newChatTrigger).toBe(200)
+  })
+
+  it('setSubmitting が showSettingsActions を反転する', async () => {
+    const useChatPageState = await importHook()
+    const { result } = renderHook(() => useChatPageState())
+
+    expect(result.current.showSettingsActions).toBe(true)
+
+    act(() => {
+      result.current.setSubmitting(true)
+    })
+
+    expect(result.current.isSubmitting).toBe(true)
+    expect(result.current.showSettingsActions).toBe(false)
+
+    act(() => {
+      result.current.setSubmitting(false)
+    })
+
+    expect(result.current.isSubmitting).toBe(false)
+    expect(result.current.showSettingsActions).toBe(true)
+  })
+
+  it('会話選択と settings 更新を独立して保持する', async () => {
+    const useChatPageState = await importHook()
+    const { result } = renderHook(() => useChatPageState())
+
+    act(() => {
+      result.current.selectConversation('conversation-2')
+      result.current.updateSettings({
+        ...result.current.settings,
+        model: 'gpt-5',
+        streamMode: false,
+      })
+    })
+
+    expect(result.current.selectedConversationId).toBe('conversation-2')
+    expect(result.current.settings.model).toBe('gpt-5')
+    expect(result.current.settings.streamMode).toBe(false)
+  })
+})

--- a/projects/portfolio/tests/types/chat.test.ts
+++ b/projects/portfolio/tests/types/chat.test.ts
@@ -1,0 +1,61 @@
+import { ConversationListResponseSchema } from '#/types'
+import { describe, expect, it } from 'vitest'
+
+describe('chat types', () => {
+  it('legacy metadata を含む会話一覧レスポンスを正規化できる', () => {
+    const response = ConversationListResponseSchema.parse({
+      data: [
+        {
+          id: 'conversation-1',
+          title: 'Legacy conversation',
+          messages: [
+            {
+              id: 'message-1',
+              role: 'user',
+              content: 'hello',
+              reasoningContent: '',
+              metadata: {},
+            },
+            {
+              id: 'message-2',
+              role: 'assistant',
+              content: 'world',
+              reasoningContent: '',
+              metadata: {},
+            },
+          ],
+        },
+      ],
+    })
+
+    expect(response).toEqual({
+      data: [
+        {
+          id: 'conversation-1',
+          title: 'Legacy conversation',
+          messages: [
+            {
+              id: 'message-1',
+              role: 'user',
+              content: 'hello',
+              reasoningContent: '',
+              metadata: {
+                model: '',
+              },
+            },
+            {
+              id: 'message-2',
+              role: 'assistant',
+              content: 'world',
+              reasoningContent: '',
+              metadata: {
+                model: '',
+                usage: {},
+              },
+            },
+          ],
+        },
+      ],
+    })
+  })
+})


### PR DESCRIPTION
## Issues

- Close #669

## Why

チャットページの状態管理が単一の `viewModel` に集約されており、状態遷移の責務が追いにくい状態でした。あわせて `/api/chat` と `/api/conversations` のレスポンス型がクライアント内で重複定義されており、型の共有境界も崩れていました。

## Summary

チャットページの UI 状態を専用 hook に分離し、会話一覧を React Query の単一ソースに整理しました。あわせて chat API の共有型と正規化 helper を導入し、関連テストを追加しています。

## Changes

- `useChatPageState` を追加し、chat page の UI state と state transition を集約
- `viewModel` を廃止し、会話一覧は React Query の `data` を直接利用
- `/api/chat` と `/api/conversations` の共有レスポンス型を `src/types` に追加
- chat response の正規化処理を helper に切り出し、表示側 props 型を統一
- state hook と response helper の単体テストを追加

## Checklist

- [x] `bun run lint`
- [x] `bun run test`
- [x] `bun run format:check`
