### PR TITLE
docs(portfolio): improve project documentation structure

### DIFF
--- a/projects/portfolio/AGENTS.md
+++ b/projects/portfolio/AGENTS.md
@@ -2,19 +2,23 @@
 
 ## Tech Stack
 
-- **Language**: TypeScript
-- **Runtime**: Node
-- **Package Manager**: Bun
-- **Linter & Formatter**: Oxlint / Oxfmt
-- **CSS Styling**: Tailwind CSS
-- **Build & Bundler**: Vite
-- **Backend**: Hono
-- **Frontend**: React (SPA)
-- **Testing**: Vitest
-- **Routing**: TanStack Router
-- **Database**: PostgreSQL
-- **ORM**: Drizzle ORM
-- **Dev Environment**: Dev Containers (VSCode)
+| Item               | Stack                   |
+| ------------------ | ----------------------- |
+| Language           | TypeScript              |
+| Runtime            | Node                    |
+| Package Manager    | Bun                     |
+| Linter & Formatter | Oxlint / Oxfmt          |
+| CSS Styling        | Tailwind CSS            |
+| Build & Bundler    | Vite                    |
+| Backend            | Hono                    |
+| Frontend           | React (SPA)             |
+| Testing            | Vitest                  |
+| Routing            | TanStack Router         |
+| Database           | PostgreSQL              |
+| ORM                | Drizzle ORM             |
+| Dev Environment    | Dev Containers (VSCode) |
+
+For development commands and operational procedures, see [DEVELOPMENT.md](./DEVELOPMENT.md).
 
 ## Code style
 

--- a/projects/portfolio/DEVELOPMENT.md
+++ b/projects/portfolio/DEVELOPMENT.md
@@ -1,0 +1,133 @@
+# Development Guide
+
+## Why
+
+開発時に必要なコマンドや運用手順を、`README.md` と分離して見やすく保つためです。
+
+## What
+
+- 開発用コマンドをまとめる
+- デプロイ、DBマイグレーション、認証まわりの運用メモをまとめる
+
+## Constraints
+
+- 実際の `package.json` と実装に合わせる
+- `README.md` は入口に留め、詳細はこのファイルに集約する
+
+## Commands
+
+### Run
+
+```sh
+bun run dev
+```
+
+open <http://localhost:3000/>
+
+### Lint
+
+```sh
+bun run lint
+```
+
+### Format
+
+```sh
+bun run format
+```
+
+### Test
+
+```sh
+bun run test
+```
+
+### Test Coverage
+
+```sh
+bun run test:coverage
+```
+
+### TypeGen
+
+```sh
+bun run typegen
+```
+
+### Build
+
+```sh
+bun run build
+```
+
+### Start With Built Artifacts
+
+```sh
+bun run start
+```
+
+open <http://localhost:3000/>
+
+## Deploy
+
+### Image Build
+
+```sh
+docker build -t portfolio .
+```
+
+### Run Container
+
+```sh
+SERVER_PORT=3000; \
+docker run \
+  -p 3000:3000 \
+  -itd \
+  --restart=always \
+  --env SERVER_PORT=$SERVER_PORT \
+  portfolio
+```
+
+## Database Migration
+
+- Dev Containers では `psql` を `postgresql-client` で利用できます
+
+### Schema Creation
+
+初回セットアップ時のみ実行します。
+
+```sql
+CREATE DATABASE portfolio;
+```
+
+### Create Migration
+
+```sh
+bun run db:generate
+```
+
+### Apply Migration
+
+```sh
+bun run db:migrate
+```
+
+### Add Auth User
+
+```sh
+bun run db:user:add -- --email test@example.com
+```
+
+パスワードはプロンプト入力です。非対話で実行する場合は、たとえば次のように標準入力から渡します。
+
+```sh
+printf 'replace-with-password\n' | bun run db:user:add -- --email test@example.com
+```
+
+同じメールアドレスが既に存在する場合、このコマンドは失敗します。
+
+## Authentication Notes
+
+- サインイン時は `users.password_hash` を使ってパスワードを検証します
+- `db:user:add` は平文パスワードを対話入力または標準入力で受け取り、ハッシュ化して登録します
+- チャット設定の `apiKey` はブラウザの `localStorage` に保存されます。安全な秘密情報ストアではありません

--- a/projects/portfolio/README.md
+++ b/projects/portfolio/README.md
@@ -1,12 +1,12 @@
 # portfolio
 
-![TypeScript](https://img.shields.io/badge/TypeScript-v5-3178C6?style=flat&logo=typescript&logoColor=white)
+![TypeScript](https://img.shields.io/badge/TypeScript-v6-3178C6?style=flat&logo=typescript&logoColor=white)
 ![React](https://img.shields.io/badge/React-v19-61DAFB?style=flat&logo=react&logoColor=white)
-![Vite](https://img.shields.io/badge/Vite-v6-646CFF?style=flat&logo=vite&logoColor=white)
+![Vite](https://img.shields.io/badge/Vite-v8-646CFF?style=flat&logo=vite&logoColor=white)
 ![Tailwind CSS](https://img.shields.io/badge/Tailwind_CSS-v4-38B2AC?style=flat&logo=tailwind-css&logoColor=white)
 ![TanStack Router](https://img.shields.io/badge/TanStack_Router-v1-FF41B4?style=flat&logo=tanstack&logoColor=white)
-![PostgreSQL](https://img.shields.io/badge/PostgreSQL-v17-4169E1?style=flat&logo=postgresql&logoColor=white)
-![Drizzle ORM](https://img.shields.io/badge/Drizzle_ORM-v0-2D87FF?style=flat&logo=drizzle&logoColor=white)
+![PostgreSQL](https://img.shields.io/badge/PostgreSQL-4169E1?style=flat&logo=postgresql&logoColor=white)
+![Drizzle ORM](https://img.shields.io/badge/Drizzle_ORM-v0.45-2D87FF?style=flat&logo=drizzle&logoColor=white)
 
 ## Architectures
 

--- a/projects/portfolio/README.md
+++ b/projects/portfolio/README.md
@@ -8,122 +8,14 @@
 ![PostgreSQL](https://img.shields.io/badge/PostgreSQL-4169E1?style=flat&logo=postgresql&logoColor=white)
 ![Drizzle ORM](https://img.shields.io/badge/Drizzle_ORM-v0.45-2D87FF?style=flat&logo=drizzle&logoColor=white)
 
-## Architectures
+## Overview
 
-| #                   | tech                                                                                       |
-| ------------------- | ------------------------------------------------------------------------------------------ |
-| Language            | [TypeScript](https://www.typescriptlang.org/)                                              |
-| Runtime             | [Node](https://nodejs.org/)                                                                |
-| Package Manager     | [Bun](https://bun.sh/)                                                                     |
-| Linter & Formatter  | [Oxlint / Oxfmt](https://oxc.rs/docs/guide/introduction.html)                              |
-| CSS Styling         | [Tailwind CSS](https://tailwindcss.com/)                                                   |
-| Build & Bundler     | [Vite](https://ja.vite.dev/)                                                               |
-| Frontend            | [React](https://react.dev/) (Single Page Application)                                      |
-| Frontend routing    | [TanStack Router](https://tanstack.com/router/latest/docs/framework/react/overview)        |
-| DB                  | [PostgreSQL](https://www.postgresql.org/)                                                  |
-| ORM                 | [Drizzle ORM](https://orm.drizzle.team/)                                                   |
-| Develop environment | [Dev Containers](https://code.visualstudio.com/docs/devcontainers/containers) (for VSCode) |
+技術構成の詳細は [AGENTS.md の Tech Stack](./AGENTS.md#tech-stack) を参照してください。  
+コーディング規約やテスト方針は [AGENTS.md](./AGENTS.md)、開発用コマンドや運用手順は [DEVELOPMENT.md](./DEVELOPMENT.md) に集約しています。
 
-## Commands
+## Development
 
-- Run:
-
-  ```sh
-  bun run dev
-  ```
-
-  open <http://localhost:3000/>
-
-- Lint:
-
-  ```sh
-  bun run lint
-  ```
-
-- Format:
-
-  ```sh
-  bun run format
-  ```
-
-- TypeGen:
-
-  ```sh
-  bun run typegen
-  ```
-
-- Build:
-
-  ```sh
-  bun run build
-  ```
-
-- Start with built artifacts:
-
-  ```sh
-  bun run start
-  ```
-
-  open <http://localhost:3000/>
-
-## Deploy
-
-- Image build:
-
-  ```sh
-  docker build -t portfolio .
-  ```
-
-- Run container:
-
-  ```sh
-  SERVER_PORT=3000; \
-  docker run \
-    -p 3000:3000 \
-    -itd \
-    --restart=always \
-    --env SERVER_PORT=$SERVER_PORT \
-    portfolio
-  ```
-
-## Database Migration
-
-- In Dev Containers, `psql` is available via `postgresql-client`.
-
-- Schema creation (only during the initial setup):
-
-  ```sh
-  CREATE DATABASE portfolio;
-  ```
-
-- Create migration:
-
-  ```sh
-  bun run db:generate
-  ```
-
-- Apply migration:
-
-  ```sh
-  bun run db:migrate
-  ```
-
-- Add auth user after migration:
-
-  ```sh
-  bun run db:user:add -- --email test@example.com
-  ```
-
-  Enter the password when prompted. For non-interactive use, pipe it via stdin, for example
-
-  ```sh
-  printf 'replace-with-password\n' | bun run db:user:add -- --email test@example.com
-  ```
-
-  The command fails if the email already exists.
-
-## Authentication Notes
-
-- Sign-in verifies the password against `users.password_hash`.
-- `db:user:add` hashes the plain password from an interactive prompt or stdin and adds a new auth user.
-- Chat settings `apiKey` is stored in browser `localStorage`. It is not a secure secret store.
+- 開発用コマンド一覧: [DEVELOPMENT.md の Commands](./DEVELOPMENT.md#commands)
+- デプロイ手順: [DEVELOPMENT.md の Deploy](./DEVELOPMENT.md#deploy)
+- DBマイグレーション: [DEVELOPMENT.md の Database Migration](./DEVELOPMENT.md#database-migration)
+- 認証まわりの注意: [DEVELOPMENT.md の Authentication Notes](./DEVELOPMENT.md#authentication-notes)

--- a/projects/portfolio/src/db/README.md
+++ b/projects/portfolio/src/db/README.md
@@ -51,31 +51,31 @@ erDiagram
 
 ### `users`
 
-| カラム | 型 | 必須 | 説明 |
-| --- | --- | --- | --- |
-| `id` | `uuid` | Yes | ユーザーを一意に識別するID |
-| `email` | `text` | Yes | ログインや識別に使うメールアドレス |
-| `password_hash` | `text` | No | パスワードハッシュ |
-| `created_at` | `timestamp` | Yes | ユーザー作成日時 |
+| カラム          | 型          | 必須 | 説明                               |
+| --------------- | ----------- | ---- | ---------------------------------- |
+| `id`            | `uuid`      | Yes  | ユーザーを一意に識別するID         |
+| `email`         | `text`      | Yes  | ログインや識別に使うメールアドレス |
+| `password_hash` | `text`      | No   | パスワードハッシュ                 |
+| `created_at`    | `timestamp` | Yes  | ユーザー作成日時                   |
 
 ### `conversations`
 
-| カラム | 型 | 必須 | 説明 |
-| --- | --- | --- | --- |
-| `id` | `uuid` | Yes | 会話を一意に識別するID |
-| `user_id` | `uuid` | Yes | 会話の所有ユーザーを指す外部キー |
-| `title` | `text` | No | 会話タイトル |
-| `created_at` | `timestamp` | Yes | 会話作成日時 |
-| `updated_at` | `timestamp` | Yes | 会話更新日時 |
+| カラム       | 型          | 必須 | 説明                             |
+| ------------ | ----------- | ---- | -------------------------------- |
+| `id`         | `uuid`      | Yes  | 会話を一意に識別するID           |
+| `user_id`    | `uuid`      | Yes  | 会話の所有ユーザーを指す外部キー |
+| `title`      | `text`      | No   | 会話タイトル                     |
+| `created_at` | `timestamp` | Yes  | 会話作成日時                     |
+| `updated_at` | `timestamp` | Yes  | 会話更新日時                     |
 
 ### `messages`
 
-| カラム | 型 | 必須 | 説明 |
-| --- | --- | --- | --- |
-| `id` | `uuid` | Yes | メッセージを一意に識別するID |
-| `conversation_id` | `uuid` | Yes | 所属する会話を指す外部キー |
-| `role` | `text` | Yes | メッセージ送信者の役割 |
-| `content` | `text` | Yes | 表示用の本文 |
-| `reasoning_content` | `text` | Yes | 推論過程や補助情報を保持する本文 |
-| `metadata` | `jsonb` | Yes | 追加情報を保持するJSON |
-| `created_at` | `timestamp` | Yes | メッセージ作成日時 |
+| カラム              | 型          | 必須 | 説明                             |
+| ------------------- | ----------- | ---- | -------------------------------- |
+| `id`                | `uuid`      | Yes  | メッセージを一意に識別するID     |
+| `conversation_id`   | `uuid`      | Yes  | 所属する会話を指す外部キー       |
+| `role`              | `text`      | Yes  | メッセージ送信者の役割           |
+| `content`           | `text`      | Yes  | 表示用の本文                     |
+| `reasoning_content` | `text`      | Yes  | 推論過程や補助情報を保持する本文 |
+| `metadata`          | `jsonb`     | Yes  | 追加情報を保持するJSON           |
+| `created_at`        | `timestamp` | Yes  | メッセージ作成日時               |

--- a/projects/portfolio/src/db/README.md
+++ b/projects/portfolio/src/db/README.md
@@ -1,0 +1,81 @@
+# DB Schema
+
+## Why
+
+`schema.ts` の構造をコードを読まずに把握できるようにし、テーブル間の関係を素早く共有するためです。
+
+## What
+
+- `src/db/schema.ts` と対応するERDを残す
+- テーブル定義と主なカラム、リレーションを俯瞰できるようにする
+
+## Constraints
+
+- `schema.ts` の現状定義に合わせる
+- マークダウン内にMermaid形式で記述する
+
+## ERD
+
+```mermaid
+erDiagram
+  users {
+    uuid id PK
+    text email UK
+    text password_hash
+    timestamp created_at
+  }
+
+  conversations {
+    uuid id PK
+    uuid user_id FK
+    text title
+    timestamp created_at
+    timestamp updated_at
+  }
+
+  messages {
+    uuid id PK
+    uuid conversation_id FK
+    text role
+    text content
+    text reasoning_content
+    jsonb metadata
+    timestamp created_at
+  }
+
+  users ||--o{ conversations : has
+  conversations ||--o{ messages : has
+```
+
+## Fields
+
+### `users`
+
+| カラム | 型 | 必須 | 説明 |
+| --- | --- | --- | --- |
+| `id` | `uuid` | Yes | ユーザーを一意に識別するID |
+| `email` | `text` | Yes | ログインや識別に使うメールアドレス |
+| `password_hash` | `text` | No | パスワードハッシュ |
+| `created_at` | `timestamp` | Yes | ユーザー作成日時 |
+
+### `conversations`
+
+| カラム | 型 | 必須 | 説明 |
+| --- | --- | --- | --- |
+| `id` | `uuid` | Yes | 会話を一意に識別するID |
+| `user_id` | `uuid` | Yes | 会話の所有ユーザーを指す外部キー |
+| `title` | `text` | No | 会話タイトル |
+| `created_at` | `timestamp` | Yes | 会話作成日時 |
+| `updated_at` | `timestamp` | Yes | 会話更新日時 |
+
+### `messages`
+
+| カラム | 型 | 必須 | 説明 |
+| --- | --- | --- | --- |
+| `id` | `uuid` | Yes | メッセージを一意に識別するID |
+| `conversation_id` | `uuid` | Yes | 所属する会話を指す外部キー |
+| `role` | `text` | Yes | メッセージ送信者の役割 |
+| `content` | `text` | Yes | 表示用の本文 |
+| `reasoning_content` | `text` | Yes | 推論過程や補助情報を保持する本文 |
+| `metadata` | `jsonb` | Yes | 追加情報を保持するJSON |
+| `created_at` | `timestamp` | Yes | メッセージ作成日時 |


### PR DESCRIPTION
## Why

The project documentation had overlapping content across `README.md` and `AGENTS.md`, and the command section in `README.md` mixed direct commands with cross-references. The database schema also lacked a colocated human-readable overview.

## Summary

This PR reorganizes the project documentation so each file has a clearer role. It keeps `README.md` as an entry point, moves development procedures into a dedicated guide, and adds a schema README with an ERD and field tables.

## Changes

- add `src/db/README.md` with a Mermaid ERD and field reference tables
- refresh README badges to match the current toolchain versions
- add `DEVELOPMENT.md` for developer commands, deploy steps, migration steps, and auth notes
- simplify `README.md` and `AGENTS.md` so they link to the right source of truth
- convert the `AGENTS.md` tech stack section into a table

## Checklist

- [x] Documentation updated
- [x] No runtime behavior changed
- [ ] Tests run (not run for documentation-only changes)
