### PR TITLE
fix(portfolio): polish chat interaction feedback

### DIFF
--- a/projects/portfolio/src/client/components/chat/chat-results.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-results.tsx
@@ -1,3 +1,4 @@
+import { ChevronRightIcon } from '#/client/components/svg/chevron-right-icon'
 import type { AssistantMetadata } from '#/types'
 import { memo, useState } from 'react'
 
@@ -29,6 +30,7 @@ function ChatResultsComponent({ metadata }: ChatResultsProps) {
         type='button'
         className='flex cursor-pointer flex-wrap items-center gap-1 text-xs text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300'
         onClick={() => setOpen((prev) => !prev)}
+        aria-expanded={open}
       >
         <span>{model}</span>
         {responseTimeMs !== undefined && (
@@ -37,34 +39,47 @@ function ChatResultsComponent({ metadata }: ChatResultsProps) {
             <span>{formatResponseTime(responseTimeMs)}</span>
           </>
         )}
-        <span className='ml-0.5'>{open ? '▲' : '▼'}</span>
+        <span className={`ml-0.5 inline-flex transition-transform duration-200 ${open ? '-rotate-90' : 'rotate-90'}`}>
+          <ChevronRightIcon />
+        </span>
       </button>
-      {open && (
-        <div className='mt-1 flex flex-wrap gap-1'>
-          {finishReason && (
-            <div className={badgeClass}>
-              <span className='mr-1'>finish_reason:</span>
-              <span>{finishReason}</span>
-            </div>
-          )}
-          <div className={badgeClass}>
-            <span className='mr-1'>usage:</span>
-            <span className='mr-0.5'>(input:</span>
-            <span>{usage.promptTokens ?? '--'}</span>
-            <span className='mr-0.5'>/</span>
-            <span className='mr-0.5'>output:</span>
-            <span>{usage.completionTokens ?? '--'}</span>
-            {usage.reasoningTokens !== undefined && (
-              <>
-                <span className='mr-0.5'>/</span>
-                <span className='mr-0.5'>reasoning:</span>
-                <span>{usage.reasoningTokens}</span>
-              </>
+      <div
+        aria-hidden={!open}
+        className={`grid overflow-hidden transition-[grid-template-rows,opacity,margin] duration-200 ease-out motion-reduce:transition-none ${
+          open ? 'mt-1 grid-rows-[1fr] opacity-100' : 'mt-0 grid-rows-[0fr] opacity-0'
+        }`}
+      >
+        <div className='min-h-0'>
+          <div
+            className={`flex flex-wrap gap-1 transition-transform duration-200 ease-out motion-reduce:transition-none ${
+              open ? 'translate-y-0' : '-translate-y-1'
+            }`}
+          >
+            {finishReason && (
+              <div className={badgeClass}>
+                <span className='mr-1'>finish_reason:</span>
+                <span>{finishReason}</span>
+              </div>
             )}
-            <span>)</span>
+            <div className={badgeClass}>
+              <span className='mr-1'>usage:</span>
+              <span className='mr-0.5'>(input:</span>
+              <span>{usage.promptTokens ?? '--'}</span>
+              <span className='mr-0.5'>/</span>
+              <span className='mr-0.5'>output:</span>
+              <span>{usage.completionTokens ?? '--'}</span>
+              {usage.reasoningTokens !== undefined && (
+                <>
+                  <span className='mr-0.5'>/</span>
+                  <span className='mr-0.5'>reasoning:</span>
+                  <span>{usage.reasoningTokens}</span>
+                </>
+              )}
+              <span>)</span>
+            </div>
           </div>
         </div>
-      )}
+      </div>
     </div>
   )
 }

--- a/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
+++ b/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
@@ -88,6 +88,44 @@ type CodeBlockRendererProps = HTMLAttributes<HTMLElement> & {
   children?: ReactNode | string
 }
 
+interface CodeBlockCopyButtonProps {
+  copied: boolean
+  onClick: () => void
+}
+
+function CodeBlockCopyButton({ copied, onClick }: CodeBlockCopyButtonProps) {
+  return (
+    <button
+      type='button'
+      onClick={onClick}
+      disabled={copied}
+      aria-label={copied ? 'Copied code block' : 'Copy code block'}
+      className={`relative inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-md text-gray-600 transition-[background-color,color] duration-200 ease-out focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 dark:text-gray-300 dark:focus-visible:ring-gray-500 disabled:cursor-default ${
+        copied
+          ? 'text-emerald-600 dark:text-emerald-400'
+          : 'hover:bg-gray-200 hover:text-gray-800 dark:hover:bg-gray-700 dark:hover:text-white'
+      }`}
+    >
+      <span className='relative h-[18px] w-[18px]' aria-hidden='true'>
+        <span
+          className={`absolute inset-0 transition-[opacity,transform] duration-200 ease-out motion-reduce:transition-none ${
+            copied ? '-translate-y-0.5 scale-90 opacity-0' : 'translate-y-0 scale-100 opacity-100'
+          }`}
+        >
+          <CopyIcon size={18} className='stroke-current' />
+        </span>
+        <span
+          className={`absolute inset-0 transition-[opacity,transform] duration-200 ease-out motion-reduce:transition-none ${
+            copied ? 'translate-y-0 scale-100 opacity-100' : 'translate-y-0.5 scale-90 opacity-0'
+          }`}
+        >
+          <CheckIcon size={18} className='stroke-current' />
+        </span>
+      </span>
+    </button>
+  )
+}
+
 export function CodeBlockRenderer({ className, children }: CodeBlockRendererProps) {
   const [copied, setCopied] = useState(false)
 
@@ -151,24 +189,7 @@ export function CodeBlockRenderer({ className, children }: CodeBlockRendererProp
             <path d='M5 7.5L10 12.5L15 7.5' strokeWidth='1.8' strokeLinecap='round' strokeLinejoin='round' />
           </svg>
         </div>
-        <button
-          type='button'
-          onClick={handleClickCopy}
-          disabled={copied}
-          className='flex cursor-pointer gap-1 align-center'
-        >
-          {copied ? (
-            <>
-              <CheckIcon size={18} className='stroke-gray-600 dark:stroke-gray-300' />
-              <span className='text-xs text-gray-600 dark:text-gray-300'>コピーしました</span>
-            </>
-          ) : (
-            <>
-              <CopyIcon size={18} className='stroke-gray-600 dark:stroke-gray-300' />
-              <span className='text-xs text-gray-600 dark:text-gray-300'>コピーする</span>
-            </>
-          )}
-        </button>
+        <CodeBlockCopyButton copied={copied} onClick={handleClickCopy} />
       </div>
       <div className='overflow-x-auto'>
         <SyntaxHighlighter

--- a/projects/portfolio/src/client/components/chat/message-renderer.tsx
+++ b/projects/portfolio/src/client/components/chat/message-renderer.tsx
@@ -30,6 +30,63 @@ interface MessageRendererProps {
   onDeleteMessage?: (index: number) => void
 }
 
+interface MessageActionBarProps {
+  copied: boolean
+  disabled?: boolean
+  children: ReactNode
+  align?: 'left' | 'right'
+}
+
+interface CopyMessageButtonProps {
+  copied: boolean
+  onClick: () => void
+}
+
+function MessageActionBar({ copied, disabled, children, align = 'left' }: MessageActionBarProps) {
+  return (
+    <div
+      className={`mt-1 ml-1 flex items-center gap-1 transition-opacity duration-200 ease-out motion-reduce:transition-none md:opacity-0 md:group-hover:opacity-100 ${
+        copied ? 'opacity-100' : ''
+      } ${align === 'right' ? 'justify-end' : ''} ${disabled ? 'invisible' : ''}`}
+    >
+      {children}
+    </div>
+  )
+}
+
+function CopyMessageButton({ copied, onClick }: CopyMessageButtonProps) {
+  return (
+    <button
+      type='button'
+      className={`relative flex h-8 w-8 cursor-pointer items-center justify-center rounded-full text-gray-500 transition-[background-color,color,transform] duration-200 ease-out focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 dark:text-gray-300 dark:focus-visible:ring-gray-500 disabled:cursor-default ${
+        copied
+          ? 'text-emerald-600 dark:text-emerald-400'
+          : 'hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-700 dark:hover:text-white'
+      }`}
+      onClick={onClick}
+      disabled={copied}
+      aria-label={copied ? 'Copied' : 'Copy message'}
+    >
+      <span
+        aria-hidden='true'
+        className={`absolute transition-[opacity,transform] duration-200 ease-out motion-reduce:transition-none ${
+          copied ? '-translate-y-0.5 scale-90 opacity-0' : 'translate-y-0 scale-100 opacity-100'
+        }`}
+      >
+        <CopyIcon size={20} className='stroke-current' />
+      </span>
+      <span
+        aria-hidden='true'
+        className={`absolute transition-[opacity,transform] duration-200 ease-out motion-reduce:transition-none ${
+          copied ? 'translate-y-0 scale-100 opacity-100' : 'translate-y-0.5 scale-90 opacity-0'
+        }`}
+      >
+        <CheckIcon size={20} className='stroke-current' />
+      </span>
+    </button>
+  )
+}
+
 function MessageRendererComponent({
   message,
   index,
@@ -62,21 +119,20 @@ function MessageRendererComponent({
                   )
                 })}
           </div>
-          <div
-            className={`mt-1 ml-1 transition-opacity duration-200 ease-in md:opacity-0 md:group-hover:opacity-100 ${copied ? 'opacity-100' : ''} ${disabled ? 'invisible' : ''}`}
-          >
+          <MessageActionBar copied={copied} disabled={disabled} align='right'>
+            <CopyMessageButton
+              copied={copied}
+              onClick={() => onCopyMessage(typeof message.content === 'string' ? message.content : '', index)}
+            />
             <button
               type='button'
-              className='cursor-pointer p-1'
-              onClick={() => onCopyMessage(typeof message.content === 'string' ? message.content : '', index)}
-              disabled={copied}
+              className='flex h-8 w-8 cursor-pointer items-center justify-center rounded-full text-gray-500 transition-[background-color,color] duration-200 ease-out hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white dark:focus-visible:ring-gray-500'
+              onClick={() => onDeleteMessage?.(index)}
+              aria-label='Delete message'
             >
-              {copied ? <CheckIcon size={20} /> : <CopyIcon size={20} />}
-            </button>
-            <button type='button' className='cursor-pointer p-1' onClick={() => onDeleteMessage?.(index)}>
               <DeleteIcon size={20} />
             </button>
-          </div>
+          </MessageActionBar>
         </div>
       </div>
     )
@@ -100,18 +156,9 @@ function MessageRendererComponent({
             <p className='wrap-break-word mt-1 inline-block whitespace-pre-wrap break-all'>{message.content}</p>
           </div>
         )}
-        <div
-          className={`mt-1 ml-1 transition-opacity duration-200 ease-in md:opacity-0 md:group-hover:opacity-100 ${copied ? 'opacity-100' : ''}`}
-        >
-          <button
-            type='button'
-            className='cursor-pointer p-1'
-            onClick={() => onCopyMessage(message.content, index)}
-            disabled={copied}
-          >
-            {copied ? <CheckIcon size={20} /> : <CopyIcon size={20} />}
-          </button>
-        </div>
+        <MessageActionBar copied={copied}>
+          <CopyMessageButton copied={copied} onClick={() => onCopyMessage(message.content, index)} />
+        </MessageActionBar>
         <ChatResults metadata={message.metadata} />
       </div>
     </div>

--- a/projects/portfolio/src/client/components/chat/reasoning-section.tsx
+++ b/projects/portfolio/src/client/components/chat/reasoning-section.tsx
@@ -1,3 +1,4 @@
+import { ChevronRightIcon } from '#/client/components/svg/chevron-right-icon'
 import { useState } from 'react'
 
 interface ReasoningSectionProps {
@@ -16,8 +17,8 @@ export function ReasoningSection({ content, isStreaming = false, defaultOpen = f
         className='flex cursor-pointer items-center gap-1 text-gray-400 hover:text-gray-500 dark:text-gray-400 dark:hover:text-gray-300'
         onClick={() => setIsOpen((prev) => !prev)}
       >
-        <span className={`inline-block text-[8px] transition-transform duration-200 ${isOpen ? 'rotate-90' : ''}`}>
-          ▶
+        <span className={`inline-flex translate-y-px transition-transform duration-200 ${isOpen ? 'rotate-90' : ''}`}>
+          <ChevronRightIcon />
         </span>
         <span>reasoning</span>
         {isStreaming && (

--- a/projects/portfolio/src/client/components/chat/reasoning-section.tsx
+++ b/projects/portfolio/src/client/components/chat/reasoning-section.tsx
@@ -16,6 +16,7 @@ export function ReasoningSection({ content, isStreaming = false, defaultOpen = f
         type='button'
         className='flex cursor-pointer items-center gap-1 rounded-sm px-0.5 text-gray-400 transition-colors hover:text-gray-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 dark:text-gray-400 dark:hover:text-gray-300 dark:focus-visible:ring-gray-500'
         onClick={() => setIsOpen((prev) => !prev)}
+        aria-expanded={isOpen}
       >
         <span className={`inline-flex transition-transform duration-200 ${isOpen ? 'rotate-90' : ''}`}>
           <ChevronRightIcon />
@@ -25,11 +26,22 @@ export function ReasoningSection({ content, isStreaming = false, defaultOpen = f
           <span className='inline-block h-3 w-3 animate-spin rounded-full border border-gray-400 border-t-transparent dark:border-gray-500 dark:border-t-transparent' />
         )}
       </button>
-      {isOpen && (
-        <div className='mt-1 wrap-break-word whitespace-pre-line break-all text-gray-400 dark:text-gray-200'>
-          {content}
+      <div
+        aria-hidden={!isOpen}
+        className={`grid overflow-hidden transition-[grid-template-rows,opacity,margin] duration-200 ease-out motion-reduce:transition-none ${
+          isOpen ? 'mt-1 grid-rows-[1fr] opacity-100' : 'mt-0 grid-rows-[0fr] opacity-0'
+        }`}
+      >
+        <div className='min-h-0'>
+          <div
+            className={`wrap-break-word whitespace-pre-line break-all text-gray-400 transition-transform duration-200 ease-out motion-reduce:transition-none dark:text-gray-200 ${
+              isOpen ? 'translate-y-0' : '-translate-y-1'
+            }`}
+          >
+            {content}
+          </div>
         </div>
-      )}
+      </div>
     </div>
   )
 }

--- a/projects/portfolio/src/client/components/chat/reasoning-section.tsx
+++ b/projects/portfolio/src/client/components/chat/reasoning-section.tsx
@@ -14,10 +14,10 @@ export function ReasoningSection({ content, isStreaming = false, defaultOpen = f
     <div className='mb-1 text-xs'>
       <button
         type='button'
-        className='flex cursor-pointer items-center gap-1 text-gray-400 hover:text-gray-500 dark:text-gray-400 dark:hover:text-gray-300'
+        className='flex cursor-pointer items-center gap-1 rounded-sm px-0.5 text-gray-400 transition-colors hover:text-gray-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 dark:text-gray-400 dark:hover:text-gray-300 dark:focus-visible:ring-gray-500'
         onClick={() => setIsOpen((prev) => !prev)}
       >
-        <span className={`inline-flex translate-y-px transition-transform duration-200 ${isOpen ? 'rotate-90' : ''}`}>
+        <span className={`inline-flex transition-transform duration-200 ${isOpen ? 'rotate-90' : ''}`}>
           <ChevronRightIcon />
         </span>
         <span>reasoning</span>

--- a/projects/portfolio/src/client/components/chat/reasoning-section.tsx
+++ b/projects/portfolio/src/client/components/chat/reasoning-section.tsx
@@ -21,7 +21,7 @@ export function ReasoningSection({ content, isStreaming = false, defaultOpen = f
         </span>
         <span>reasoning</span>
         {isStreaming && (
-          <span className='inline-block h-3 w-3 animate-spin rounded-full border border-gray-400 border-t-transparent dark:border-gray-500' />
+          <span className='inline-block h-3 w-3 animate-spin rounded-full border border-gray-400 border-t-transparent dark:border-gray-500 dark:border-t-transparent' />
         )}
       </button>
       {isOpen && (

--- a/projects/portfolio/src/client/components/svg/chevron-right-icon.tsx
+++ b/projects/portfolio/src/client/components/svg/chevron-right-icon.tsx
@@ -1,0 +1,15 @@
+import { type IconProps, SvgIcon } from './icon-base'
+
+export function ChevronRightIcon({ size = 8, className = 'stroke-current' }: IconProps) {
+  return (
+    <SvgIcon size={size} title='chevron-right-icon' viewBox='0 0 8 8'>
+      <path
+        d='M2 1.5L5 4L2 6.5'
+        strokeWidth='1.25'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+        className={className}
+      />
+    </SvgIcon>
+  )
+}


### PR DESCRIPTION
## Why

チャット画面のトグルやコピーボタンの見た目が端末や状態によって不安定で、操作フィードバックも急に切り替わっていました。
UI の一貫性を上げて、開閉やコピー時の反応を自然に見せるための調整です。

## Summary

チャット UI の細かい操作要素を SVG とアニメーションで統一しました。
`reasoning`、`chat results`、メッセージのコピーボタン、コードブロックのコピーボタンの表示と状態変化を滑らかにしています。

## Changes

- `reasoning` のスピナー表示をモバイルのダークモードでも視認できるよう修正
- `reasoning` と `chat results` のトグル記号を SVG に置き換え
- `reasoning` と `chat results` の開閉をふわっと開いてシュッと閉じるアニメーションに変更
- メッセージのコピー関連ボタンを右寄せ・ホバー・コピー完了時の見え方まで含めて調整
- コードブロックのコピーボタンをアイコンのみのアニメーション付き UI に変更

## Checklist

- [x] チャット UI の記号文字を SVG ベースへ寄せた
- [x] 開閉とコピー完了時の状態変化にアニメーションを追加した
- [ ] `bun run test`
