### PR TITLE
fix(portfolio): fix code block overflow on mobile layout

### DIFF
--- a/projects/portfolio/src/client/components/app-layout.tsx
+++ b/projects/portfolio/src/client/components/app-layout.tsx
@@ -84,7 +84,7 @@ export const AppLayout: FC<Props> = ({ version, menuItems, children }: Props) =>
       )}
 
       {/* メインコンテンツ */}
-      <main className='flex-1 overflow-y-hidden bg-white md:overflow-y-auto dark:bg-gray-900 pt-14 md:pt-0'>
+      <main className='min-w-0 flex-1 overflow-y-hidden bg-white md:overflow-y-auto dark:bg-gray-900 pt-14 md:pt-0'>
         {children}
       </main>
     </div>

--- a/projects/portfolio/src/client/components/chat/chat-layout.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-layout.tsx
@@ -23,7 +23,7 @@ export function ChatLayout({ conversations, isSidebarOpen, onToggleSidebar, chil
         <div className='fixed top-14 bottom-0 left-0 right-0 bg-black/50 z-40 md:hidden' onClick={onToggleSidebar} />
       )}
 
-      <div className='flex h-full min-h-0 flex-1 flex-col bg-white dark:bg-gray-900'>{children}</div>
+      <div className='min-w-0 flex h-full min-h-0 flex-1 flex-col bg-white dark:bg-gray-900'>{children}</div>
     </div>
   ) : (
     <div className='flex h-[calc(100dvh-3.5rem)] flex-col bg-white md:h-dvh dark:bg-gray-900'>{children}</div>

--- a/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
+++ b/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
@@ -12,6 +12,9 @@ const CUSTOM_STYLE: CSSProperties = {
   fontSize: '0.875rem',
   margin: 0,
   borderRadius: 0,
+  whiteSpace: 'pre',
+  wordBreak: 'normal',
+  overflowWrap: 'normal',
 }
 
 type MarkdownLinkProps = AnchorHTMLAttributes<HTMLAnchorElement>
@@ -157,16 +160,18 @@ export function CodeBlockRenderer({ className, children }: CodeBlockRendererProp
           )}
         </button>
       </div>
-      <SyntaxHighlighter
-        style={atomDark}
-        language={selectedLanguage}
-        customStyle={CUSTOM_STYLE}
-        codeTagProps={{ style: CUSTOM_STYLE }}
-        showLineNumbers={selectedLanguage !== 'plain'}
-        lineNumberStyle={{ color: '#6b7280', minWidth: '2.5em' }}
-      >
-        {code}
-      </SyntaxHighlighter>
+      <div className='overflow-x-auto'>
+        <SyntaxHighlighter
+          style={atomDark}
+          language={selectedLanguage}
+          customStyle={CUSTOM_STYLE}
+          codeTagProps={{ style: CUSTOM_STYLE }}
+          showLineNumbers={selectedLanguage !== 'plain'}
+          lineNumberStyle={{ color: '#6b7280', minWidth: '2.5em' }}
+        >
+          {code}
+        </SyntaxHighlighter>
+      </div>
     </div>
   )
 }

--- a/projects/portfolio/src/client/components/chat/message-renderer.tsx
+++ b/projects/portfolio/src/client/components/chat/message-renderer.tsx
@@ -87,7 +87,7 @@ function MessageRendererComponent({
       <div className='flex h-8 w-8 justify-center rounded-full border border-gray-300 bg-white align-center dark:border-gray-600 dark:bg-gray-800'>
         <ChatbotIcon size={32} className='stroke-gray-600 dark:stroke-white' />
       </div>
-      <div className='message group ml-2 text-left'>
+      <div className='message group ml-2 min-w-0 flex-1 text-left'>
         {message.reasoningContent && <ReasoningSection content={message.reasoningContent} />}
         {markdownPreview ? (
           <div className='prose mt-1 max-w-(--breakpoint-md) break-all'>


### PR DESCRIPTION
## Why

モバイルレイアウトでコードブロックのコンテンツが長い場合、レイアウトが崩れてコードが画面外にはみ出し、横スクロールも効かない状態になっていた。

原因は2点：
1. `flex-row` コンテナ内の `flex-1` 要素に `min-w-0` がなく、デフォルトの `min-width: auto` によりコードブロックのコンテンツ幅（約480px）まで親要素が広がってしまっていた
2. `prose` コンテナの `word-break: break-all` がコードブロック内に継承されており、長い行が折り返されて横スクロールが意味をなさない状態になっていた

## Summary

flex チェーン全体に `min-w-0` を適用してビューポート幅を超えないよう修正し、コードブロックを `overflow-x-auto` でラップして横スクロールを有効化した。

## Changes

- `app-layout.tsx`: `<main>` に `min-w-0` を追加（flex-row コンテナ内の flex-1 要素）
- `chat-layout.tsx`: メインコンテンツ `<div>` に `min-w-0` を追加（同上）
- `message-renderer.tsx`: アシスタントメッセージのテキストコンテナに `min-w-0 flex-1` を追加
- `code-block-renderer.tsx`: `SyntaxHighlighter` を `overflow-x-auto` の div でラップし、`CUSTOM_STYLE` に `whiteSpace: pre` / `wordBreak: normal` / `overflowWrap: normal` を追加して `break-all` の継承を防止

## Checklist

- [ ] モバイルでコードブロックが画面幅に収まることを確認
- [ ] モバイルでコードブロックの横スクロールが動作することを確認
- [ ] デスクトップレイアウトに影響がないことを確認
