### PR TITLE
refactor: simplify chat display and improve mobile UX

### DIFF
--- a/projects/portfolio/src/client/components/chat/chat-results.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-results.tsx
@@ -33,36 +33,18 @@ function ChatResultsComponent({ metadata }: ChatResultsProps) {
         <span>{model}</span>
         {responseTimeMs !== undefined && (
           <>
-            <span>·</span>
+            <span>/</span>
             <span>{formatResponseTime(responseTimeMs)}</span>
-          </>
-        )}
-        {(usage.promptTokens || usage.completionTokens) && (
-          <>
-            <span>·</span>
-            <span>
-              {usage.promptTokens ?? '--'}→{usage.completionTokens ?? '--'} tokens
-            </span>
           </>
         )}
         <span className='ml-0.5'>{open ? '▲' : '▼'}</span>
       </button>
       {open && (
         <div className='mt-1 flex flex-wrap gap-1'>
-          <div className={badgeClass}>
-            <span className='mr-1'>model:</span>
-            <span>{model}</span>
-          </div>
           {finishReason && (
             <div className={badgeClass}>
               <span className='mr-1'>finish_reason:</span>
               <span>{finishReason}</span>
-            </div>
-          )}
-          {responseTimeMs !== undefined && (
-            <div className={badgeClass}>
-              <span className='mr-1'>time:</span>
-              <span>{formatResponseTime(responseTimeMs)}</span>
             </div>
           )}
           <div className={badgeClass}>

--- a/projects/portfolio/src/client/components/chat/message-renderer.tsx
+++ b/projects/portfolio/src/client/components/chat/message-renderer.tsx
@@ -63,7 +63,7 @@ function MessageRendererComponent({
                 })}
           </div>
           <div
-            className={`mt-1 ml-1 transition-opacity duration-200 ease-in group-hover:opacity-100 ${copied ? 'opacity-100' : 'opacity-0'} ${disabled ? 'invisible' : ''}`}
+            className={`mt-1 ml-1 transition-opacity duration-200 ease-in md:opacity-0 md:group-hover:opacity-100 ${copied ? 'opacity-100' : ''} ${disabled ? 'invisible' : ''}`}
           >
             <button
               type='button'
@@ -101,7 +101,7 @@ function MessageRendererComponent({
           </div>
         )}
         <div
-          className={`mt-1 ml-1 transition-opacity duration-200 ease-in group-hover:opacity-100 ${copied ? 'opacity-100' : 'opacity-0'}`}
+          className={`mt-1 ml-1 transition-opacity duration-200 ease-in md:opacity-0 md:group-hover:opacity-100 ${copied ? 'opacity-100' : ''}`}
         >
           <button
             type='button'


### PR DESCRIPTION
## Why

チャット結果表示の UI を簡潔にし、モバイル環境での操作性を改善する。

## Summary

展開時の重複情報を削除し、モバイルではコピー/削除ボタンを常に表示、デスクトップではホバー時のみ表示するよう改善。

## Changes

- **chat-results.tsx**
  - 展開時バッジから `model` と `time` を削除（非展開時に既表示）
  - 非展開時からトークン数表示を削除（展開時の詳細で確認可能）
  - 区切り文字を `·` から `/` に変更

- **message-renderer.tsx**
  - モバイル（md未満）ではコピー/削除ボタンを常に表示
  - デスクトップ（md以上）ではホバー時のみ表示に変更

## Checklist

- [x] 非展開時の表示が簡潔になった
- [x] モバイルでコピー/削除ボタンにアクセス可能
- [x] デスクトップのホバー動作は変わらない
