### PR TITLE
feat(deploy): add Bifrost deployment definition

### DIFF
--- a/deploy/bifrost.yml
+++ b/deploy/bifrost.yml
@@ -1,0 +1,18 @@
+networks:
+  default:
+    name: home_network
+
+services:
+  bifrost:
+    container_name: bifrost
+    image: maximhq/bifrost:latest
+    restart: always
+    ports:
+      - 5000:8080
+    environment:
+      - TZ=Asia/Tokyo
+    volumes:
+      - bifrost-data:/app/data
+
+volumes:
+  bifrost-data:


### PR DESCRIPTION
## Issue
- closes #793

## Summary
- Add `deploy/bifrost.yml` for Bifrost evaluation alongside the existing LiteLLM setup on the self-hosted server
- Uses `maximhq/bifrost:latest` with port `5000:8080`, persistent `/app/data` storage via named volume, and `TZ=Asia/Tokyo`
- No `extra_hosts` or `config.json` — minimal initial setup for Web UI operation

## Validation
- [x] `docker compose -f deploy/bifrost.yml config` succeeds
- [x] Port 5000 does not conflict with existing deploy targets
- [x] Sync script will automatically pick up `bifrost` as a manual deploy target after merge

## Test plan
- [ ] `docker compose -f deploy/bifrost.yml up -d` starts successfully
- [ ] `http://<server>:5000` opens the Bifrost UI
- [ ] Settings saved via UI persist across `down` and `up -d`
- [ ] Basic request to Bifrost's OpenAI-compatible endpoint succeeds
- [ ] Manual deploy target sync includes `bifrost` in self-hosted-runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)