### PR TITLE
feat(portfolio): normalize chat API contract for Hono RPC type-safety

### DIFF
--- a/projects/portfolio/src/client/components/chat/chat-message-list.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-message-list.tsx
@@ -1,9 +1,10 @@
 import { CodeBlockRenderer, MarkdownLink } from '#/client/components/chat/code-block-renderer'
+import type { ChatStreamState } from '#/client/components/chat/hooks/chat-response'
 import { MessageRenderer } from '#/client/components/chat/message-renderer'
 import { ReasoningSection } from '#/client/components/chat/reasoning-section'
 import { ChatbotIcon } from '#/client/components/svg/chatbot-icon'
 import { SpinnerIcon } from '#/client/components/svg/spinner-icon'
-import type { ChatStreamState, Message } from '#/types'
+import type { Message } from '#/types'
 import { memo, type ReactNode, type RefObject } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
@@ -54,8 +55,8 @@ export function ChatMessageList({
             </div>
             {stream ? (
               <div className='message ml-2 text-left'>
-                {stream.reasoning_content && (
-                  <ReasoningSection content={stream.reasoning_content} isStreaming={!stream.content} />
+                {stream.reasoningContent && (
+                  <ReasoningSection content={stream.reasoningContent} isStreaming={!stream.content} />
                 )}
                 {markdownPreview ? (
                   <div className='prose mt-1 max-w-(--breakpoint-md) break-all dark:text-white'>

--- a/projects/portfolio/src/client/components/chat/hooks/chat-response.ts
+++ b/projects/portfolio/src/client/components/chat/hooks/chat-response.ts
@@ -1,74 +1,20 @@
-import {
-  ChatCompletionResponseSchema,
-  ChatCompletionStreamChunkSchema,
-  type ChatCompletionResponse,
-  type ChatCompletionResult,
-  type ChatCompletionStreamChunk,
-  type ChatStreamState,
-} from '#/types'
+import { ChatStreamEventSchema, type ChatStreamEvent } from '#/types/chat-api'
 
-type ApiUsage = ChatCompletionResponse['usage'] | ChatCompletionStreamChunk['usage']
-
-export function parseChatCompletionResponse(value: unknown): ChatCompletionResponse {
-  return ChatCompletionResponseSchema.parse(value)
+export interface ChatStreamState {
+  content: string
+  reasoningContent: string
 }
 
-export function parseChatCompletionStreamChunk(value: string): ChatCompletionStreamChunk {
-  return ChatCompletionStreamChunkSchema.parse(JSON.parse(value))
+export function parseChatStreamEvent(value: string): ChatStreamEvent {
+  return ChatStreamEventSchema.parse(JSON.parse(value))
 }
 
-export function updateChatStream(
-  stream: ChatStreamState,
-  chunk: ChatCompletionStreamChunk
-): {
-  stream: ChatStreamState
-  finishReason: string
-  model?: string
-  usage: ChatCompletionResult['usage']
-} {
-  const choice = chunk.choices.at(0)
-  const nextStream = {
-    content: stream.content + (choice?.delta.content ?? ''),
-    reasoning_content: (stream.reasoning_content ?? '') + (choice?.delta.reasoning_content ?? ''),
+export function updateChatStream(stream: ChatStreamState, event: ChatStreamEvent): ChatStreamState {
+  if (event.event === 'delta') {
+    return {
+      content: stream.content + (event.content ?? ''),
+      reasoningContent: stream.reasoningContent + (event.reasoningContent ?? ''),
+    }
   }
-
-  return {
-    stream: nextStream,
-    finishReason: choice?.finish_reason ?? '',
-    model: chunk.model,
-    usage: normalizeUsage(chunk.usage),
-  }
-}
-
-export function toChatCompletionResult(response: ChatCompletionResponse): ChatCompletionResult | null {
-  const choice = response.choices.at(0)
-  const content = choice?.message.content ?? ''
-
-  if (!content) {
-    return null
-  }
-
-  return {
-    model: response.model ?? 'N/A',
-    finishReason: choice?.finish_reason ?? '',
-    message: {
-      content,
-      reasoningContent: choice?.message.reasoning_content ?? '',
-    },
-    responseTimeMs: 0,
-    usage: normalizeUsage(response.usage),
-  }
-}
-
-function normalizeUsage(usage: ApiUsage): ChatCompletionResult['usage'] {
-  if (!usage) {
-    return null
-  }
-
-  return {
-    promptTokens: usage.prompt_tokens,
-    completionTokens: usage.completion_tokens,
-    totalTokens: usage.total_tokens,
-    reasoningTokens: usage.reasoning_tokens ?? usage.completion_tokens_details?.reasoning_tokens,
-  }
+  return stream
 }

--- a/projects/portfolio/src/client/components/chat/hooks/use-message-scroll.ts
+++ b/projects/portfolio/src/client/components/chat/hooks/use-message-scroll.ts
@@ -1,4 +1,5 @@
-import type { ChatStreamState, Message } from '#/types'
+import type { ChatStreamState } from '#/client/components/chat/hooks/chat-response'
+import type { Message } from '#/types'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 interface UseMessageScrollParams {

--- a/projects/portfolio/src/client/components/chat/hooks/use-stream-processor.ts
+++ b/projects/portfolio/src/client/components/chat/hooks/use-stream-processor.ts
@@ -118,6 +118,9 @@ const makeErrorResponse = (message: string): ChatResponse => ({
   usage: null,
 })
 
+const hasAssistantOutput = ({ content, reasoningContent }: ChatResponse['message']): boolean =>
+  content.length > 0 || reasoningContent.length > 0
+
 const sendNonStreamCompletion = async (req: SendCompletionParams): Promise<ChatResponse | null> => {
   try {
     const res = await client.api.chat.$post(
@@ -144,7 +147,7 @@ const sendNonStreamCompletion = async (req: SendCompletionParams): Promise<ChatR
     }
 
     const data = (await res.json()) as ChatResponse
-    if (!data.message?.content) return null
+    if (!hasAssistantOutput(data.message)) return null
 
     return data
   } catch (error) {
@@ -246,7 +249,7 @@ const sendStreamCompletion = async (
     }
   }
 
-  if (!accumulated.content) return null
+  if (!hasAssistantOutput(accumulated)) return null
 
   return {
     id,

--- a/projects/portfolio/src/client/components/chat/hooks/use-stream-processor.ts
+++ b/projects/portfolio/src/client/components/chat/hooks/use-stream-processor.ts
@@ -1,13 +1,9 @@
 import type { AppType } from '#/server/app.d'
-import type { ApiChatMessage, ChatCompletionResult, ChatStreamState } from '#/types'
+import type { ApiChatMessage } from '#/types'
+import type { ChatResponse, ChatUsage } from '#/types/chat-api'
 import { hc } from 'hono/client'
 import { useCallback, useRef, useState } from 'react'
-import {
-  parseChatCompletionResponse,
-  parseChatCompletionStreamChunk,
-  toChatCompletionResult,
-  updateChatStream,
-} from './chat-response'
+import { type ChatStreamState, parseChatStreamEvent, updateChatStream } from './chat-response'
 
 const client = hc<AppType>('/')
 
@@ -51,26 +47,33 @@ export function useStreamProcessor({ onSubmitting }: UseStreamProcessorParams = 
       temperature,
       maxTokens,
       reasoningEffort,
-    }: SubmitChatCompletionParams): Promise<{ result: ChatCompletionResult | null; responseTimeMs: number }> => {
+    }: SubmitChatCompletionParams): Promise<{ result: ChatResponse | null; responseTimeMs: number }> => {
       setLoading(true)
       abortControllerRef.current = new AbortController()
       onSubmitting?.(true)
       const requestStartTime = Date.now()
 
       try {
-        const result = await sendChatCompletion({
-          abortController: abortControllerRef.current,
-          header,
-          model,
-          messages,
-          stream: streamMode,
-          temperature,
-          maxTokens,
-          reasoningEffort,
-          onStream: (stream) => {
-            setStream(stream)
-          },
-        })
+        const result = streamMode
+          ? await sendStreamCompletion({
+              abortController: abortControllerRef.current,
+              header,
+              model,
+              messages,
+              temperature,
+              maxTokens,
+              reasoningEffort,
+              onStream: (stream) => setStream(stream),
+            })
+          : await sendNonStreamCompletion({
+              abortController: abortControllerRef.current,
+              header,
+              model,
+              messages,
+              temperature,
+              maxTokens,
+              reasoningEffort,
+            })
         const responseTimeMs = Date.now() - requestStartTime
 
         return { result, responseTimeMs }
@@ -92,7 +95,7 @@ export function useStreamProcessor({ onSubmitting }: UseStreamProcessorParams = 
   }
 }
 
-const sendChatCompletion = async (req: {
+interface SendCompletionParams {
   abortController: AbortController
   header: {
     apiKey: string
@@ -101,20 +104,21 @@ const sendChatCompletion = async (req: {
   }
   model: string
   messages: ApiChatMessage[]
-  stream: boolean
   temperature?: number
   maxTokens?: number
   reasoningEffort?: 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'
-  onStream?: (stream: ChatStreamState) => void
-}): Promise<ChatCompletionResult | null> => {
-  let result: ChatStreamState = {
-    content: '',
-    reasoning_content: '',
-  }
-  let finish_reason = ''
-  let usage: ChatCompletionResult['usage'] = null
-  let responseModel = 'N/A'
+}
 
+const makeErrorResponse = (message: string): ChatResponse => ({
+  id: '',
+  created: 0,
+  model: 'N/A',
+  finishReason: '',
+  message: { content: message, reasoningContent: '' },
+  usage: null,
+})
+
+const sendNonStreamCompletion = async (req: SendCompletionParams): Promise<ChatResponse | null> => {
   try {
     const res = await client.api.chat.$post(
       {
@@ -126,105 +130,133 @@ const sendChatCompletion = async (req: {
         json: {
           messages: req.messages,
           model: req.model,
-          stream: req.stream,
           temperature: req.temperature,
-          max_tokens: req.maxTokens,
-          reasoning_effort: req.reasoningEffort,
-          stream_options: req.stream
-            ? {
-                include_usage: true,
-              }
-            : undefined,
+          maxTokens: req.maxTokens,
+          reasoningEffort: req.reasoningEffort,
         },
       },
       { init: { signal: req.abortController.signal } }
     )
+
     if (!res.ok) {
-      const error = (await res.json()) as { message?: string }
-      result.content = error?.message || JSON.stringify(error)
-    } else {
-      const nonStream = res.headers.get('Content-Type')?.includes('application/json') ?? false
-      if (nonStream) {
-        const data = parseChatCompletionResponse(await res.json())
-        const completion = toChatCompletionResult(data)
+      const error = (await res.json()) as { error?: string }
+      return makeErrorResponse(error?.error || JSON.stringify(error))
+    }
 
-        if (!completion) {
-          return null
+    const data = (await res.json()) as ChatResponse
+    if (!data.message?.content) return null
+
+    return data
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') return null
+    throw error
+  }
+}
+
+const sendStreamCompletion = async (
+  req: SendCompletionParams & { onStream?: (stream: ChatStreamState) => void }
+): Promise<ChatResponse | null> => {
+  let accumulated: ChatStreamState = { content: '', reasoningContent: '' }
+  let id = ''
+  let created = 0
+  let model = 'N/A'
+  let finishReason = ''
+  let usage: ChatUsage | null = null
+
+  try {
+    const res = await client.api.chat.stream.$post(
+      {
+        header: {
+          'api-key': req.header.apiKey,
+          'base-url': req.header.baseURL,
+          'mcp-server-urls': req.header.mcpServerURLs,
+        },
+        json: {
+          messages: req.messages,
+          model: req.model,
+          temperature: req.temperature,
+          maxTokens: req.maxTokens,
+          reasoningEffort: req.reasoningEffort,
+        },
+      },
+      { init: { signal: req.abortController.signal } }
+    )
+
+    if (!res.ok) {
+      const error = (await res.json()) as { error?: string }
+      return makeErrorResponse(error?.error || JSON.stringify(error))
+    }
+
+    const reader = res.body?.getReader()
+    if (!reader) throw new Error('Failed to get reader from response body.')
+
+    const decoder = new TextDecoder('utf-8')
+    let buffer = ''
+    let running = true
+
+    while (running) {
+      const { done, value } = await reader.read()
+      if (done) break
+
+      buffer += decoder.decode(value, { stream: true })
+      while (running) {
+        const idx = buffer.indexOf('\n')
+        if (idx === -1) break
+
+        const line = buffer.slice(0, idx).trim()
+        buffer = buffer.slice(idx + 1)
+        if (!line.startsWith('data: ')) continue
+
+        const jsonStr = line.replace(/^data:\s*/, '')
+        if (jsonStr === '[DONE]') {
+          console.log('Stream completed.')
+          running = false
+          break
         }
 
-        return completion
-      } else {
-        const reader = res.body?.getReader()
-        if (!reader) {
-          throw new Error('Failed to get reader from response body.')
-        }
-        const decoder = new TextDecoder('utf-8')
-        let buffer = ''
-        let running = true
-        while (running) {
-          const { done, value } = await reader.read()
-          if (done) break
+        try {
+          const event = parseChatStreamEvent(jsonStr)
+          accumulated = updateChatStream(accumulated, event)
 
-          buffer += decoder.decode(value, { stream: true })
-          while (running) {
-            const idx = buffer.indexOf('\n')
-            if (idx === -1) break
-
-            const line = buffer.slice(0, idx).trim()
-            buffer = buffer.slice(idx + 1)
-            if (!line.startsWith('data: ')) continue
-
-            const jsonStr = line.replace(/^data:\s*/, '')
-            if (jsonStr === '[DONE]') {
-              console.log('Stream completed.')
-              running = false
-              break
-            }
-            try {
-              const parsedChunk = parseChatCompletionStreamChunk(jsonStr)
-              const next = updateChatStream(result, parsedChunk)
-
-              result = next.stream
-              if (next.finishReason) {
-                finish_reason = next.finishReason
-              }
-              if (next.model) {
-                responseModel = next.model
-              }
-              if (next.usage) {
-                usage = next.usage
-              }
-              req.onStream?.({
-                content: result.content,
-                reasoning_content: result.reasoning_content ?? '',
-              })
-            } catch (error) {
-              console.error('JSON parse error:', error)
-              running = false
-              break
-            }
+          if (event.event === 'delta') {
+            id = event.id
+            created = event.created
+            model = event.model
           }
+          if (event.event === 'finish') {
+            finishReason = event.finishReason
+          }
+          if (event.event === 'usage') {
+            usage = event.usage
+          }
+
+          req.onStream?.(accumulated)
+        } catch (error) {
+          console.error('JSON parse error:', error)
+          running = false
+          break
         }
       }
     }
   } catch (error) {
-    if (!(error instanceof Error && error.name === 'AbortError')) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      // キャンセル時は蓄積した内容があれば返す
+    } else {
       throw error
     }
   }
 
-  if (!result.content) {
-    return null
-  }
+  if (!accumulated.content) return null
 
   return {
-    model: responseModel,
-    finishReason: finish_reason,
+    id,
+    created,
+    model,
+    finishReason,
     message: {
-      content: result.content,
-      reasoningContent: result.reasoning_content ?? '',
+      content: accumulated.content,
+      reasoningContent: accumulated.reasoningContent,
     },
-    responseTimeMs: 0,
     usage,
   }
 }

--- a/projects/portfolio/src/server/app.d.ts
+++ b/projects/portfolio/src/server/app.d.ts
@@ -1,6 +1,14 @@
 import { HonoEnv } from './routes/shared';
-declare const app: import('hono/hono-base').HonoBase<HonoEnv, import('hono/types').BlankSchema, "/", "/">;
-declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/types').BlankSchema | import('hono/types').MergeSchemaPath<{
+declare const app: import('hono/hono-base').HonoBase<HonoEnv & {
+    Variables: {
+        logger: import('hono-pino').PinoLogger;
+    };
+}, import('hono/types').BlankSchema, "/", "*">;
+declare const routes: import('hono/hono-base').HonoBase<HonoEnv & {
+    Variables: {
+        logger: import('hono-pino').PinoLogger;
+    };
+}, import('hono/types').BlankSchema | import('hono/types').MergeSchemaPath<{
     "/api/signin": {
         $post: {
             input: {
@@ -67,13 +75,9 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                         content: string;
                     })[];
                     model: string;
-                    stream?: boolean | undefined;
                     temperature?: number | undefined;
-                    max_tokens?: number | undefined;
-                    reasoning_effort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | undefined;
-                    stream_options?: {
-                        include_usage?: boolean | undefined;
-                    } | undefined;
+                    maxTokens?: number | undefined;
+                    reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | undefined;
                 };
             };
             output: {
@@ -111,18 +115,17 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                         content: string;
                     })[];
                     model: string;
-                    stream?: boolean | undefined;
                     temperature?: number | undefined;
-                    max_tokens?: number | undefined;
-                    reasoning_effort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | undefined;
-                    stream_options?: {
-                        include_usage?: boolean | undefined;
-                    } | undefined;
+                    maxTokens?: number | undefined;
+                    reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | undefined;
                 };
             };
-            output: {};
-            outputFormat: string;
-            status: import('hono/utils/http-status').StatusCode;
+            output: {
+                error: string;
+                code: "VALIDATION_ERROR";
+            };
+            outputFormat: "json";
+            status: 400;
         } | {
             input: {
                 header: {
@@ -151,20 +154,187 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                         content: string;
                     })[];
                     model: string;
-                    stream?: boolean | undefined;
                     temperature?: number | undefined;
-                    max_tokens?: number | undefined;
-                    reasoning_effort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | undefined;
-                    stream_options?: {
-                        include_usage?: boolean | undefined;
-                    } | undefined;
+                    maxTokens?: number | undefined;
+                    reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | undefined;
                 };
             };
             output: {
-                message: string;
+                id: string;
+                created: number;
+                model: string;
+                finishReason: string;
+                message: {
+                    content: string;
+                    reasoningContent: string;
+                };
+                usage: {
+                    promptTokens: number;
+                    completionTokens: number;
+                    totalTokens: number;
+                    reasoningTokens?: number | undefined;
+                } | null;
+            };
+            outputFormat: "json";
+            status: import('hono/utils/http-status').ContentfulStatusCode;
+        } | {
+            input: {
+                header: {
+                    'api-key': string;
+                    'base-url': string;
+                    'mcp-server-urls': string | undefined;
+                };
+            } & {
+                json: {
+                    messages: ({
+                        role: "user";
+                        content: string | ({
+                            type: "image_url";
+                            image_url: {
+                                url: string;
+                            };
+                        } | {
+                            type: "text";
+                            text: string;
+                        })[];
+                    } | {
+                        role: "assistant";
+                        content: string;
+                    } | {
+                        role: "system";
+                        content: string;
+                    })[];
+                    model: string;
+                    temperature?: number | undefined;
+                    maxTokens?: number | undefined;
+                    reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | undefined;
+                };
+            };
+            output: {
+                error: string;
+                code: "UPSTREAM_ERROR";
+            };
+            outputFormat: "json";
+            status: 502;
+        };
+    };
+} & {
+    "/api/chat/stream": {
+        $post: {
+            input: {
+                header: {
+                    'api-key': string;
+                    'base-url': string;
+                    'mcp-server-urls': string | undefined;
+                };
+            } & {
+                json: {
+                    messages: ({
+                        role: "user";
+                        content: string | ({
+                            type: "image_url";
+                            image_url: {
+                                url: string;
+                            };
+                        } | {
+                            type: "text";
+                            text: string;
+                        })[];
+                    } | {
+                        role: "assistant";
+                        content: string;
+                    } | {
+                        role: "system";
+                        content: string;
+                    })[];
+                    model: string;
+                    temperature?: number | undefined;
+                    maxTokens?: number | undefined;
+                    reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | undefined;
+                };
+            };
+            output: {
+                readonly success: false;
+                readonly error: readonly import("@standard-schema/spec").StandardSchemaV1.Issue[];
+                readonly data: any;
             };
             outputFormat: "json";
             status: 400;
+        } | {
+            input: {
+                header: {
+                    'api-key': string;
+                    'base-url': string;
+                    'mcp-server-urls': string | undefined;
+                };
+            } & {
+                json: {
+                    messages: ({
+                        role: "user";
+                        content: string | ({
+                            type: "image_url";
+                            image_url: {
+                                url: string;
+                            };
+                        } | {
+                            type: "text";
+                            text: string;
+                        })[];
+                    } | {
+                        role: "assistant";
+                        content: string;
+                    } | {
+                        role: "system";
+                        content: string;
+                    })[];
+                    model: string;
+                    temperature?: number | undefined;
+                    maxTokens?: number | undefined;
+                    reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | undefined;
+                };
+            };
+            output: {
+                error: string;
+                code: "VALIDATION_ERROR";
+            };
+            outputFormat: "json";
+            status: 400;
+        } | {
+            input: {
+                header: {
+                    'api-key': string;
+                    'base-url': string;
+                    'mcp-server-urls': string | undefined;
+                };
+            } & {
+                json: {
+                    messages: ({
+                        role: "user";
+                        content: string | ({
+                            type: "image_url";
+                            image_url: {
+                                url: string;
+                            };
+                        } | {
+                            type: "text";
+                            text: string;
+                        })[];
+                    } | {
+                        role: "assistant";
+                        content: string;
+                    } | {
+                        role: "system";
+                        content: string;
+                    })[];
+                    model: string;
+                    temperature?: number | undefined;
+                    maxTokens?: number | undefined;
+                    reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | undefined;
+                };
+            };
+            output: {};
+            outputFormat: string;
+            status: import('hono/utils/http-status').StatusCode;
         };
     };
 } & {
@@ -510,6 +680,6 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
             status: import('hono/utils/http-status').StatusCode;
         };
     };
-}, "/">, "/", "/">;
+}, "/">, "/", "*">;
 export type AppType = typeof routes;
 export default app;

--- a/projects/portfolio/src/server/features/chat/converter.ts
+++ b/projects/portfolio/src/server/features/chat/converter.ts
@@ -120,6 +120,6 @@ function normalizeUsage(usage: RawUsage): ChatUsage | null {
     promptTokens: usage.prompt_tokens,
     completionTokens: usage.completion_tokens,
     totalTokens: usage.total_tokens,
-    reasoningTokens: usage.completion_tokens_details?.reasoning_tokens,
+    reasoningTokens: usage.reasoning_tokens ?? usage.completion_tokens_details?.reasoning_tokens,
   }
 }

--- a/projects/portfolio/src/server/features/chat/converter.ts
+++ b/projects/portfolio/src/server/features/chat/converter.ts
@@ -1,0 +1,125 @@
+import type { ChatResponse, ChatStreamEvent, ChatUsage } from '#/types/chat-api'
+import type { CompletionChunk, StreamCompletionChunk, StreamChunk } from './transport'
+
+// ============================================
+// 非ストリーム変換
+// ============================================
+
+export function convertCompletion(raw: CompletionChunk): ChatResponse {
+  const choice = raw.choices[0]
+  const message = choice?.message
+
+  return {
+    id: raw.id,
+    created: raw.created,
+    model: raw.model,
+    finishReason: choice?.finish_reason ?? '',
+    message: {
+      content: message?.content ?? '',
+      reasoningContent: extractReasoning(message),
+    },
+    usage: normalizeUsage(raw.usage),
+  }
+}
+
+// ============================================
+// ストリーム変換
+// ============================================
+
+export async function* convertStreamChunks(raw: StreamChunk): AsyncGenerator<ChatStreamEvent> {
+  let lastId = ''
+  let lastCreated = 0
+  let lastModel = ''
+
+  for await (const chunk of raw) {
+    if (chunk.id) lastId = chunk.id
+    if (chunk.created) lastCreated = chunk.created
+    if (chunk.model) lastModel = chunk.model
+
+    const choice = chunk.choices[0]
+
+    const content = choice?.delta?.content
+    const reasoningContent = extractStreamReasoning(choice?.delta)
+
+    if (content !== undefined || reasoningContent !== undefined) {
+      yield {
+        event: 'delta',
+        id: lastId,
+        created: lastCreated,
+        model: lastModel,
+        content: content ?? undefined,
+        reasoningContent: reasoningContent ?? undefined,
+      }
+    }
+
+    if (choice?.finish_reason) {
+      yield {
+        event: 'finish',
+        id: lastId,
+        created: lastCreated,
+        model: lastModel,
+        finishReason: choice.finish_reason,
+      }
+    }
+
+    if (chunk.usage) {
+      const usage = normalizeUsage(chunk.usage)
+      if (usage) {
+        yield {
+          event: 'usage',
+          id: lastId,
+          created: lastCreated,
+          model: lastModel,
+          usage,
+        }
+      }
+    }
+  }
+}
+
+// ============================================
+// ヘルパー
+// ============================================
+
+function extractReasoning(message: CompletionChunk['choices'][0]['message'] | undefined): string {
+  if (!message) return ''
+
+  // LiteLLM: message.reasoning_content を優先
+  if (message.reasoning_content) return message.reasoning_content
+  if (message.provider_specific_fields?.reasoning_content) return message.provider_specific_fields.reasoning_content
+
+  // Bifrost: message.reasoning を優先、なければ reasoning_details[].text を結合
+  if (message.reasoning) return message.reasoning
+  if (message.reasoning_details?.length) {
+    return message.reasoning_details.map((d) => d.text).join('')
+  }
+
+  return ''
+}
+
+function extractStreamReasoning(delta: StreamCompletionChunk['choices'][0]['delta'] | undefined): string | undefined {
+  if (!delta) return undefined
+
+  // LiteLLM: delta.reasoning_content
+  if (delta.reasoning_content !== undefined) return delta.reasoning_content
+  // Bifrost: delta.reasoning
+  if (delta.reasoning !== undefined) return delta.reasoning
+
+  return undefined
+}
+
+type RawUsage = CompletionChunk['usage'] | StreamCompletionChunk['usage']
+
+function normalizeUsage(usage: RawUsage): ChatUsage | null {
+  if (!usage) return null
+  if (usage.prompt_tokens === undefined || usage.completion_tokens === undefined || usage.total_tokens === undefined) {
+    return null
+  }
+
+  return {
+    promptTokens: usage.prompt_tokens,
+    completionTokens: usage.completion_tokens,
+    totalTokens: usage.total_tokens,
+    reasoningTokens: usage.completion_tokens_details?.reasoning_tokens,
+  }
+}

--- a/projects/portfolio/src/server/features/chat/transport.ts
+++ b/projects/portfolio/src/server/features/chat/transport.ts
@@ -17,6 +17,7 @@ export type CompletionChunk = OpenAI.ChatCompletion & {
     }
   }[]
   usage?: {
+    reasoning_tokens?: number
     completion_tokens_details?: {
       reasoning_tokens: number
     }
@@ -31,6 +32,7 @@ export type StreamCompletionChunk = OpenAI.ChatCompletionChunk & {
     }
   }[]
   usage?: {
+    reasoning_tokens?: number
     completion_tokens_details?: {
       reasoning_tokens: number
     }

--- a/projects/portfolio/src/server/features/chat/transport.ts
+++ b/projects/portfolio/src/server/features/chat/transport.ts
@@ -10,12 +10,15 @@ import type { Stream } from 'openai/streaming'
 export type CompletionChunk = OpenAI.ChatCompletion & {
   choices: {
     message: {
-      reasoning_content?: string // OpenAI APIでは提供されていないフィールド。LiteLLM経由の推論モデルでのみ取得可能。
+      reasoning_content?: string // LiteLLM 経由の推論モデル
+      reasoning?: string // Bifrost 経由の推論モデル
+      reasoning_details?: Array<{ type: string; text: string }> // Bifrost fallback
+      provider_specific_fields?: { reasoning_content?: string } // LiteLLM fallback
     }
   }[]
   usage?: {
     completion_tokens_details?: {
-      reasoning_tokens: number // OpenAI APIでは提供されていないフィールド。LiteLLM経由の推論モデルでのみ取得可能。
+      reasoning_tokens: number
     }
   }
 }
@@ -23,12 +26,13 @@ export type CompletionChunk = OpenAI.ChatCompletion & {
 export type StreamCompletionChunk = OpenAI.ChatCompletionChunk & {
   choices: {
     delta: {
-      reasoning_content?: string // OpenAI APIでは提供されていないフィールド。LiteLLM経由の推論モデルでのみ取得可能。
+      reasoning_content?: string // LiteLLM 経由の推論モデル
+      reasoning?: string // Bifrost 経由の推論モデル
     }
   }[]
   usage?: {
     completion_tokens_details?: {
-      reasoning_tokens: number // OpenAI APIでは提供されていないフィールド。LiteLLM経由の推論モデルでのみ取得可能。
+      reasoning_tokens: number
     }
   }
 }

--- a/projects/portfolio/src/server/routes/chat.ts
+++ b/projects/portfolio/src/server/routes/chat.ts
@@ -66,6 +66,35 @@ const chatHeaderValidator = validator('header', (value, c) => {
   }
 })
 
+const formatValidationPath = (path: unknown): string => {
+  if (!Array.isArray(path) || path.length === 0) return 'request body'
+
+  const keys = path
+    .map((segment) => {
+      if (typeof segment === 'string' || typeof segment === 'number') return String(segment)
+      if (segment && typeof segment === 'object' && 'key' in segment) return String(segment.key)
+      return null
+    })
+    .filter((segment): segment is string => Boolean(segment))
+
+  return keys.join('.') || 'request body'
+}
+
+const chatBodyValidator = sValidator('json', ChatApiRequestSchema, (result, c) => {
+  if (result.success) return
+
+  const issue = result.error[0]
+  const fieldName = formatValidationPath(issue?.path)
+
+  return c.json(
+    {
+      error: `Invalid request body '${fieldName}'`,
+      code: 'VALIDATION_ERROR' as const,
+    },
+    400
+  )
+})
+
 const streamStubCompletion = (
   c: Parameters<typeof streamSSE>[0],
   req: z.infer<typeof StubChatRequestSchema>,
@@ -101,7 +130,7 @@ const streamStubCompletion = (
 
 const chatRoutes = new Hono<HonoEnv>()
   // 非ストリーム専用
-  .post('/api/chat', chatHeaderValidator, sValidator('json', ChatApiRequestSchema), async (c) => {
+  .post('/api/chat', chatHeaderValidator, chatBodyValidator, async (c) => {
     const header = c.req.valid('header')
     const req = c.req.valid('json')
 
@@ -134,7 +163,7 @@ const chatRoutes = new Hono<HonoEnv>()
     }
   })
   // SSE ストリーム専用
-  .post('/api/chat/stream', chatHeaderValidator, sValidator('json', ChatApiRequestSchema), async (c) => {
+  .post('/api/chat/stream', chatHeaderValidator, chatBodyValidator, async (c) => {
     const header = c.req.valid('header')
     const req = c.req.valid('json')
 

--- a/projects/portfolio/src/server/routes/chat.ts
+++ b/projects/portfolio/src/server/routes/chat.ts
@@ -1,10 +1,12 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { chatStub } from '#/server/features/chat-stub/chat-stub'
-import type { StreamChunk } from '#/server/features/chat/chat'
 import { chat } from '#/server/features/chat/chat'
+import { convertCompletion, convertStreamChunks } from '#/server/features/chat/converter'
+import type { CompletionChunk, StreamChunk } from '#/server/features/chat/transport'
 import { logger } from '#/server/lib/logger'
-import { ApiChatRequestSchema } from '#/types'
+import { ApiChatMessageSchema } from '#/types'
+import { ChatApiRequestSchema } from '#/types/chat-api'
 import { sValidator } from '@hono/standard-validator'
 import { Hono } from 'hono'
 import { streamSSE } from 'hono/streaming'
@@ -19,8 +21,19 @@ const ChatHeaderSchema = z.object({
   'mcp-server-urls': z.string().optional(),
 })
 
-// /api/chat stub endpoint 用スキーマ（reasoning_effort なし）
-const StubChatRequestSchema = ApiChatRequestSchema.omit({ reasoning_effort: true })
+// /api/chat/completions stub endpoint 用スキーマ (OpenAI 互換)
+const StubChatRequestSchema = z.object({
+  messages: ApiChatMessageSchema.array(),
+  model: z.string().min(1),
+  stream: z.boolean().default(false),
+  temperature: z.number().min(0).max(1).optional(),
+  max_tokens: z.number().min(1).optional(),
+  stream_options: z
+    .object({
+      include_usage: z.boolean().optional(),
+    })
+    .optional(),
+})
 
 const chatHeaderValidator = validator('header', (value, c) => {
   const parsed = ChatHeaderSchema.safeParse({
@@ -33,14 +46,14 @@ const chatHeaderValidator = validator('header', (value, c) => {
     const issue = parsed.error.issues[0]
     const headerName = String(issue?.path[0] ?? 'unknown')
 
-    return c.json({ message: `Validation Error: Missing required header '${headerName}'` }, 400)
+    return c.json({ error: `Missing required header '${headerName}'`, code: 'VALIDATION_ERROR' as const }, 400)
   }
 
   const headers = parsed.data
   const fakeMode = headers['api-key'] === 'fakemode'
 
   if (!fakeMode && !z.string().url().safeParse(headers['base-url']).success) {
-    return c.json({ message: `Validation Error: Invalid url 'base-url'` }, 400)
+    return c.json({ error: `Invalid url 'base-url'`, code: 'VALIDATION_ERROR' as const }, 400)
   }
 
   const { SERVER_PORT: port } = getServerEnv(c)
@@ -52,26 +65,6 @@ const chatHeaderValidator = validator('header', (value, c) => {
     'mcp-server-urls': headers['mcp-server-urls'],
   }
 })
-
-const streamChatCompletion = (c: Parameters<typeof streamSSE>[0], completion: StreamChunk) =>
-  streamSSE(c, async (stream) => {
-    let aborted = false
-
-    stream.onAbort(() => {
-      aborted = true
-      completion.controller.abort()
-    })
-
-    for await (const chunk of completion) {
-      logger.debug({ chunk }, 'Stream chunk received')
-      await stream.writeSSE({ data: JSON.stringify(chunk) })
-      await new Promise((resolve) => setTimeout(resolve, 10))
-    }
-
-    if (!aborted) {
-      await stream.writeSSE({ data: '[DONE]' })
-    }
-  })
 
 const streamStubCompletion = (
   c: Parameters<typeof streamSSE>[0],
@@ -106,37 +99,93 @@ const streamStubCompletion = (
     }
   })
 
-const debugLogCompletion = <T>(completion: T, message: string): T => {
-  logger.debug({ completion }, message)
-  return completion
-}
-
 const chatRoutes = new Hono<HonoEnv>()
-  .post('/api/chat', chatHeaderValidator, sValidator('json', ApiChatRequestSchema), async (c) => {
+  // 非ストリーム専用
+  .post('/api/chat', chatHeaderValidator, sValidator('json', ChatApiRequestSchema), async (c) => {
     const header = c.req.valid('header')
     const req = c.req.valid('json')
 
-    const completion = await chat.completions(
-      {
-        apiKey: header['api-key'],
-        baseURL: header['base-url'],
-        mcpServerURLs: header['mcp-server-urls'] ?? '',
-      },
-      {
-        model: req.model,
-        messages: req.messages,
-        temperature: req.temperature,
-        maxTokens: req.max_tokens,
-        reasoningEffort: req.reasoning_effort,
-        stream: req.stream,
-        includeUsage: req.stream_options?.include_usage,
-      }
-    )
+    try {
+      const completion = await chat.completions(
+        {
+          apiKey: header['api-key'],
+          baseURL: header['base-url'],
+          mcpServerURLs: header['mcp-server-urls'] ?? '',
+        },
+        {
+          model: req.model,
+          messages: req.messages,
+          temperature: req.temperature,
+          maxTokens: req.maxTokens,
+          reasoningEffort: req.reasoningEffort,
+          stream: false,
+        }
+      )
 
-    return req.stream
-      ? streamChatCompletion(c, completion as StreamChunk)
-      : c.json(debugLogCompletion(completion, 'Chat completion received'))
+      const response = convertCompletion(completion as CompletionChunk)
+      logger.debug({ response }, 'Chat completion converted')
+      return c.json(response)
+    } catch (err) {
+      logger.error({ err }, 'Upstream chat completion failed')
+      return c.json(
+        { error: err instanceof Error ? err.message : 'Upstream error', code: 'UPSTREAM_ERROR' as const },
+        502
+      )
+    }
   })
+  // SSE ストリーム専用
+  .post('/api/chat/stream', chatHeaderValidator, sValidator('json', ChatApiRequestSchema), async (c) => {
+    const header = c.req.valid('header')
+    const req = c.req.valid('json')
+
+    let completion
+    try {
+      completion = await chat.completions(
+        {
+          apiKey: header['api-key'],
+          baseURL: header['base-url'],
+          mcpServerURLs: header['mcp-server-urls'] ?? '',
+        },
+        {
+          model: req.model,
+          messages: req.messages,
+          temperature: req.temperature,
+          maxTokens: req.maxTokens,
+          reasoningEffort: req.reasoningEffort,
+          stream: true,
+          includeUsage: true,
+        }
+      )
+    } catch (err) {
+      logger.error({ err }, 'Upstream stream chat failed')
+      return c.json(
+        { error: err instanceof Error ? err.message : 'Upstream error', code: 'UPSTREAM_ERROR' as const },
+        502
+      )
+    }
+
+    const streamCompletion = completion as StreamChunk
+
+    return streamSSE(c, async (stream) => {
+      let aborted = false
+
+      stream.onAbort(() => {
+        aborted = true
+        streamCompletion.controller.abort()
+      })
+
+      for await (const event of convertStreamChunks(streamCompletion)) {
+        logger.debug({ event }, 'Stream event emitted')
+        await stream.writeSSE({ data: JSON.stringify(event) })
+        await new Promise((resolve) => setTimeout(resolve, 10))
+      }
+
+      if (!aborted) {
+        await stream.writeSSE({ data: '[DONE]' })
+      }
+    })
+  })
+  // Stub endpoint (OpenAI 互換、変更なし)
   .post('/api/chat/completions', sValidator('json', StubChatRequestSchema), async (c) => {
     const req = c.req.valid('json')
 
@@ -154,8 +203,9 @@ const chatRoutes = new Hono<HonoEnv>()
     }
 
     const completion = await chatStub.completions(req.model, content)
+    logger.debug({ completion }, 'Stub chat completion received')
 
-    return c.json(debugLogCompletion(completion, 'Stub chat completion received'))
+    return c.json(completion)
   })
 
 export { chatRoutes }

--- a/projects/portfolio/src/types/chat-api.ts
+++ b/projects/portfolio/src/types/chat-api.ts
@@ -1,0 +1,102 @@
+import { z } from 'zod'
+import { ApiChatMessageSchema } from './chat'
+
+// ============================================
+// /api/chat, /api/chat/stream 公開コントラクト
+// ============================================
+
+/** /api/chat, /api/chat/stream 共通リクエストスキーマ */
+export const ChatApiRequestSchema = z.object({
+  messages: ApiChatMessageSchema.array(),
+  model: z.string().min(1),
+  temperature: z.number().min(0).max(1).optional(),
+  maxTokens: z.number().min(1).optional(),
+  reasoningEffort: z.enum(['none', 'minimal', 'low', 'medium', 'high', 'xhigh']).optional(),
+})
+
+export type ChatApiRequest = z.infer<typeof ChatApiRequestSchema>
+
+// ============================================
+// Usage
+// ============================================
+
+export const ChatUsageSchema = z.object({
+  promptTokens: z.number(),
+  completionTokens: z.number(),
+  totalTokens: z.number(),
+  reasoningTokens: z.number().optional(),
+})
+
+export type ChatUsage = z.infer<typeof ChatUsageSchema>
+
+// ============================================
+// 非ストリームレスポンス
+// ============================================
+
+export const ChatResponseSchema = z.object({
+  id: z.string(),
+  created: z.number(),
+  model: z.string(),
+  finishReason: z.string(),
+  message: z.object({
+    content: z.string(),
+    reasoningContent: z.string(),
+  }),
+  usage: ChatUsageSchema.nullable(),
+})
+
+export type ChatResponse = z.infer<typeof ChatResponseSchema>
+
+// ============================================
+// SSE ストリームイベント (discriminated union)
+// ============================================
+
+export const ChatStreamDeltaEventSchema = z.object({
+  event: z.literal('delta'),
+  id: z.string(),
+  created: z.number(),
+  model: z.string(),
+  content: z.string().optional(),
+  reasoningContent: z.string().optional(),
+})
+
+export type ChatStreamDeltaEvent = z.infer<typeof ChatStreamDeltaEventSchema>
+
+export const ChatStreamFinishEventSchema = z.object({
+  event: z.literal('finish'),
+  id: z.string(),
+  created: z.number(),
+  model: z.string(),
+  finishReason: z.string(),
+})
+
+export type ChatStreamFinishEvent = z.infer<typeof ChatStreamFinishEventSchema>
+
+export const ChatStreamUsageEventSchema = z.object({
+  event: z.literal('usage'),
+  id: z.string(),
+  created: z.number(),
+  model: z.string(),
+  usage: ChatUsageSchema,
+})
+
+export type ChatStreamUsageEvent = z.infer<typeof ChatStreamUsageEventSchema>
+
+export const ChatStreamEventSchema = z.discriminatedUnion('event', [
+  ChatStreamDeltaEventSchema,
+  ChatStreamFinishEventSchema,
+  ChatStreamUsageEventSchema,
+])
+
+export type ChatStreamEvent = z.infer<typeof ChatStreamEventSchema>
+
+// ============================================
+// 統一エラーレスポンス
+// ============================================
+
+export const ChatErrorResponseSchema = z.object({
+  error: z.string(),
+  code: z.enum(['VALIDATION_ERROR', 'UPSTREAM_ERROR', 'INTERNAL_ERROR']),
+})
+
+export type ChatErrorResponse = z.infer<typeof ChatErrorResponseSchema>

--- a/projects/portfolio/src/types/chat.ts
+++ b/projects/portfolio/src/types/chat.ts
@@ -136,23 +136,6 @@ export const ApiChatMessageSchema = z.discriminatedUnion('role', [
 
 export type ApiChatMessage = z.infer<typeof ApiChatMessageSchema>
 
-/** /api/chat リクエスト本体の共有スキーマ */
-export const ApiChatRequestSchema = z.object({
-  messages: ApiChatMessageSchema.array(),
-  model: z.string().min(1),
-  stream: z.boolean().default(false),
-  temperature: z.number().min(0).max(1).optional(),
-  max_tokens: z.number().min(1).optional(),
-  reasoning_effort: z.enum(['none', 'minimal', 'low', 'medium', 'high', 'xhigh']).optional(),
-  stream_options: z
-    .object({
-      include_usage: z.boolean().optional(),
-    })
-    .optional(),
-})
-
-export type ApiChatRequest = z.infer<typeof ApiChatRequestSchema>
-
 /** ドメイン Message → /api/chat wire メッセージへの変換 */
 export function toApiChatMessage(message: Message): ApiChatMessage {
   if (message.role === 'user') {
@@ -162,77 +145,6 @@ export function toApiChatMessage(message: Message): ApiChatMessage {
     return { role: 'assistant', content: message.content }
   }
   return { role: 'system', content: message.content }
-}
-
-// ============================================
-// API レスポンス型
-// ============================================
-
-const ApiUsageSchema = z
-  .object({
-    prompt_tokens: z.number(),
-    completion_tokens: z.number(),
-    total_tokens: z.number(),
-    reasoning_tokens: z.number().optional(),
-    completion_tokens_details: z
-      .object({
-        reasoning_tokens: z.number().optional(),
-      })
-      .optional(),
-  })
-  .nullable()
-
-export const ChatCompletionResponseSchema = z.object({
-  choices: z.array(
-    z.object({
-      message: z.object({
-        content: z.string().nullable(),
-        reasoning_content: z.string().optional(),
-      }),
-      finish_reason: z.string().nullable().optional(),
-    })
-  ),
-  model: z.string().optional(),
-  usage: ApiUsageSchema.optional(),
-})
-
-export type ChatCompletionResponse = z.infer<typeof ChatCompletionResponseSchema>
-
-export const ChatCompletionStreamChunkSchema = z.object({
-  choices: z.array(
-    z.object({
-      delta: z.object({
-        content: z.string().optional(),
-        reasoning_content: z.string().optional(),
-      }),
-      finish_reason: z.string().nullable().optional(),
-    })
-  ),
-  model: z.string().optional(),
-  usage: ApiUsageSchema.optional(),
-})
-
-export type ChatCompletionStreamChunk = z.infer<typeof ChatCompletionStreamChunkSchema>
-
-export interface ChatStreamState {
-  content: string
-  reasoning_content?: string
-}
-
-export interface ChatCompletionResult {
-  model: string
-  finishReason: string
-  message: {
-    content: string
-    reasoningContent: string
-  }
-  responseTimeMs: number
-  usage: {
-    promptTokens: number
-    completionTokens: number
-    totalTokens: number
-    reasoningTokens?: number
-  } | null
 }
 
 // ============================================

--- a/projects/portfolio/src/types/index.ts
+++ b/projects/portfolio/src/types/index.ts
@@ -12,9 +12,6 @@ export {
   TextContentSchema,
   // /api/chat wire schemas
   ApiChatMessageSchema,
-  ApiChatRequestSchema,
-  ChatCompletionResponseSchema,
-  ChatCompletionStreamChunkSchema,
   // Types
   type Conversation,
   type ConversationListResponse,
@@ -28,12 +25,6 @@ export {
   type TextContent,
   // /api/chat wire types
   type ApiChatMessage,
-  type ApiChatRequest,
-  type ChatCompletionResponse,
-  type ChatCompletionStreamChunk,
-  // API レスポンス型
-  type ChatStreamState,
-  type ChatCompletionResult,
   // Converters
   toApiChatMessage,
   // Guards
@@ -42,3 +33,24 @@ export {
   isSystemMessage,
   isImageContentArray,
 } from './chat.js'
+
+export {
+  // Chat API contract schemas
+  ChatApiRequestSchema,
+  ChatResponseSchema,
+  ChatUsageSchema,
+  ChatStreamEventSchema,
+  ChatStreamDeltaEventSchema,
+  ChatStreamFinishEventSchema,
+  ChatStreamUsageEventSchema,
+  ChatErrorResponseSchema,
+  // Chat API contract types
+  type ChatApiRequest,
+  type ChatResponse,
+  type ChatUsage,
+  type ChatStreamEvent,
+  type ChatStreamDeltaEvent,
+  type ChatStreamFinishEvent,
+  type ChatStreamUsageEvent,
+  type ChatErrorResponse,
+} from './chat-api.js'

--- a/projects/portfolio/tests/client/hooks/chat-response.test.ts
+++ b/projects/portfolio/tests/client/hooks/chat-response.test.ts
@@ -1,120 +1,160 @@
-import {
-  parseChatCompletionResponse,
-  parseChatCompletionStreamChunk,
-  toChatCompletionResult,
-  updateChatStream,
-} from '#/client/components/chat/hooks/chat-response'
+import { parseChatStreamEvent, updateChatStream } from '#/client/components/chat/hooks/chat-response'
 import { describe, expect, it } from 'vitest'
 
 describe('chat-response helpers', () => {
-  it('non-stream response を共有型で正規化できる', () => {
-    const response = parseChatCompletionResponse({
-      model: 'gpt-test',
-      choices: [
-        {
-          message: {
-            content: 'assistant answer',
-            reasoning_content: 'thinking',
-          },
-          finish_reason: 'stop',
-        },
-      ],
-      usage: {
-        prompt_tokens: 10,
-        completion_tokens: 20,
-        total_tokens: 30,
-        reasoning_tokens: 5,
-      },
-    })
+  it('delta イベントで content を蓄積できる', () => {
+    const state = { content: '', reasoningContent: '' }
 
-    expect(toChatCompletionResult(response)).toEqual({
-      model: 'gpt-test',
-      finishReason: 'stop',
-      message: {
-        content: 'assistant answer',
+    const event = parseChatStreamEvent(
+      JSON.stringify({
+        event: 'delta',
+        id: 'chunk-1',
+        created: 1700000000,
+        model: 'gpt-test',
+        content: 'hello',
+      })
+    )
+
+    const next = updateChatStream(state, event)
+
+    expect(next).toEqual({
+      content: 'hello',
+      reasoningContent: '',
+    })
+  })
+
+  it('delta イベントで reasoningContent を蓄積できる', () => {
+    const state = { content: '', reasoningContent: '' }
+
+    const event = parseChatStreamEvent(
+      JSON.stringify({
+        event: 'delta',
+        id: 'chunk-1',
+        created: 1700000000,
+        model: 'gpt-test',
         reasoningContent: 'thinking',
-      },
-      responseTimeMs: 0,
-      usage: {
-        promptTokens: 10,
-        completionTokens: 20,
-        totalTokens: 30,
-        reasoningTokens: 5,
-      },
-    })
-  })
-
-  it('non-stream response の content=null を結果なしとして扱える', () => {
-    const response = parseChatCompletionResponse({
-      model: 'gpt-test',
-      choices: [
-        {
-          message: {
-            content: null,
-          },
-          finish_reason: 'tool_calls',
-        },
-      ],
-      usage: null,
-    })
-
-    expect(toChatCompletionResult(response)).toBeNull()
-  })
-
-  it('stream chunk を蓄積して finish reason と usage を取り出せる', () => {
-    const firstChunk = parseChatCompletionStreamChunk(
-      JSON.stringify({
-        model: 'gpt-stream',
-        choices: [
-          {
-            delta: {
-              reasoning_content: 'thinking',
-            },
-            finish_reason: null,
-          },
-        ],
-      })
-    )
-    const secondChunk = parseChatCompletionStreamChunk(
-      JSON.stringify({
-        model: 'gpt-stream',
-        choices: [
-          {
-            delta: {
-              content: 'answer',
-            },
-            finish_reason: 'stop',
-          },
-        ],
-        usage: {
-          prompt_tokens: 11,
-          completion_tokens: 22,
-          total_tokens: 33,
-          completion_tokens_details: {
-            reasoning_tokens: 7,
-          },
-        },
       })
     )
 
-    const accumulated = updateChatStream({ content: '', reasoning_content: '' }, firstChunk)
-    const completed = updateChatStream(accumulated.stream, secondChunk)
+    const next = updateChatStream(state, event)
 
-    expect(accumulated.stream).toEqual({
+    expect(next).toEqual({
       content: '',
-      reasoning_content: 'thinking',
+      reasoningContent: 'thinking',
     })
-    expect(completed.stream).toEqual({
+  })
+
+  it('finish, usage イベントではストリーム状態が変わらない', () => {
+    const state = { content: 'hello', reasoningContent: 'thinking' }
+
+    const finishEvent = parseChatStreamEvent(
+      JSON.stringify({
+        event: 'finish',
+        id: 'chunk-2',
+        created: 1700000000,
+        model: 'gpt-test',
+        finishReason: 'stop',
+      })
+    )
+
+    const usageEvent = parseChatStreamEvent(
+      JSON.stringify({
+        event: 'usage',
+        id: 'chunk-3',
+        created: 1700000000,
+        model: 'gpt-test',
+        usage: {
+          promptTokens: 10,
+          completionTokens: 20,
+          totalTokens: 30,
+          reasoningTokens: 5,
+        },
+      })
+    )
+
+    expect(updateChatStream(state, finishEvent)).toEqual(state)
+    expect(updateChatStream(state, usageEvent)).toEqual(state)
+  })
+
+  it('複数の delta イベントを順次蓄積できる', () => {
+    let state = { content: '', reasoningContent: '' }
+
+    const events = [
+      {
+        event: 'delta',
+        id: 'chunk-1',
+        created: 1700000000,
+        model: 'gpt-stream',
+        reasoningContent: 'think',
+      },
+      {
+        event: 'delta',
+        id: 'chunk-2',
+        created: 1700000000,
+        model: 'gpt-stream',
+        reasoningContent: 'ing',
+      },
+      {
+        event: 'delta',
+        id: 'chunk-3',
+        created: 1700000000,
+        model: 'gpt-stream',
+        content: 'answer',
+      },
+    ]
+
+    for (const raw of events) {
+      const event = parseChatStreamEvent(JSON.stringify(raw))
+      state = updateChatStream(state, event)
+    }
+
+    expect(state).toEqual({
       content: 'answer',
-      reasoning_content: 'thinking',
+      reasoningContent: 'thinking',
     })
-    expect(completed.finishReason).toBe('stop')
-    expect(completed.model).toBe('gpt-stream')
-    expect(completed.usage).toEqual({
-      promptTokens: 11,
-      completionTokens: 22,
-      totalTokens: 33,
-      reasoningTokens: 7,
-    })
+  })
+
+  it('finish イベントから finishReason を取得できる', () => {
+    const event = parseChatStreamEvent(
+      JSON.stringify({
+        event: 'finish',
+        id: 'chunk-finish',
+        created: 1700000000,
+        model: 'gpt-test',
+        finishReason: 'stop',
+      })
+    )
+
+    expect(event.event).toBe('finish')
+    if (event.event === 'finish') {
+      expect(event.finishReason).toBe('stop')
+    }
+  })
+
+  it('usage イベントから token 情報を取得できる', () => {
+    const event = parseChatStreamEvent(
+      JSON.stringify({
+        event: 'usage',
+        id: 'chunk-usage',
+        created: 1700000000,
+        model: 'gpt-test',
+        usage: {
+          promptTokens: 11,
+          completionTokens: 22,
+          totalTokens: 33,
+          reasoningTokens: 7,
+        },
+      })
+    )
+
+    expect(event.event).toBe('usage')
+    if (event.event === 'usage') {
+      expect(event.usage).toEqual({
+        promptTokens: 11,
+        completionTokens: 22,
+        totalTokens: 33,
+        reasoningTokens: 7,
+      })
+    }
   })
 })

--- a/projects/portfolio/tests/client/hooks/use-stream-processor.test.tsx
+++ b/projects/portfolio/tests/client/hooks/use-stream-processor.test.tsx
@@ -1,0 +1,150 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('useStreamProcessor', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  const importSubject = async () => {
+    const chatPostMock = vi.fn()
+    const chatStreamPostMock = vi.fn()
+
+    vi.doMock('hono/client', () => ({
+      hc: () => ({
+        api: {
+          chat: {
+            $post: chatPostMock,
+            stream: {
+              $post: chatStreamPostMock,
+            },
+          },
+        },
+      }),
+    }))
+
+    const mod = await import('#/client/components/chat/hooks/use-stream-processor')
+
+    return {
+      useStreamProcessor: mod.useStreamProcessor,
+      chatPostMock,
+      chatStreamPostMock,
+    }
+  }
+
+  const request = {
+    header: {
+      apiKey: 'api-key',
+      baseURL: 'https://example.com',
+      mcpServerURLs: '',
+    },
+    model: 'gpt-test',
+    messages: [],
+    temperature: undefined,
+    maxTokens: undefined,
+    reasoningEffort: undefined,
+  }
+
+  it('非 stream の reasoning-only 応答を保持する', async () => {
+    const { useStreamProcessor, chatPostMock } = await importSubject()
+    chatPostMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        id: 'chatcmpl-1',
+        created: 1700000000,
+        model: 'gpt-test',
+        finishReason: 'stop',
+        message: {
+          content: '',
+          reasoningContent: 'thinking only',
+        },
+        usage: null,
+      }),
+    })
+
+    const { result } = renderHook(() => useStreamProcessor())
+
+    let response: Awaited<ReturnType<typeof result.current.submitChatCompletion>> | undefined
+    await act(async () => {
+      response = await result.current.submitChatCompletion({
+        ...request,
+        streamMode: false,
+      })
+    })
+
+    expect(response).toEqual({
+      result: {
+        id: 'chatcmpl-1',
+        created: 1700000000,
+        model: 'gpt-test',
+        finishReason: 'stop',
+        message: {
+          content: '',
+          reasoningContent: 'thinking only',
+        },
+        usage: null,
+      },
+      responseTimeMs: expect.any(Number),
+    })
+  })
+
+  it('stream の reasoning-only 応答を保持する', async () => {
+    const { useStreamProcessor, chatStreamPostMock } = await importSubject()
+    const encoder = new TextEncoder()
+    const chunks = [
+      encoder.encode(
+        'data: {"event":"delta","id":"chunk-1","created":1700000000,"model":"gpt-test","reasoningContent":"thinking"}\n'
+      ),
+      encoder.encode(
+        'data: {"event":"finish","id":"chunk-1","created":1700000000,"model":"gpt-test","finishReason":"stop"}\n'
+      ),
+      encoder.encode('data: [DONE]\n'),
+    ]
+
+    chatStreamPostMock.mockResolvedValue({
+      ok: true,
+      body: {
+        getReader() {
+          let index = 0
+
+          return {
+            read: async () => {
+              if (index >= chunks.length) {
+                return { done: true, value: undefined }
+              }
+
+              return { done: false, value: chunks[index++] }
+            },
+          }
+        },
+      },
+    })
+
+    const { result } = renderHook(() => useStreamProcessor())
+
+    let response: Awaited<ReturnType<typeof result.current.submitChatCompletion>> | undefined
+    await act(async () => {
+      response = await result.current.submitChatCompletion({
+        ...request,
+        streamMode: true,
+      })
+    })
+
+    expect(response).toEqual({
+      result: {
+        id: 'chunk-1',
+        created: 1700000000,
+        model: 'gpt-test',
+        finishReason: 'stop',
+        message: {
+          content: '',
+          reasoningContent: 'thinking',
+        },
+        usage: null,
+      },
+      responseTimeMs: expect.any(Number),
+    })
+  })
+})

--- a/projects/portfolio/tests/features/chat/converter.test.ts
+++ b/projects/portfolio/tests/features/chat/converter.test.ts
@@ -171,6 +171,37 @@ describe('convertCompletion', () => {
     expect(result.message.reasoningContent).toBe('')
     expect(result.usage).toBeNull()
   })
+
+  it('usage.reasoning_tokens を reasoningTokens に正規化できる', () => {
+    const raw = {
+      id: 'chatcmpl-top-level-reasoning',
+      object: 'chat.completion',
+      created: 1700000005,
+      model: 'gpt-4.1',
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: 'assistant',
+            content: 'answer',
+            refusal: null,
+          },
+          finish_reason: 'stop',
+          logprobs: null,
+        },
+      ],
+      usage: {
+        prompt_tokens: 10,
+        completion_tokens: 20,
+        total_tokens: 30,
+        reasoning_tokens: 7,
+      },
+    } as unknown as CompletionChunk
+
+    const result = convertCompletion(raw)
+
+    expect(result.usage?.reasoningTokens).toBe(7)
+  })
 })
 
 describe('convertStreamChunks', () => {
@@ -365,5 +396,43 @@ describe('convertStreamChunks', () => {
         reasoningTokens: undefined,
       },
     })
+  })
+
+  it('stream usage の top-level reasoning_tokens を正規化できる', async () => {
+    const stream = createMockStream([
+      {
+        id: 'chunk-top-level-usage',
+        object: 'chat.completion.chunk',
+        created: 1700000000,
+        model: 'gpt-stream',
+        choices: [{ index: 0, delta: {}, finish_reason: null }],
+        usage: {
+          prompt_tokens: 10,
+          completion_tokens: 20,
+          total_tokens: 30,
+          reasoning_tokens: 9,
+        },
+      } as unknown as StreamCompletionChunk,
+    ])
+
+    const events = []
+    for await (const event of convertStreamChunks(stream)) {
+      events.push(event)
+    }
+
+    expect(events).toEqual([
+      {
+        event: 'usage',
+        id: 'chunk-top-level-usage',
+        created: 1700000000,
+        model: 'gpt-stream',
+        usage: {
+          promptTokens: 10,
+          completionTokens: 20,
+          totalTokens: 30,
+          reasoningTokens: 9,
+        },
+      },
+    ])
   })
 })

--- a/projects/portfolio/tests/features/chat/converter.test.ts
+++ b/projects/portfolio/tests/features/chat/converter.test.ts
@@ -1,0 +1,369 @@
+import { convertCompletion, convertStreamChunks } from '#/server/features/chat/converter'
+import type { CompletionChunk, StreamCompletionChunk, StreamChunk } from '#/server/features/chat/transport'
+import { describe, expect, it } from 'vitest'
+
+describe('convertCompletion', () => {
+  it('LiteLLM レスポンスを正規化できる', () => {
+    const raw = {
+      id: 'chatcmpl-abc',
+      object: 'chat.completion',
+      created: 1700000000,
+      model: 'gpt-4.1',
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: 'assistant',
+            content: 'answer',
+            reasoning_content: 'thinking',
+            refusal: null,
+          },
+          finish_reason: 'stop',
+          logprobs: null,
+        },
+      ],
+      usage: {
+        prompt_tokens: 10,
+        completion_tokens: 20,
+        total_tokens: 30,
+        completion_tokens_details: {
+          reasoning_tokens: 5,
+        },
+      },
+    } as unknown as CompletionChunk
+
+    const result = convertCompletion(raw)
+
+    expect(result).toEqual({
+      id: 'chatcmpl-abc',
+      created: 1700000000,
+      model: 'gpt-4.1',
+      finishReason: 'stop',
+      message: {
+        content: 'answer',
+        reasoningContent: 'thinking',
+      },
+      usage: {
+        promptTokens: 10,
+        completionTokens: 20,
+        totalTokens: 30,
+        reasoningTokens: 5,
+      },
+    })
+  })
+
+  it('LiteLLM provider_specific_fields からの reasoning fallback', () => {
+    const raw = {
+      id: 'chatcmpl-fallback',
+      object: 'chat.completion',
+      created: 1700000001,
+      model: 'gpt-4.1',
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: 'assistant',
+            content: 'answer',
+            provider_specific_fields: { reasoning_content: 'fallback thinking' },
+            refusal: null,
+          },
+          finish_reason: 'stop',
+          logprobs: null,
+        },
+      ],
+    } as unknown as CompletionChunk
+
+    const result = convertCompletion(raw)
+
+    expect(result.message.reasoningContent).toBe('fallback thinking')
+  })
+
+  it('Bifrost レスポンスの reasoning を正規化��きる', () => {
+    const raw = {
+      id: 'chatcmpl-bifrost',
+      object: 'chat.completion',
+      created: 1700000002,
+      model: 'claude-sonnet',
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: 'assistant',
+            content: 'answer',
+            reasoning: 'bifrost thinking',
+            refusal: null,
+          },
+          finish_reason: 'end_turn',
+          logprobs: null,
+        },
+      ],
+      usage: {
+        prompt_tokens: 5,
+        completion_tokens: 15,
+        total_tokens: 20,
+      },
+    } as unknown as CompletionChunk
+
+    const result = convertCompletion(raw)
+
+    expect(result.message.reasoningContent).toBe('bifrost thinking')
+    expect(result.finishReason).toBe('end_turn')
+    expect(result.usage).toEqual({
+      promptTokens: 5,
+      completionTokens: 15,
+      totalTokens: 20,
+      reasoningTokens: undefined,
+    })
+  })
+
+  it('Bifrost reasoning_details からの fallback', () => {
+    const raw = {
+      id: 'chatcmpl-bifrost-details',
+      object: 'chat.completion',
+      created: 1700000003,
+      model: 'claude-sonnet',
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: 'assistant',
+            content: 'answer',
+            reasoning_details: [
+              { type: 'text', text: 'part1' },
+              { type: 'text', text: 'part2' },
+            ],
+            refusal: null,
+          },
+          finish_reason: 'stop',
+          logprobs: null,
+        },
+      ],
+    } as unknown as CompletionChunk
+
+    const result = convertCompletion(raw)
+
+    expect(result.message.reasoningContent).toBe('part1part2')
+  })
+
+  it('content が null の場合は空文字になる', () => {
+    const raw = {
+      id: 'chatcmpl-null',
+      object: 'chat.completion',
+      created: 1700000004,
+      model: 'gpt-4.1',
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: 'assistant',
+            content: null,
+            refusal: null,
+          },
+          finish_reason: 'tool_calls',
+          logprobs: null,
+        },
+      ],
+    } as unknown as CompletionChunk
+
+    const result = convertCompletion(raw)
+
+    expect(result.message.content).toBe('')
+    expect(result.message.reasoningContent).toBe('')
+    expect(result.usage).toBeNull()
+  })
+})
+
+describe('convertStreamChunks', () => {
+  const createMockStream = (chunks: StreamCompletionChunk[]): StreamChunk => {
+    async function* generate() {
+      for (const chunk of chunks) {
+        yield chunk
+      }
+    }
+    return generate() as unknown as StreamChunk
+  }
+
+  it('LiteLLM reasoning_content delta を delta イベントに変換する', async () => {
+    const stream = createMockStream([
+      {
+        id: 'chunk-1',
+        object: 'chat.completion.chunk',
+        created: 1700000000,
+        model: 'gpt-4.1',
+        choices: [
+          {
+            index: 0,
+            delta: { role: 'assistant', reasoning_content: 'thinking' },
+            finish_reason: null,
+          },
+        ],
+        usage: null,
+      } as unknown as StreamCompletionChunk,
+    ])
+
+    const events = []
+    for await (const event of convertStreamChunks(stream)) {
+      events.push(event)
+    }
+
+    expect(events).toEqual([
+      {
+        event: 'delta',
+        id: 'chunk-1',
+        created: 1700000000,
+        model: 'gpt-4.1',
+        reasoningContent: 'thinking',
+        content: undefined,
+      },
+    ])
+  })
+
+  it('Bifrost reasoning delta を delta イベントに変換する', async () => {
+    const stream = createMockStream([
+      {
+        id: 'chunk-bifrost',
+        object: 'chat.completion.chunk',
+        created: 1700000001,
+        model: 'claude-sonnet',
+        choices: [
+          {
+            index: 0,
+            delta: { role: 'assistant', reasoning: 'bifrost thinking' },
+            finish_reason: null,
+          },
+        ],
+        usage: null,
+      } as unknown as StreamCompletionChunk,
+    ])
+
+    const events = []
+    for await (const event of convertStreamChunks(stream)) {
+      events.push(event)
+    }
+
+    expect(events).toEqual([
+      {
+        event: 'delta',
+        id: 'chunk-bifrost',
+        created: 1700000001,
+        model: 'claude-sonnet',
+        reasoningContent: 'bifrost thinking',
+        content: undefined,
+      },
+    ])
+  })
+
+  it('delta, finish, usage の順でイベントを正しく emit する', async () => {
+    const stream = createMockStream([
+      {
+        id: 'chunk-1',
+        object: 'chat.completion.chunk',
+        created: 1700000000,
+        model: 'gpt-stream',
+        choices: [{ index: 0, delta: { content: 'hello' }, finish_reason: null }],
+        usage: null,
+      } as unknown as StreamCompletionChunk,
+      {
+        id: 'chunk-2',
+        object: 'chat.completion.chunk',
+        created: 1700000000,
+        model: 'gpt-stream',
+        choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+        usage: null,
+      } as unknown as StreamCompletionChunk,
+      {
+        id: 'chunk-3',
+        object: 'chat.completion.chunk',
+        created: 1700000000,
+        model: 'gpt-stream',
+        choices: [{ index: 0, delta: {}, finish_reason: null }],
+        usage: {
+          prompt_tokens: 10,
+          completion_tokens: 20,
+          total_tokens: 30,
+          completion_tokens_details: { reasoning_tokens: 5 },
+        },
+      } as unknown as StreamCompletionChunk,
+    ])
+
+    const events = []
+    for await (const event of convertStreamChunks(stream)) {
+      events.push(event)
+    }
+
+    expect(events).toHaveLength(3)
+    expect(events[0]).toEqual({
+      event: 'delta',
+      id: 'chunk-1',
+      created: 1700000000,
+      model: 'gpt-stream',
+      content: 'hello',
+      reasoningContent: undefined,
+    })
+    expect(events[1]).toEqual({
+      event: 'finish',
+      id: 'chunk-2',
+      created: 1700000000,
+      model: 'gpt-stream',
+      finishReason: 'stop',
+    })
+    expect(events[2]).toEqual({
+      event: 'usage',
+      id: 'chunk-3',
+      created: 1700000000,
+      model: 'gpt-stream',
+      usage: {
+        promptTokens: 10,
+        completionTokens: 20,
+        totalTokens: 30,
+        reasoningTokens: 5,
+      },
+    })
+  })
+
+  it('usage-only 最終チャンクで metadata を補完する', async () => {
+    const stream = createMockStream([
+      {
+        id: 'chunk-1',
+        object: 'chat.completion.chunk',
+        created: 1700000000,
+        model: 'gpt-stream',
+        choices: [{ index: 0, delta: { content: 'hello' }, finish_reason: null }],
+        usage: null,
+      } as unknown as StreamCompletionChunk,
+      // Bifrost の usage-only 最終チャンク (model/id/created が空の場合)
+      {
+        id: '',
+        object: 'chat.completion.chunk',
+        created: 0,
+        model: '',
+        choices: [{ index: 0, delta: {}, finish_reason: null }],
+        usage: {
+          prompt_tokens: 10,
+          completion_tokens: 20,
+          total_tokens: 30,
+        },
+      } as unknown as StreamCompletionChunk,
+    ])
+
+    const events = []
+    for await (const event of convertStreamChunks(stream)) {
+      events.push(event)
+    }
+
+    expect(events).toHaveLength(2)
+    // usage イベントが前のチャンクの metadata を引き���ぐ
+    expect(events[1]).toEqual({
+      event: 'usage',
+      id: 'chunk-1',
+      created: 1700000000,
+      model: 'gpt-stream',
+      usage: {
+        promptTokens: 10,
+        completionTokens: 20,
+        totalTokens: 30,
+        reasoningTokens: undefined,
+      },
+    })
+  })
+})

--- a/projects/portfolio/tests/routes/chat.test.ts
+++ b/projects/portfolio/tests/routes/chat.test.ts
@@ -53,162 +53,161 @@ const importSubject = async () => {
   }
 }
 
-const createStreamChunk = async function* () {
-  yield {
-    id: 'chunk-1',
-    object: 'chat.completion.chunk',
-    created: 1,
-    model: 'gpt-test',
-    choices: [
-      {
-        index: 0,
-        delta: {
-          content: 'hello',
-        },
-        finish_reason: null,
-      },
-    ],
-    usage: null,
-  }
-}
-
 describe('chatRoutes', () => {
   beforeEach(() => {
     vi.resetModules()
     vi.useRealTimers()
   })
 
-  it('必須 header がない場合は 400 を返す', async () => {
-    const { chatRoutes } = await importSubject()
+  describe('POST /api/chat', () => {
+    it('必須 header がない場合は 400 を返す', async () => {
+      const { chatRoutes } = await importSubject()
 
-    const res = await chatRoutes.request('/api/chat', {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json',
-      },
-      body: JSON.stringify({
-        model: 'gpt-test',
-        messages: [],
-        stream: false,
-      }),
-    })
-
-    expect(res.status).toBe(400)
-  })
-
-  it('fakemode では base-url をローカル endpoint に置き換える', async () => {
-    vi.stubEnv('SERVER_PORT', '3456')
-    const { chatRoutes, completionsMock } = await importSubject()
-    completionsMock.mockResolvedValue({ id: 'completion-1' })
-
-    const res = await chatRoutes.request('/api/chat', {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json',
-        'api-key': 'fakemode',
-        'base-url': 'not-a-url',
-      },
-      body: JSON.stringify({
-        model: 'gpt-test',
-        messages: [],
-        stream: false,
-      }),
-    })
-
-    expect(res.status).toBe(200)
-    expect(completionsMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        baseURL: 'http://localhost:3456/api',
-      }),
-      expect.objectContaining({
-        model: 'gpt-test',
+      const res = await chatRoutes.request('/api/chat', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          model: 'gpt-test',
+          messages: [],
+        }),
       })
-    )
-  })
 
-  it('stream=false の場合は JSON を返す', async () => {
-    const { chatRoutes, completionsMock } = await importSubject()
-    completionsMock.mockResolvedValue({ id: 'completion-1', choices: [] })
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body).toHaveProperty('error')
+      expect(body).toHaveProperty('code', 'VALIDATION_ERROR')
+    })
 
-    const res = await chatRoutes.request('/api/chat', {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json',
-        'api-key': 'api-key',
-        'base-url': 'https://example.com',
-      },
-      body: JSON.stringify({
+    it('fakemode では base-url をローカル endpoint に置き換える', async () => {
+      vi.stubEnv('SERVER_PORT', '3456')
+      const { chatRoutes, completionsMock } = await importSubject()
+      completionsMock.mockResolvedValue({
+        id: 'completion-1',
+        created: 1700000000,
         model: 'gpt-test',
-        messages: [],
-        stream: false,
-      }),
+        choices: [
+          {
+            index: 0,
+            message: { role: 'assistant', content: 'answer', refusal: null },
+            finish_reason: 'stop',
+            logprobs: null,
+          },
+        ],
+      })
+
+      const res = await chatRoutes.request('/api/chat', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'api-key': 'fakemode',
+          'base-url': 'not-a-url',
+        },
+        body: JSON.stringify({
+          model: 'gpt-test',
+          messages: [],
+        }),
+      })
+
+      expect(res.status).toBe(200)
+      expect(completionsMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseURL: 'http://localhost:3456/api',
+        }),
+        expect.objectContaining({
+          model: 'gpt-test',
+          stream: false,
+        })
+      )
     })
 
-    expect(res.status).toBe(200)
-    await expect(res.json()).resolves.toEqual({ id: 'completion-1', choices: [] })
-  })
-
-  it('stream=true の場合は SSE で [DONE] を返す', async () => {
-    const { chatRoutes, completionsMock } = await importSubject()
-    completionsMock.mockResolvedValue({
-      controller: { abort: vi.fn() },
-      [Symbol.asyncIterator]: createStreamChunk,
-    })
-
-    const res = await chatRoutes.request('/api/chat', {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json',
-        'api-key': 'api-key',
-        'base-url': 'https://example.com',
-      },
-      body: JSON.stringify({
+    it('正規化された ChatResponse を返す', async () => {
+      const { chatRoutes, completionsMock } = await importSubject()
+      completionsMock.mockResolvedValue({
+        id: 'chatcmpl-abc',
+        created: 1700000000,
         model: 'gpt-test',
-        messages: [],
-        stream: true,
-      }),
-    })
+        choices: [
+          {
+            index: 0,
+            message: { role: 'assistant', content: 'answer', reasoning_content: 'thinking', refusal: null },
+            finish_reason: 'stop',
+            logprobs: null,
+          },
+        ],
+        usage: {
+          prompt_tokens: 10,
+          completion_tokens: 20,
+          total_tokens: 30,
+          completion_tokens_details: { reasoning_tokens: 5 },
+        },
+      })
 
-    const body = await res.text()
+      const res = await chatRoutes.request('/api/chat', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'api-key': 'api-key',
+          'base-url': 'https://example.com',
+        },
+        body: JSON.stringify({
+          model: 'gpt-test',
+          messages: [],
+        }),
+      })
 
-    expect(res.headers.get('content-type')).toContain('text/event-stream')
-    expect(body).toContain('data: {')
-    expect(body).toContain('data: [DONE]')
-  })
-
-  it('stub endpoint は非 stream で chatStub.completions を返す', async () => {
-    vi.useFakeTimers()
-    const { chatRoutes, chatStubCompletionsMock } = await importSubject()
-    chatStubCompletionsMock.mockResolvedValue({ id: 'stub-completion' })
-
-    const pending = chatRoutes.request('/api/chat/completions', {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json',
-      },
-      body: JSON.stringify({
+      expect(res.status).toBe(200)
+      await expect(res.json()).resolves.toEqual({
+        id: 'chatcmpl-abc',
+        created: 1700000000,
         model: 'gpt-test',
-        messages: [],
-        stream: false,
-      }),
+        finishReason: 'stop',
+        message: {
+          content: 'answer',
+          reasoningContent: 'thinking',
+        },
+        usage: {
+          promptTokens: 10,
+          completionTokens: 20,
+          totalTokens: 30,
+          reasoningTokens: 5,
+        },
+      })
     })
 
-    await vi.advanceTimersByTimeAsync(3000)
-    const res = await pending
+    it('upstream エラー時は 502 を返す', async () => {
+      const { chatRoutes, completionsMock } = await importSubject()
+      completionsMock.mockRejectedValue(new Error('Connection refused'))
 
-    expect(res.status).toBe(200)
-    await expect(res.json()).resolves.toEqual({ id: 'stub-completion' })
-    expect(chatStubCompletionsMock).toHaveBeenCalledWith('gpt-test', 'response content')
+      const res = await chatRoutes.request('/api/chat', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'api-key': 'api-key',
+          'base-url': 'https://example.com',
+        },
+        body: JSON.stringify({
+          model: 'gpt-test',
+          messages: [],
+        }),
+      })
+
+      expect(res.status).toBe(502)
+      const body = await res.json()
+      expect(body).toEqual({
+        error: 'Connection refused',
+        code: 'UPSTREAM_ERROR',
+      })
+    })
   })
 
-  it('stub endpoint は stream で chatStub.streamCompletions を呼ぶ', async () => {
-    vi.useFakeTimers()
-    const { chatRoutes, chatStubStreamCompletionsMock } = await importSubject()
-    chatStubStreamCompletionsMock.mockImplementation(async ({ onChunk }) => {
-      await onChunk?.({
+  describe('POST /api/chat/stream', () => {
+    const createStreamChunk = async function* () {
+      yield {
         id: 'chunk-1',
         object: 'chat.completion.chunk',
-        created: 1,
+        created: 1700000000,
         model: 'gpt-test',
         choices: [
           {
@@ -220,26 +219,137 @@ describe('chatRoutes', () => {
           },
         ],
         usage: null,
-      })
-    })
-
-    const pending = chatRoutes.request('/api/chat/completions', {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json',
-      },
-      body: JSON.stringify({
+      }
+      yield {
+        id: 'chunk-2',
+        object: 'chat.completion.chunk',
+        created: 1700000000,
         model: 'gpt-test',
-        messages: [],
-        stream: true,
-      }),
+        choices: [
+          {
+            index: 0,
+            delta: {},
+            finish_reason: 'stop',
+          },
+        ],
+        usage: null,
+      }
+    }
+
+    it('app イベント形式の SSE を返す', async () => {
+      const { chatRoutes, completionsMock } = await importSubject()
+      completionsMock.mockResolvedValue({
+        controller: { abort: vi.fn() },
+        [Symbol.asyncIterator]: createStreamChunk,
+      })
+
+      const res = await chatRoutes.request('/api/chat/stream', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'api-key': 'api-key',
+          'base-url': 'https://example.com',
+        },
+        body: JSON.stringify({
+          model: 'gpt-test',
+          messages: [],
+        }),
+      })
+
+      const body = await res.text()
+
+      expect(res.headers.get('content-type')).toContain('text/event-stream')
+      expect(body).toContain('"event":"delta"')
+      expect(body).toContain('"event":"finish"')
+      expect(body).toContain('data: [DONE]')
     })
 
-    await vi.advanceTimersByTimeAsync(3000)
-    const res = await pending
-    const body = await res.text()
+    it('必須 header がない場合は 400 を返す', async () => {
+      const { chatRoutes } = await importSubject()
 
-    expect(body).toContain('data: {')
-    expect(body).toContain('data: [DONE]')
+      const res = await chatRoutes.request('/api/chat/stream', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          model: 'gpt-test',
+          messages: [],
+        }),
+      })
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body).toHaveProperty('code', 'VALIDATION_ERROR')
+    })
+  })
+
+  describe('POST /api/chat/completions (stub)', () => {
+    it('非 stream で chatStub.completions を返す', async () => {
+      vi.useFakeTimers()
+      const { chatRoutes, chatStubCompletionsMock } = await importSubject()
+      chatStubCompletionsMock.mockResolvedValue({ id: 'stub-completion' })
+
+      const pending = chatRoutes.request('/api/chat/completions', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          model: 'gpt-test',
+          messages: [],
+          stream: false,
+        }),
+      })
+
+      await vi.advanceTimersByTimeAsync(3000)
+      const res = await pending
+
+      expect(res.status).toBe(200)
+      await expect(res.json()).resolves.toEqual({ id: 'stub-completion' })
+      expect(chatStubCompletionsMock).toHaveBeenCalledWith('gpt-test', 'response content')
+    })
+
+    it('stream で chatStub.streamCompletions を呼ぶ', async () => {
+      vi.useFakeTimers()
+      const { chatRoutes, chatStubStreamCompletionsMock } = await importSubject()
+      chatStubStreamCompletionsMock.mockImplementation(async ({ onChunk }) => {
+        await onChunk?.({
+          id: 'chunk-1',
+          object: 'chat.completion.chunk',
+          created: 1,
+          model: 'gpt-test',
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content: 'hello',
+              },
+              finish_reason: null,
+            },
+          ],
+          usage: null,
+        })
+      })
+
+      const pending = chatRoutes.request('/api/chat/completions', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          model: 'gpt-test',
+          messages: [],
+          stream: true,
+        }),
+      })
+
+      await vi.advanceTimersByTimeAsync(3000)
+      const res = await pending
+      const body = await res.text()
+
+      expect(body).toContain('data: {')
+      expect(body).toContain('data: [DONE]')
+    })
   })
 })

--- a/projects/portfolio/tests/routes/chat.test.ts
+++ b/projects/portfolio/tests/routes/chat.test.ts
@@ -176,6 +176,29 @@ describe('chatRoutes', () => {
       })
     })
 
+    it('不正な body は公開契約の validation error 形式で 400 を返す', async () => {
+      const { chatRoutes } = await importSubject()
+
+      const res = await chatRoutes.request('/api/chat', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'api-key': 'api-key',
+          'base-url': 'https://example.com',
+        },
+        body: JSON.stringify({
+          model: '',
+          messages: [],
+        }),
+      })
+
+      expect(res.status).toBe(400)
+      await expect(res.json()).resolves.toEqual({
+        error: "Invalid request body 'model'",
+        code: 'VALIDATION_ERROR',
+      })
+    })
+
     it('upstream エラー時は 502 を返す', async () => {
       const { chatRoutes, completionsMock } = await importSubject()
       completionsMock.mockRejectedValue(new Error('Connection refused'))
@@ -281,6 +304,29 @@ describe('chatRoutes', () => {
       expect(res.status).toBe(400)
       const body = await res.json()
       expect(body).toHaveProperty('code', 'VALIDATION_ERROR')
+    })
+
+    it('不正な body は公開契約の validation error 形式で 400 を返す', async () => {
+      const { chatRoutes } = await importSubject()
+
+      const res = await chatRoutes.request('/api/chat/stream', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'api-key': 'api-key',
+          'base-url': 'https://example.com',
+        },
+        body: JSON.stringify({
+          model: '',
+          messages: [],
+        }),
+      })
+
+      expect(res.status).toBe(400)
+      await expect(res.json()).resolves.toEqual({
+        error: "Invalid request body 'model'",
+        code: 'VALIDATION_ERROR',
+      })
     })
   })
 


### PR DESCRIPTION
## Issue
- Closes #798

## Summary

- Split `POST /api/chat` into non-stream (`POST /api/chat`) and SSE-only (`POST /api/chat/stream`) endpoints
- Add backend converter layer (`converter.ts`) to normalize LiteLLM/Bifrost provider responses into app-specific camelCase contract (`ChatResponse`, `ChatStreamEvent`)
- Define new public API contract (`chat-api.ts`) with `ChatApiRequestSchema`, `ChatResponseSchema`, `ChatStreamEventSchema`, `ChatErrorResponseSchema`
- Remove frontend dependency on raw provider schemas (`ChatCompletionResponseSchema`, `ChatCompletionStreamChunkSchema`)
- Add unified error responses (`400 VALIDATION_ERROR`, `502 UPSTREAM_ERROR`)
- Extend transport types for Bifrost-specific fields (`reasoning`, `reasoning_details`, `provider_specific_fields`)

## Test plan

- [x] Converter unit tests (LiteLLM/Bifrost non-stream + stream normalization) — 9 tests
- [x] Route tests (`/api/chat` normalized JSON, `/api/chat/stream` app events SSE, error responses) — 8 tests
- [x] Frontend hook tests (delta/finish/usage event accumulation) — 6 tests
- [x] `bun run test` — 29 files, 117 tests all passed
- [x] `bun run lint` — 0 errors, 0 warnings
- [x] `bun run typegen` — `app.d.ts` correctly outputs `/api/chat` and `/api/chat/stream` types
- [x] `bun run build` — production build success

🤖 Generated with [Claude Code](https://claude.com/claude-code)