### PR TITLE
[codex] Polish chat history sidebar metadata

### DIFF
--- a/projects/portfolio/src/client/components/chat/conversation-history.tsx
+++ b/projects/portfolio/src/client/components/chat/conversation-history.tsx
@@ -1,7 +1,14 @@
 import { DeleteIcon } from '#/client/components/svg/delete-icon'
+import { MessageIcon } from '#/client/components/svg/message-icon'
 import { NewChatIcon } from '#/client/components/svg/new-chat-icon'
 import type { Conversation } from '#/types'
 import { useState } from 'react'
+
+const conversationDateFormatter = new Intl.DateTimeFormat('ja-JP', {
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+})
 
 interface Props {
   conversations: Conversation[]
@@ -10,6 +17,14 @@ interface Props {
   onSelectConversation: (conversationId: string) => void
   onDeleteConversation: (conversationId: string) => void
   onNewConversation: () => void
+}
+
+function getConversationDateLabel(conversation: Conversation) {
+  if (!conversation.updatedAt) {
+    return null
+  }
+
+  return conversationDateFormatter.format(conversation.updatedAt)
 }
 
 export function ConversationHistory({
@@ -48,50 +63,78 @@ export function ConversationHistory({
           <div className='p-4 text-center text-gray-500 text-sm dark:text-gray-400'>会話履歴がありません</div>
         ) : (
           <div className='p-2'>
-            {conversations.map((conversation) => (
-              <div
-                key={conversation.id}
-                className={`group relative mb-1 w-full rounded-md p-3 text-left transition-colors ${
-                  currentConversationId === conversation.id
-                    ? 'border border-primary-200 bg-primary-100 dark:border-primary-600 dark:bg-primary-900/30'
-                    : 'hover:bg-gray-100 dark:hover:bg-gray-700'
-                } ${disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'}`}
-                onMouseEnter={() => setHoveredId(conversation.id)}
-                onMouseLeave={() => setHoveredId(null)}
-              >
-                <div
-                  role='button'
-                  tabIndex={disabled ? -1 : 0}
-                  className='flex items-start justify-between'
-                  onClick={() => !disabled && onSelectConversation(conversation.id)}
-                  onKeyDown={(e) => {
-                    if (!disabled && (e.key === 'Enter' || e.key === ' ')) {
-                      e.preventDefault()
-                      onSelectConversation(conversation.id)
-                    }
-                  }}
-                >
-                  <div className='min-w-0 flex-1'>
-                    <h3 className='truncate font-medium text-gray-900 text-sm dark:text-gray-100'>
-                      {conversation.title}
-                    </h3>
-                    <p className='mt-1 text-gray-500 text-xs dark:text-gray-400'>
-                      {conversation.messages.length} メッセージ
-                    </p>
-                  </div>
-                </div>
-                {(hoveredId === conversation.id || currentConversationId === conversation.id) && !disabled && (
-                  <button
-                    type='button'
-                    onClick={(e) => handleDeleteClick(e, conversation.id)}
-                    className='absolute right-3 top-3 ml-2 p-1 text-gray-400 opacity-0 transition-opacity hover:text-red-500 group-hover:opacity-100 dark:text-gray-500 dark:hover:text-red-400'
-                    title='会話を削除'
+            {conversations.map((conversation, index) => {
+              const nextConversation = conversations[index + 1]
+              const shouldShowDivider =
+                index < conversations.length - 1 &&
+                hoveredId !== conversation.id &&
+                currentConversationId !== conversation.id &&
+                hoveredId !== nextConversation?.id &&
+                currentConversationId !== nextConversation?.id
+
+              return (
+                <div key={conversation.id}>
+                  <div
+                    className={`group relative w-full rounded-md p-3 text-left transition-colors ${
+                      currentConversationId === conversation.id
+                        ? 'border border-primary-200 bg-primary-100 dark:border-primary-600 dark:bg-primary-900/30'
+                        : 'hover:bg-gray-100/90 dark:hover:bg-gray-700/80'
+                    } ${disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'}`}
+                    onMouseEnter={() => setHoveredId(conversation.id)}
+                    onMouseLeave={() => setHoveredId(null)}
                   >
-                    <DeleteIcon size={14} />
-                  </button>
-                )}
-              </div>
-            ))}
+                    <div
+                      role='button'
+                      tabIndex={disabled ? -1 : 0}
+                      className='flex items-center justify-between pr-8'
+                      onClick={() => !disabled && onSelectConversation(conversation.id)}
+                      onKeyDown={(e) => {
+                        if (!disabled && (e.key === 'Enter' || e.key === ' ')) {
+                          e.preventDefault()
+                          onSelectConversation(conversation.id)
+                        }
+                      }}
+                    >
+                      <div className='min-w-0 flex-1'>
+                        <h3 className='truncate font-medium text-gray-900 text-sm dark:text-gray-100'>
+                          {conversation.title}
+                        </h3>
+                        <div className='mt-1 flex items-center gap-2 text-gray-500 text-xs dark:text-gray-400'>
+                          <span className='inline-flex shrink-0 items-center gap-1 tabular-nums'>
+                            <MessageIcon size={12} className='stroke-gray-400 dark:stroke-gray-500' />
+                            <span>{conversation.messages.length}</span>
+                          </span>
+                          {getConversationDateLabel(conversation) && (
+                            <>
+                              <span className='h-px min-w-2 flex-1 bg-gray-300 dark:bg-gray-600' />
+                              <span className='shrink-0 tabular-nums'>{getConversationDateLabel(conversation)}</span>
+                            </>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                    {(hoveredId === conversation.id || currentConversationId === conversation.id) && !disabled && (
+                      <button
+                        type='button'
+                        onClick={(e) => handleDeleteClick(e, conversation.id)}
+                        className='absolute right-3 top-1/2 ml-2 -translate-y-1/2 rounded-md p-1 text-gray-400 opacity-0 transition-[opacity,background-color,color] hover:bg-red-50 hover:text-red-500 group-hover:opacity-100 dark:text-gray-500 dark:hover:bg-red-500/10 dark:hover:text-red-400'
+                        title='会話を削除'
+                      >
+                        <DeleteIcon size={14} className='stroke-current' />
+                      </button>
+                    )}
+                  </div>
+                  {index < conversations.length - 1 && (
+                    <div
+                      className={`mx-3 h-px bg-gray-200 transition-opacity dark:bg-gray-700 ${
+                        shouldShowDivider ? 'opacity-100' : 'opacity-0'
+                      }`}
+                      aria-hidden='true'
+                    />
+                  )}
+                </div>
+              )
+            })}
           </div>
         )}
       </div>

--- a/projects/portfolio/src/client/components/svg/message-icon.tsx
+++ b/projects/portfolio/src/client/components/svg/message-icon.tsx
@@ -1,0 +1,17 @@
+import { type IconProps, SvgIcon } from './icon-base'
+
+export function MessageIcon({ size = 24, className = 'stroke-black dark:stroke-white' }: IconProps) {
+  return (
+    <SvgIcon size={size} title='message-icon'>
+      <path
+        d='M5 6.5C5 5.67157 5.67157 5 6.5 5H17.5C18.3284 5 19 5.67157 19 6.5V13.5C19 14.3284 18.3284 15 17.5 15H11.2L8 18V15H6.5C5.67157 15 5 14.3284 5 13.5V6.5Z'
+        className={className}
+        strokeWidth='1.5'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+      />
+      <path d='M8 8.5H16' className={className} strokeWidth='1.5' strokeLinecap='round' />
+      <path d='M8 11.5H13' className={className} strokeWidth='1.5' strokeLinecap='round' />
+    </SvgIcon>
+  )
+}

--- a/projects/portfolio/src/server/app.d.ts
+++ b/projects/portfolio/src/server/app.d.ts
@@ -291,6 +291,7 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                         id?: string | undefined;
                         metadata?: {} | undefined;
                     })[];
+                    updatedAt?: string | undefined;
                 }[];
             };
             outputFormat: "json";
@@ -346,6 +347,7 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                         reasoningContent?: string | undefined;
                         metadata?: Record<string, never> | undefined;
                     })[];
+                    updatedAt?: unknown;
                 };
             };
             output: {
@@ -402,6 +404,7 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                         reasoningContent?: string | undefined;
                         metadata?: Record<string, never> | undefined;
                     })[];
+                    updatedAt?: unknown;
                 };
             };
             output: {

--- a/projects/portfolio/src/server/features/chat-conversations/read-conversations.ts
+++ b/projects/portfolio/src/server/features/chat-conversations/read-conversations.ts
@@ -54,6 +54,7 @@ export async function readConversations(databaseUrl: string, email: string): Pro
       conversationId: conversationsTable.id,
       conversationTitle: conversationsTable.title,
       conversationCreatedAt: conversationsTable.createdAt,
+      conversationUpdatedAt: conversationsTable.updatedAt,
       messageId: messagesTable.id,
       messageRole: messagesTable.role,
       messageContent: messagesTable.content,
@@ -74,6 +75,7 @@ export async function readConversations(databaseUrl: string, email: string): Pro
       conversationMap.set(row.conversationId, {
         id: row.conversationId,
         title: row.conversationTitle || 'Untitled Conversation',
+        updatedAt: row.conversationUpdatedAt,
         messages: [],
       })
     }

--- a/projects/portfolio/src/types/chat.ts
+++ b/projects/portfolio/src/types/chat.ts
@@ -102,6 +102,7 @@ export type Message = z.infer<typeof MessageSchema>
 export const ConversationSchema = z.object({
   id: z.string(),
   title: z.string(),
+  updatedAt: z.coerce.date().optional(),
   messages: z.array(MessageSchema),
 })
 

--- a/projects/portfolio/tests/client/components/conversation-history.test.tsx
+++ b/projects/portfolio/tests/client/components/conversation-history.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+
+import { ConversationHistory } from '#/client/components/chat/conversation-history'
+import { render, screen, within } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+describe('ConversationHistory', () => {
+  it('updatedAt がある会話は日付とメッセージ数アイコンを表示する', () => {
+    const { container } = render(
+      <ConversationHistory
+        conversations={[
+          {
+            id: 'conversation-1',
+            title: '会話1',
+            updatedAt: new Date('2026-04-14T12:34:56.000Z'),
+            messages: [
+              {
+                id: 'message-1',
+                role: 'user',
+                content: 'hello',
+                reasoningContent: '',
+                metadata: { model: 'gpt-test' },
+              },
+              {
+                id: 'message-2',
+                role: 'assistant',
+                content: 'world',
+                reasoningContent: '',
+                metadata: { model: 'gpt-test', usage: {} },
+              },
+            ],
+          },
+        ]}
+        currentConversationId={null}
+        onSelectConversation={vi.fn()}
+        onDeleteConversation={vi.fn()}
+        onNewConversation={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('2026/04/14')).toBeTruthy()
+    expect(screen.getByText('2')).toBeTruthy()
+    expect(within(container).getByTitle('message-icon')).toBeTruthy()
+  })
+
+  it('updatedAt がない会話はメッセージ数アイコンのみ表示する', () => {
+    const { container } = render(
+      <ConversationHistory
+        conversations={[
+          {
+            id: 'conversation-1',
+            title: '会話1',
+            messages: [
+              {
+                id: 'message-1',
+                role: 'user',
+                content: 'hello',
+                reasoningContent: '',
+                metadata: { model: 'gpt-test' },
+              },
+            ],
+          },
+        ]}
+        currentConversationId={null}
+        onSelectConversation={vi.fn()}
+        onDeleteConversation={vi.fn()}
+        onNewConversation={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('1')).toBeTruthy()
+    expect(within(container).getByTitle('message-icon')).toBeTruthy()
+  })
+})

--- a/projects/portfolio/tests/features/chat-conversations/read-conversations.test.ts
+++ b/projects/portfolio/tests/features/chat-conversations/read-conversations.test.ts
@@ -46,6 +46,9 @@ describe('readConversations', () => {
   })
 
   it('会話ごとにグループ化して title fallback と message 順を維持する', async () => {
+    const firstConversationUpdatedAt = new Date('2026-04-14T12:34:56.000Z')
+    const secondConversationUpdatedAt = new Date('2026-04-13T10:00:00.000Z')
+
     const { readConversations } = await importSubject({
       users: [{ id: 'user-1', email: 'test@example.com' }],
       rows: [
@@ -53,6 +56,7 @@ describe('readConversations', () => {
           conversationId: 'conversation-1',
           conversationTitle: null,
           conversationCreatedAt: new Date(),
+          conversationUpdatedAt: firstConversationUpdatedAt,
           messageId: 'message-1',
           messageRole: 'system',
           messageContent: 'system',
@@ -64,6 +68,7 @@ describe('readConversations', () => {
           conversationId: 'conversation-1',
           conversationTitle: null,
           conversationCreatedAt: new Date(),
+          conversationUpdatedAt: firstConversationUpdatedAt,
           messageId: 'message-2',
           messageRole: 'user',
           messageContent: 'hello',
@@ -75,6 +80,7 @@ describe('readConversations', () => {
           conversationId: 'conversation-2',
           conversationTitle: 'Second',
           conversationCreatedAt: new Date(),
+          conversationUpdatedAt: secondConversationUpdatedAt,
           messageId: null,
           messageRole: null,
           messageContent: null,
@@ -89,6 +95,7 @@ describe('readConversations', () => {
       {
         id: 'conversation-1',
         title: 'Untitled Conversation',
+        updatedAt: firstConversationUpdatedAt,
         messages: [
           {
             id: 'message-1',
@@ -110,6 +117,7 @@ describe('readConversations', () => {
       {
         id: 'conversation-2',
         title: 'Second',
+        updatedAt: secondConversationUpdatedAt,
         messages: [],
       },
     ])
@@ -123,6 +131,7 @@ describe('readConversations', () => {
           conversationId: 'conversation-1',
           conversationTitle: 'Test',
           conversationCreatedAt: new Date(),
+          conversationUpdatedAt: new Date('2026-04-14T12:34:56.000Z'),
           messageId: 'message-1',
           messageRole: 'user',
           // 配列 content が JSON 文字列として保存されている
@@ -152,6 +161,7 @@ describe('readConversations', () => {
           conversationId: 'conversation-1',
           conversationTitle: 'Test',
           conversationCreatedAt: new Date(),
+          conversationUpdatedAt: new Date('2026-04-14T12:34:56.000Z'),
           messageId: 'message-1',
           messageRole: 'user',
           messageContent: 'hello',

--- a/projects/portfolio/tests/routes/conversations.test.ts
+++ b/projects/portfolio/tests/routes/conversations.test.ts
@@ -51,6 +51,29 @@ describe('conversationsRoutes', () => {
     expect(repositoryMock.read).toHaveBeenCalledWith('postgres://db', 'test@example.com')
   })
 
+  it('認証済み GET は updatedAt を JSON 文字列で返す', async () => {
+    vi.stubEnv('DATABASE_URL', 'postgres://db')
+    getSignedCookieMock.mockResolvedValue('test@example.com')
+    repositoryMock.read.mockResolvedValue([
+      {
+        ...createConversationFixture(),
+        updatedAt: new Date('2026-04-14T12:34:56.000Z'),
+      },
+    ])
+
+    const res = await conversationsRoutes.request('/api/conversations')
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({
+      data: [
+        {
+          ...createConversationFixture(),
+          updatedAt: '2026-04-14T12:34:56.000Z',
+        },
+      ],
+    })
+  })
+
   it('未認証の POST は 401 を返す', async () => {
     vi.stubEnv('DATABASE_URL', 'postgres://db')
     getSignedCookieMock.mockResolvedValue(null)

--- a/projects/portfolio/tests/types/chat.test.ts
+++ b/projects/portfolio/tests/types/chat.test.ts
@@ -2,12 +2,13 @@ import { ConversationListResponseSchema } from '#/types'
 import { describe, expect, it } from 'vitest'
 
 describe('chat types', () => {
-  it('legacy metadata を含む会話一覧レスポンスを正規化できる', () => {
+  it('updatedAt を含む会話一覧レスポンスを正規化できる', () => {
     const response = ConversationListResponseSchema.parse({
       data: [
         {
           id: 'conversation-1',
           title: 'Legacy conversation',
+          updatedAt: '2026-04-14T12:34:56.000Z',
           messages: [
             {
               id: 'message-1',
@@ -33,6 +34,7 @@ describe('chat types', () => {
         {
           id: 'conversation-1',
           title: 'Legacy conversation',
+          updatedAt: new Date('2026-04-14T12:34:56.000Z'),
           messages: [
             {
               id: 'message-1',
@@ -54,6 +56,28 @@ describe('chat types', () => {
               },
             },
           ],
+        },
+      ],
+    })
+  })
+
+  it('updatedAt が無い既存レスポンスも正規化できる', () => {
+    const response = ConversationListResponseSchema.parse({
+      data: [
+        {
+          id: 'conversation-1',
+          title: 'Legacy conversation',
+          messages: [],
+        },
+      ],
+    })
+
+    expect(response).toEqual({
+      data: [
+        {
+          id: 'conversation-1',
+          title: 'Legacy conversation',
+          messages: [],
         },
       ],
     })


### PR DESCRIPTION
## Issues

- None

## Why

チャット履歴一覧で会話の新しさや状態が分かりづらく、削除操作まわりの視認性も弱かったためです。

## Summary

会話履歴一覧に最終更新日を追加し、件数表示をコンパクトなアイコン表現へ置き換えました。あわせて、Divider・ホバー・アクティブ・削除ボタンの見た目を整理し、一覧の視認性を改善しました。

## Changes

- `Conversation` に `updatedAt` を追加し、会話一覧 API で返すように変更
- 履歴一覧で日付、件数アイコン、伸びる区切り線を表示
- 削除ボタンの配置とホバー色を調整し、アイコン色も追従するように変更
- 型・ルート・読取・UI のテストを追加更新

## Checklist

- [x] `bun run test`
- [x] `bun run lint`
- [x] `bun run format:check`
