### PR TITLE
refactor(portfolio): redesign chat conversation history UI with split header

### DIFF
--- a/projects/portfolio/src/client/components/chat/chat-layout.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-layout.tsx
@@ -11,7 +11,7 @@ export function ChatLayout({ conversations, isSidebarOpen, onToggleSidebar, chil
     <div className='flex h-[calc(100dvh-3.5rem)] overflow-hidden bg-white md:h-dvh dark:bg-gray-900'>
       {/* サイドバー - モバイルではドロワー、デスクトップでは常時表示 */}
       <div
-        className={`fixed inset-y-0 left-0 z-50 w-64 min-h-screen border-gray-200 border-r bg-white dark:border-gray-700 dark:bg-gray-800 transform transition-transform duration-300 ease-in-out md:relative md:translate-x-0 md:w-40 md:z-auto ${
+        className={`fixed top-14 bottom-0 left-0 z-50 w-64 border-gray-200 border-r bg-white dark:border-gray-700 dark:bg-gray-800 transform transition-transform duration-300 ease-in-out md:relative md:top-0 md:translate-x-0 md:w-56 md:z-auto ${
           isSidebarOpen ? 'translate-x-0' : '-translate-x-full'
         }`}
       >
@@ -19,11 +19,13 @@ export function ChatLayout({ conversations, isSidebarOpen, onToggleSidebar, chil
       </div>
 
       {/* オーバーレイ背景 - モバイルのみ */}
-      {isSidebarOpen && <div className='fixed inset-0 bg-black/50 z-40 md:hidden' onClick={onToggleSidebar} />}
+      {isSidebarOpen && (
+        <div className='fixed top-14 bottom-0 left-0 right-0 bg-black/50 z-40 md:hidden' onClick={onToggleSidebar} />
+      )}
 
-      <div className='flex h-full min-h-0 flex-1 bg-white dark:bg-gray-900'>{children}</div>
+      <div className='flex h-full min-h-0 flex-1 flex-col bg-white dark:bg-gray-900'>{children}</div>
     </div>
   ) : (
-    <div className='h-[calc(100dvh-3.5rem)] bg-white md:h-dvh dark:bg-gray-900'>{children}</div>
+    <div className='flex h-[calc(100dvh-3.5rem)] flex-col bg-white md:h-dvh dark:bg-gray-900'>{children}</div>
   )
 }

--- a/projects/portfolio/src/client/components/chat/chat-settings/chat-settings.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-settings/chat-settings.tsx
@@ -34,40 +34,45 @@ export function ChatSettings({
 
   return (
     <>
-      {/* Button Group - Fixed position (top-left, accounting for sidebar on desktop) */}
-      <div className='fixed top-0 left-0 z-30 p-4 md:left-16'>
+      {/* Header Bar */}
+      <div className='flex h-12 shrink-0 items-center justify-between border-b border-gray-200 px-4 dark:border-gray-700'>
         {showActions && (
-          <div className='flex flex-col items-center gap-2 sm:flex-row'>
-            {/* Sidebar Toggle - Mobile only (shown only when logged in) */}
-            {showSidebarToggle && (
+          <>
+            {/* Left side */}
+            <div className='flex items-center gap-2'>
+              {showSidebarToggle && (
+                <button
+                  type='button'
+                  onClick={onToggleSidebar}
+                  className='flex cursor-pointer items-center justify-center rounded-md p-2 text-gray-600 transition hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-400 md:hidden dark:text-gray-300 dark:hover:bg-gray-700 dark:focus:ring-gray-500'
+                >
+                  <SidebarIcon className='fill-[#5D5D5D] dark:fill-gray-300' />
+                </button>
+              )}
+              {showNewChat && (
+                <button
+                  type='button'
+                  onClick={onNewChat}
+                  className='flex cursor-pointer items-center justify-center rounded-md p-2 text-gray-600 transition hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-400 dark:text-gray-300 dark:hover:bg-gray-700 dark:focus:ring-gray-500'
+                >
+                  <NewChatIcon className='fill-[#5D5D5D] dark:fill-gray-300' />
+                </button>
+              )}
+            </div>
+            {/* Right side */}
+            <div className='flex items-center gap-2'>
+              <span className='max-w-48 truncate text-xs font-medium text-gray-500 dark:text-gray-400'>
+                {contextValue.fakeMode ? 'Fake Mode' : contextValue.settings.model}
+              </span>
               <button
                 type='button'
-                onClick={onToggleSidebar}
-                className='flex transform cursor-pointer items-center justify-center rounded-full bg-white p-2 transition duration-300 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-400 md:hidden dark:bg-gray-800 dark:hover:bg-gray-700 dark:focus:ring-gray-500'
+                onClick={onShowMenu}
+                className='flex cursor-pointer items-center justify-center rounded-md p-2 text-gray-600 transition hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-400 dark:text-gray-300 dark:hover:bg-gray-700 dark:focus:ring-gray-500'
               >
-                <SidebarIcon className='fill-[#5D5D5D] dark:fill-gray-300' />
+                <GearIcon className='fill-[#5D5D5D] dark:fill-gray-300' />
               </button>
-            )}
-            {showNewChat && (
-              <button
-                type='button'
-                onClick={onNewChat}
-                className='flex transform cursor-pointer items-center justify-center rounded-full bg-white p-2 transition duration-300 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-400 dark:bg-gray-800 dark:hover:bg-gray-700 dark:focus:ring-gray-500'
-              >
-                <NewChatIcon className='fill-[#5D5D5D] dark:fill-gray-300' />
-              </button>
-            )}
-            <button
-              type='button'
-              onClick={onShowMenu}
-              className='flex transform cursor-pointer items-center justify-center rounded-full bg-white p-2 transition duration-300 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-400 dark:bg-gray-800 dark:hover:bg-gray-700 dark:focus:ring-gray-500'
-            >
-              <GearIcon className='fill-[#5D5D5D] dark:fill-gray-300' />
-            </button>
-            <span className='hidden max-w-48 truncate text-xs font-medium text-gray-900 sm:block dark:text-gray-200'>
-              {contextValue.fakeMode ? 'Fake Mode' : contextValue.settings.model}
-            </span>
-          </div>
+            </div>
+          </>
         )}
       </div>
 

--- a/projects/portfolio/src/client/components/chat/conversation-history.tsx
+++ b/projects/portfolio/src/client/components/chat/conversation-history.tsx
@@ -31,12 +31,12 @@ export function ConversationHistory({
 
   return (
     <div className='flex h-full flex-col bg-gray-50 dark:bg-gray-800'>
-      <div className='border-gray-200 border-b p-3 dark:border-gray-700'>
+      <div className='flex h-12 items-center border-gray-200 border-b px-3 dark:border-gray-700'>
         <button
           type='button'
           onClick={onNewConversation}
           disabled={disabled}
-          className='flex w-full items-center gap-2 rounded-md border border-gray-300 bg-white px-3 py-2 font-medium text-gray-700 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 enabled:cursor-pointer hover:enabled:bg-gray-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:hover:enabled:bg-gray-600'
+          className='flex w-full items-center gap-2 rounded-md border border-gray-300 bg-white px-3 py-1.5 font-medium text-gray-700 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 enabled:cursor-pointer hover:enabled:bg-gray-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:hover:enabled:bg-gray-600'
         >
           <NewChatIcon className='fill-gray-600 dark:fill-gray-400' size={16} />
           新しい会話

--- a/projects/portfolio/src/client/components/chat/prompt-template.tsx
+++ b/projects/portfolio/src/client/components/chat/prompt-template.tsx
@@ -143,7 +143,7 @@ function PromptTemplateComponent({ placeholder, onSubmit }: Props) {
                 <input
                   type='text'
                   spellCheck='false'
-                  className='w-full rounded-sm border p-1 text-sm transition-colors hover:border-primary-700 focus:outline-hidden dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200'
+                  className='w-full rounded-sm border p-1 text-sm transition-colors placeholder-gray-400 hover:border-primary-700 focus:outline-hidden dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:placeholder-gray-400'
                   placeholder={template.placeholder}
                   onKeyDown={(e) => handleKeyDownTemplate(e, template)}
                   onCompositionStart={() => handleChangeComposition(true)}
@@ -151,7 +151,7 @@ function PromptTemplateComponent({ placeholder, onSubmit }: Props) {
                 />
               ) : (
                 <textarea
-                  className='max-h-64 min-h-8 w-full rounded-sm border p-1 text-sm transition-colors hover:border-primary-700 focus:outline-hidden dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:placeholder-gray-400'
+                  className='max-h-64 min-h-8 w-full rounded-sm border p-1 text-sm transition-colors placeholder-gray-400 hover:border-primary-700 focus:outline-hidden dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:placeholder-gray-400'
                   placeholder={template.placeholder}
                   onKeyDown={(e) => handleKeyDownTemplate(e, template)}
                   onCompositionStart={() => handleChangeComposition(true)}


### PR DESCRIPTION
## Issue
- Close #630

## Why

ChatSettings のボタン群（サイドバートグル、新規チャット、設定ギア、モデル名）が `fixed top-0 left-0 z-30` でフローティング配置されており、会話履歴サイドバーと重なっていた。また、モバイルでの会話履歴ドロワー表示が AppLayout ヘッダーと干渉していた。

## Summary

Split Header パターンを採用し、サイドバーとメインエリアにそれぞれ専用ヘッダーバーを持たせる構造に変更。フローティングボタンを廃止し、レイアウトフローに沿ったインラインヘッダーに統一した。

## Changes

- `chat-settings.tsx`: `fixed` 配置を削除し、`flex h-12` のインラインヘッダーバーに変更。左側にサイドバートグル+新規チャット、右側にモデル名+設定ギアを配置
- `chat-layout.tsx`: メインコンテンツに `flex-col` 追加、デスクトップサイドバー幅を `md:w-40` → `md:w-56` に拡大、モバイルサイドバーを `top-14` 起点に修正
- `conversation-history.tsx`: ヘッダー高さを `h-12` に統一してメインヘッダーと水平ラインを揃える

## Checklist

- [x] lint / format パス
- [x] テスト全件パス (26 files, 96 tests)
- [ ] デスクトップ表示確認（会話履歴あり/なし）
- [ ] モバイル表示確認（サイドバードロワー動作）
- [ ] ダークモード表示確認
