### PR TITLE
fix(portfolio): secure db:user:add password input

### DIFF
--- a/projects/portfolio/README.md
+++ b/projects/portfolio/README.md
@@ -111,7 +111,13 @@
 - Add auth user after migration:
 
   ```sh
-  bun run db:user:add -- --email test@example.com --password 'replace-with-password'
+  bun run db:user:add -- --email test@example.com
+  ```
+
+  Enter the password when prompted. For non-interactive use, pipe it via stdin, for example
+
+  ```sh
+  printf 'replace-with-password\n' | bun run db:user:add -- --email test@example.com
   ```
 
   The command fails if the email already exists.
@@ -119,5 +125,5 @@
 ## Authentication Notes
 
 - Sign-in verifies the password against `users.password_hash`.
-- `db:user:add` hashes the plain password and adds a new auth user.
+- `db:user:add` hashes the plain password from an interactive prompt or stdin and adds a new auth user.
 - Chat settings `apiKey` is stored in browser `localStorage`. It is not a secure secret store.

--- a/projects/portfolio/src/db/seeders/add-user-args.ts
+++ b/projects/portfolio/src/db/seeders/add-user-args.ts
@@ -1,21 +1,18 @@
 import { z } from 'zod'
 
-const usage = 'Usage: bun run db:user:add -- --email <email> --password <password>'
+export const addUserUsage = 'Usage: bun run db:user:add -- --email <email>'
 
 const AddUserArgsSchema = z.object({
   email: z.email(),
-  password: z.string().min(1),
 })
 
 export interface AddUserArgs {
   email: string
-  password: string
 }
 
 export function parseAddUserArgs(argv: string[]): AddUserArgs {
   const args = argv.slice(2)
   let email = ''
-  let password = ''
 
   for (let index = 0; index < args.length; index++) {
     const arg = args[index]
@@ -27,19 +24,13 @@ export function parseAddUserArgs(argv: string[]): AddUserArgs {
       continue
     }
 
-    if (arg === '--password' && value) {
-      password = value
-      index++
-      continue
-    }
-
-    throw new Error(usage)
+    throw new Error(addUserUsage)
   }
 
-  const parsed = AddUserArgsSchema.safeParse({ email, password })
+  const parsed = AddUserArgsSchema.safeParse({ email })
 
   if (!parsed.success) {
-    throw new Error(usage)
+    throw new Error(addUserUsage)
   }
 
   return parsed.data

--- a/projects/portfolio/src/db/seeders/add-user-record.ts
+++ b/projects/portfolio/src/db/seeders/add-user-record.ts
@@ -17,6 +17,20 @@ export class UserAlreadyExistsError extends Error {
   }
 }
 
+async function hasUserWithEmail(db: ReturnType<typeof getDatabase>, email: string) {
+  const users = await db.select().from(usersTable).where(eq(usersTable.email, email))
+
+  return Boolean(users[0])
+}
+
+export async function ensureUserDoesNotExist(databaseUrl: string, email: string) {
+  const db = getDatabase(databaseUrl)
+
+  if (await hasUserWithEmail(db, email)) {
+    throw new UserAlreadyExistsError(email)
+  }
+}
+
 function isDuplicateUserEmailError(error: unknown) {
   if (!error || typeof error !== 'object') {
     return false
@@ -27,9 +41,8 @@ function isDuplicateUserEmailError(error: unknown) {
 
 export async function addUser({ databaseUrl, email, passwordHash }: AddUserInput) {
   const db = getDatabase(databaseUrl)
-  const users = await db.select().from(usersTable).where(eq(usersTable.email, email))
 
-  if (users[0]) {
+  if (await hasUserWithEmail(db, email)) {
     throw new UserAlreadyExistsError(email)
   }
 

--- a/projects/portfolio/src/db/seeders/add-user.ts
+++ b/projects/portfolio/src/db/seeders/add-user.ts
@@ -1,6 +1,6 @@
 import { hashPassword } from '../../server/features/auth/password-hash'
 import { parseAddUserArgs } from './add-user-args'
-import { addUser } from './add-user-record'
+import { addUser, ensureUserDoesNotExist } from './add-user-record'
 import { readPassword } from './read-password'
 
 async function main() {
@@ -11,6 +11,7 @@ async function main() {
   }
 
   const { email } = parseAddUserArgs(process.argv)
+  await ensureUserDoesNotExist(databaseUrl, email)
   const password = await readPassword()
   const passwordHash = hashPassword(password)
 

--- a/projects/portfolio/src/db/seeders/add-user.ts
+++ b/projects/portfolio/src/db/seeders/add-user.ts
@@ -1,6 +1,7 @@
 import { hashPassword } from '../../server/features/auth/password-hash'
 import { parseAddUserArgs } from './add-user-args'
 import { addUser } from './add-user-record'
+import { readPassword } from './read-password'
 
 async function main() {
   const databaseUrl = process.env.DATABASE_URL || ''
@@ -9,7 +10,8 @@ async function main() {
     throw new Error('DATABASE_URL is required')
   }
 
-  const { email, password } = parseAddUserArgs(process.argv)
+  const { email } = parseAddUserArgs(process.argv)
+  const password = await readPassword()
   const passwordHash = hashPassword(password)
 
   await addUser({ databaseUrl, email, passwordHash })

--- a/projects/portfolio/src/db/seeders/read-password.ts
+++ b/projects/portfolio/src/db/seeders/read-password.ts
@@ -1,0 +1,104 @@
+import { stderr, stdin } from 'node:process'
+import { createInterface } from 'node:readline/promises'
+import { Writable } from 'node:stream'
+
+export const passwordPrompt = 'Password: '
+export const passwordRequiredMessage = 'Password is required'
+
+type PasswordInput = NodeJS.ReadableStream & {
+  isTTY?: boolean
+}
+
+type PasswordOutput = NodeJS.WritableStream
+
+interface ReadPasswordOptions {
+  input?: PasswordInput
+  output?: PasswordOutput
+  promptPassword?: (options?: PromptPasswordOptions) => Promise<string>
+  readPasswordFromStdin?: (input?: PasswordInput) => Promise<string>
+}
+
+interface PromptPasswordOptions {
+  input?: PasswordInput
+  output?: PasswordOutput
+}
+
+export async function readPassword(options: ReadPasswordOptions = {}) {
+  const input = options.input ?? stdin
+  const promptPassword = options.promptPassword ?? readPasswordFromPrompt
+  const readPasswordFromStdin = options.readPasswordFromStdin ?? readPasswordViaStdin
+
+  if (input.isTTY) {
+    return promptPassword({
+      input,
+      output: options.output,
+    })
+  }
+
+  return readPasswordFromStdin(input)
+}
+
+export async function readPasswordFromPrompt(options: PromptPasswordOptions = {}) {
+  const input = options.input ?? stdin
+  const output = options.output ?? stderr
+  const mutedOutput = new MutedWriteStream(output)
+  const reader = createInterface({
+    input,
+    output: mutedOutput,
+    terminal: true,
+  })
+
+  try {
+    const question = reader.question(passwordPrompt)
+    mutedOutput.muted = true
+    const password = await question
+
+    output.write('\n')
+
+    return validatePassword(password)
+  } finally {
+    reader.close()
+  }
+}
+
+export async function readPasswordViaStdin(input: PasswordInput = stdin) {
+  const chunks: Buffer[] = []
+
+  for await (const chunk of input) {
+    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : Buffer.from(chunk))
+  }
+
+  return validatePassword(
+    Buffer.concat(chunks)
+      .toString('utf8')
+      .replace(/[\r\n]+$/, '')
+  )
+}
+
+function validatePassword(password: string) {
+  if (password.length === 0) {
+    throw new Error(passwordRequiredMessage)
+  }
+
+  return password
+}
+
+class MutedWriteStream extends Writable {
+  muted = false
+
+  constructor(private readonly target: PasswordOutput) {
+    super()
+  }
+
+  override _write(chunk: Buffer | string, encoding: BufferEncoding, callback: (error?: Error | null) => void) {
+    if (!this.muted) {
+      if (typeof chunk === 'string') {
+        this.target.write(chunk, encoding)
+      } else {
+        this.target.write(chunk)
+      }
+    }
+
+    callback()
+  }
+}

--- a/projects/portfolio/tests/db/seeders/add-user-args.test.ts
+++ b/projects/portfolio/tests/db/seeders/add-user-args.test.ts
@@ -1,25 +1,26 @@
-import { parseAddUserArgs } from '#/db/seeders/add-user-args'
+import { addUserUsage, parseAddUserArgs } from '#/db/seeders/add-user-args'
 import { describe, expect, it } from 'vitest'
 
 describe('parseAddUserArgs', () => {
-  it('email と password を受け取って返す', () => {
-    expect(
-      parseAddUserArgs(['bun', 'src/db/seeders/add-user.ts', '--email', 'test@example.com', '--password', 'testpass'])
-    ).toEqual({
+  it('email を受け取って返す', () => {
+    expect(parseAddUserArgs(['bun', 'src/db/seeders/add-user.ts', '--email', 'test@example.com'])).toEqual({
       email: 'test@example.com',
-      password: 'testpass',
     })
   })
 
   it('email がない場合は usage error を投げる', () => {
-    expect(() => parseAddUserArgs(['bun', 'src/db/seeders/add-user.ts', '--password', 'testpass'])).toThrow(
-      'Usage: bun run db:user:add -- --email <email> --password <password>'
-    )
+    expect(() => parseAddUserArgs(['bun', 'src/db/seeders/add-user.ts'])).toThrow(addUserUsage)
+  })
+
+  it('--password が指定された場合は usage error を投げる', () => {
+    expect(() =>
+      parseAddUserArgs(['bun', 'src/db/seeders/add-user.ts', '--email', 'test@example.com', '--password', 'testpass'])
+    ).toThrow(addUserUsage)
   })
 
   it('未知の引数がある場合は usage error を投げる', () => {
     expect(() =>
       parseAddUserArgs(['bun', 'src/db/seeders/add-user.ts', '--email', 'test@example.com', '--unknown', 'value'])
-    ).toThrow('Usage: bun run db:user:add -- --email <email> --password <password>')
+    ).toThrow(addUserUsage)
   })
 })

--- a/projects/portfolio/tests/db/seeders/add-user-record.test.ts
+++ b/projects/portfolio/tests/db/seeders/add-user-record.test.ts
@@ -1,5 +1,5 @@
 import { getDatabase } from '#/db'
-import { addUser, UserAlreadyExistsError } from '#/db/seeders/add-user-record'
+import { addUser, ensureUserDoesNotExist, UserAlreadyExistsError } from '#/db/seeders/add-user-record'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('#/db', () => ({
@@ -97,5 +97,27 @@ describe('addUser', () => {
         passwordHash: 'hashed-password',
       })
     ).rejects.toBe(expectedError)
+  })
+})
+
+describe('ensureUserDoesNotExist', () => {
+  beforeEach(() => {
+    mockedGetDatabase.mockReset()
+  })
+
+  it('同じメールアドレスのユーザーがいなければ成功する', async () => {
+    const { db } = createDbStub([])
+    mockedGetDatabase.mockReturnValue(db as never)
+
+    await expect(ensureUserDoesNotExist('postgres://db', 'test@example.com')).resolves.toBeUndefined()
+  })
+
+  it('同じメールアドレスのユーザーがいれば UserAlreadyExistsError を投げる', async () => {
+    const { db } = createDbStub([{ id: 'user-1' }])
+    mockedGetDatabase.mockReturnValue(db as never)
+
+    await expect(ensureUserDoesNotExist('postgres://db', 'test@example.com')).rejects.toBeInstanceOf(
+      UserAlreadyExistsError
+    )
   })
 })

--- a/projects/portfolio/tests/db/seeders/read-password.test.ts
+++ b/projects/portfolio/tests/db/seeders/read-password.test.ts
@@ -1,0 +1,89 @@
+import { PassThrough, Writable } from 'node:stream'
+import {
+  passwordPrompt,
+  passwordRequiredMessage,
+  readPassword,
+  readPasswordFromPrompt,
+  readPasswordViaStdin,
+} from '#/db/seeders/read-password'
+import { describe, expect, it, vi } from 'vitest'
+
+describe('readPassword', () => {
+  it('TTY ありでは対話入力を使う', async () => {
+    const promptPassword = vi.fn().mockResolvedValue('secret-password')
+    const readPasswordFromStdin = vi.fn()
+
+    await expect(
+      readPassword({
+        input: { isTTY: true } as NodeJS.ReadStream,
+        promptPassword,
+        readPasswordFromStdin,
+      })
+    ).resolves.toBe('secret-password')
+
+    expect(promptPassword).toHaveBeenCalledOnce()
+    expect(readPasswordFromStdin).not.toHaveBeenCalled()
+  })
+
+  it('TTY なしでは stdin を使う', async () => {
+    const promptPassword = vi.fn()
+    const readPasswordFromStdin = vi.fn().mockResolvedValue('secret-password')
+
+    await expect(
+      readPassword({
+        input: { isTTY: false } as NodeJS.ReadStream,
+        promptPassword,
+        readPasswordFromStdin,
+      })
+    ).resolves.toBe('secret-password')
+
+    expect(readPasswordFromStdin).toHaveBeenCalledOnce()
+    expect(promptPassword).not.toHaveBeenCalled()
+  })
+})
+
+describe('readPasswordFromPrompt', () => {
+  it('入力後に改行だけを出力し、平文は出力しない', async () => {
+    const input = new PassThrough()
+    Object.assign(input, { isTTY: true })
+    const output = new CaptureWritable()
+
+    const promise = readPasswordFromPrompt({
+      input,
+      output,
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    input.end('secret-password\n')
+
+    await expect(promise).resolves.toBe('secret-password')
+    expect(output.value).toContain(passwordPrompt)
+    expect(output.value).not.toContain('secret-password')
+    expect(output.value.endsWith('\n')).toBe(true)
+  })
+})
+
+describe('readPasswordViaStdin', () => {
+  it('stdin から受け取ったパスワードを返す', async () => {
+    const input = new PassThrough()
+    input.end('secret-password\n')
+
+    await expect(readPasswordViaStdin(input)).resolves.toBe('secret-password')
+  })
+
+  it('空入力の場合は失敗する', async () => {
+    const input = new PassThrough()
+    input.end('\n')
+
+    await expect(readPasswordViaStdin(input)).rejects.toThrow(passwordRequiredMessage)
+  })
+})
+
+class CaptureWritable extends Writable {
+  value = ''
+
+  override _write(chunk: Buffer | string, _: BufferEncoding, callback: (error?: Error | null) => void) {
+    this.value += chunk.toString()
+    callback()
+  }
+}


### PR DESCRIPTION
## Issues

- Close #750

## Why

`db:user:add` が平文パスワードを `--password` 引数で受け取っており、shell history や `ps` の引数一覧に秘密情報が残る状態でした。加えて、既存メールアドレスで必ず失敗する場合でも先にパスワード入力を求めており、運用上の無駄がありました。

## Summary

`db:user:add` のパスワード入力を引数から外し、対話プロンプトまたは stdin で受け取るように変更しました。あわせて、メール重複時はパスワード入力前に失敗するようにして、並行実行時は insert 側でも同じ分かりやすいエラーへ寄せています。

## Changes

- `--password` 引数を廃止し、`db:user:add` で対話プロンプトと stdin の両方をサポート
- パスワード入力ユーティリティとそのテストを追加
- 既存ユーザーの事前チェックを追加し、重複時はパスワード入力前に終了
- insert 側の unique violation を引き続き `UserAlreadyExistsError` に変換
- README の使用例を新しい CLI 仕様に更新

## Checklist

- [x] `bun run lint`
- [x] `bun run test`
- [x] `bun run format:check`
