### PR TITLE
feat: sync manual deploy targets on deploy changes

### DIFF
--- a/.github/actions/sync-manual-deploy-targets/action.yml
+++ b/.github/actions/sync-manual-deploy-targets/action.yml
@@ -1,0 +1,32 @@
+name: Sync Manual Deploy Targets
+description: Trigger repository dispatch to sync manual deploy targets
+
+inputs:
+  token:
+    description: "GitHub token for repository dispatch"
+    required: true
+  repo-name:
+    description: "Target repository name for sync"
+    required: true
+  source-repository:
+    description: "Source repository name"
+    required: true
+  source-ref:
+    description: "Source git ref"
+    required: true
+  source-sha:
+    description: "Source commit SHA"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Trigger Sync Workflow
+      shell: bash
+      run: |
+        ${{ github.action_path }}/sync-manual-deploy-targets.sh \
+          "${{ inputs.token }}" \
+          "${{ inputs.repo-name }}" \
+          "${{ inputs.source-repository }}" \
+          "${{ inputs.source-ref }}" \
+          "${{ inputs.source-sha }}"

--- a/.github/actions/sync-manual-deploy-targets/sync-manual-deploy-targets.sh
+++ b/.github/actions/sync-manual-deploy-targets/sync-manual-deploy-targets.sh
@@ -23,10 +23,16 @@ if [[ -z "$SOURCE_REPOSITORY" || -z "$SOURCE_REF" || -z "$SOURCE_SHA" ]]; then
   exit 1
 fi
 
-PAYLOAD=$(printf '{"event_type":"sync_manual_deploy_targets","client_payload":{"source_repository":"%s","source_ref":"%s","source_sha":"%s"}}' \
-  "$SOURCE_REPOSITORY" \
-  "$SOURCE_REF" \
-  "$SOURCE_SHA")
+if ! command -v jq >/dev/null 2>&1; then
+  echo "Error: jq is required."
+  exit 1
+fi
+
+PAYLOAD=$(jq -n \
+  --arg repo "$SOURCE_REPOSITORY" \
+  --arg ref "$SOURCE_REF" \
+  --arg sha "$SOURCE_SHA" \
+  '{event_type:"sync_manual_deploy_targets",client_payload:{source_repository:$repo,source_ref:$ref,source_sha:$sha}}')
 
 echo "Triggering manual deploy target sync"
 echo "source_repository=$SOURCE_REPOSITORY"

--- a/.github/actions/sync-manual-deploy-targets/sync-manual-deploy-targets.sh
+++ b/.github/actions/sync-manual-deploy-targets/sync-manual-deploy-targets.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -euo pipefail
+
+TOKEN="$1"
+REPO_NAME="$2"
+SOURCE_REPOSITORY="$3"
+SOURCE_REF="$4"
+SOURCE_SHA="$5"
+
+if [[ -z "$TOKEN" ]]; then
+  echo "Error: GitHub token is required."
+  exit 1
+fi
+
+if [[ -z "$REPO_NAME" ]]; then
+  echo "Error: Repository name is required."
+  exit 1
+fi
+
+if [[ -z "$SOURCE_REPOSITORY" || -z "$SOURCE_REF" || -z "$SOURCE_SHA" ]]; then
+  echo "Error: Source repository, ref, and SHA are required."
+  exit 1
+fi
+
+PAYLOAD=$(printf '{"event_type":"sync_manual_deploy_targets","client_payload":{"source_repository":"%s","source_ref":"%s","source_sha":"%s"}}' \
+  "$SOURCE_REPOSITORY" \
+  "$SOURCE_REF" \
+  "$SOURCE_SHA")
+
+echo "Triggering manual deploy target sync"
+echo "source_repository=$SOURCE_REPOSITORY"
+echo "source_ref=$SOURCE_REF"
+echo "source_sha=$SOURCE_SHA"
+
+curl --fail-with-body -sS -X POST \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer $TOKEN" \
+  "https://api.github.com/repos/u7chan/$REPO_NAME/dispatches" \
+  -d "$PAYLOAD"
+
+echo ""
+echo "Manual deploy target sync trigger sent successfully."

--- a/.github/workflows/sync-manual-deploy-targets.yml
+++ b/.github/workflows/sync-manual-deploy-targets.yml
@@ -1,0 +1,34 @@
+name: Sync Manual Deploy Targets
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      # 直下の deploy 定義のみを対象にし、deploy/abolished/** は含めない
+      - "deploy/*.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  trigger-sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Trigger repository dispatch
+        uses: ./.github/actions/sync-manual-deploy-targets
+        with:
+          token: ${{ secrets.PRIVATE_REPO_TOKEN }}
+          repo-name: ${{ secrets.PRIVATE_REPO_NAME }}
+          source-repository: ${{ github.repository }}
+          source-ref: ${{ github.ref }}
+          source-sha: ${{ github.sha }}

--- a/docs/about-cicd.md
+++ b/docs/about-cicd.md
@@ -6,6 +6,7 @@
 
 - CI は `main` 向け PR で、変更のあったプロジェクトの Dockerfile にある `test` ステージを検証します。
 - CD は `main` への push または手動実行で、対象プロジェクトの Dockerfile にある `final` ステージを build して GHCR に push します。
+- deploy 定義の同期は `main` への push で `deploy/*.yml` が変わったときに走り、`u7chan/self-hosted-runner` 側へ `repository_dispatch` を送って Manual Deploy の `target` 選択肢を同期します。
 - 手動実行では `Git ref` に branch 名やコミットハッシュを指定でき、`project directories` とあわせて対象を絞れます。deploy handoff に使う `image_tag` もログに出力します。
 
 ```mermaid
@@ -38,6 +39,15 @@ flowchart LR
     GHCR --> HANDOFF
   end
 
+  subgraph SYNC["Deploy Target Sync"]
+    DEPLOY_PUSH["main への push<br/>deploy/*.yml 変更"]
+    DISPATCH["sync-manual-deploy-targets.yml"]
+    SELF_HOSTED["self-hosted-runner に<br/>repository_dispatch"]
+
+    DEPLOY_PUSH --> DISPATCH
+    DISPATCH --> SELF_HOSTED
+  end
+
   PR --> CI_DIRS
   PUSH --> CD_AUTO
   MANUAL --> CD_MANUAL
@@ -54,6 +64,8 @@ flowchart LR
 | 対象ステージ | `test` | `final` |
 | 目的 | 変更の検証 | 配布用イメージの作成と push |
 | 成果物 | ビルド結果の確認 | GHCR イメージ |
+
+加えて、`deploy/*.yml` の変更時には `sync-manual-deploy-targets.yml` が動き、`self-hosted-runner` 側の Manual Deploy 選択肢同期を起動します。これは Docker build 自体は行わず、deploy 定義変更を通知するための workflow です。
 
 ## 対象になるプロジェクト
 
@@ -164,6 +176,34 @@ sequenceDiagram
 5. `ghcr.io/{repo}/{project}:{image_tag}` へ push する
 6. 古い manual image を含む不要イメージを cleanup する
 
+## Deploy 定義変更時の同期
+
+### いつ動くか
+
+- `main` への push で `deploy/*.yml` が追加・削除・リネーム・更新されたときに実行されます。
+- `deploy/abolished/**` は対象外です。
+
+### 何をするか
+
+```mermaid
+sequenceDiagram
+  participant Push as main への push
+  participant Sync as sync-manual-deploy-targets.yml
+  participant Repo as u7chan/self-hosted-runner
+
+  Push->>Sync: deploy/*.yml の変更を検知
+  Sync->>Repo: repository_dispatch
+  Note right of Repo: event_type=sync_manual_deploy_targets
+  Note right of Repo: source_repository / source_ref / source_sha
+```
+
+- `PRIVATE_REPO_TOKEN` と `PRIVATE_REPO_NAME` を使って `u7chan/self-hosted-runner` に `repository_dispatch` を送ります。
+- payload には次の値を含めます。
+  - `source_repository`
+  - `source_ref`
+  - `source_sha`
+- この workflow 自体は deploy を実行しません。Manual Deploy の `target` プルダウン同期だけを起動します。
+
 ## カスタムアクション
 
 ### 役割の対応表
@@ -177,6 +217,7 @@ sequenceDiagram
 | `build-docker-images` | Docker image を build する | build 結果 |
 | `push-docker-images` | GHCR に push する | `project_names_csv` |
 | `cleanup-docker-images` | 古い image を cleanup する | cleanup 結果 |
+| `sync-manual-deploy-targets` | deploy 定義変更を別 repo に通知する | dispatch 実行結果 |
 
 ### 各アクションの詳細
 
@@ -228,6 +269,12 @@ push 成功時は、対象プロジェクト名と deploy handoff 用の `target
 
 CD 実行後、不要な古いイメージの cleanup を行います。manual build では `keep-count=3` が使われます。
 
+#### `sync-manual-deploy-targets`
+
+- 入力: `token`, `repo-name`, `source-repository`, `source-ref`, `source-sha`
+
+`deploy/*.yml` の変更を契機に、`u7chan/self-hosted-runner` へ `sync_manual_deploy_targets` の `repository_dispatch` を送ります。
+
 ## データの受け渡し
 
 ```mermaid
@@ -257,3 +304,11 @@ flowchart LR
 
 - `PRIVATE_REPO_TOKEN` が正しいか確認する
 - `write:packages` 権限があるか確認する
+
+### deploy 定義変更の同期通知が飛ばない
+
+- `main` への push か確認する
+- 変更ファイルが `deploy/*.yml` 直下か確認する
+- `deploy/abolished/**` 配下の変更ではないか確認する
+- `PRIVATE_REPO_NAME` が `self-hosted-runner` を指しているか確認する
+- `PRIVATE_REPO_TOKEN` に dispatch 先 repo へのアクセス権限があるか確認する


### PR DESCRIPTION
## Issues

- Close #791

## Why

`deploy/*.yml` の変更と `self-hosted-runner` 側の Manual Deploy の選択肢同期を自動で揃える必要があるためです。

## Summary

`main` への push で `deploy/*.yml` が変更された場合に、`self-hosted-runner` へ `repository_dispatch` を送る workflow を追加しました。通知 payload には通知元の repository、ref、sha を含めています。

## Changes

- `deploy/*.yml` 変更時のみ動く `Sync Manual Deploy Targets` workflow を追加
- `PRIVATE_REPO_TOKEN` と `PRIVATE_REPO_NAME` を使って `sync_manual_deploy_targets` を送る composite action と shell script を追加
- `deploy/abolished/**` を含まないよう、workflow の監視対象を `deploy/*.yml` に限定

## Checklist

- [x] shell script の構文を `bash -n` で確認
- [x] workflow/action YAML を `python3` で読み込み確認
- [ ] GitHub Actions 上での実 dispatch 動作確認
