### PR TITLE
chore: reduce Dependabot CI noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,16 @@ updates:
       - "/projects/file-server"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 2
+    rebase-strategy: "disabled"
+    groups:
+      bun-non-major:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "uv"
     directories:
@@ -13,3 +23,13 @@ updates:
       - "/projects/simple-agent-poc"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 2
+    rebase-strategy: "disabled"
+    groups:
+      uv-non-major:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/docs/dependabot-guide.md
+++ b/docs/dependabot-guide.md
@@ -73,6 +73,39 @@
 - `weekly`
 - `monthly`
 
+### PR 数を減らす
+
+`open-pull-requests-limit` を使うと、同時に開く version update PR の本数を制限できます。
+
+```yaml
+open-pull-requests-limit: 2
+```
+
+### minor / patch をまとめる
+
+同じプロジェクトの lockfile を何本も同時に更新しないよう、`groups` で non-major 更新をまとめられます。
+
+```yaml
+groups:
+  non-major:
+    applies-to: version-updates
+    patterns:
+      - "*"
+    update-types:
+      - "minor"
+      - "patch"
+```
+
+### 自動 rebase を止める
+
+`rebase-strategy: disabled` を指定すると、他の Dependabot PR のマージ後に未マージ PR が自動 rebase されにくくなり、`pull_request` CI の再実行回数を減らせます。
+
+```yaml
+rebase-strategy: "disabled"
+```
+
+この設定を入れると CI ノイズは減りますが、競合解消は手動で見る前提になります。
+
 ### 特定パッケージを無視する
 
 `ignore` を追加します。
@@ -95,4 +128,6 @@ labels:
 
 - `bun` と `uv` は別の `updates` ブロックに分ける
 - 対象外プロジェクトは `directories` に追加しない限り更新されない
+- 同じ lockfile を触る PR が多い場合は `groups` と `open-pull-requests-limit` を優先して調整する
+- `rebase-strategy: disabled` は CI ノイズ低減に有効だが、古い PR の競合は手動確認が必要になる
 - 変更後は GitHub 上で Dependabot 設定エラーが出ていないことを確認する


### PR DESCRIPTION
## Why

Dependabot の PR が同一プロジェクトの lockfile を並行して更新し、1 件マージ後の自動 rebase で `pull_request` CI が繰り返し走っていました。Dependabot 側の PR 生成数と rebase 方針を調整して、CI ノイズを減らしたいです。

## Summary

Dependabot の Bun / uv 設定に grouped updates、PR 数制限、rebase 無効化を追加しました。あわせて運用ガイドに調整意図とトレードオフを追記しています。

## Changes

- `open-pull-requests-limit: 2` を追加
- `rebase-strategy: "disabled"` を追加
- minor / patch をまとめる `groups` を追加
- `docs/dependabot-guide.md` に運用方針と注意点を追記

## Checklist

- [x] `.github/dependabot.yml` の設定を更新
- [x] ドキュメントを更新
- [x] YAML の読み込み確認
- [ ] 既存 Dependabot PR の整理は merge 後に実施
