### PR TITLE
fix(portfolio): improve code block renderer UI and font rendering

### DIFF
--- a/projects/portfolio/src/client/components/chat/chat-message-list.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-message-list.tsx
@@ -4,7 +4,7 @@ import { ReasoningSection } from '#/client/components/chat/reasoning-section'
 import { ChatbotIcon } from '#/client/components/svg/chatbot-icon'
 import { SpinnerIcon } from '#/client/components/svg/spinner-icon'
 import type { ChatStreamState, Message } from '#/types'
-import { memo, type RefObject } from 'react'
+import { memo, type ReactNode, type RefObject } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 
@@ -12,6 +12,7 @@ const markdownRemarkPlugins = [remarkGfm]
 const markdownComponents = {
   a: MarkdownLink,
   code: CodeBlockRenderer,
+  pre: ({ children }: { children?: ReactNode }) => <>{children}</>,
 }
 
 interface ChatMessageListProps {

--- a/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
+++ b/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
@@ -160,6 +160,8 @@ export function CodeBlockRenderer({ className, children }: CodeBlockRendererProp
         style={isDarkMode ? atomDark : undefined}
         language={selectedLanguage === 'plain' ? undefined : selectedLanguage}
         customStyle={{ fontSize: '0.875rem', margin: 0, borderRadius: 0 }}
+        showLineNumbers
+        lineNumberStyle={{ color: isDarkMode ? '#6b7280' : '#9ca3af', minWidth: '2.5em' }}
       >
         {code}
       </SyntaxHighlighter>

--- a/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
+++ b/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
@@ -93,7 +93,11 @@ export function CodeBlockRenderer({ className, children }: CodeBlockRendererProp
   const isBlock = detectedLanguage !== undefined || (typeof children === 'string' && code.includes('\n'))
 
   if (!isBlock || typeof children !== 'string') {
-    return <code className={className}>{children}</code>
+    return (
+      <code className={`${className ?? ''} before:content-none after:content-none rounded bg-gray-100 px-1 py-0.5 font-mono text-sm dark:bg-gray-700`}>
+        {children}
+      </code>
+    )
   }
 
   // Include detected language in options even if not in the standard list

--- a/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
+++ b/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
@@ -159,6 +159,7 @@ export function CodeBlockRenderer({ className, children }: CodeBlockRendererProp
       <SyntaxHighlighter
         style={isDarkMode ? atomDark : undefined}
         language={selectedLanguage === 'plain' ? undefined : selectedLanguage}
+        customStyle={{ fontSize: '0.875rem' }}
       >
         {code}
       </SyntaxHighlighter>

--- a/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
+++ b/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
@@ -94,7 +94,9 @@ export function CodeBlockRenderer({ className, children }: CodeBlockRendererProp
 
   if (!isBlock || typeof children !== 'string') {
     return (
-      <code className={`${className ?? ''} before:content-none after:content-none rounded bg-gray-100 px-1 py-0.5 font-mono text-sm dark:bg-gray-700`}>
+      <code
+        className={`${className ?? ''} before:content-none after:content-none rounded bg-gray-100 px-1 py-0.5 font-mono text-sm dark:bg-gray-700`}
+      >
         {children}
       </code>
     )
@@ -117,19 +119,17 @@ export function CodeBlockRenderer({ className, children }: CodeBlockRendererProp
   }
 
   const selectOptionStyle = {
-    backgroundColor: isDarkMode ? '#282c34' : '#ffffff',
-    color: isDarkMode ? '#d1d5db' : '#4b5563',
+    backgroundColor: isDarkMode ? '#282c34' : '#f9fafb',
+    color: isDarkMode ? '#d1d5db' : '#374151',
   }
 
   return (
-    <>
-      <div className='flex items-center justify-between'>
+    <div className='my-2 overflow-hidden rounded-lg border border-gray-200 dark:border-gray-600'>
+      <div className='flex items-center justify-between border-b border-gray-200 bg-gray-50 px-3 py-1.5 dark:border-gray-600 dark:bg-[#282c34]'>
         <select
           value={selectedLanguage}
           onChange={(e) => setSelectedLanguage(e.target.value)}
-          className={`cursor-pointer rounded border-none text-xs ${
-            isDarkMode ? 'bg-[#282c34] text-gray-300' : 'bg-white text-gray-600'
-          }`}
+          className='cursor-pointer rounded border-none bg-transparent text-xs text-gray-600 dark:text-gray-300'
         >
           {languageOptions.map((lang) => (
             <option key={lang} value={lang} style={selectOptionStyle}>
@@ -145,13 +145,13 @@ export function CodeBlockRenderer({ className, children }: CodeBlockRendererProp
         >
           {copied ? (
             <>
-              <CheckIcon size={18} className='stroke-white' />
-              <span className='text-white text-xs'>コピーしました</span>
+              <CheckIcon size={18} className='stroke-gray-600 dark:stroke-gray-300' />
+              <span className='text-xs text-gray-600 dark:text-gray-300'>コピーしました</span>
             </>
           ) : (
             <>
-              <CopyIcon size={18} className='stroke-white' />
-              <span className='text-white text-xs'>コピーする</span>
+              <CopyIcon size={18} className='stroke-gray-600 dark:stroke-gray-300' />
+              <span className='text-xs text-gray-600 dark:text-gray-300'>コピーする</span>
             </>
           )}
         </button>
@@ -159,10 +159,10 @@ export function CodeBlockRenderer({ className, children }: CodeBlockRendererProp
       <SyntaxHighlighter
         style={isDarkMode ? atomDark : undefined}
         language={selectedLanguage === 'plain' ? undefined : selectedLanguage}
-        customStyle={{ fontSize: '0.875rem' }}
+        customStyle={{ fontSize: '0.875rem', margin: 0, borderRadius: 0 }}
       >
         {code}
       </SyntaxHighlighter>
-    </>
+    </div>
   )
 }

--- a/projects/portfolio/src/client/components/chat/message-renderer.tsx
+++ b/projects/portfolio/src/client/components/chat/message-renderer.tsx
@@ -7,7 +7,7 @@ import { CopyIcon } from '#/client/components/svg/copy-icon'
 import { DeleteIcon } from '#/client/components/svg/delete-icon'
 import type { Message } from '#/types'
 import { isImageContentArray } from '#/types'
-import { Fragment, memo } from 'react'
+import { Fragment, memo, type ReactNode } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 
@@ -15,6 +15,7 @@ const markdownRemarkPlugins = [remarkGfm]
 const markdownComponents = {
   a: MarkdownLink,
   code: CodeBlockRenderer,
+  pre: ({ children }: { children?: ReactNode }) => <>{children}</>,
 }
 
 interface MessageRendererProps {

--- a/projects/portfolio/src/client/main.css
+++ b/projects/portfolio/src/client/main.css
@@ -1,6 +1,6 @@
 @import 'tailwindcss';
 /* @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP&display=swap'); */
-@import url('https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400;500;700&display=swap');
 
 @config "../../tailwind.config.ts";
 
@@ -45,6 +45,7 @@
 body {
   /* font-family: "Noto Sans JP", sans-serif; */
   font-family: 'M PLUS Rounded 1c', sans-serif;
+  font-weight: 400;
 }
 
 .line-clamp-2 {
@@ -64,6 +65,11 @@ body {
   line-height: 1.5em;
   margin-top: 0em;
   margin-bottom: 2em;
+}
+
+.prose strong,
+.prose b {
+  font-weight: 700;
 }
 
 .prose > blockquote > p {


### PR DESCRIPTION
## Why

チャットUIのコードブロックレンダリングが視覚的に不統一で、インラインコードのスタイルが欠如しており、フォントの太さによるコントラストも不十分だったため、全体的な品質を改善する。

## Summary

コードブロックレンダラーのUI/UXを全面的に改善。インラインコードへのスタイル付与、ブロックコードへの行番号表示・ボーダー付きカード表示、フォントの太さとコントラストを修正した。

## Changes

- インラインコードに背景色・パディング・モノスペースフォントのスタイルを適用
- コードブロックをボーダー付きカード（角丸＋ヘッダー分離）で表示するよう改善
- `SyntaxHighlighter` に行番号を追加し、フォントサイズを `0.875rem` に統一
- コピーボタン・言語セレクターの文字・アイコン色をライト/ダークモード対応に修正
- `pre` タグのカスタムコンポーネントを設定し、prose の二重ラッパー問題を解消
- `M PLUS Rounded 1c` フォントの `wght@400;500;700` バリアントを読み込み、`body` に `font-weight: 400` を設定
- `.prose strong, .prose b` に `font-weight: 700` を追加してボールドのコントラストを改善

## Checklist

- [ ] インラインコードが背景色付きで表示される
- [ ] コードブロックが行番号付きカードで表示される
- [ ] ライト/ダークモード双方でコピーボタンと言語セレクターが見やすい
- [ ] 太字テキストのコントラストが改善されている
