### PR TITLE
feat(portfolio): display assistant metadata per message instead of end-of-list

### DIFF
--- a/projects/portfolio/drizzle/0003_nappy_sage.sql
+++ b/projects/portfolio/drizzle/0003_nappy_sage.sql
@@ -1,0 +1,3 @@
+UPDATE "messages" SET "metadata" = '{}'::jsonb WHERE "metadata" IS NULL;--> statement-breakpoint
+ALTER TABLE "messages" ALTER COLUMN "metadata" SET DEFAULT '{}'::jsonb;--> statement-breakpoint
+ALTER TABLE "messages" ALTER COLUMN "metadata" SET NOT NULL;

--- a/projects/portfolio/drizzle/meta/0003_snapshot.json
+++ b/projects/portfolio/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,184 @@
+{
+  "id": "85c2cc6d-d7d1-422b-ae1f-c9f652f36ac4",
+  "prevId": "0c05c15d-1ca0-4dc2-952b-addd05784cd2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversations_user_id_users_id_fk": {
+          "name": "conversations_user_id_users_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reasoning_content": {
+          "name": "reasoning_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_conversation_id_conversations_id_fk": {
+          "name": "messages_conversation_id_conversations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/projects/portfolio/drizzle/meta/_journal.json
+++ b/projects/portfolio/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1775922883832,
       "tag": "0002_ambitious_gorgon",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1775990886633,
+      "tag": "0003_nappy_sage",
+      "breakpoints": true
     }
   ]
 }

--- a/projects/portfolio/src/client/components/chat/chat-main.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-main.tsx
@@ -129,6 +129,7 @@ export function ChatMain({
         // assistant メッセージを state に追加（ドメイン型で保持）
         const assistantMessage: Message | null = result
           ? {
+              id: uuidv7(),
               role: 'assistant' as const,
               content: result.message.content,
               reasoningContent: result.message.reasoningContent,

--- a/projects/portfolio/src/client/components/chat/chat-main.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-main.tsx
@@ -50,7 +50,7 @@ export function ChatMain({
     resetAfterSubmit,
   } = useChatForm({ initTrigger, formRef })
   const { copiedId, copyMessage } = useMessageCopy()
-  const { loading, stream, chatResults, cancelStream, resetChatResults, submitChatCompletion } = useStreamProcessor({
+  const { loading, stream, cancelStream, submitChatCompletion } = useStreamProcessor({
     onSubmitting,
   })
   const { scrollContainerRef, bottomChatInputContainerRef, messageEndRef, handleScroll, scrollToMessageEnd } =
@@ -58,14 +58,13 @@ export function ChatMain({
       loading,
       streamMode: settings.streamMode,
       stream,
-      chatResults,
+      messages,
     })
 
   useEffect(() => {
     setMessages([])
     setConversationId(null)
-    resetChatResults()
-  }, [initTrigger, resetChatResults])
+  }, [initTrigger])
 
   // 選択された会話のメッセージを設定
   useEffect(() => {
@@ -76,11 +75,10 @@ export function ChatMain({
     // 会話が選択された時、そのメッセージをドメイン型のまま設定（変換不要）
     setConversationId(currentConversation.id)
     setMessages(currentConversation.messages)
-    resetChatResults()
     setTimeout(() => {
       scrollToMessageEnd()
     }, 0)
-  }, [currentConversation, resetChatResults, scrollToMessageEnd])
+  }, [currentConversation, scrollToMessageEnd])
 
   const handleSubmit = useCallback(
     (event: FormEvent<HTMLFormElement>) => {
@@ -112,7 +110,6 @@ export function ChatMain({
           : [...messages, params.draftUserMessage]
       setMessages(nextMessages)
       resetAfterSubmit()
-      resetChatResults()
 
       submitChatCompletion({
         header: {
@@ -175,7 +172,6 @@ export function ChatMain({
       messages,
       onConversationChange,
       resetAfterSubmit,
-      resetChatResults,
       settings.apiKey,
       settings.baseURL,
       settings.fakeMode,
@@ -293,7 +289,6 @@ export function ChatMain({
             markdownPreview={settings.markdownPreview}
             loading={loading}
             stream={stream}
-            chatResults={chatResults}
             copiedId={copiedId}
             messageEndRef={messageEndRef}
             onCopyMessage={copyMessage}

--- a/projects/portfolio/src/client/components/chat/chat-message-list.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-message-list.tsx
@@ -101,7 +101,7 @@ const MessageHistory = memo(function MessageHistory({
 }: MessageHistoryProps) {
   return messages.map((message, index) => (
     <MessageRenderer
-      key={`chat_${index}`}
+      key={message.id ?? `chat_${index}`}
       message={message}
       index={index}
       markdownPreview={markdownPreview}

--- a/projects/portfolio/src/client/components/chat/chat-message-list.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-message-list.tsx
@@ -1,9 +1,8 @@
-import { ChatResults } from '#/client/components/chat/chat-results'
 import { CodeBlockRenderer, MarkdownLink } from '#/client/components/chat/code-block-renderer'
 import { MessageRenderer } from '#/client/components/chat/message-renderer'
 import { ChatbotIcon } from '#/client/components/svg/chatbot-icon'
 import { SpinnerIcon } from '#/client/components/svg/spinner-icon'
-import type { ChatResultSummary, ChatStreamState, Message } from '#/types'
+import type { ChatStreamState, Message } from '#/types'
 import { memo, type RefObject } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
@@ -19,7 +18,6 @@ interface ChatMessageListProps {
   markdownPreview: boolean
   loading: boolean
   stream: ChatStreamState | null
-  chatResults: ChatResultSummary | null
   copiedId: string
   messageEndRef: RefObject<HTMLDivElement | null>
   onCopyMessage: (message: string, index: number) => void
@@ -31,7 +29,6 @@ export function ChatMessageList({
   markdownPreview,
   loading,
   stream,
-  chatResults,
   copiedId,
   messageEndRef,
   onCopyMessage,
@@ -78,14 +75,6 @@ export function ChatMessageList({
               </div>
             )}
           </div>
-        )}
-        {!loading && chatResults && (
-          <ChatResults
-            model={chatResults.model}
-            finishReason={chatResults.finish_reason}
-            responseTimeMs={chatResults.responseTimeMs}
-            usage={chatResults.usage}
-          />
         )}
         <div ref={messageEndRef} className='h-4' />
       </div>

--- a/projects/portfolio/src/client/components/chat/chat-results.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-results.tsx
@@ -1,11 +1,8 @@
-import type { ChatResultSummary } from '#/types'
-import { memo } from 'react'
+import type { AssistantMetadata } from '#/types'
+import { memo, useState } from 'react'
 
 interface ChatResultsProps {
-  model?: ChatResultSummary['model']
-  finishReason?: string
-  responseTimeMs?: ChatResultSummary['responseTimeMs']
-  usage?: ChatResultSummary['usage']
+  metadata: AssistantMetadata
 }
 
 function formatResponseTime(ms: number): string {
@@ -15,34 +12,77 @@ function formatResponseTime(ms: number): string {
   return `${(ms / 1000).toFixed(1)}s`
 }
 
-function ChatResultsComponent({ model, finishReason, responseTimeMs, usage }: ChatResultsProps) {
+const badgeClass = 'flex items-center rounded-md bg-gray-100 px-2 py-1 text-xs dark:bg-gray-700 dark:text-gray-300'
+
+function ChatResultsComponent({ metadata }: ChatResultsProps) {
+  const [open, setOpen] = useState(false)
+
+  if (!metadata.model) {
+    return null
+  }
+
+  const { model, finishReason, responseTimeMs, usage } = metadata
+
   return (
-    <div className='mt-2 flex flex-wrap justify-end gap-1'>
-      <div className='flex items-center rounded-md bg-gray-100 px-2 py-1 text-xs dark:bg-gray-700 dark:text-gray-300'>
-        <span className='mr-1'>model:</span>
+    <div className='mt-2'>
+      <button
+        type='button'
+        className='flex cursor-pointer flex-wrap items-center gap-1 text-xs text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300'
+        onClick={() => setOpen((prev) => !prev)}
+      >
         <span>{model}</span>
-      </div>
-      {finishReason && (
-        <div className='flex items-center rounded-md bg-gray-100 px-2 py-1 text-xs dark:bg-gray-700 dark:text-gray-300'>
-          <span className='mr-1'>finish_reason:</span>
-          <span>{finishReason}</span>
+        {responseTimeMs !== undefined && (
+          <>
+            <span>·</span>
+            <span>{formatResponseTime(responseTimeMs)}</span>
+          </>
+        )}
+        {(usage.promptTokens || usage.completionTokens) && (
+          <>
+            <span>·</span>
+            <span>
+              {usage.promptTokens ?? '--'}→{usage.completionTokens ?? '--'} tokens
+            </span>
+          </>
+        )}
+        <span className='ml-0.5'>{open ? '▲' : '▼'}</span>
+      </button>
+      {open && (
+        <div className='mt-1 flex flex-wrap gap-1'>
+          <div className={badgeClass}>
+            <span className='mr-1'>model:</span>
+            <span>{model}</span>
+          </div>
+          {finishReason && (
+            <div className={badgeClass}>
+              <span className='mr-1'>finish_reason:</span>
+              <span>{finishReason}</span>
+            </div>
+          )}
+          {responseTimeMs !== undefined && (
+            <div className={badgeClass}>
+              <span className='mr-1'>time:</span>
+              <span>{formatResponseTime(responseTimeMs)}</span>
+            </div>
+          )}
+          <div className={badgeClass}>
+            <span className='mr-1'>usage:</span>
+            <span className='mr-0.5'>(input:</span>
+            <span>{usage.promptTokens ?? '--'}</span>
+            <span className='mr-0.5'>/</span>
+            <span className='mr-0.5'>output:</span>
+            <span>{usage.completionTokens ?? '--'}</span>
+            {usage.reasoningTokens !== undefined && (
+              <>
+                <span className='mr-0.5'>/</span>
+                <span className='mr-0.5'>reasoning:</span>
+                <span>{usage.reasoningTokens}</span>
+              </>
+            )}
+            <span>)</span>
+          </div>
         </div>
       )}
-      {responseTimeMs !== undefined && (
-        <div className='flex items-center rounded-md bg-gray-100 px-2 py-1 text-xs dark:bg-gray-700 dark:text-gray-300'>
-          <span className='mr-1'>time:</span>
-          <span>{formatResponseTime(responseTimeMs)}</span>
-        </div>
-      )}
-      <div className='flex items-center rounded-md bg-gray-100 px-2 py-1 text-xs dark:bg-gray-700 dark:text-gray-300'>
-        <span className='mr-1'>usage:</span>
-        <span className='mr-0.5'>(input:</span>
-        <span>{usage?.promptTokens || '--'}</span>
-        <span className='mr-0.5'>/</span>
-        <span className='mr-0.5'>output:</span>
-        <span>{usage?.completionTokens || '--'}</span>
-        <span>)</span>
-      </div>
     </div>
   )
 }

--- a/projects/portfolio/src/client/components/chat/hooks/chat-response.ts
+++ b/projects/portfolio/src/client/components/chat/hooks/chat-response.ts
@@ -4,7 +4,6 @@ import {
   type ChatCompletionResponse,
   type ChatCompletionResult,
   type ChatCompletionStreamChunk,
-  type ChatResultSummary,
   type ChatStreamState,
 } from '#/types'
 
@@ -25,7 +24,7 @@ export function updateChatStream(
   stream: ChatStreamState
   finishReason: string
   model?: string
-  usage: ChatResultSummary['usage']
+  usage: ChatCompletionResult['usage']
 } {
   const choice = chunk.choices.at(0)
   const nextStream = {
@@ -61,21 +60,7 @@ export function toChatCompletionResult(response: ChatCompletionResponse): ChatCo
   }
 }
 
-export function toChatResultSummary(params: {
-  model?: string
-  finishReason: string
-  responseTimeMs?: number
-  usage: ApiUsage
-}): ChatResultSummary {
-  return {
-    model: params.model,
-    finish_reason: params.finishReason,
-    responseTimeMs: params.responseTimeMs,
-    usage: normalizeUsage(params.usage),
-  }
-}
-
-function normalizeUsage(usage: ApiUsage): ChatResultSummary['usage'] {
+function normalizeUsage(usage: ApiUsage): ChatCompletionResult['usage'] {
   if (!usage) {
     return null
   }

--- a/projects/portfolio/src/client/components/chat/hooks/use-chat-form.ts
+++ b/projects/portfolio/src/client/components/chat/hooks/use-chat-form.ts
@@ -2,6 +2,7 @@ import type { TemplateInput } from '#/client/components/chat/prompt-template'
 import type { ApiChatMessage, Message } from '#/types'
 import { toApiChatMessage } from '#/types'
 import { type ChangeEvent, type KeyboardEvent, type RefObject, useEffect, useState } from 'react'
+import { uuidv7 } from 'uuidv7'
 
 const MIN_TEXT_LINE_COUNT = 2
 const MAX_TEXT_LINE_COUNT = 5
@@ -123,6 +124,7 @@ const createMessage = (
   }
 
   const draftUserMessage: Message = {
+    id: uuidv7(),
     role: 'user',
     content:
       uploadImages.length > 0
@@ -159,12 +161,14 @@ const createTemplateMessage = (
   { interactiveMode, messages }: { interactiveMode: boolean; messages: Message[] }
 ): BuiltChatMessages => {
   const draftUserMessage: Message = {
+    id: uuidv7(),
     role: 'user',
     content: templateInput.content,
     reasoningContent: '',
     metadata: { model: templateInput.model || model },
   }
   const systemMessage: Message = {
+    id: uuidv7(),
     role: 'system',
     content: templateInput.prompt,
     reasoningContent: '',

--- a/projects/portfolio/src/client/components/chat/hooks/use-message-scroll.ts
+++ b/projects/portfolio/src/client/components/chat/hooks/use-message-scroll.ts
@@ -1,14 +1,14 @@
-import type { ChatResultSummary, ChatStreamState } from '#/types'
+import type { ChatStreamState, Message } from '#/types'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 interface UseMessageScrollParams {
   loading: boolean
   streamMode: boolean
   stream: ChatStreamState | null
-  chatResults: ChatResultSummary | null
+  messages: Message[]
 }
 
-export function useMessageScroll({ loading, streamMode, stream, chatResults }: UseMessageScrollParams) {
+export function useMessageScroll({ loading, streamMode, stream, messages }: UseMessageScrollParams) {
   const scrollContainerRef = useRef<HTMLDivElement>(null)
   const bottomChatInputContainerRef = useRef<HTMLDivElement>(null)
   const messageEndRef = useRef<HTMLDivElement>(null)
@@ -39,7 +39,7 @@ export function useMessageScroll({ loading, streamMode, stream, chatResults }: U
   useEffect(() => {
     if (!autoScroll) return
     messageEndRef.current?.scrollIntoView(!streamMode && { behavior: 'smooth' })
-  }, [stream, chatResults, streamMode, autoScroll, bottomChatInputContainerHeight])
+  }, [stream, messages.length, streamMode, autoScroll, bottomChatInputContainerHeight])
 
   const handleScroll = useCallback(() => {
     if (!scrollContainerRef.current) return

--- a/projects/portfolio/src/client/components/chat/hooks/use-stream-processor.ts
+++ b/projects/portfolio/src/client/components/chat/hooks/use-stream-processor.ts
@@ -1,12 +1,11 @@
 import type { AppType } from '#/server/app.d'
-import type { ApiChatMessage, ChatCompletionResult, ChatResultSummary, ChatStreamState } from '#/types'
+import type { ApiChatMessage, ChatCompletionResult, ChatStreamState } from '#/types'
 import { hc } from 'hono/client'
 import { useCallback, useRef, useState } from 'react'
 import {
   parseChatCompletionResponse,
   parseChatCompletionStreamChunk,
   toChatCompletionResult,
-  toChatResultSummary,
   updateChatStream,
 } from './chat-response'
 
@@ -35,17 +34,12 @@ export function useStreamProcessor({ onSubmitting }: UseStreamProcessorParams = 
   const abortControllerRef = useRef<AbortController | null>(null)
   const [loading, setLoading] = useState(false)
   const [stream, setStream] = useState<ChatStreamState | null>(null)
-  const [chatResults, setChatResults] = useState<ChatResultSummary | null>(null)
 
   const cancelStream = useCallback(() => {
     if (abortControllerRef.current) {
       abortControllerRef.current.abort()
       abortControllerRef.current = null
     }
-  }, [])
-
-  const resetChatResults = useCallback(() => {
-    setChatResults(null)
   }, [])
 
   const submitChatCompletion = useCallback(
@@ -59,7 +53,6 @@ export function useStreamProcessor({ onSubmitting }: UseStreamProcessorParams = 
       reasoningEffort,
     }: SubmitChatCompletionParams): Promise<{ result: ChatCompletionResult | null; responseTimeMs: number }> => {
       setLoading(true)
-      setChatResults(null)
       abortControllerRef.current = new AbortController()
       onSubmitting?.(true)
       const requestStartTime = Date.now()
@@ -80,24 +73,6 @@ export function useStreamProcessor({ onSubmitting }: UseStreamProcessorParams = 
         })
         const responseTimeMs = Date.now() - requestStartTime
 
-        if (result) {
-          setChatResults(
-            toChatResultSummary({
-              model: result.model,
-              finishReason: result.finishReason,
-              responseTimeMs,
-              usage: result.usage
-                ? {
-                    prompt_tokens: result.usage.promptTokens,
-                    completion_tokens: result.usage.completionTokens,
-                    total_tokens: result.usage.totalTokens,
-                    reasoning_tokens: result.usage.reasoningTokens,
-                  }
-                : null,
-            })
-          )
-        }
-
         return { result, responseTimeMs }
       } finally {
         abortControllerRef.current = null
@@ -112,9 +87,7 @@ export function useStreamProcessor({ onSubmitting }: UseStreamProcessorParams = 
   return {
     loading,
     stream,
-    chatResults,
     cancelStream,
-    resetChatResults,
     submitChatCompletion,
   }
 }
@@ -139,7 +112,7 @@ const sendChatCompletion = async (req: {
     reasoning_content: '',
   }
   let finish_reason = ''
-  let usage: ChatResultSummary['usage'] = null
+  let usage: ChatCompletionResult['usage'] = null
   let responseModel = 'N/A'
 
   try {

--- a/projects/portfolio/src/client/components/chat/message-renderer.tsx
+++ b/projects/portfolio/src/client/components/chat/message-renderer.tsx
@@ -1,3 +1,4 @@
+import { ChatResults } from '#/client/components/chat/chat-results'
 import { CodeBlockRenderer, MarkdownLink } from '#/client/components/chat/code-block-renderer'
 import { ChatbotIcon } from '#/client/components/svg/chatbot-icon'
 import { CheckIcon } from '#/client/components/svg/check-icon'
@@ -111,6 +112,7 @@ function MessageRendererComponent({
             {copied ? <CheckIcon size={20} /> : <CopyIcon size={20} />}
           </button>
         </div>
+        <ChatResults metadata={message.metadata} />
       </div>
     </div>
   )

--- a/projects/portfolio/src/db/schema.ts
+++ b/projects/portfolio/src/db/schema.ts
@@ -29,7 +29,7 @@ export const messagesTable = pgTable('messages', {
   role: text('role').notNull(), // 'user' | 'assistant'
   content: text('content').notNull(),
   reasoningContent: text('reasoning_content').notNull(),
-  metadata: jsonb('metadata'), // JSONデータ型
+  metadata: jsonb('metadata').notNull().default({}),
   createdAt: timestamp('created_at', { mode: 'date' }).notNull(),
 })
 

--- a/projects/portfolio/src/server/features/chat-conversations/read-conversations.ts
+++ b/projects/portfolio/src/server/features/chat-conversations/read-conversations.ts
@@ -1,7 +1,7 @@
 import { getDatabase } from '#/db'
 import { conversationsTable, messagesTable, usersTable } from '#/db/schema'
 import type { AssistantMetadata, Conversation, ImageContent, Message, TextContent, UserMetadata } from '#/types'
-import { asc, desc, eq, sql } from 'drizzle-orm'
+import { asc, desc, eq } from 'drizzle-orm'
 
 /**
  * DB から読み出した content 文字列を deserialize する。
@@ -64,16 +64,7 @@ export async function readConversations(databaseUrl: string, email: string): Pro
     .from(conversationsTable)
     .leftJoin(messagesTable, eq(conversationsTable.id, messagesTable.conversationId))
     .where(eq(conversationsTable.userId, userId))
-    .orderBy(
-      desc(conversationsTable.updatedAt),
-      asc(messagesTable.createdAt),
-      sql`CASE
-        WHEN ${messagesTable.role} = 'system' THEN 1
-        WHEN ${messagesTable.role} = 'user' THEN 2
-        WHEN ${messagesTable.role} = 'assistant' THEN 3
-        ELSE 4
-      END`
-    )
+    .orderBy(desc(conversationsTable.updatedAt), asc(messagesTable.createdAt))
 
   // JOINの結果を会話ごとにグループ化
   const conversationMap = new Map<string, Conversation>()

--- a/projects/portfolio/src/server/features/chat-conversations/upsert-conversation.ts
+++ b/projects/portfolio/src/server/features/chat-conversations/upsert-conversation.ts
@@ -46,14 +46,16 @@ export async function upsertConversation(databaseUrl: string, email: string, { i
     }
 
     // メッセージの登録（全件挿入）
-    const messageValues = messages.map((message) => ({
+    // index を ms 単位でずらすことで元の配列順序を createdAt に反映し、
+    // DB から読み戻したときの ORDER BY createdAt で順序が保たれるようにする
+    const messageValues = messages.map((message, index) => ({
       id: uuidv7(),
       conversationId: id,
       role: message.role,
       content: serializeContent(message.content),
       reasoningContent: message.reasoningContent ?? '',
       metadata: message.metadata ?? {},
-      createdAt: now,
+      createdAt: new Date(now.getTime() + index),
     }))
 
     await tx.insert(messagesTable).values(messageValues)

--- a/projects/portfolio/src/server/features/chat-conversations/upsert-conversation.ts
+++ b/projects/portfolio/src/server/features/chat-conversations/upsert-conversation.ts
@@ -52,8 +52,7 @@ export async function upsertConversation(databaseUrl: string, email: string, { i
       role: message.role,
       content: serializeContent(message.content),
       reasoningContent: message.reasoningContent ?? '',
-      // metadata は jsonb カラムにオブジェクトのまま渡す（JSON.stringify は不要）
-      metadata: message.metadata ?? null,
+      metadata: message.metadata ?? {},
       createdAt: now,
     }))
 

--- a/projects/portfolio/src/types/chat.ts
+++ b/projects/portfolio/src/types/chat.ts
@@ -218,18 +218,6 @@ export interface ChatStreamState {
   reasoning_content?: string
 }
 
-export interface ChatResultSummary {
-  model?: string
-  finish_reason: string
-  responseTimeMs?: number
-  usage: {
-    promptTokens: number
-    completionTokens: number
-    totalTokens: number
-    reasoningTokens?: number
-  } | null
-}
-
 export interface ChatCompletionResult {
   model: string
   finishReason: string

--- a/projects/portfolio/src/types/index.ts
+++ b/projects/portfolio/src/types/index.ts
@@ -33,7 +33,6 @@ export {
   type ChatCompletionStreamChunk,
   // API レスポンス型
   type ChatStreamState,
-  type ChatResultSummary,
   type ChatCompletionResult,
   // Converters
   toApiChatMessage,

--- a/projects/portfolio/tests/client/hooks/chat-response.test.ts
+++ b/projects/portfolio/tests/client/hooks/chat-response.test.ts
@@ -2,7 +2,6 @@ import {
   parseChatCompletionResponse,
   parseChatCompletionStreamChunk,
   toChatCompletionResult,
-  toChatResultSummary,
   updateChatStream,
 } from '#/client/components/chat/hooks/chat-response'
 import { describe, expect, it } from 'vitest'
@@ -36,25 +35,6 @@ describe('chat-response helpers', () => {
         reasoningContent: 'thinking',
       },
       responseTimeMs: 0,
-      usage: {
-        promptTokens: 10,
-        completionTokens: 20,
-        totalTokens: 30,
-        reasoningTokens: 5,
-      },
-    })
-
-    expect(
-      toChatResultSummary({
-        model: response.model,
-        finishReason: response.choices[0]?.finish_reason ?? '',
-        responseTimeMs: 1234,
-        usage: response.usage,
-      })
-    ).toEqual({
-      model: 'gpt-test',
-      finish_reason: 'stop',
-      responseTimeMs: 1234,
       usage: {
         promptTokens: 10,
         completionTokens: 20,


### PR DESCRIPTION
## Issues

- Close #755

## Why

Currently, assistant message metadata (model, tokens, response time) is only displayed at the end of the chat in a `chatResults` state that gets lost on page refresh or conversation switch. This creates inconsistency where historical messages lack metadata display.

## Summary

Embed assistant message metadata display directly into each message, making it persistent and visible regardless of refresh or navigation. Use `messages.metadata` as the source of truth instead of relying on temporary hook state.

## Changes

- **DB Migration**: Add `drizzle/0003_nappy_sage.sql` to migrate `messages.metadata` from nullable to `NOT NULL DEFAULT '{}'`
- **Schema & Upsert**: Update `messages.metadata` definition and ensure upsert always stores metadata as an object
- **Message Display**: Embed metadata (model, response time, tokens) directly in `MessageRenderer` for assistant messages
- **Chat Results Component**: Refactor to accept `AssistantMetadata` with summary + expandable details UI
- **Remove Hook State Dependency**: Remove `chatResults` state from `useStreamProcessor` and its references throughout the app
- **Scroll Logic**: Update `useMessageScroll` to track `messages` length instead of `chatResults`
- **Tests**: Remove `toChatResultSummary` function and its test case
- **Type Cleanup**: Delete `ChatResultSummary` type (replaced by per-message metadata)

## Checklist

- [x] `bun run lint` passes
- [x] `bun run test` passes (96 tests)
- [x] `bun run format:check` passes
- [x] Metadata displays per assistant message (summary + expandable)
- [x] Legacy messages without metadata don't show placeholder
- [x] Metadata persists across page refresh and conversation switches

## Details

### Architecture

The implementation uses `message.metadata` as the canonical source for assistant message details:
- **Summary line**: Shows model name, response time, token counts on a single clickable line
- **Expanded view**: Shows full details (model, finish_reason, time, usage breakdown)
- **No action required for legacy messages**: Empty metadata gracefully hides the display

### Migration

The migration script first normalizes existing NULL metadata to empty objects before adding the NOT NULL constraint, ensuring zero downtime.

### UI/UX

- Summary fits on one line and is always visible
- Click/tap to expand detailed badge display
- Works on mobile (not hover-dependent)
- Dark mode support included
