### PR TITLE
[portfolio] Harden auth and secret handling

### DIFF
--- a/projects/portfolio/.env.example
+++ b/projects/portfolio/.env.example
@@ -4,4 +4,6 @@ COOKIE_SECRET=test
 COOKIE_NAME=sid
 COOKIE_EXPIRES=1d
 DATABASE_URL=postgresql://{{ user }}:{{ password }}@localhost:5432/{{ database }}
+AUTH_SEED_EMAIL=
+AUTH_SEED_PASSWORD_HASH=
 CHAT_CONVERSATION_ENABLED=TRUE

--- a/projects/portfolio/Dockerfile
+++ b/projects/portfolio/Dockerfile
@@ -32,7 +32,7 @@ RUN groupadd --gid $USER_GID $USERNAME \
   && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME
 
 RUN apt-get update \
-  && apt-get install --no-install-recommends -y ca-certificates sudo curl git openssh-client \
+  && apt-get install --no-install-recommends -y ca-certificates sudo curl git openssh-client postgresql-client \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
   && npm i -g @aikidosec/safe-chain \

--- a/projects/portfolio/README.md
+++ b/projects/portfolio/README.md
@@ -106,8 +106,22 @@
   bun run db:migrate
   ```
 
-- Run Seeders:
+- Generate password hash for auth seed:
 
   ```sh
+  node -e "const { randomBytes, scryptSync } = require('node:crypto'); const password = process.argv[1]; const salt = randomBytes(16); const N = 16384; const r = 8; const p = 1; const hash = scryptSync(password, salt, 64, { N, r, p }); console.log(\`scrypt$N=\${N},r=\${r},p=\${p}$\${salt.toString('base64')}$\${hash.toString('base64')}\`)" 'replace-with-password'
+  ```
+
+- Upsert auth user after migration:
+
+  ```sh
+  AUTH_SEED_EMAIL=test@example.com \
+  AUTH_SEED_PASSWORD_HASH='replace-with-generated-hash' \
   bun run db:seed:users
   ```
+
+## Authentication Notes
+
+- Sign-in verifies the password against `users.password_hash`.
+- `AUTH_SEED_EMAIL` and `AUTH_SEED_PASSWORD_HASH` are used only when seeding or updating the initial auth user.
+- Chat settings `apiKey` is stored in browser `localStorage`. It is not a secure secret store.

--- a/projects/portfolio/README.md
+++ b/projects/portfolio/README.md
@@ -88,6 +88,8 @@
 
 ## Database Migration
 
+- In Dev Containers, `psql` is available via `postgresql-client`.
+
 - Schema creation (only during the initial setup):
 
   ```sh

--- a/projects/portfolio/drizzle/0002_ambitious_gorgon.sql
+++ b/projects/portfolio/drizzle/0002_ambitious_gorgon.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "users" ADD COLUMN "password_hash" text;

--- a/projects/portfolio/drizzle/meta/0002_snapshot.json
+++ b/projects/portfolio/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,183 @@
+{
+  "id": "0c05c15d-1ca0-4dc2-952b-addd05784cd2",
+  "prevId": "1ecd1cf3-981b-40bd-b820-4c31b450391c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversations_user_id_users_id_fk": {
+          "name": "conversations_user_id_users_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reasoning_content": {
+          "name": "reasoning_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_conversation_id_conversations_id_fk": {
+          "name": "messages_conversation_id_conversations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/projects/portfolio/drizzle/meta/_journal.json
+++ b/projects/portfolio/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1750518377202,
       "tag": "0001_many_crystal",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1775922883832,
+      "tag": "0002_ambitious_gorgon",
+      "breakpoints": true
     }
   ]
 }

--- a/projects/portfolio/src/client/components/chat/chat-settings/chat-settings-form.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-settings/chat-settings-form.tsx
@@ -57,15 +57,20 @@ export function ChatSettingsForm() {
             onChange={handleChangeBaseURL}
           />
 
-          <TextInput
-            name='apiKey'
-            label='API Key'
-            type='password'
-            defaultValue={settings.apiKey}
-            placeholder='Enter your API key'
-            disabled={fakeMode}
-            onChange={handleChangeApiKey}
-          />
+          <div className='space-y-2'>
+            <TextInput
+              name='apiKey'
+              label='API Key'
+              type='password'
+              defaultValue={settings.apiKey}
+              placeholder='Enter your API key'
+              disabled={fakeMode}
+              onChange={handleChangeApiKey}
+            />
+            <p className='text-xs text-gray-500 dark:text-gray-400'>
+              API Key はブラウザの localStorage に保存されます。秘匿ストアではありません。
+            </p>
+          </div>
 
           <TextInput
             name='mcpServerURLs'

--- a/projects/portfolio/src/client/pages/home/index.tsx
+++ b/projects/portfolio/src/client/pages/home/index.tsx
@@ -33,9 +33,8 @@ export function Home() {
 
   const handleSignOut = () => {
     setError(null)
-    fetch('/api/signout', {
-      method: 'POST',
-    })
+    client.api.signout
+      .$post()
       .then((res) => {
         if (!res.ok) {
           setError('サインアウトに失敗しました。')

--- a/projects/portfolio/src/client/pages/home/index.tsx
+++ b/projects/portfolio/src/client/pages/home/index.tsx
@@ -10,6 +10,7 @@ export function Home() {
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault()
+    setError(null)
     const formData = new FormData(e.currentTarget)
     const email = formData.get('email') as string
     const password = formData.get('password') as string
@@ -25,6 +26,26 @@ export function Home() {
         }
         window.location.reload()
       })
+      .catch(() => {
+        setError('サインインに失敗しました。')
+      })
+  }
+
+  const handleSignOut = () => {
+    setError(null)
+    fetch('/api/signout', {
+      method: 'POST',
+    })
+      .then((res) => {
+        if (!res.ok) {
+          setError('サインアウトに失敗しました。')
+          return
+        }
+        window.location.reload()
+      })
+      .catch(() => {
+        setError('サインアウトに失敗しました。')
+      })
   }
 
   return (
@@ -32,18 +53,28 @@ export function Home() {
       <div className='w-full max-w-md rounded-2xl border border-gray-200 bg-white p-8 dark:border-gray-700 dark:bg-gray-800'>
         <h2 className='mb-6 text-center font-bold text-2xl text-gray-900 dark:text-white'>Home</h2>
 
+        {error && (
+          <div className='mb-4 rounded bg-red-100 p-3 text-red-700 text-xs dark:bg-red-900/30 dark:text-red-400'>
+            {error}
+          </div>
+        )}
+
         {email ? (
-          <p className='text-center text-gray-700 text-lg dark:text-gray-300'>
-            <span className='font-semibold'>User：</span>
-            <span className='break-all font-mono text-gray-600 dark:text-gray-400'>{email}</span>
-          </p>
+          <div className='space-y-4'>
+            <p className='text-center text-gray-700 text-lg dark:text-gray-300'>
+              <span className='font-semibold'>User：</span>
+              <span className='break-all font-mono text-gray-600 dark:text-gray-400'>{email}</span>
+            </p>
+            <button
+              type='button'
+              onClick={handleSignOut}
+              className='w-full cursor-pointer rounded-sm border border-gray-300 p-2 text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700'
+            >
+              Sign Out
+            </button>
+          </div>
         ) : (
           <form onSubmit={handleSubmit} className='space-y-4'>
-            {error && (
-              <div className='mb-2 rounded bg-red-100 p-3 text-red-700 text-xs dark:bg-red-900/30 dark:text-red-400'>
-                {error}
-              </div>
-            )}
             <div>
               <label htmlFor='email' className='mb-1 block font-semibold text-gray-700 text-sm dark:text-gray-300'>
                 Email

--- a/projects/portfolio/src/client/storage/legacy-remote-storage.ts
+++ b/projects/portfolio/src/client/storage/legacy-remote-storage.ts
@@ -1,0 +1,21 @@
+import crypto from 'crypto-js'
+
+const LEGACY_CRYPTO_JS_PREFIX = 'U2FsdGVkX1'
+const LEGACY_SETTINGS_AES_KEY = '3f1a9c7e5d4b8f012367a9c4e2d5b7f0'
+
+export function decryptLegacyApiKey(value: string): string | null {
+  if (!value) {
+    return ''
+  }
+
+  if (!value.startsWith(LEGACY_CRYPTO_JS_PREFIX)) {
+    return value
+  }
+
+  try {
+    const decrypted = crypto.AES.decrypt(value, LEGACY_SETTINGS_AES_KEY).toString(crypto.enc.Utf8)
+    return decrypted || null
+  } catch {
+    return null
+  }
+}

--- a/projects/portfolio/src/client/storage/remote-storage-settings.ts
+++ b/projects/portfolio/src/client/storage/remote-storage-settings.ts
@@ -1,7 +1,7 @@
-import crypto from 'crypto-js'
+import { decryptLegacyApiKey } from './legacy-remote-storage'
 
-const SCHEMA_VERSION = '1.0.0'
-const AES_KEY = '3f1a9c7e5d4b8f012367a9c4e2d5b7f0'
+const STORAGE_KEY = 'portfolio.chat-settings'
+const SCHEMA_VERSION = '1.1.0'
 
 export interface Settings {
   schemaVersion: string
@@ -26,7 +26,11 @@ export interface Settings {
   }
 }
 
-const defaultSettings: Partial<Settings> = {
+type StoredSettings = Partial<Settings> & {
+  schemaVersion?: string
+}
+
+const defaultSettings: Settings = {
   schemaVersion: SCHEMA_VERSION,
   model: 'gpt-4.1-mini',
   baseURL: '',
@@ -46,35 +50,79 @@ const defaultSettings: Partial<Settings> = {
 }
 
 export function readFromLocalStorage(): Settings {
-  const key = 'portfolio.chat-settings'
-  const value = localStorage.getItem(key)
-  const settings = (value && JSON.parse(value)) || defaultSettings
+  const settings = parseStoredSettings(localStorage.getItem(STORAGE_KEY))
 
-  // SCHEMA_VERSIONのメジャーバージョンチェック
-  const currentMajorVersion = SCHEMA_VERSION.split('.')[0]
-  const settingsMajorVersion = settings.schemaVersion?.split('.')[0]
-
-  // schemaVersionが空文字、undefined、または異なるメジャーバージョンの場合はdefaultSettingsで上書き
-  const finalSettings =
-    !settings.schemaVersion || !settingsMajorVersion || settingsMajorVersion !== currentMajorVersion
-      ? defaultSettings
-      : settings
-
-  return {
-    ...finalSettings,
-    apiKey: crypto.AES.decrypt(finalSettings.apiKey, AES_KEY).toString(crypto.enc.Utf8),
+  if (!settings) {
+    return defaultSettings
   }
+
+  if (isLegacySettings(settings)) {
+    const migratedSettings = migrateLegacySettings(settings)
+    writeToLocalStorage(migratedSettings)
+    return migratedSettings
+  }
+
+  if (!isCompatibleSchema(settings.schemaVersion)) {
+    return defaultSettings
+  }
+
+  return mergeSettings(settings)
 }
 
 export function saveToLocalStorage(settings: Partial<Settings>): Settings {
-  const key = 'portfolio.chat-settings'
-  const newSettings = { ...readFromLocalStorage(), ...settings }
-  localStorage.setItem(
-    key,
-    JSON.stringify({
-      ...newSettings,
-      apiKey: crypto.AES.encrypt(newSettings.apiKey, AES_KEY).toString(),
-    })
-  )
-  return readFromLocalStorage()
+  const nextSettings = mergeSettings({
+    ...readFromLocalStorage(),
+    ...settings,
+    schemaVersion: SCHEMA_VERSION,
+  })
+
+  writeToLocalStorage(nextSettings)
+  return nextSettings
+}
+
+function parseStoredSettings(value: string | null): StoredSettings | null {
+  if (!value) {
+    return null
+  }
+
+  try {
+    const parsed = JSON.parse(value)
+    return isRecord(parsed) ? (parsed as StoredSettings) : null
+  } catch {
+    return null
+  }
+}
+
+function mergeSettings(settings: Partial<Settings>): Settings {
+  return {
+    ...defaultSettings,
+    ...settings,
+    schemaVersion: SCHEMA_VERSION,
+  }
+}
+
+function writeToLocalStorage(settings: Settings): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(settings))
+}
+
+function isCompatibleSchema(schemaVersion: string | undefined): boolean {
+  return schemaVersion?.split('.')[0] === SCHEMA_VERSION.split('.')[0]
+}
+
+function isLegacySettings(settings: StoredSettings): boolean {
+  return settings.schemaVersion?.startsWith('1.0.') ?? false
+}
+
+function migrateLegacySettings(settings: StoredSettings): Settings {
+  const apiKey = typeof settings.apiKey === 'string' ? (decryptLegacyApiKey(settings.apiKey) ?? '') : ''
+
+  return mergeSettings({
+    ...settings,
+    apiKey,
+    schemaVersion: SCHEMA_VERSION,
+  })
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
 }

--- a/projects/portfolio/src/db/schema.ts
+++ b/projects/portfolio/src/db/schema.ts
@@ -5,6 +5,7 @@ import { jsonb, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core'
 export const usersTable = pgTable('users', {
   id: uuid('id').primaryKey().defaultRandom(),
   email: text('email').notNull().unique(),
+  passwordHash: text('password_hash'),
   createdAt: timestamp('created_at', { mode: 'date' }).notNull(),
 })
 

--- a/projects/portfolio/src/db/seeders/users.ts
+++ b/projects/portfolio/src/db/seeders/users.ts
@@ -2,18 +2,36 @@ import { uuidv7 } from 'uuidv7'
 import { getDatabase } from '../'
 import { usersTable } from '../schema'
 
-const initialUsers = [
-  {
-    id: uuidv7(),
-    email: 'test@example.com',
-    createdAt: new Date(),
-  },
-]
-
 async function main() {
-  const db = getDatabase(process.env.DATABASE_URL || '')
-  await db.insert(usersTable).values(initialUsers)
-  console.log('🚀 User initial data seeding has been completed successfully.')
+  const databaseUrl = process.env.DATABASE_URL || ''
+  const email = process.env.AUTH_SEED_EMAIL || ''
+  const passwordHash = process.env.AUTH_SEED_PASSWORD_HASH || ''
+
+  if (!databaseUrl) {
+    throw new Error('DATABASE_URL is required')
+  }
+
+  if (!email || !passwordHash) {
+    throw new Error('AUTH_SEED_EMAIL and AUTH_SEED_PASSWORD_HASH are required')
+  }
+
+  const db = getDatabase(databaseUrl)
+  await db
+    .insert(usersTable)
+    .values({
+      id: uuidv7(),
+      email,
+      passwordHash,
+      createdAt: new Date(),
+    })
+    .onConflictDoUpdate({
+      target: usersTable.email,
+      set: {
+        passwordHash,
+      },
+    })
+
+  console.log(`User auth seed has been upserted for ${email}.`)
 }
 
 main()

--- a/projects/portfolio/src/server/app.d.ts
+++ b/projects/portfolio/src/server/app.d.ts
@@ -1,6 +1,7 @@
 import { HonoEnv } from './routes/shared';
-declare const app: import('hono/hono-base').HonoBase<HonoEnv, import('hono/types').BlankSchema | import('hono/types').MergeSchemaPath<{
-    "api/signin": {
+declare const app: import('hono/hono-base').HonoBase<HonoEnv, import('hono/types').BlankSchema, "/", "/">;
+declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/types').BlankSchema | import('hono/types').MergeSchemaPath<{
+    "/api/signin": {
         $post: {
             input: {
                 json: {
@@ -27,6 +28,15 @@ declare const app: import('hono/hono-base').HonoBase<HonoEnv, import('hono/types
             status: import('hono/utils/http-status').ContentfulStatusCode;
         };
     };
+} & {
+    "/api/signout": {
+        $post: {
+            input: {};
+            output: {};
+            outputFormat: "json";
+            status: import('hono/utils/http-status').ContentfulStatusCode;
+        };
+    };
 }, "/"> | import('hono/types').MergeSchemaPath<{
     "/api/chat": {
         $post: {
@@ -39,29 +49,28 @@ declare const app: import('hono/hono-base').HonoBase<HonoEnv, import('hono/types
             } & {
                 json: {
                     messages: ({
-                        role: "system";
-                        content: string;
+                        role: "user";
+                        content: string | ({
+                            type: "image_url";
+                            image_url: {
+                                url: string;
+                            };
+                        } | {
+                            type: "text";
+                            text: string;
+                        })[];
                     } | {
                         role: "assistant";
                         content: string;
                     } | {
-                        role: "user";
-                        content: string | ({
-                            type: "text";
-                            text: string;
-                        } | {
-                            type: "image_url";
-                            image_url: {
-                                url: string;
-                                detail?: "auto" | "low" | "high" | undefined;
-                            };
-                        })[];
+                        role: "system";
+                        content: string;
                     })[];
                     model: string;
                     stream?: boolean | undefined;
                     temperature?: number | undefined;
                     max_tokens?: number | undefined;
-                    reasoning_effort?: "none" | "low" | "high" | "minimal" | "medium" | "xhigh" | undefined;
+                    reasoning_effort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | undefined;
                     stream_options?: {
                         include_usage?: boolean | undefined;
                     } | undefined;
@@ -84,29 +93,28 @@ declare const app: import('hono/hono-base').HonoBase<HonoEnv, import('hono/types
             } & {
                 json: {
                     messages: ({
-                        role: "system";
-                        content: string;
+                        role: "user";
+                        content: string | ({
+                            type: "image_url";
+                            image_url: {
+                                url: string;
+                            };
+                        } | {
+                            type: "text";
+                            text: string;
+                        })[];
                     } | {
                         role: "assistant";
                         content: string;
                     } | {
-                        role: "user";
-                        content: string | ({
-                            type: "text";
-                            text: string;
-                        } | {
-                            type: "image_url";
-                            image_url: {
-                                url: string;
-                                detail?: "auto" | "low" | "high" | undefined;
-                            };
-                        })[];
+                        role: "system";
+                        content: string;
                     })[];
                     model: string;
                     stream?: boolean | undefined;
                     temperature?: number | undefined;
                     max_tokens?: number | undefined;
-                    reasoning_effort?: "none" | "low" | "high" | "minimal" | "medium" | "xhigh" | undefined;
+                    reasoning_effort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | undefined;
                     stream_options?: {
                         include_usage?: boolean | undefined;
                     } | undefined;
@@ -125,29 +133,28 @@ declare const app: import('hono/hono-base').HonoBase<HonoEnv, import('hono/types
             } & {
                 json: {
                     messages: ({
-                        role: "system";
-                        content: string;
+                        role: "user";
+                        content: string | ({
+                            type: "image_url";
+                            image_url: {
+                                url: string;
+                            };
+                        } | {
+                            type: "text";
+                            text: string;
+                        })[];
                     } | {
                         role: "assistant";
                         content: string;
                     } | {
-                        role: "user";
-                        content: string | ({
-                            type: "text";
-                            text: string;
-                        } | {
-                            type: "image_url";
-                            image_url: {
-                                url: string;
-                                detail?: "auto" | "low" | "high" | undefined;
-                            };
-                        })[];
+                        role: "system";
+                        content: string;
                     })[];
                     model: string;
                     stream?: boolean | undefined;
                     temperature?: number | undefined;
                     max_tokens?: number | undefined;
-                    reasoning_effort?: "none" | "low" | "high" | "minimal" | "medium" | "xhigh" | undefined;
+                    reasoning_effort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | undefined;
                     stream_options?: {
                         include_usage?: boolean | undefined;
                     } | undefined;
@@ -166,23 +173,22 @@ declare const app: import('hono/hono-base').HonoBase<HonoEnv, import('hono/types
             input: {
                 json: {
                     messages: ({
-                        role: "system";
-                        content: string;
+                        role: "user";
+                        content: string | ({
+                            type: "image_url";
+                            image_url: {
+                                url: string;
+                            };
+                        } | {
+                            type: "text";
+                            text: string;
+                        })[];
                     } | {
                         role: "assistant";
                         content: string;
                     } | {
-                        role: "user";
-                        content: string | ({
-                            type: "text";
-                            text: string;
-                        } | {
-                            type: "image_url";
-                            image_url: {
-                                url: string;
-                                detail?: "auto" | "low" | "high" | undefined;
-                            };
-                        })[];
+                        role: "system";
+                        content: string;
                     })[];
                     model: string;
                     stream?: boolean | undefined;
@@ -204,23 +210,22 @@ declare const app: import('hono/hono-base').HonoBase<HonoEnv, import('hono/types
             input: {
                 json: {
                     messages: ({
-                        role: "system";
-                        content: string;
+                        role: "user";
+                        content: string | ({
+                            type: "image_url";
+                            image_url: {
+                                url: string;
+                            };
+                        } | {
+                            type: "text";
+                            text: string;
+                        })[];
                     } | {
                         role: "assistant";
                         content: string;
                     } | {
-                        role: "user";
-                        content: string | ({
-                            type: "text";
-                            text: string;
-                        } | {
-                            type: "image_url";
-                            image_url: {
-                                url: string;
-                                detail?: "auto" | "low" | "high" | undefined;
-                            };
-                        })[];
+                        role: "system";
+                        content: string;
                     })[];
                     model: string;
                     stream?: boolean | undefined;
@@ -579,5 +584,5 @@ declare const app: import('hono/hono-base').HonoBase<HonoEnv, import('hono/types
         };
     };
 }, "/">, "/", "/">;
-export type AppType = typeof app;
+export type AppType = typeof routes;
 export default app;

--- a/projects/portfolio/src/server/app.tsx
+++ b/projects/portfolio/src/server/app.tsx
@@ -6,20 +6,20 @@ import { htmlRoutes } from './routes/html'
 import { modelsRoutes } from './routes/models'
 import type { HonoEnv } from './routes/shared'
 
-const app = new Hono<HonoEnv>()
-  .onError((err, c) => {
-    if (err instanceof AuthenticationError) {
-      return c.json({ error: err.message }, 401)
-    }
+const app = new Hono<HonoEnv>().onError((err, c) => {
+  if (err instanceof AuthenticationError) {
+    return c.json({ error: err.message }, 401)
+  }
 
-    console.error('Unknown Error', err)
-    return c.json({ error: err.message }, 500)
-  })
+  console.error('Unknown Error', err)
+  return c.json({ error: err.message }, 500)
+})
+const routes = app
   .route('/', authRoutes)
   .route('/', chatRoutes)
   .route('/', conversationsRoutes)
   .route('/', modelsRoutes)
   .route('/', htmlRoutes)
 
-export type AppType = typeof app
+export type AppType = typeof routes
 export default app

--- a/projects/portfolio/src/server/features/auth/auth.ts
+++ b/projects/portfolio/src/server/features/auth/auth.ts
@@ -1,5 +1,6 @@
 import { getDatabase } from '#/db'
 import { usersTable } from '#/db/schema'
+import { verifyPassword } from '#/server/features/auth/password-hash'
 import { eq } from 'drizzle-orm'
 
 export class AuthenticationError extends Error {
@@ -12,22 +13,21 @@ export class AuthenticationError extends Error {
 
 interface Auth {
   login(databaseUrl: string, email: string, password: string): Promise<void>
-  logout(email: string): Promise<void>
+  logout(): Promise<void>
 }
 
 export const auth: Auth = {
   async login(databaseUrl: string, email: string, password: string): Promise<void> {
     const db = getDatabase(databaseUrl)
     const users = await db.select().from(usersTable).where(eq(usersTable.email, email))
-    const userExists = users.length > 0
+    const user = users[0]
 
-    // TODO: DBを用いたパスワード認証に置き換える
-    if (!userExists || password !== 'testexample') {
+    if (!user?.passwordHash || !verifyPassword(password, user.passwordHash)) {
       throw new AuthenticationError('認証に失敗しました')
     }
   },
 
-  async logout(_email: string): Promise<void> {
-    // TODO
+  async logout(): Promise<void> {
+    return Promise.resolve()
   },
 }

--- a/projects/portfolio/src/server/features/auth/auth.ts
+++ b/projects/portfolio/src/server/features/auth/auth.ts
@@ -1,6 +1,6 @@
 import { getDatabase } from '#/db'
 import { usersTable } from '#/db/schema'
-import { verifyPassword } from '#/server/features/auth/password-hash'
+import { hashPassword, verifyPassword } from '#/server/features/auth/password-hash'
 import { eq } from 'drizzle-orm'
 
 export class AuthenticationError extends Error {
@@ -16,13 +16,17 @@ interface Auth {
   logout(): Promise<void>
 }
 
+const DUMMY_PASSWORD_HASH = hashPassword('dummy-password-for-timing-padding')
+
 export const auth: Auth = {
   async login(databaseUrl: string, email: string, password: string): Promise<void> {
     const db = getDatabase(databaseUrl)
     const users = await db.select().from(usersTable).where(eq(usersTable.email, email))
     const user = users[0]
+    const passwordHash = user?.passwordHash ?? DUMMY_PASSWORD_HASH
+    const passwordMatched = verifyPassword(password, passwordHash)
 
-    if (!user?.passwordHash || !verifyPassword(password, user.passwordHash)) {
+    if (!user?.passwordHash || !passwordMatched) {
       throw new AuthenticationError('認証に失敗しました')
     }
   },

--- a/projects/portfolio/src/server/features/auth/password-hash.ts
+++ b/projects/portfolio/src/server/features/auth/password-hash.ts
@@ -1,0 +1,84 @@
+import { randomBytes, scryptSync, timingSafeEqual } from 'node:crypto'
+
+const PASSWORD_HASH_ALGORITHM = 'scrypt'
+const SCRYPT_OPTIONS = {
+  N: 16384,
+  r: 8,
+  p: 1,
+  keyLength: 64,
+} as const
+
+interface ParsedPasswordHash {
+  N: number
+  r: number
+  p: number
+  salt: Buffer
+  hash: Buffer
+}
+
+export function hashPassword(password: string): string {
+  const salt = randomBytes(16)
+  const hash = scryptSync(password, salt, SCRYPT_OPTIONS.keyLength, {
+    N: SCRYPT_OPTIONS.N,
+    r: SCRYPT_OPTIONS.r,
+    p: SCRYPT_OPTIONS.p,
+  })
+
+  return [
+    PASSWORD_HASH_ALGORITHM,
+    `N=${SCRYPT_OPTIONS.N},r=${SCRYPT_OPTIONS.r},p=${SCRYPT_OPTIONS.p}`,
+    salt.toString('base64'),
+    hash.toString('base64'),
+  ].join('$')
+}
+
+export function verifyPassword(password: string, encodedHash: string): boolean {
+  try {
+    const parsed = parsePasswordHash(encodedHash)
+    const derivedHash = scryptSync(password, parsed.salt, parsed.hash.length, {
+      N: parsed.N,
+      r: parsed.r,
+      p: parsed.p,
+    })
+
+    return timingSafeEqual(derivedHash, parsed.hash)
+  } catch {
+    return false
+  }
+}
+
+function parsePasswordHash(encodedHash: string): ParsedPasswordHash {
+  const [algorithm, params, saltBase64, hashBase64] = encodedHash.split('$')
+
+  if (algorithm !== PASSWORD_HASH_ALGORITHM || !params || !saltBase64 || !hashBase64) {
+    throw new Error('Unsupported password hash format')
+  }
+
+  const parsedParams = Object.fromEntries(
+    params.split(',').map((entry) => {
+      const [key, value] = entry.split('=')
+      return [key, Number(value)]
+    })
+  )
+
+  const salt = Buffer.from(saltBase64, 'base64')
+  const hash = Buffer.from(hashBase64, 'base64')
+
+  if (
+    !salt.length ||
+    !hash.length ||
+    !Number.isFinite(parsedParams.N) ||
+    !Number.isFinite(parsedParams.r) ||
+    !Number.isFinite(parsedParams.p)
+  ) {
+    throw new Error('Invalid password hash payload')
+  }
+
+  return {
+    N: parsedParams.N,
+    r: parsedParams.r,
+    p: parsedParams.p,
+    salt,
+    hash,
+  }
+}

--- a/projects/portfolio/src/server/routes/auth.ts
+++ b/projects/portfolio/src/server/routes/auth.ts
@@ -2,7 +2,7 @@ import { AuthenticationError, auth } from '#/server/features/auth/auth'
 import { cookie } from '#/server/features/cookie/cookie'
 import { sValidator } from '@hono/standard-validator'
 import { Hono } from 'hono'
-import { setSignedCookie } from 'hono/cookie'
+import { deleteCookie, setSignedCookie } from 'hono/cookie'
 import { z } from 'zod'
 import type { HonoEnv } from './shared'
 import { getServerEnv } from './shared'
@@ -12,14 +12,25 @@ const SignInBodySchema = z.object({
   password: z.string().min(1),
 })
 
-const authRoutes = new Hono<HonoEnv>().post('api/signin', sValidator('json', SignInBodySchema), async (c) => {
-  const { email, password } = c.req.valid('json')
-  const { DATABASE_URL = '', COOKIE_SECRET = '', COOKIE_NAME = '', COOKIE_EXPIRES = '1d' } = getServerEnv(c)
+const authRoutes = new Hono<HonoEnv>()
+  .post('api/signin', sValidator('json', SignInBodySchema), async (c) => {
+    const { email, password } = c.req.valid('json')
+    const { DATABASE_URL = '', COOKIE_SECRET = '', COOKIE_NAME = '', COOKIE_EXPIRES = '1d' } = getServerEnv(c)
 
-  await auth.login(DATABASE_URL, email, password)
-  await setSignedCookie(c, COOKIE_NAME, email, COOKIE_SECRET, cookie.createOptions(COOKIE_EXPIRES))
+    await auth.login(DATABASE_URL, email, password)
+    await setSignedCookie(c, COOKIE_NAME, email, COOKIE_SECRET, cookie.createOptions(COOKIE_EXPIRES))
 
-  return c.json({})
-})
+    return c.json({})
+  })
+  .post('api/signout', async (c) => {
+    const { COOKIE_NAME = '' } = getServerEnv(c)
+
+    await auth.logout()
+    if (COOKIE_NAME) {
+      deleteCookie(c, COOKIE_NAME, { path: '/' })
+    }
+
+    return c.json({})
+  })
 
 export { AuthenticationError, authRoutes }

--- a/projects/portfolio/src/server/routes/auth.ts
+++ b/projects/portfolio/src/server/routes/auth.ts
@@ -13,7 +13,7 @@ const SignInBodySchema = z.object({
 })
 
 const authRoutes = new Hono<HonoEnv>()
-  .post('api/signin', sValidator('json', SignInBodySchema), async (c) => {
+  .post('/api/signin', sValidator('json', SignInBodySchema), async (c) => {
     const { email, password } = c.req.valid('json')
     const { DATABASE_URL = '', COOKIE_SECRET = '', COOKIE_NAME = '', COOKIE_EXPIRES = '1d' } = getServerEnv(c)
 
@@ -22,7 +22,7 @@ const authRoutes = new Hono<HonoEnv>()
 
     return c.json({})
   })
-  .post('api/signout', async (c) => {
+  .post('/api/signout', async (c) => {
     const { COOKIE_NAME = '' } = getServerEnv(c)
 
     await auth.logout()

--- a/projects/portfolio/tests/client/hooks/use-chat-page-state.test.ts
+++ b/projects/portfolio/tests/client/hooks/use-chat-page-state.test.ts
@@ -3,20 +3,10 @@
 import { act, renderHook } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-vi.mock('crypto-js', () => ({
-  default: {
-    AES: {
-      encrypt: (value: string) => ({ toString: () => value }),
-      decrypt: (value: string) => ({ toString: () => value }),
-    },
-    enc: { Utf8: 'utf8' },
-  },
-}))
-
 const STORAGE_KEY = 'portfolio.chat-settings'
 
 const defaultSettings = {
-  schemaVersion: '1.0.0',
+  schemaVersion: '1.1.0',
   model: 'gpt-4.1-mini',
   baseURL: '',
   apiKey: '',

--- a/projects/portfolio/tests/client/hooks/use-local-storage-settings.test.ts
+++ b/projects/portfolio/tests/client/hooks/use-local-storage-settings.test.ts
@@ -3,16 +3,6 @@
 import { renderHook, act } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-vi.mock('crypto-js', () => ({
-  default: {
-    AES: {
-      encrypt: (value: string) => ({ toString: () => value }),
-      decrypt: (value: string) => ({ toString: () => value }),
-    },
-    enc: { Utf8: 'utf8' },
-  },
-}))
-
 const STORAGE_KEY = 'portfolio.chat-settings'
 
 const createLocalStorageMock = (initialEntries: Record<string, string> = {}) => {
@@ -33,7 +23,7 @@ const createLocalStorageMock = (initialEntries: Record<string, string> = {}) => 
 }
 
 const defaultSettings = {
-  schemaVersion: '1.0.0',
+  schemaVersion: '1.1.0',
   model: 'gpt-4.1-mini',
   baseURL: '',
   apiKey: '',

--- a/projects/portfolio/tests/client/hooks/use-settings-handlers.test.ts
+++ b/projects/portfolio/tests/client/hooks/use-settings-handlers.test.ts
@@ -3,16 +3,6 @@
 import { renderHook, act } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-vi.mock('crypto-js', () => ({
-  default: {
-    AES: {
-      encrypt: (value: string) => ({ toString: () => value }),
-      decrypt: (value: string) => ({ toString: () => value }),
-    },
-    enc: { Utf8: 'utf8' },
-  },
-}))
-
 const STORAGE_KEY = 'portfolio.chat-settings'
 
 const createLocalStorageMock = (initialEntries: Record<string, string> = {}) => {
@@ -33,7 +23,7 @@ const createLocalStorageMock = (initialEntries: Record<string, string> = {}) => 
 }
 
 const defaultSettings = {
-  schemaVersion: '1.0.0',
+  schemaVersion: '1.1.0',
   model: 'gpt-4.1-mini',
   baseURL: '',
   apiKey: '',
@@ -243,10 +233,10 @@ describe('useSettingsHandlers', () => {
       })
 
       act(() => {
-        result.current.handlers.handleChangeManualModel(createChangeEvent('custom-model'))
+        result.current.handlers.handleChangeAutoModel(createChangeEvent('gpt-4.1-nano'))
       })
 
-      expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ model: 'custom-model' }))
+      expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ model: 'gpt-4.1-nano' }))
     })
   })
 })

--- a/projects/portfolio/tests/client/storage/remote-storage-settings.test.ts
+++ b/projects/portfolio/tests/client/storage/remote-storage-settings.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+
+import crypto from 'crypto-js'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const LEGACY_SETTINGS_AES_KEY = '3f1a9c7e5d4b8f012367a9c4e2d5b7f0'
+const STORAGE_KEY = 'portfolio.chat-settings'
+
+const createLocalStorageMock = (initialEntries: Record<string, string> = {}) => {
+  const store = new Map(Object.entries(initialEntries))
+
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value)
+    },
+    removeItem: (key: string) => {
+      store.delete(key)
+    },
+    clear: () => {
+      store.clear()
+    },
+  }
+}
+
+describe('remote-storage-settings', () => {
+  beforeEach(() => {
+    vi.stubGlobal('localStorage', createLocalStorageMock())
+    vi.resetModules()
+  })
+
+  it('localStorage が空ならデフォルト設定を返す', async () => {
+    const { readFromLocalStorage } = await import('#/client/storage/remote-storage-settings')
+
+    const settings = readFromLocalStorage()
+
+    expect(settings).toEqual(
+      expect.objectContaining({
+        schemaVersion: '1.1.0',
+        model: 'gpt-4.1-mini',
+        apiKey: '',
+      })
+    )
+  })
+
+  it('1.0.x の暗号化 apiKey を 1 回だけ平文へ移行する', async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        schemaVersion: '1.0.0',
+        model: 'gpt-4.1',
+        baseURL: 'https://api.openai.com/v1',
+        apiKey: crypto.AES.encrypt('secret-api-key', LEGACY_SETTINGS_AES_KEY).toString(),
+        mcpServerURLs: '',
+        temperature: 0.7,
+        temperatureEnabled: false,
+        reasoningEffort: 'medium',
+        reasoningEffortEnabled: false,
+        fakeMode: false,
+        autoModel: false,
+        markdownPreview: true,
+        streamMode: true,
+        interactiveMode: true,
+        templateModels: {},
+      })
+    )
+
+    const { readFromLocalStorage } = await import('#/client/storage/remote-storage-settings')
+    const settings = readFromLocalStorage()
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}')
+
+    expect(settings.schemaVersion).toBe('1.1.0')
+    expect(settings.apiKey).toBe('secret-api-key')
+    expect(stored.apiKey).toBe('secret-api-key')
+    expect(stored.schemaVersion).toBe('1.1.0')
+  })
+
+  it('壊れた legacy apiKey は空文字にして他設定を維持する', async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        schemaVersion: '1.0.0',
+        model: 'gpt-4.1',
+        baseURL: 'https://api.openai.com/v1',
+        apiKey: 'U2FsdGVkX1broken',
+        mcpServerURLs: 'http://localhost:3001',
+        temperature: 0.3,
+        temperatureEnabled: true,
+        reasoningEffort: 'high',
+        reasoningEffortEnabled: true,
+        fakeMode: false,
+        autoModel: true,
+        markdownPreview: false,
+        streamMode: false,
+        interactiveMode: false,
+        templateModels: {},
+      })
+    )
+
+    const { readFromLocalStorage } = await import('#/client/storage/remote-storage-settings')
+    const settings = readFromLocalStorage()
+
+    expect(settings.schemaVersion).toBe('1.1.0')
+    expect(settings.apiKey).toBe('')
+    expect(settings.model).toBe('gpt-4.1')
+    expect(settings.temperature).toBe(0.3)
+    expect(settings.mcpServerURLs).toBe('http://localhost:3001')
+  })
+})

--- a/projects/portfolio/tests/features/auth/auth.test.ts
+++ b/projects/portfolio/tests/features/auth/auth.test.ts
@@ -6,10 +6,11 @@ vi.mock('#/db', () => ({
 
 import { getDatabase } from '#/db'
 import { AuthenticationError, auth } from '#/server/features/auth/auth'
+import { hashPassword } from '#/server/features/auth/password-hash'
 
 const mockedGetDatabase = vi.mocked(getDatabase)
 
-const createDbStub = (users: Array<{ id: string; email: string }>) => ({
+const createDbStub = (users: Array<{ id: string; email: string; passwordHash: string | null }>) => ({
   select: vi.fn(() => ({
     from: vi.fn(() => ({
       where: vi.fn().mockResolvedValue(users),
@@ -22,8 +23,10 @@ describe('auth.login', () => {
     mockedGetDatabase.mockReset()
   })
 
-  it('ユーザーが存在し password が一致すれば成功する', async () => {
-    mockedGetDatabase.mockReturnValue(createDbStub([{ id: 'user-1', email: 'test@example.com' }]) as never)
+  it('ユーザーが存在し password_hash が一致すれば成功する', async () => {
+    mockedGetDatabase.mockReturnValue(
+      createDbStub([{ id: 'user-1', email: 'test@example.com', passwordHash: hashPassword('testexample') }]) as never
+    )
 
     await expect(auth.login('postgres://db', 'test@example.com', 'testexample')).resolves.toBeUndefined()
     expect(mockedGetDatabase).toHaveBeenCalledWith('postgres://db')
@@ -37,8 +40,20 @@ describe('auth.login', () => {
     )
   })
 
+  it('password_hash が未設定の場合は AuthenticationError を投げる', async () => {
+    mockedGetDatabase.mockReturnValue(
+      createDbStub([{ id: 'user-1', email: 'test@example.com', passwordHash: null }]) as never
+    )
+
+    await expect(auth.login('postgres://db', 'test@example.com', 'testexample')).rejects.toBeInstanceOf(
+      AuthenticationError
+    )
+  })
+
   it('password が一致しない場合は AuthenticationError を投げる', async () => {
-    mockedGetDatabase.mockReturnValue(createDbStub([{ id: 'user-1', email: 'test@example.com' }]) as never)
+    mockedGetDatabase.mockReturnValue(
+      createDbStub([{ id: 'user-1', email: 'test@example.com', passwordHash: hashPassword('testexample') }]) as never
+    )
 
     await expect(auth.login('postgres://db', 'test@example.com', 'wrong-password')).rejects.toBeInstanceOf(
       AuthenticationError

--- a/projects/portfolio/tests/features/auth/auth.test.ts
+++ b/projects/portfolio/tests/features/auth/auth.test.ts
@@ -4,11 +4,21 @@ vi.mock('#/db', () => ({
   getDatabase: vi.fn(),
 }))
 
+vi.mock('#/server/features/auth/password-hash', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('#/server/features/auth/password-hash')>()
+
+  return {
+    ...actual,
+    verifyPassword: vi.fn(actual.verifyPassword),
+  }
+})
+
 import { getDatabase } from '#/db'
 import { AuthenticationError, auth } from '#/server/features/auth/auth'
-import { hashPassword } from '#/server/features/auth/password-hash'
+import { hashPassword, verifyPassword } from '#/server/features/auth/password-hash'
 
 const mockedGetDatabase = vi.mocked(getDatabase)
+const mockedVerifyPassword = vi.mocked(verifyPassword)
 
 const createDbStub = (users: Array<{ id: string; email: string; passwordHash: string | null }>) => ({
   select: vi.fn(() => ({
@@ -21,6 +31,7 @@ const createDbStub = (users: Array<{ id: string; email: string; passwordHash: st
 describe('auth.login', () => {
   beforeEach(() => {
     mockedGetDatabase.mockReset()
+    mockedVerifyPassword.mockClear()
   })
 
   it('ユーザーが存在し password_hash が一致すれば成功する', async () => {
@@ -32,15 +43,16 @@ describe('auth.login', () => {
     expect(mockedGetDatabase).toHaveBeenCalledWith('postgres://db')
   })
 
-  it('ユーザーが存在しない場合は AuthenticationError を投げる', async () => {
+  it('ユーザーが存在しない場合もダミーハッシュを検証して AuthenticationError を投げる', async () => {
     mockedGetDatabase.mockReturnValue(createDbStub([]) as never)
 
     await expect(auth.login('postgres://db', 'missing@example.com', 'testexample')).rejects.toBeInstanceOf(
       AuthenticationError
     )
+    expect(mockedVerifyPassword).toHaveBeenCalledTimes(1)
   })
 
-  it('password_hash が未設定の場合は AuthenticationError を投げる', async () => {
+  it('password_hash が未設定の場合もダミーハッシュを検証して AuthenticationError を投げる', async () => {
     mockedGetDatabase.mockReturnValue(
       createDbStub([{ id: 'user-1', email: 'test@example.com', passwordHash: null }]) as never
     )
@@ -48,6 +60,7 @@ describe('auth.login', () => {
     await expect(auth.login('postgres://db', 'test@example.com', 'testexample')).rejects.toBeInstanceOf(
       AuthenticationError
     )
+    expect(mockedVerifyPassword).toHaveBeenCalledTimes(1)
   })
 
   it('password が一致しない場合は AuthenticationError を投げる', async () => {

--- a/projects/portfolio/tests/routes/auth.test.ts
+++ b/projects/portfolio/tests/routes/auth.test.ts
@@ -1,14 +1,17 @@
 import { describe, expect, it, vi } from 'vitest'
 
-const { loginMock, setSignedCookieMock } = vi.hoisted(() => ({
+const { loginMock, logoutMock, setSignedCookieMock, deleteCookieMock } = vi.hoisted(() => ({
   loginMock: vi.fn(),
+  logoutMock: vi.fn(),
   setSignedCookieMock: vi.fn(),
+  deleteCookieMock: vi.fn(),
 }))
 
 vi.mock('#/server/features/auth/auth', () => ({
   AuthenticationError: class AuthenticationError extends Error {},
   auth: {
     login: loginMock,
+    logout: logoutMock,
   },
 }))
 
@@ -18,6 +21,7 @@ vi.mock('hono/cookie', async () => {
   return {
     ...actual,
     setSignedCookie: setSignedCookieMock,
+    deleteCookie: deleteCookieMock,
   }
 })
 
@@ -52,6 +56,18 @@ describe('authRoutes', () => {
         maxAge: 86400,
       })
     )
+  })
+
+  it('signout で cookie を削除する', async () => {
+    vi.stubEnv('COOKIE_NAME', 'session')
+
+    const res = await authRoutes.request('/api/signout', {
+      method: 'POST',
+    })
+
+    expect(res.status).toBe(200)
+    expect(logoutMock).toHaveBeenCalled()
+    expect(deleteCookieMock).toHaveBeenCalledWith(expect.anything(), 'session', { path: '/' })
   })
 
   it('不正な body は 400 を返す', async () => {

--- a/projects/portfolio/vite.config.ts
+++ b/projects/portfolio/vite.config.ts
@@ -17,12 +17,12 @@ export default defineConfig(({ mode }) => {
         plugins: [
           dts({
             include: resolve(rootDir, 'src/server/app.tsx'),
-            outDir: resolve(rootDir, 'src/server'),
+            outDir: rootDir,
             declarationOnly: true,
             insertTypesEntry: false,
             rollupTypes: false,
             copyDtsFiles: false,
-            entryRoot: resolve(rootDir, 'src/server'),
+            entryRoot: resolve(rootDir, 'src'),
           }),
         ],
         resolve: {


### PR DESCRIPTION
## Issues

- Close #666

## Why

portfolio の認証が固定平文パスワードと client 側の固定 AES キーに依存しており、実際の安全性とコードの見た目が一致していませんでした。認証を DB 上のハッシュ検証に置き換え、logout と設定保存の扱いを明確にする必要があります。

## Summary

認証を `users.password_hash` ベースの `scrypt` 検証へ切り替え、`/api/signout` を追加しました。あわせて chat 設定の疑似的な暗号化を廃止し、既存 `1.0.x` localStorage データの 1 回限りの移行と DB migration / seed 手順を整備しました。

## Changes

- `users.password_hash` を追加する Drizzle migration と schema 更新
- `auth.login` を固定文字列比較から `scrypt` ハッシュ検証へ変更
- `POST /api/signout` と Home 画面の Sign Out 導線を追加
- client 設定から固定 AES キーを除去し、legacy localStorage の移行処理を追加
- `.env.example` と README に auth seed / migration 手順を追記
- 認証・route・storage migration のテストを追加・更新

## Checklist

- [x] `bun run lint`
- [x] `bun run test`
- [x] `bun run format:check`

## Details

- `password_hash` は段階移行のため nullable のまま追加しています
- 既存 `1.0.x` の `apiKey` は初回読込時に復号を試み、成功時は平文保存へ再保存します
