### PR TITLE
style(portfolio): enhance code block styling with unified font properties

### DIFF
--- a/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
+++ b/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
@@ -2,12 +2,20 @@ import { copyToClipboard } from '#/client/components/chat/copy-to-clipboard'
 import { CheckIcon } from '#/client/components/svg/check-icon'
 import { CopyIcon } from '#/client/components/svg/copy-icon'
 import { useDarkMode } from '#/client/hooks/use-dark-mode'
-import type { AnchorHTMLAttributes, HTMLAttributes, MouseEvent, ReactNode } from 'react'
+import type { AnchorHTMLAttributes, CSSProperties, HTMLAttributes, MouseEvent, ReactNode } from 'react'
 import { useState } from 'react'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 import { atomDark } from 'react-syntax-highlighter/dist/cjs/styles/prism'
 
 const CODE_BLOCK_FONT_FAMILY = "'M PLUS 1 Code', monospace"
+const CODE_TEXT_STYLE: CSSProperties = {
+  fontFamily: CODE_BLOCK_FONT_FAMILY,
+  fontWeight: 500,
+  letterSpacing: 0,
+  wordSpacing: 0,
+  fontKerning: 'none',
+  fontVariantLigatures: 'none',
+}
 
 type MarkdownLinkProps = AnchorHTMLAttributes<HTMLAnchorElement>
 
@@ -160,10 +168,22 @@ export function CodeBlockRenderer({ className, children }: CodeBlockRendererProp
       </div>
       <SyntaxHighlighter
         style={isDarkMode ? atomDark : undefined}
-        language={selectedLanguage === 'plain' ? undefined : selectedLanguage}
-        customStyle={{ fontSize: '0.875rem', margin: 0, borderRadius: 0, fontFamily: CODE_BLOCK_FONT_FAMILY }}
-        codeTagProps={{ style: { fontFamily: CODE_BLOCK_FONT_FAMILY } }}
-        showLineNumbers
+        language={selectedLanguage}
+        customStyle={{
+          fontSize: '0.875rem',
+          margin: 0,
+          borderRadius: 0,
+          backgroundColor: selectedLanguage === 'plain' ? 'transparent' : undefined,
+          color: selectedLanguage === 'plain' ? (isDarkMode ? '#f3f4f6' : '#111827') : undefined,
+          ...CODE_TEXT_STYLE,
+        }}
+        codeTagProps={{
+          style: {
+            ...CODE_TEXT_STYLE,
+            color: selectedLanguage === 'plain' ? 'inherit' : undefined,
+          },
+        }}
+        showLineNumbers={selectedLanguage !== 'plain'}
         lineNumberStyle={{ color: isDarkMode ? '#6b7280' : '#9ca3af', minWidth: '2.5em' }}
       >
         {code}

--- a/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
+++ b/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
@@ -7,6 +7,8 @@ import { useState } from 'react'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 import { atomDark } from 'react-syntax-highlighter/dist/cjs/styles/prism'
 
+const CODE_BLOCK_FONT_FAMILY = "'M PLUS 1 Code', monospace"
+
 type MarkdownLinkProps = AnchorHTMLAttributes<HTMLAnchorElement>
 
 export function MarkdownLink({ href, children }: MarkdownLinkProps) {
@@ -159,7 +161,8 @@ export function CodeBlockRenderer({ className, children }: CodeBlockRendererProp
       <SyntaxHighlighter
         style={isDarkMode ? atomDark : undefined}
         language={selectedLanguage === 'plain' ? undefined : selectedLanguage}
-        customStyle={{ fontSize: '0.875rem', margin: 0, borderRadius: 0 }}
+        customStyle={{ fontSize: '0.875rem', margin: 0, borderRadius: 0, fontFamily: CODE_BLOCK_FONT_FAMILY }}
+        codeTagProps={{ style: { fontFamily: CODE_BLOCK_FONT_FAMILY } }}
         showLineNumbers
         lineNumberStyle={{ color: isDarkMode ? '#6b7280' : '#9ca3af', minWidth: '2.5em' }}
       >

--- a/projects/portfolio/src/client/main.css
+++ b/projects/portfolio/src/client/main.css
@@ -1,6 +1,7 @@
 @import 'tailwindcss';
 /* @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP&display=swap'); */
 @import url('https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400;500;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=M+PLUS+1+Code&display=swap');
 
 @config "../../tailwind.config.ts";
 


### PR DESCRIPTION
## Issues

- Close #783

## Why

コードブロックのスタイリング設定がまだ不完全だったため、フォント関連の設定（カーニング、リガチャ、レターのスペーシング）が統一されていませんでした。また、プレーンテキスト言語での表示ルールも明確に定義されていませんでした。

## Summary

日本語対応モノスペースフォント（M PLUS 1 Code）のスタイリングを最適化し、フォント設定を一元化しました。プレーンテキストコードブロックの表示制御も改善されています。
|before|after|
|-|-|
|<img width="1058" height="542" alt="image" src="https://github.com/user-attachments/assets/23553d64-b932-4951-98a3-140278b6440d" />|<img width="1068" height="504" alt="image" src="https://github.com/user-attachments/assets/df26d59b-3aaf-4f5b-a51f-deca4ad33326" />|

## Changes

- フォント関連のスタイルを `CODE_TEXT_STYLE` オブジェクトに一元化
- カーニングとリガチャの無効化設定を追加
- プレーンテキスト言語の背景色と色を条件付けで適用
- ライン番号の表示を言語選択によって制御（plain言語では非表示）

## Checklist

- [x] コードブロックレンダラーのスタイリング改善
- [x] 日本語フォントの統一的なスタイリング適用
- [x] プレーンテキスト言語の特別な処理実装

🤖 Generated with [Claude Code](https://claude.com/claude-code)
