### PR TITLE
fix: code block language selector theme in dark mode

### DIFF
--- a/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
+++ b/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
@@ -130,17 +130,27 @@ export function CodeBlockRenderer({ className, children }: CodeBlockRendererProp
   return (
     <div className='my-2 overflow-hidden rounded-lg border border-gray-200 dark:border-gray-600'>
       <div className='flex items-center justify-between border-b border-gray-200 bg-gray-50 px-3 py-1.5 dark:border-gray-600 dark:bg-[#282c34]'>
-        <select
-          value={selectedLanguage}
-          onChange={(e) => setSelectedLanguage(e.target.value)}
-          className='cursor-pointer rounded border-none bg-transparent text-xs text-gray-600 dark:text-gray-300'
-        >
-          {languageOptions.map((lang) => (
-            <option key={lang} value={lang}>
-              {lang}
-            </option>
-          ))}
-        </select>
+        <div className='relative'>
+          <select
+            value={selectedLanguage}
+            onChange={(e) => setSelectedLanguage(e.target.value)}
+            className='cursor-pointer appearance-none rounded border-none bg-gray-50 pr-6 text-xs text-gray-600 dark:bg-[#282c34] dark:text-gray-300'
+          >
+            {languageOptions.map((lang) => (
+              <option key={lang} value={lang} className='bg-white text-gray-900 dark:bg-[#282c34] dark:text-gray-100'>
+                {lang}
+              </option>
+            ))}
+          </select>
+          <svg
+            viewBox='0 0 20 20'
+            aria-hidden='true'
+            className='pointer-events-none absolute top-1/2 right-1 h-3.5 w-3.5 -translate-y-1/2 stroke-gray-600 dark:stroke-gray-300'
+            fill='none'
+          >
+            <path d='M5 7.5L10 12.5L15 7.5' strokeWidth='1.8' strokeLinecap='round' strokeLinejoin='round' />
+          </svg>
+        </div>
         <button
           type='button'
           onClick={handleClickCopy}


### PR DESCRIPTION
## Why

コードブロックの言語プルダウンがダークモード時に読めず、モバイルでは標準の矢印アイコンもテーマ色に追従していませんでした。

## Summary

コードブロックの言語プルダウンにダークモード用の背景色と文字色を追加しました。
あわせて、ブラウザ標準の矢印ではなくテーマ追従する自前アイコンに差し替え、モバイルでも見た目が崩れないようにしました。

## Changes

- `select` と `option` にダークモード向けの背景色・文字色を追加
- `select` を `appearance-none` にし、自前の矢印アイコンを右端に表示
- 既存のコードブロックヘッダー配色に合わせてプルダウンの見た目を調整

## Checklist

- [x] `bun run lint`
- [x] ブラウザ実機での最終確認
