### PR TITLE
refactor(portfolio): remove mcp-server-urls and request bypass processing

### DIFF
--- a/projects/portfolio/src/client/components/chat/chat-main.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-main.tsx
@@ -88,7 +88,6 @@ export function ChatMain({
         model: settings.fakeMode ? 'fakemode' : settings.model,
         baseURL: settings.fakeMode ? 'fakemode' : settings.baseURL,
         apiKey: settings.fakeMode ? 'fakemode' : settings.apiKey,
-        mcpServerURLs: settings.fakeMode ? '' : settings.mcpServerURLs,
         temperature: settings.temperatureEnabled ? settings.temperature : undefined,
         maxTokens: settings.maxTokens ? Number(settings.maxTokens) : undefined,
         userInput: formData.get('userInput')?.toString() || '',
@@ -115,7 +114,6 @@ export function ChatMain({
         header: {
           apiKey: form.apiKey,
           baseURL: form.baseURL,
-          mcpServerURLs: form.mcpServerURLs,
         },
         model: params.model,
         messages: params.apiMessages,
@@ -178,7 +176,6 @@ export function ChatMain({
       settings.fakeMode,
       settings.interactiveMode,
       settings.maxTokens,
-      settings.mcpServerURLs,
       settings.model,
       settings.reasoningEffort,
       settings.reasoningEffortEnabled,

--- a/projects/portfolio/src/client/components/chat/chat-settings/chat-settings-context.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-settings/chat-settings-context.tsx
@@ -22,7 +22,6 @@ export interface ChatSettingsContextValue {
   handleChangeManualModel: (event: ChangeEvent<HTMLInputElement>) => void
   handleChangeBaseURL: (event: ChangeEvent<HTMLInputElement>) => void
   handleChangeApiKey: (event: ChangeEvent<HTMLInputElement>) => void
-  handleChangeMcpServerURLs: (event: ChangeEvent<HTMLInputElement>) => void
   handleChangeTemperature: (event: ChangeEvent<HTMLInputElement>) => void
   handleChangeMaxTokens: (event: ChangeEvent<HTMLInputElement>) => void
   handleChangeReasoningEffort: (event: ChangeEvent<HTMLSelectElement>) => void

--- a/projects/portfolio/src/client/components/chat/chat-settings/chat-settings-form.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-settings/chat-settings-form.tsx
@@ -15,7 +15,6 @@ export function ChatSettingsForm() {
     interactiveMode,
     handleChangeBaseURL,
     handleChangeApiKey,
-    handleChangeMcpServerURLs,
     handleChangeMaxTokens,
     handleToggleFakeMode,
     handleToggleMarkdownPreview,
@@ -71,16 +70,6 @@ export function ChatSettingsForm() {
               API Key はブラウザの localStorage に保存されます。秘匿ストアではありません。
             </p>
           </div>
-
-          <TextInput
-            name='mcpServerURLs'
-            label='MCP Server URLs'
-            suffix='(comma separated)'
-            defaultValue={settings.mcpServerURLs || ''}
-            placeholder='http://localhost:3001, http://localhost:3002'
-            disabled={fakeMode}
-            onChange={handleChangeMcpServerURLs}
-          />
         </div>
       </section>
 

--- a/projects/portfolio/src/client/components/chat/chat-settings/hooks/use-settings-handlers.ts
+++ b/projects/portfolio/src/client/components/chat/chat-settings/hooks/use-settings-handlers.ts
@@ -30,7 +30,6 @@ interface UseSettingsHandlersReturn {
   handleChangeManualModel: (event: ChangeEvent<HTMLInputElement>) => void
   handleChangeBaseURL: (event: ChangeEvent<HTMLInputElement>) => void
   handleChangeApiKey: (event: ChangeEvent<HTMLInputElement>) => void
-  handleChangeMcpServerURLs: (event: ChangeEvent<HTMLInputElement>) => void
   handleChangeTemperature: (event: ChangeEvent<HTMLInputElement>) => void
   handleChangeMaxTokens: (event: ChangeEvent<HTMLInputElement>) => void
   handleChangeReasoningEffort: (event: ChangeEvent<HTMLSelectElement>) => void
@@ -91,13 +90,6 @@ export function useSettingsHandlers(deps: UseSettingsHandlersDeps): UseSettingsH
   const handleChangeApiKey = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
       updateSetting('apiKey', event.target.value)
-    },
-    [updateSetting]
-  )
-
-  const handleChangeMcpServerURLs = useCallback(
-    (event: ChangeEvent<HTMLInputElement>) => {
-      updateSetting('mcpServerURLs', event.target.value)
     },
     [updateSetting]
   )
@@ -175,7 +167,6 @@ export function useSettingsHandlers(deps: UseSettingsHandlersDeps): UseSettingsH
     handleChangeManualModel,
     handleChangeBaseURL,
     handleChangeApiKey,
-    handleChangeMcpServerURLs,
     handleChangeTemperature,
     handleChangeMaxTokens,
     handleChangeReasoningEffort,

--- a/projects/portfolio/src/client/components/chat/hooks/use-stream-processor.ts
+++ b/projects/portfolio/src/client/components/chat/hooks/use-stream-processor.ts
@@ -11,7 +11,6 @@ interface SubmitChatCompletionParams {
   header: {
     apiKey: string
     baseURL: string
-    mcpServerURLs: string
   }
   model: string
   /** /api/chat wire 形式のメッセージ（toApiChatMessage で変換済み） */
@@ -100,7 +99,6 @@ interface SendCompletionParams {
   header: {
     apiKey: string
     baseURL: string
-    mcpServerURLs: string
   }
   model: string
   messages: ApiChatMessage[]
@@ -128,7 +126,6 @@ const sendNonStreamCompletion = async (req: SendCompletionParams): Promise<ChatR
         header: {
           'api-key': req.header.apiKey,
           'base-url': req.header.baseURL,
-          'mcp-server-urls': req.header.mcpServerURLs,
         },
         json: {
           messages: req.messages,
@@ -172,7 +169,6 @@ const sendStreamCompletion = async (
         header: {
           'api-key': req.header.apiKey,
           'base-url': req.header.baseURL,
-          'mcp-server-urls': req.header.mcpServerURLs,
         },
         json: {
           messages: req.messages,

--- a/projects/portfolio/src/client/storage/remote-storage-settings.ts
+++ b/projects/portfolio/src/client/storage/remote-storage-settings.ts
@@ -8,7 +8,6 @@ export interface Settings {
   model: string
   baseURL: string
   apiKey: string
-  mcpServerURLs: string
   temperature: number
   temperatureEnabled: boolean
   maxTokens?: number
@@ -35,7 +34,6 @@ const defaultSettings: Settings = {
   model: 'gpt-4.1-mini',
   baseURL: '',
   apiKey: '',
-  mcpServerURLs: '',
   temperature: 0.7,
   temperatureEnabled: false,
   maxTokens: undefined,
@@ -93,10 +91,11 @@ function parseStoredSettings(value: string | null): StoredSettings | null {
   }
 }
 
-function mergeSettings(settings: Partial<Settings>): Settings {
+function mergeSettings(settings: Partial<Settings> & { mcpServerURLs?: unknown }): Settings {
+  const { mcpServerURLs: _dropped, ...rest } = settings
   return {
     ...defaultSettings,
-    ...settings,
+    ...rest,
     schemaVersion: SCHEMA_VERSION,
   }
 }

--- a/projects/portfolio/src/server/app.d.ts
+++ b/projects/portfolio/src/server/app.d.ts
@@ -52,47 +52,6 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv & {
                 header: {
                     'api-key': string;
                     'base-url': string;
-                    'mcp-server-urls': string | undefined;
-                };
-            } & {
-                json: {
-                    messages: ({
-                        role: "user";
-                        content: string | ({
-                            type: "image_url";
-                            image_url: {
-                                url: string;
-                            };
-                        } | {
-                            type: "text";
-                            text: string;
-                        })[];
-                    } | {
-                        role: "assistant";
-                        content: string;
-                    } | {
-                        role: "system";
-                        content: string;
-                    })[];
-                    model: string;
-                    temperature?: number | undefined;
-                    maxTokens?: number | undefined;
-                    reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | undefined;
-                };
-            };
-            output: {
-                readonly success: false;
-                readonly error: readonly import("@standard-schema/spec").StandardSchemaV1.Issue[];
-                readonly data: any;
-            };
-            outputFormat: "json";
-            status: 400;
-        } | {
-            input: {
-                header: {
-                    'api-key': string;
-                    'base-url': string;
-                    'mcp-server-urls': string | undefined;
                 };
             } & {
                 json: {
@@ -131,7 +90,44 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv & {
                 header: {
                     'api-key': string;
                     'base-url': string;
-                    'mcp-server-urls': string | undefined;
+                };
+            } & {
+                json: {
+                    messages: ({
+                        role: "user";
+                        content: string | ({
+                            type: "image_url";
+                            image_url: {
+                                url: string;
+                            };
+                        } | {
+                            type: "text";
+                            text: string;
+                        })[];
+                    } | {
+                        role: "assistant";
+                        content: string;
+                    } | {
+                        role: "system";
+                        content: string;
+                    })[];
+                    model: string;
+                    temperature?: number | undefined;
+                    maxTokens?: number | undefined;
+                    reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | undefined;
+                };
+            };
+            output: {
+                error: string;
+                code: "VALIDATION_ERROR";
+            };
+            outputFormat: "json";
+            status: 400;
+        } | {
+            input: {
+                header: {
+                    'api-key': string;
+                    'base-url': string;
                 };
             } & {
                 json: {
@@ -182,7 +178,6 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv & {
                 header: {
                     'api-key': string;
                     'base-url': string;
-                    'mcp-server-urls': string | undefined;
                 };
             } & {
                 json: {
@@ -225,47 +220,6 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv & {
                 header: {
                     'api-key': string;
                     'base-url': string;
-                    'mcp-server-urls': string | undefined;
-                };
-            } & {
-                json: {
-                    messages: ({
-                        role: "user";
-                        content: string | ({
-                            type: "image_url";
-                            image_url: {
-                                url: string;
-                            };
-                        } | {
-                            type: "text";
-                            text: string;
-                        })[];
-                    } | {
-                        role: "assistant";
-                        content: string;
-                    } | {
-                        role: "system";
-                        content: string;
-                    })[];
-                    model: string;
-                    temperature?: number | undefined;
-                    maxTokens?: number | undefined;
-                    reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | undefined;
-                };
-            };
-            output: {
-                readonly success: false;
-                readonly error: readonly import("@standard-schema/spec").StandardSchemaV1.Issue[];
-                readonly data: any;
-            };
-            outputFormat: "json";
-            status: 400;
-        } | {
-            input: {
-                header: {
-                    'api-key': string;
-                    'base-url': string;
-                    'mcp-server-urls': string | undefined;
                 };
             } & {
                 json: {
@@ -304,7 +258,44 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv & {
                 header: {
                     'api-key': string;
                     'base-url': string;
-                    'mcp-server-urls': string | undefined;
+                };
+            } & {
+                json: {
+                    messages: ({
+                        role: "user";
+                        content: string | ({
+                            type: "image_url";
+                            image_url: {
+                                url: string;
+                            };
+                        } | {
+                            type: "text";
+                            text: string;
+                        })[];
+                    } | {
+                        role: "assistant";
+                        content: string;
+                    } | {
+                        role: "system";
+                        content: string;
+                    })[];
+                    model: string;
+                    temperature?: number | undefined;
+                    maxTokens?: number | undefined;
+                    reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | undefined;
+                };
+            };
+            output: {
+                error: string;
+                code: "VALIDATION_ERROR";
+            };
+            outputFormat: "json";
+            status: 400;
+        } | {
+            input: {
+                header: {
+                    'api-key': string;
+                    'base-url': string;
                 };
             } & {
                 json: {

--- a/projects/portfolio/src/server/features/chat/chat.ts
+++ b/projects/portfolio/src/server/features/chat/chat.ts
@@ -9,7 +9,6 @@ interface Chat {
     headers: {
       apiKey: string
       baseURL: string
-      mcpServerURLs: string
     },
     params: {
       model: string
@@ -28,11 +27,9 @@ export const chat: Chat = {
     {
       apiKey,
       baseURL,
-      mcpServerURLs,
     }: {
       apiKey: string
       baseURL: string
-      mcpServerURLs: string
     },
     {
       model,
@@ -55,37 +52,6 @@ export const chat: Chat = {
     const openai = new OpenAI({
       apiKey,
       baseURL,
-      fetch: async (url, options = {}) => {
-        // カスタムヘッダーを追加
-        const customHeaders = {
-          'mcp-server-urls': mcpServerURLs,
-        }
-        // options.headers の型をチェックして、適切にマージ
-        let existingHeaders: Record<string, string> = {}
-
-        if (options.headers instanceof Headers) {
-          // Headersオブジェクトの場合は安全にRecord<string, string>に変換
-          existingHeaders = {}
-          options.headers.forEach((value, key) => {
-            if (typeof key === 'string' && typeof value === 'string') {
-              existingHeaders[key] = value
-            }
-          })
-        } else if (typeof options.headers === 'object' && options.headers !== null) {
-          // plain objectの場合は安全にフィルタリングしてコピー
-          existingHeaders = Object.fromEntries(
-            Object.entries(options.headers).filter(
-              ([key, value]) => typeof key === 'string' && typeof value === 'string'
-            )
-          )
-        }
-        // マージして新しいヘッダーをセット
-        options.headers = {
-          ...existingHeaders,
-          ...customHeaders,
-        }
-        return fetch(url, options)
-      },
     })
     const completion = await openai.chat.completions.create({
       model,

--- a/projects/portfolio/src/server/routes/chat.ts
+++ b/projects/portfolio/src/server/routes/chat.ts
@@ -18,7 +18,6 @@ import { getServerEnv } from './shared'
 const ChatHeaderSchema = z.object({
   'api-key': z.string().min(1),
   'base-url': z.string().min(1),
-  'mcp-server-urls': z.string().optional(),
 })
 
 // /api/chat/completions stub endpoint 用スキーマ (OpenAI 互換)
@@ -39,7 +38,6 @@ const chatHeaderValidator = validator('header', (value, c) => {
   const parsed = ChatHeaderSchema.safeParse({
     'api-key': value['api-key'],
     'base-url': value['base-url'],
-    'mcp-server-urls': value['mcp-server-urls'],
   })
 
   if (!parsed.success) {
@@ -62,7 +60,6 @@ const chatHeaderValidator = validator('header', (value, c) => {
   return {
     'api-key': headers['api-key'],
     'base-url': fakeMode ? fakeBaseURL : headers['base-url'],
-    'mcp-server-urls': headers['mcp-server-urls'],
   }
 })
 
@@ -139,7 +136,6 @@ const chatRoutes = new Hono<HonoEnv>()
         {
           apiKey: header['api-key'],
           baseURL: header['base-url'],
-          mcpServerURLs: header['mcp-server-urls'] ?? '',
         },
         {
           model: req.model,
@@ -173,7 +169,6 @@ const chatRoutes = new Hono<HonoEnv>()
         {
           apiKey: header['api-key'],
           baseURL: header['base-url'],
-          mcpServerURLs: header['mcp-server-urls'] ?? '',
         },
         {
           model: req.model,

--- a/projects/portfolio/tests/client/hooks/use-chat-page-state.test.ts
+++ b/projects/portfolio/tests/client/hooks/use-chat-page-state.test.ts
@@ -10,7 +10,6 @@ const defaultSettings = {
   model: 'gpt-4.1-mini',
   baseURL: '',
   apiKey: '',
-  mcpServerURLs: '',
   temperature: 0.7,
   temperatureEnabled: false,
   maxTokens: undefined,

--- a/projects/portfolio/tests/client/hooks/use-local-storage-settings.test.ts
+++ b/projects/portfolio/tests/client/hooks/use-local-storage-settings.test.ts
@@ -27,7 +27,6 @@ const defaultSettings = {
   model: 'gpt-4.1-mini',
   baseURL: '',
   apiKey: '',
-  mcpServerURLs: '',
   temperature: 0.7,
   temperatureEnabled: false,
   maxTokens: undefined,

--- a/projects/portfolio/tests/client/hooks/use-settings-handlers.test.ts
+++ b/projects/portfolio/tests/client/hooks/use-settings-handlers.test.ts
@@ -27,7 +27,6 @@ const defaultSettings = {
   model: 'gpt-4.1-mini',
   baseURL: '',
   apiKey: '',
-  mcpServerURLs: '',
   temperature: 0.7,
   temperatureEnabled: false,
   maxTokens: undefined,

--- a/projects/portfolio/tests/client/hooks/use-stream-processor.test.tsx
+++ b/projects/portfolio/tests/client/hooks/use-stream-processor.test.tsx
@@ -38,7 +38,6 @@ describe('useStreamProcessor', () => {
     header: {
       apiKey: 'api-key',
       baseURL: 'https://example.com',
-      mcpServerURLs: '',
     },
     model: 'gpt-test',
     messages: [],

--- a/projects/portfolio/tests/client/storage/remote-storage-settings.test.ts
+++ b/projects/portfolio/tests/client/storage/remote-storage-settings.test.ts
@@ -51,7 +51,6 @@ describe('remote-storage-settings', () => {
         model: 'gpt-4.1',
         baseURL: 'https://api.openai.com/v1',
         apiKey: crypto.AES.encrypt('secret-api-key', LEGACY_SETTINGS_AES_KEY).toString(),
-        mcpServerURLs: '',
         temperature: 0.7,
         temperatureEnabled: false,
         reasoningEffort: 'medium',
@@ -83,7 +82,6 @@ describe('remote-storage-settings', () => {
         model: 'gpt-4.1',
         baseURL: 'https://api.openai.com/v1',
         apiKey: 'U2FsdGVkX1broken',
-        mcpServerURLs: 'http://localhost:3001',
         temperature: 0.3,
         temperatureEnabled: true,
         reasoningEffort: 'high',
@@ -104,6 +102,22 @@ describe('remote-storage-settings', () => {
     expect(settings.apiKey).toBe('')
     expect(settings.model).toBe('gpt-4.1')
     expect(settings.temperature).toBe(0.3)
-    expect(settings.mcpServerURLs).toBe('http://localhost:3001')
+  })
+
+  it('旧 localStorage に mcpServerURLs があっても読み込み後に除去される', async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        schemaVersion: '1.1.0',
+        model: 'gpt-4.1-mini',
+        apiKey: 'some-key',
+        mcpServerURLs: 'http://localhost:3001',
+      })
+    )
+
+    const { readFromLocalStorage } = await import('#/client/storage/remote-storage-settings')
+    const settings = readFromLocalStorage()
+
+    expect('mcpServerURLs' in settings).toBe(false)
   })
 })

--- a/projects/portfolio/tests/features/chat/chat.test.ts
+++ b/projects/portfolio/tests/features/chat/chat.test.ts
@@ -40,7 +40,6 @@ describe('chat.completions', () => {
       {
         apiKey: 'api-key',
         baseURL: 'https://example.com',
-        mcpServerURLs: 'https://mcp.example.com',
       },
       {
         model: 'gpt-4.1',
@@ -66,18 +65,14 @@ describe('chat.completions', () => {
     })
   })
 
-  it('custom fetch が既存 header を保持して mcp-server-urls を追加する', async () => {
+  it('OpenAI クライアントに apiKey と baseURL が渡される', async () => {
     const { chat, completionsCreateMock, constructorOptionsSpy } = await importSubject()
     completionsCreateMock.mockResolvedValue({ id: 'completion-1' })
-
-    const fetchMock = vi.fn().mockResolvedValue({ ok: true })
-    vi.stubGlobal('fetch', fetchMock)
 
     await chat.completions(
       {
         apiKey: 'api-key',
         baseURL: 'https://example.com',
-        mcpServerURLs: 'https://mcp.example.com',
       },
       {
         model: 'gpt-4.1',
@@ -86,23 +81,10 @@ describe('chat.completions', () => {
       }
     )
 
-    const constructorOptions = constructorOptionsSpy.mock.calls[0]?.[0] as {
-      fetch: (url: string, options?: RequestInit) => Promise<unknown>
-    }
-
-    await constructorOptions.fetch('https://example.com/v1/chat/completions', {
-      headers: new Headers({
-        Authorization: 'Bearer api-key',
-      }),
-    })
-
-    expect(fetchMock).toHaveBeenCalledWith(
-      'https://example.com/v1/chat/completions',
+    expect(constructorOptionsSpy).toHaveBeenCalledWith(
       expect.objectContaining({
-        headers: {
-          authorization: 'Bearer api-key',
-          'mcp-server-urls': 'https://mcp.example.com',
-        },
+        apiKey: 'api-key',
+        baseURL: 'https://example.com',
       })
     )
   })


### PR DESCRIPTION
## Issues

- Close #801

## Why

チャット設定に残っていた MCP Server URLs 入力と、クライアント→サーバー間の `mcp-server-urls` header 透過処理が不要になったため削除する。

## Summary

UI の MCP Server URLs 入力・localStorage の `mcpServerURLs`・クライアントとサーバー間の header 契約・OpenAI クライアントの custom `fetch` によるリクエストバイパス処理を一式撤去した。旧 localStorage データに `mcpServerURLs` が残っていても、読み込み時に `mergeSettings` で自動除去する。

## Changes

- `Settings` 型と defaultSettings から `mcpServerURLs` を削除し、`mergeSettings` で旧データを自動クリーンアップ
- `ChatSettingsForm` から MCP Server URLs 入力フィールドを削除
- `ChatSettingsContext` / `useSettingsHandlers` から `handleChangeMcpServerURLs` を削除
- `useStreamProcessor` / `chat-main` のリクエスト header から `mcp-server-urls` を削除
- `ChatHeaderSchema` と header validator から `mcp-server-urls` を削除
- `chat.completions` の引数から `mcpServerURLs` を削除し、OpenAI クライアントの custom `fetch` を廃止
- `bun run typegen` で `src/server/app.d.ts` を再生成
- 関連テストを更新し、旧 `mcpServerURLs` が読み込み時に除去されることを確認するテストを追加

## Checklist

- [x] UI から MCP Server URLs 入力が削除されている
- [x] `mcp-server-urls` header がクライアント・サーバー契約から削除されている
- [x] OpenAI クライアントの custom `fetch` が削除されている
- [x] 旧 localStorage の `mcpServerURLs` が読み込み後に再利用・再保存されない
- [x] lint / test / format がすべて成功している
