### PR TITLE
[portfolio] Replace hono-pino with Hono structured logger

### DIFF
--- a/projects/portfolio/bun.lock
+++ b/projects/portfolio/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@hono/node-server": "^1.19.14",
         "@hono/standard-validator": "^0.2.2",
+        "@hono/structured-logger": "^0.1.0",
         "@monaco-editor/react": "^4.7.0",
         "@tailwindcss/typography": "^0.5.19",
         "@tanstack/react-query": "^5.99.0",
@@ -14,7 +15,6 @@
         "crypto-js": "^4.2.0",
         "drizzle-orm": "^0.45.2",
         "hono": "^4.12.14",
-        "hono-pino": "^0.10.3",
         "openai": "^6.34.0",
         "pg": "^8.20.0",
         "pino": "^10.3.1",
@@ -210,6 +210,8 @@
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 
     "@hono/standard-validator": ["@hono/standard-validator@0.2.2", "", { "peerDependencies": { "@standard-schema/spec": "^1.0.0", "hono": ">=3.9.0" } }, "sha512-mJ7W84Bt/rSvoIl63Ynew+UZOHAzzRAoAXb3JaWuxAkM/Lzg+ZHTCUiz77KOtn2e623WNN8LkD57Dk0szqUrIw=="],
+
+    "@hono/structured-logger": ["@hono/structured-logger@0.1.0", "", { "peerDependencies": { "hono": ">=4.0.0" } }, "sha512-06QUXbNnvb6lSJz/79WcC8yhGCbWT4EO2Zq3rodzQLwUT40OVXNerCKXUcwv4KgVZGKhVebzv1Vr84w/GKEl6Q=="],
 
     "@hono/vite-dev-server": ["@hono/vite-dev-server@0.25.1", "", { "dependencies": { "@hono/node-server": "^1.19.11", "minimatch": "^9.0.3" }, "peerDependencies": { "hono": "*", "miniflare": "*", "wrangler": "*" }, "optionalPeers": ["miniflare", "wrangler"] }, "sha512-H6EqoPtCV+uH1fu8nKyRy5Wh3LU012QxloEYMlUcyMjjEfVFiRXPjHx/0TQiiRi140Vu8San5A4XQWyElKFKaw=="],
 
@@ -655,8 +657,6 @@
 
     "decode-named-character-reference": ["decode-named-character-reference@1.0.2", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg=="],
 
-    "defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
-
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
     "detect-libc": ["detect-libc@2.0.4", "", {}, "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA=="],
@@ -766,8 +766,6 @@
     "highlightjs-vue": ["highlightjs-vue@1.0.0", "", {}, "sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA=="],
 
     "hono": ["hono@4.12.14", "", {}, "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w=="],
-
-    "hono-pino": ["hono-pino@0.10.3", "", { "dependencies": { "defu": "^6.1.4" }, "peerDependencies": { "hono": ">=4.0.0", "pino": ">=7.1.0" } }, "sha512-n0RNPIFOoq25Fg8b4D5gus4sVqI0z+8I17ibl96+p43d07UnZ0EMM/It0qSgfc7UtaC+XP5FkFmRHwBp6owsNA=="],
 
     "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
 

--- a/projects/portfolio/package.json
+++ b/projects/portfolio/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@hono/node-server": "^1.19.14",
     "@hono/standard-validator": "^0.2.2",
+    "@hono/structured-logger": "^0.1.0",
     "@monaco-editor/react": "^4.7.0",
     "@tailwindcss/typography": "^0.5.19",
     "@tanstack/react-query": "^5.99.0",
@@ -27,7 +28,6 @@
     "crypto-js": "^4.2.0",
     "drizzle-orm": "^0.45.2",
     "hono": "^4.12.14",
-    "hono-pino": "^0.10.3",
     "openai": "^6.34.0",
     "pg": "^8.20.0",
     "pino": "^10.3.1",

--- a/projects/portfolio/src/server/app.d.ts
+++ b/projects/portfolio/src/server/app.d.ts
@@ -1,14 +1,6 @@
 import { HonoEnv } from './routes/shared';
-declare const app: import('hono/hono-base').HonoBase<HonoEnv & {
-    Variables: {
-        logger: import('hono-pino').PinoLogger;
-    };
-}, import('hono/types').BlankSchema, "/", "*">;
-declare const routes: import('hono/hono-base').HonoBase<HonoEnv & {
-    Variables: {
-        logger: import('hono-pino').PinoLogger;
-    };
-}, import('hono/types').BlankSchema | import('hono/types').MergeSchemaPath<{
+declare const app: import('hono/hono-base').HonoBase<HonoEnv, import('hono/types').BlankSchema, "/", "*">;
+declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/types').BlankSchema | import('hono/types').MergeSchemaPath<{
     "/api/signin": {
         $post: {
             input: {

--- a/projects/portfolio/src/server/app.tsx
+++ b/projects/portfolio/src/server/app.tsx
@@ -1,5 +1,7 @@
+import { structuredLogger } from '@hono/structured-logger'
 import { Hono } from 'hono'
-import { pinoLogger } from 'hono-pino'
+import { requestId } from 'hono/request-id'
+import type pino from 'pino'
 import { logger } from './lib/logger'
 import { AuthenticationError, authRoutes } from './routes/auth'
 import { chatRoutes } from './routes/chat'
@@ -8,14 +10,66 @@ import { htmlRoutes } from './routes/html'
 import { modelsRoutes } from './routes/models'
 import type { HonoEnv } from './routes/shared'
 
-const app = new Hono<HonoEnv>().use(pinoLogger({ pino: logger })).onError((err, c) => {
-  if (err instanceof AuthenticationError) {
-    return c.json({ error: err.message }, 401)
-  }
+const app = new Hono<HonoEnv>()
+  .use(requestId())
+  .use(
+    structuredLogger<pino.Logger>({
+      createLogger: (c) => logger.child({ requestId: c.var.requestId }),
+      onRequest: (requestLogger, c) => {
+        requestLogger.info(
+          {
+            req: {
+              method: c.req.method,
+              url: c.req.path,
+              headers: c.req.header(),
+            },
+          },
+          'request start'
+        )
+      },
+      onResponse: (requestLogger, c, elapsedMs) => {
+        requestLogger.info(
+          {
+            req: {
+              method: c.req.method,
+              url: c.req.path,
+            },
+            res: {
+              status: c.res.status,
+            },
+            responseTime: Math.round(elapsedMs),
+          },
+          'request end'
+        )
+      },
+      onError: (requestLogger, err, c) => {
+        const bindings = {
+          err,
+          req: {
+            method: c.req.method,
+            url: c.req.path,
+          },
+          res: {
+            status: c.res.status,
+          },
+        }
 
-  logger.error({ err }, 'Unhandled error')
-  return c.json({ error: err.message }, 500)
-})
+        if (err instanceof AuthenticationError) {
+          requestLogger.warn(bindings, 'request unauthorized')
+          return
+        }
+
+        requestLogger.error(bindings, 'request error')
+      },
+    })
+  )
+  .onError((err, c) => {
+    if (err instanceof AuthenticationError) {
+      return c.json({ error: err.message }, 401)
+    }
+
+    return c.json({ error: err.message }, 500)
+  })
 const routes = app
   .route('/', authRoutes)
   .route('/', chatRoutes)

--- a/projects/portfolio/src/server/routes/chat.ts
+++ b/projects/portfolio/src/server/routes/chat.ts
@@ -130,6 +130,7 @@ const chatRoutes = new Hono<HonoEnv>()
   .post('/api/chat', chatHeaderValidator, chatBodyValidator, async (c) => {
     const header = c.req.valid('header')
     const req = c.req.valid('json')
+    const requestLogger = c.var.logger ?? logger
 
     try {
       const completion = await chat.completions(
@@ -148,10 +149,10 @@ const chatRoutes = new Hono<HonoEnv>()
       )
 
       const response = convertCompletion(completion as CompletionChunk)
-      logger.debug({ response }, 'Chat completion converted')
+      requestLogger.debug({ response }, 'Chat completion converted')
       return c.json(response)
     } catch (err) {
-      logger.error({ err }, 'Upstream chat completion failed')
+      requestLogger.error({ err }, 'Upstream chat completion failed')
       return c.json(
         { error: err instanceof Error ? err.message : 'Upstream error', code: 'UPSTREAM_ERROR' as const },
         502
@@ -162,6 +163,7 @@ const chatRoutes = new Hono<HonoEnv>()
   .post('/api/chat/stream', chatHeaderValidator, chatBodyValidator, async (c) => {
     const header = c.req.valid('header')
     const req = c.req.valid('json')
+    const requestLogger = c.var.logger ?? logger
 
     let completion
     try {
@@ -181,7 +183,7 @@ const chatRoutes = new Hono<HonoEnv>()
         }
       )
     } catch (err) {
-      logger.error({ err }, 'Upstream stream chat failed')
+      requestLogger.error({ err }, 'Upstream stream chat failed')
       return c.json(
         { error: err instanceof Error ? err.message : 'Upstream error', code: 'UPSTREAM_ERROR' as const },
         502
@@ -199,7 +201,7 @@ const chatRoutes = new Hono<HonoEnv>()
       })
 
       for await (const event of convertStreamChunks(streamCompletion)) {
-        logger.debug({ event }, 'Stream event emitted')
+        requestLogger.debug({ event }, 'Stream event emitted')
         await stream.writeSSE({ data: JSON.stringify(event) })
         await new Promise((resolve) => setTimeout(resolve, 10))
       }
@@ -212,8 +214,9 @@ const chatRoutes = new Hono<HonoEnv>()
   // Stub endpoint (OpenAI 互換、変更なし)
   .post('/api/chat/completions', sValidator('json', StubChatRequestSchema), async (c) => {
     const req = c.req.valid('json')
+    const requestLogger = c.var.logger ?? logger
 
-    logger.debug({ req }, 'Stub chat request received')
+    requestLogger.debug({ req }, 'Stub chat request received')
     await new Promise((resolve) => setTimeout(resolve, 3000))
 
     const reasoningContent = fs.readFileSync(
@@ -227,7 +230,7 @@ const chatRoutes = new Hono<HonoEnv>()
     }
 
     const completion = await chatStub.completions(req.model, content)
-    logger.debug({ completion }, 'Stub chat completion received')
+    requestLogger.debug({ completion }, 'Stub chat completion received')
 
     return c.json(completion)
   })

--- a/projects/portfolio/src/server/routes/models.ts
+++ b/projects/portfolio/src/server/routes/models.ts
@@ -27,6 +27,7 @@ const modelsHeaderValidator = validator('header', (value, c) => {
 
 const modelsRoutes = new Hono<HonoEnv>().get('/api/fetch-models', modelsHeaderValidator, async (c) => {
   const { 'api-key': apiKey, 'base-url': baseURL } = c.req.valid('header')
+  const requestLogger = c.var.logger ?? logger
 
   try {
     const response = await fetch(`${baseURL}/models`, {
@@ -44,7 +45,7 @@ const modelsRoutes = new Hono<HonoEnv>().get('/api/fetch-models', modelsHeaderVa
       return c.json(models.toSorted())
     }
   } catch (error) {
-    logger.error({ err: error }, 'Failed to fetch models')
+    requestLogger.error({ err: error }, 'Failed to fetch models')
   }
 
   return c.json([])

--- a/projects/portfolio/src/server/routes/shared.ts
+++ b/projects/portfolio/src/server/routes/shared.ts
@@ -1,7 +1,7 @@
 import type { Context } from 'hono'
-import type { PinoLogger } from 'hono-pino'
 import { env } from 'hono/adapter'
 import { deleteCookie, getSignedCookie } from 'hono/cookie'
+import type pino from 'pino'
 
 export type Env = Partial<{
   NODE_ENV: string
@@ -18,7 +18,8 @@ export type HonoEnv = {
   Bindings: Env
   Variables: {
     email: string
-    logger: PinoLogger
+    logger: pino.Logger
+    requestId: string
   }
 }
 

--- a/projects/portfolio/tests/app.test.tsx
+++ b/projects/portfolio/tests/app.test.tsx
@@ -3,10 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { mockLogger } from './helpers/mock-logger'
 
 const importSubject = async () => {
-  mockLogger()
-  vi.doMock('hono-pino', () => ({
-    pinoLogger: () => async (_c: any, next: any) => await next(),
-  }))
+  const logger = mockLogger()
   vi.doMock('#/server/routes/auth', () => {
     class AuthenticationError extends Error {}
 
@@ -37,7 +34,10 @@ const importSubject = async () => {
   }))
 
   const mod = await import('#/server/app')
-  return mod.default
+  return {
+    app: mod.default,
+    logger,
+  }
 }
 
 describe('app', () => {
@@ -46,18 +46,23 @@ describe('app', () => {
   })
 
   it('AuthenticationError は 401 JSON に変換する', async () => {
-    const app = await importSubject()
+    const { app, logger } = await importSubject()
     const res = await app.request('/auth-error')
+    const requestId = res.headers.get('X-Request-Id')
 
     expect(res.status).toBe(401)
+    expect(requestId).toEqual(expect.any(String))
     await expect(res.json()).resolves.toEqual({ error: 'auth failed' })
+    expect(logger.child).toHaveBeenCalledWith({ requestId })
+    expect(logger.warn).toHaveBeenCalledTimes(1)
   })
 
   it('その他の Error は 500 JSON に変換する', async () => {
-    const app = await importSubject()
+    const { app, logger } = await importSubject()
     const res = await app.request('/unknown-error')
 
     expect(res.status).toBe(500)
     await expect(res.json()).resolves.toEqual({ error: 'boom' })
+    expect(logger.error).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
## Issues

- Close #809

## Why

`portfolio` の logger 依存は `hono-pino` 由来の独自 `PinoLogger` 型に寄っており、request-scoped logger と `requestId` の扱いが分かりづらい状態でした。
Hono 公式 middleware に寄せて依存を整理し、HTTP ログと route ログを一貫した形で扱えるようにするためです。

## Summary

`hono-pino` を削除し、`@hono/structured-logger` と `hono/request-id` を使う構成へ置き換えました。
`requestId` を child logger に載せ、route 層では request-scoped logger を優先して使うように更新しています。

## Changes

- `hono-pino` を削除し `@hono/structured-logger` を追加
- `src/server/app.tsx` を `requestId()` + `structuredLogger()` 構成へ更新
- `HonoEnv` の `logger` 型を `pino.Logger` に変更し `requestId` を追加
- `chatRoutes` と `modelsRoutes` のログを request-scoped logger 優先へ変更
- `app.d.ts` を再生成し `tests/app.test.tsx` を更新

## Checklist

- [x] `bun run typegen`
- [x] `bun run lint`
- [x] `bun run test`
- [x] `bun run format:check`

## Details

- route 単体テストでは middleware が走らないため、`c.var.logger` 未設定時は共通 `logger` にフォールバックするようにしています
- `AuthenticationError` は 401 応答を維持しつつ `warn` ログに寄せ、`app.onError()` 側の重複 error ログは削除しています
