### PR TITLE
fix(portfolio): improve dark mode UI for chat icon and loading state

### DIFF
--- a/projects/portfolio/src/client/components/chat/chat-message-list.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-message-list.tsx
@@ -49,8 +49,8 @@ export function ChatMessageList({
         />
         {loading && (
           <div className='flex align-item'>
-            <div className='flex h-8 w-8 justify-center rounded-full border border-gray-300 bg-white align-center dark:border-gray-600 dark:bg-gray-900'>
-              <ChatbotIcon size={32} className='stroke-gray-600 dark:stroke-gray-300' />
+            <div className='flex h-8 w-8 justify-center rounded-full border border-gray-300 bg-white align-center dark:border-gray-600 dark:bg-gray-800'>
+              <ChatbotIcon size={32} className='stroke-gray-600 dark:stroke-white' />
             </div>
             {stream ? (
               <div className='message ml-2 text-left'>

--- a/projects/portfolio/src/client/components/chat/message-renderer.tsx
+++ b/projects/portfolio/src/client/components/chat/message-renderer.tsx
@@ -84,8 +84,8 @@ function MessageRendererComponent({
 
   return (
     <div className='flex'>
-      <div className='flex h-8 w-8 justify-center rounded-full border border-gray-300 bg-white align-center dark:border-gray-600 dark:bg-gray-900'>
-        <ChatbotIcon size={32} className='stroke-gray-600 dark:stroke-gray-300' />
+      <div className='flex h-8 w-8 justify-center rounded-full border border-gray-300 bg-white align-center dark:border-gray-600 dark:bg-gray-800'>
+        <ChatbotIcon size={32} className='stroke-gray-600 dark:stroke-white' />
       </div>
       <div className='message group ml-2 text-left'>
         {message.reasoningContent && <ReasoningSection content={message.reasoningContent} />}

--- a/projects/portfolio/src/client/main.css
+++ b/projects/portfolio/src/client/main.css
@@ -1,6 +1,6 @@
 @import 'tailwindcss';
 /* @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP&display=swap'); */
-@import url('https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400;500;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400&display=swap');
 
 @config "../../tailwind.config.ts";
 

--- a/projects/portfolio/src/client/pages/chat/index.tsx
+++ b/projects/portfolio/src/client/pages/chat/index.tsx
@@ -2,6 +2,7 @@ import { ChatLayout } from '#/client/components/chat/chat-layout'
 import { ChatMain } from '#/client/components/chat/chat-main'
 import { ChatSettings } from '#/client/components/chat/chat-settings'
 import { ConversationHistory } from '#/client/components/chat/conversation-history'
+import { SpinnerIcon } from '#/client/components/svg/spinner-icon'
 import { useChatPageState } from '#/client/pages/chat/use-chat-page-state'
 import { useMetaProps } from '#/client/pages/home'
 import type { AppType } from '#/server/app.d'
@@ -121,18 +122,23 @@ export function Chat() {
       isSidebarOpen={isSidebarOpen}
       onToggleSidebar={() => setIsSidebarOpen(!isSidebarOpen)}
       conversations={
-        query.isLoading
-          ? 'Loading...'
-          : conversations.length > 0 && (
-              <ConversationHistory
-                conversations={conversations}
-                currentConversationId={selectedConversationId}
-                disabled={!showSettingsActions}
-                onSelectConversation={selectConversation}
-                onDeleteConversation={handleDeleteConversation}
-                onNewConversation={startNewConversation}
-              />
-            )
+        query.isLoading ? (
+          <div className='flex h-full flex-col items-center justify-center gap-2'>
+            <SpinnerIcon />
+            <span className='text-sm text-gray-500 dark:text-gray-400'>Loading...</span>
+          </div>
+        ) : (
+          conversations.length > 0 && (
+            <ConversationHistory
+              conversations={conversations}
+              currentConversationId={selectedConversationId}
+              disabled={!showSettingsActions}
+              onSelectConversation={selectConversation}
+              onDeleteConversation={handleDeleteConversation}
+              onNewConversation={startNewConversation}
+            />
+          )
+        )
       }
     >
       <ChatSettings


### PR DESCRIPTION
## Why

チャット画面のダークモードで、アイコンのストロークが背景と同色に近く視認性が低い問題と、フォントの不要なウェイトインポートを修正する。

## Summary

チャットボットアイコンのダークモード表示を改善し、ローディング表示をスピナー付きコンポーネントに置き換えた。また、フォントインポートを実際に使用するウェイト400のみに絞り、パフォーマンスを改善した。

## Changes

- `main.css`: M PLUS Rounded 1c フォントのインポートを `wght@400` のみに変更（400;500;700 → 400）
- `message-renderer.tsx` / `chat-message-list.tsx`: チャットボットアイコンのダークモードストロークを `stroke-gray-300` → `stroke-white` に変更
- `message-renderer.tsx` / `chat-message-list.tsx`: アイコンコンテナ背景をページ背景と同色の `dark:bg-gray-900` からひとつ明るい `dark:bg-gray-800` に変更
- `chat/index.tsx`: サイドバーのローディング表示を文字列 `'Loading...'` から `SpinnerIcon` + ラベルのコンポーネントに置き換え

## Checklist

- [ ] ダークモードでチャットボットアイコンが白くハッキリ表示されること
- [ ] ダークモードでアイコンコンテナがページ背景から浮き出て見えること
- [ ] サイドバーのローディング表示がスピナー付きで表示されること
- [ ] ライトモードで見た目が変わっていないこと
