### PR TITLE
feat(file-server): add admin bootstrap and GUI user management (#814)

### DIFF
--- a/projects/file-server/.env.example
+++ b/projects/file-server/.env.example
@@ -1,7 +1,12 @@
 # File storage base directory
 UPLOAD_DIR=./tmp
 
-# Enable auth by setting both values below.
+# Enable authentication by setting SESSION_SECRET (32+ characters).
+# Users are stored at UPLOAD_DIR/.auth/users.json.
+# On first startup an 'admin' user is bootstrapped automatically.
 # Bun loads .env automatically for `bun run`.
-USERS_FILE=./users.dev.json
 SESSION_SECRET=replace-with-32+chars-secret
+
+# Optional: set the initial admin password on first bootstrap.
+# If unset, a random password is printed once to stdout.
+# INITIAL_ADMIN_PASSWORD=changeme

--- a/projects/file-server/AGENTS.md
+++ b/projects/file-server/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md
 
 Web-based file server built with Bun + Hono + HTMX.
-Current features include empty file creation, per-directory Zip download via `/file/archive`, and unauthenticated public file serving via `GET /public/*`.
+Current features include empty file creation, per-directory Zip download via `/file/archive`, unauthenticated public file serving via `GET /public/*`, and GUI-based user management via `/admin/users`.
 
 ## Commands
 
@@ -9,7 +9,7 @@ Current features include empty file creation, per-directory Zip download via `/f
 - `bun run dev` - Start dev server
 - `bun run lint` - TypeScript check + Biome format
 - `bun test` - Run tests
-- `bun run hash-password 'password'` - Generate bcrypt hash for USERS_FILE
+- `bun run hash-password 'password'` - Generate bcrypt hash (for manual recovery/testing)
 
 ## Code Style
 
@@ -23,7 +23,7 @@ Current features include empty file creation, per-directory Zip download via `/f
 - `src/index.tsx` - Entry point (re-exports `createApp()`)
 - `src/app.ts` - `createApp()` factory (initializes dirs, wires middleware + routes)
 - `src/middleware/auth.ts` - Auth middleware
-- `src/routes/` - Route definitions (api, auth, browse, file, public)
+- `src/routes/` - Route definitions (admin, api, auth, browse, file, public)
 - `src/api/handlers.tsx` - API handlers
 - `src/components/` - JSX components
 - `src/utils/` - Utilities (incl. `virtualPath.ts` for scope resolution)
@@ -33,8 +33,8 @@ Current features include empty file creation, per-directory Zip download via `/f
 ## Environment Variables
 
 - `UPLOAD_DIR` - File storage root directory (default: `./tmp`)
-- `USERS_FILE` - Path to users JSON file (enables authentication when set)
-- `SESSION_SECRET` - Session signing secret (required when `USERS_FILE` is set)
+- `SESSION_SECRET` - Session signing secret (32+ chars). Setting this enables authentication.
+- `INITIAL_ADMIN_PASSWORD` - Password for the `admin` user on first bootstrap. If unset, a random password is printed to stdout once at startup.
 - Use `.env.example` as a template and set values in `.env` for local development (`bun run` loads `.env` automatically)
 
 ## Directory Layout
@@ -50,6 +50,10 @@ UPLOAD_DIR/
 ```
 
 `createApp()` creates both directories at startup if they do not exist.
+
+When `SESSION_SECRET` is set, `createApp()` also creates `UPLOAD_DIR/.auth/users.json` with a bootstrapped `admin` user if the file is absent or empty. On subsequent startups the file is validated (must contain `admin` with `role: "admin"`).
+
+**Docker / Docker Compose**: mount `UPLOAD_DIR` as a persistent volume so `UPLOAD_DIR/.auth/users.json` survives container restarts.
 
 ## Virtual Path Resolution
 
@@ -71,13 +75,35 @@ All browse/API requests use a virtual path that maps to one of two scopes:
 - This route bypasses session authentication — it is always accessible.
 - Path traversal is detected and blocked at the handler level.
 
-## Authentication Roles
+## Authentication
 
-- `USERS_FILE` entries must include `role` with `"user"` or `"admin"`.
+Authentication is enabled when `SESSION_SECRET` is set. Users are stored in `UPLOAD_DIR/.auth/users.json`.
+
+### Roles
+
 - `user`: restricted to `UPLOAD_DIR/private/<username>/`. Cannot access other users' directories.
-- `admin`: full access to `UPLOAD_DIR` (all scopes and users).
-- Session stores only `username`; role is reloaded from `USERS_FILE` on each request.
-- Reserved usernames `public` and `private` are rejected by `isValidUsername`.
+- `admin`: full access to `UPLOAD_DIR` (all scopes and users). Can manage users via `/admin/users`.
+
+### Master Admin
+
+- Username `admin` is the master admin: deletion-protected and role-change-protected.
+- Changing `admin`'s own password requires the current password.
+- `UPLOAD_DIR/.auth/users.json` must always contain `admin` with `role: "admin"` when non-empty; otherwise startup fails.
+
+### Session Versioning
+
+Users have a `sessionVersion` counter stored in `users.json`. It is embedded in the session cookie. On password change, role change, or role update the counter increments, invalidating all previous sessions for that user.
+
+### User Management GUI
+
+`GET /admin/users` — accessible to admin-role users only. Provides:
+- Create user (username, password, role)
+- Change role (non-master-admin users)
+- Reset password (other users)
+- Delete user (non-master-admin users)
+- Change own password (requires current password; re-issues session cookie)
+
+Reserved usernames `public` and `private` are rejected by `isValidUsername`.
 
 ## Migration Guide (from pre-Issue-#806)
 

--- a/projects/file-server/src/app.ts
+++ b/projects/file-server/src/app.ts
@@ -2,6 +2,7 @@ import { mkdir } from "node:fs/promises"
 import * as path from "node:path"
 import { Hono } from "hono"
 import { authMiddleware, requireAuthMiddleware } from "./middleware/auth"
+import adminRoutes from "./routes/admin"
 import apiRoutes from "./routes/api"
 import authRoutes from "./routes/auth"
 import browseRoutes from "./routes/browse"
@@ -9,36 +10,43 @@ import fileRoutes from "./routes/file"
 import publicRoutes from "./routes/public"
 import type { AppBindings } from "./types"
 import { DEFAULT_UPLOAD_DIR, validateAuthConfig } from "./utils/auth"
+import { bootstrapAdminUser } from "./utils/bootstrap"
 
 export interface CreateAppOptions {
-  uploadDir?: string
-  usersFile?: string
-  sessionSecret?: string
+	uploadDir?: string
+	sessionSecret?: string
+	initialAdminPassword?: string
 }
 
 export async function createApp(
-  options: CreateAppOptions = {},
+	options: CreateAppOptions = {},
 ): Promise<Hono<AppBindings>> {
-  const uploadDir =
-    options.uploadDir ?? process.env.UPLOAD_DIR ?? DEFAULT_UPLOAD_DIR
-  const usersFile = options.usersFile ?? process.env.USERS_FILE
-  const sessionSecret = options.sessionSecret ?? process.env.SESSION_SECRET
+	const uploadDir =
+		options.uploadDir ?? process.env.UPLOAD_DIR ?? DEFAULT_UPLOAD_DIR
+	const sessionSecret = options.sessionSecret ?? process.env.SESSION_SECRET
+	const initialAdminPassword =
+		options.initialAdminPassword ?? process.env.INITIAL_ADMIN_PASSWORD
 
-  validateAuthConfig(usersFile, sessionSecret)
+	validateAuthConfig(sessionSecret)
 
-  await mkdir(path.join(uploadDir, "public"), { recursive: true })
-  await mkdir(path.join(uploadDir, "private"), { recursive: true })
+	await mkdir(path.join(uploadDir, "public"), { recursive: true })
+	await mkdir(path.join(uploadDir, "private"), { recursive: true })
 
-  const app = new Hono<AppBindings>()
+	if (sessionSecret) {
+		await bootstrapAdminUser(uploadDir, initialAdminPassword)
+	}
 
-  app.use("*", authMiddleware)
-  app.use("*", requireAuthMiddleware)
+	const app = new Hono<AppBindings>()
 
-  app.route("/", authRoutes)
-  app.route("/public", publicRoutes)
-  app.route("/api", apiRoutes)
-  app.route("/", browseRoutes)
-  app.route("/file", fileRoutes)
+	app.use("*", authMiddleware)
+	app.use("*", requireAuthMiddleware)
 
-  return app
+	app.route("/", authRoutes)
+	app.route("/public", publicRoutes)
+	app.route("/api", apiRoutes)
+	app.route("/admin", adminRoutes)
+	app.route("/", browseRoutes)
+	app.route("/file", fileRoutes)
+
+	return app
 }

--- a/projects/file-server/src/components/PageShell.tsx
+++ b/projects/file-server/src/components/PageShell.tsx
@@ -130,6 +130,14 @@ export const PageShell: FC<PageShellProps> = ({ children, user }) => {
                   <span className="rounded-md bg-gray-100 px-2 py-1 font-medium text-gray-700">
                     {user.role}
                   </span>
+                  {user.role === "admin" && (
+                    <a
+                      href="/admin/users"
+                      className="rounded-md bg-indigo-50 px-3 py-1.5 font-medium text-indigo-700 hover:bg-indigo-100"
+                    >
+                      User Management
+                    </a>
+                  )}
                   <form action="/logout" method="post">
                     <button
                       type="submit"

--- a/projects/file-server/src/middleware/auth.ts
+++ b/projects/file-server/src/middleware/auth.ts
@@ -5,129 +5,127 @@ import { env } from "hono/adapter"
 import { getCookie } from "hono/cookie"
 import type { AppBindings } from "../types"
 import {
-  DEFAULT_UPLOAD_DIR,
-  loadUsersConfig,
-  normalizeReturnTo,
-  SESSION_COOKIE_NAME,
-  validateAuthConfig,
-  verifySession,
+	DEFAULT_UPLOAD_DIR,
+	getUsersFilePath,
+	normalizeReturnTo,
+	SESSION_COOKIE_NAME,
+	validateAuthConfig,
+	verifySession,
 } from "../utils/auth"
+import { loadUsersFromFileWithCache } from "../utils/userConfigCache"
 import { errorResponse } from "../utils/requestUtils"
 
 function getRequestPathWithQuery(c: Context<AppBindings>): string {
-  const url = new URL(c.req.url)
-  const pathWithQuery = `${url.pathname}${url.search}`
-  return normalizeReturnTo(pathWithQuery)
+	const url = new URL(c.req.url)
+	const pathWithQuery = `${url.pathname}${url.search}`
+	return normalizeReturnTo(pathWithQuery)
 }
 
 function isPublicPath(pathname: string): boolean {
-  return (
-    pathname === "/login" ||
-    pathname === "/logout" ||
-    pathname.startsWith("/public/") ||
-    pathname === "/public"
-  )
+	return (
+		pathname === "/login" ||
+		pathname === "/logout" ||
+		pathname.startsWith("/public/") ||
+		pathname === "/public"
+	)
 }
 
 export async function authMiddleware(c: Context<AppBindings>, next: Next) {
-  c.set("user", { type: "anonymous" })
+	c.set("user", { type: "anonymous" })
 
-  const { UPLOAD_DIR, USERS_FILE, SESSION_SECRET } = env(c)
-  const uploadBaseDir = UPLOAD_DIR || DEFAULT_UPLOAD_DIR
+	const { UPLOAD_DIR, SESSION_SECRET } = env(c)
+	const uploadBaseDir = UPLOAD_DIR || DEFAULT_UPLOAD_DIR
 
-  try {
-    validateAuthConfig(USERS_FILE, SESSION_SECRET)
-  } catch (error) {
-    console.error(error)
-    return errorResponse(
-      c,
-      "AuthConfigError",
-      "Invalid authentication configuration",
-      500,
-    )
-  }
+	try {
+		validateAuthConfig(SESSION_SECRET)
+	} catch (error) {
+		console.error(error)
+		return errorResponse(
+			c,
+			"AuthConfigError",
+			"Invalid authentication configuration",
+			500,
+		)
+	}
 
-  if (!USERS_FILE) {
-    return next()
-  }
-  if (!SESSION_SECRET) {
-    return errorResponse(
-      c,
-      "AuthConfigError",
-      "SESSION_SECRET is required when USERS_FILE is set",
-      500,
-    )
-  }
+	if (!SESSION_SECRET) {
+		return next()
+	}
 
-  let users: Awaited<ReturnType<typeof loadUsersConfig>> = null
-  try {
-    users = await loadUsersConfig(USERS_FILE)
-  } catch (error) {
-    console.error(error)
-    return errorResponse(
-      c,
-      "AuthConfigError",
-      "Failed to load users configuration",
-      500,
-    )
-  }
+	const usersFile = getUsersFilePath(uploadBaseDir)
+	let users: Awaited<ReturnType<typeof loadUsersFromFileWithCache>>
+	try {
+		users = await loadUsersFromFileWithCache(usersFile)
+	} catch (error) {
+		console.error(error)
+		return errorResponse(
+			c,
+			"AuthConfigError",
+			"Failed to load users configuration",
+			500,
+		)
+	}
 
-  const session = getCookie(c, SESSION_COOKIE_NAME)
-  if (!session || !users) {
-    return next()
-  }
+	const session = getCookie(c, SESSION_COOKIE_NAME)
+	if (!session) {
+		return next()
+	}
 
-  const payload = await verifySession(session, SESSION_SECRET)
-  if (!payload) {
-    return next()
-  }
+	const payload = await verifySession(session, SESSION_SECRET)
+	if (!payload) {
+		return next()
+	}
 
-  const user = users.find((entry) => entry.username === payload.username)
-  if (!user) {
-    return next()
-  }
+	const user = users.find((entry) => entry.username === payload.username)
+	if (!user) {
+		return next()
+	}
 
-  const authenticated = {
-    type: "authenticated" as const,
-    username: user.username,
-    role: user.role,
-  }
-  c.set("user", authenticated)
+	if (user.sessionVersion !== payload.sessionVersion) {
+		return next()
+	}
 
-  if (authenticated.role === "user") {
-    await mkdir(path.join(uploadBaseDir, "private", authenticated.username), {
-      recursive: true,
-    })
-  }
+	const authenticated = {
+		type: "authenticated" as const,
+		username: user.username,
+		role: user.role,
+	}
+	c.set("user", authenticated)
 
-  return next()
+	if (authenticated.role === "user") {
+		await mkdir(path.join(uploadBaseDir, "private", authenticated.username), {
+			recursive: true,
+		})
+	}
+
+	return next()
 }
 
 export async function requireAuthMiddleware(
-  c: Context<AppBindings>,
-  next: Next,
+	c: Context<AppBindings>,
+	next: Next,
 ) {
-  const { USERS_FILE } = env(c)
-  if (!USERS_FILE) {
-    return next()
-  }
+	const { SESSION_SECRET } = env(c)
+	if (!SESSION_SECRET) {
+		return next()
+	}
 
-  if (isPublicPath(c.req.path)) {
-    return next()
-  }
+	if (isPublicPath(c.req.path)) {
+		return next()
+	}
 
-  const user = c.get("user")
-  if (user.type === "authenticated") {
-    return next()
-  }
+	const user = c.get("user")
+	if (user.type === "authenticated") {
+		return next()
+	}
 
-  const returnTo = encodeURIComponent(getRequestPathWithQuery(c))
-  const loginUrl = `/login?returnTo=${returnTo}`
+	const returnTo = encodeURIComponent(getRequestPathWithQuery(c))
+	const loginUrl = `/login?returnTo=${returnTo}`
 
-  if (c.req.header("HX-Request") === "true") {
-    c.header("HX-Redirect", loginUrl)
-    return c.body(null, 401)
-  }
+	if (c.req.header("HX-Request") === "true") {
+		c.header("HX-Redirect", loginUrl)
+		return c.body(null, 401)
+	}
 
-  return c.redirect(loginUrl)
+	return c.redirect(loginUrl)
 }

--- a/projects/file-server/src/routes/admin.tsx
+++ b/projects/file-server/src/routes/admin.tsx
@@ -400,6 +400,12 @@ adminRoutes.post("/users/:username/password", async (c) => {
 	const targetUsername = c.req.param("username")
 	const currentUser = c.get("user") as Extract<typeof c.var.user, { type: "authenticated" }>
 
+	if (targetUsername === MASTER_ADMIN_USERNAME) {
+		return c.redirect(
+			`/admin/users?error=${encodeURIComponent("Cannot reset master admin password via this endpoint. Use 'Change My Password'.")}`,
+		)
+	}
+
 	if (targetUsername === currentUser.username) {
 		return c.redirect(
 			`/admin/users?error=${encodeURIComponent("Use 'Change My Password' to change your own password.")}`,

--- a/projects/file-server/src/routes/admin.tsx
+++ b/projects/file-server/src/routes/admin.tsx
@@ -1,0 +1,506 @@
+import { Hono } from "hono"
+import { env } from "hono/adapter"
+import { setCookie } from "hono/cookie"
+import { PageShell } from "../components/PageShell"
+import type { AppBindings, UserConfig } from "../types"
+import {
+	DEFAULT_UPLOAD_DIR,
+	getUsersFilePath,
+	isValidUsername,
+	MASTER_ADMIN_USERNAME,
+	SESSION_COOKIE_NAME,
+	SESSION_MAX_AGE_SECONDS,
+	signSession,
+	verifyPassword,
+} from "../utils/auth"
+import { loadUsersFromFileWithCache, saveUsersToFile } from "../utils/userConfigCache"
+
+interface AdminUsersPageProps {
+	users: UserConfig[]
+	currentUsername: string
+	error?: string
+	success?: string
+}
+
+function AdminUsersPage({ users, currentUsername, error, success }: AdminUsersPageProps) {
+	return (
+		<div className="space-y-6">
+			<div className="flex flex-wrap items-center justify-between gap-3">
+				<h2 className="text-xl font-semibold text-gray-900">User Management</h2>
+				<a
+					href="/"
+					className="rounded-md bg-gray-100 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-200"
+				>
+					← Back
+				</a>
+			</div>
+
+			{error && (
+				<div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+					{error}
+				</div>
+			)}
+			{success && (
+				<div className="rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700">
+					{success}
+				</div>
+			)}
+
+			<section className="rounded-xl border border-indigo-100 bg-white p-5">
+				<h3 className="mb-3 font-medium text-gray-800">Change My Password</h3>
+				<form
+					action="/admin/change-password"
+					method="post"
+					className="flex flex-wrap items-end gap-3"
+				>
+					<div className="flex-1 min-w-36">
+						<label for="change-current-password" className="mb-1 block text-sm text-gray-600">Current password</label>
+						<input
+							id="change-current-password"
+							name="currentPassword"
+							type="password"
+							required
+							className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+						/>
+					</div>
+					<div className="flex-1 min-w-36">
+						<label for="change-new-password" className="mb-1 block text-sm text-gray-600">New password</label>
+						<input
+							id="change-new-password"
+							name="newPassword"
+							type="password"
+							required
+							className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+						/>
+					</div>
+					<button
+						type="submit"
+						className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700"
+					>
+						Change
+					</button>
+				</form>
+			</section>
+
+			<section className="rounded-xl border border-indigo-100 bg-white p-5">
+				<h3 className="mb-3 font-medium text-gray-800">Users</h3>
+				<div className="overflow-x-auto">
+					<table className="w-full text-sm">
+						<thead>
+							<tr className="border-b border-gray-200 text-left text-xs font-medium uppercase tracking-wide text-gray-500">
+								<th className="pb-2 pr-4">Username</th>
+								<th className="pb-2 pr-4">Role</th>
+								<th className="pb-2">Actions</th>
+							</tr>
+						</thead>
+						<tbody className="divide-y divide-gray-100">
+							{users.map((user) => (
+								<tr key={user.username}>
+									<td className="py-3 pr-4 font-medium text-gray-800">
+										{user.username}
+										{user.username === currentUsername && (
+											<span className="ml-2 text-xs text-gray-400">(you)</span>
+										)}
+									</td>
+									<td className="py-3 pr-4 text-gray-600">{user.role}</td>
+									<td className="py-3">
+										{user.username === MASTER_ADMIN_USERNAME ? (
+											<span className="text-xs text-gray-400">Protected</span>
+										) : (
+											<div className="flex flex-wrap items-center gap-2">
+												<form
+													action={`/admin/users/${user.username}/role`}
+													method="post"
+													className="flex items-center gap-1"
+												>
+													<select
+														name="role"
+														className="rounded border border-gray-300 px-2 py-1 text-xs focus:border-indigo-500 focus:outline-none"
+													>
+														<option value="user" selected={user.role === "user"}>
+															user
+														</option>
+														<option value="admin" selected={user.role === "admin"}>
+															admin
+														</option>
+													</select>
+													<button
+														type="submit"
+														className="rounded bg-gray-100 px-2 py-1 text-xs font-medium text-gray-700 hover:bg-gray-200"
+													>
+														Change Role
+													</button>
+												</form>
+												{user.username !== currentUsername && (
+													<form
+														action={`/admin/users/${user.username}/password`}
+														method="post"
+														className="flex items-center gap-1"
+													>
+														<input
+															name="newPassword"
+															type="password"
+															required
+															placeholder="New password"
+															className="rounded border border-gray-300 px-2 py-1 text-xs focus:border-indigo-500 focus:outline-none"
+														/>
+														<button
+															type="submit"
+															className="rounded bg-gray-100 px-2 py-1 text-xs font-medium text-gray-700 hover:bg-gray-200"
+														>
+															Reset PW
+														</button>
+													</form>
+												)}
+												<form
+													action={`/admin/users/${user.username}/delete`}
+													method="post"
+												>
+													<button
+														type="submit"
+														className="rounded bg-red-50 px-2 py-1 text-xs font-medium text-red-600 hover:bg-red-100"
+													>
+														Delete
+													</button>
+												</form>
+											</div>
+										)}
+									</td>
+								</tr>
+							))}
+						</tbody>
+					</table>
+				</div>
+			</section>
+
+			<section className="rounded-xl border border-indigo-100 bg-white p-5">
+				<h3 className="mb-3 font-medium text-gray-800">Create User</h3>
+				<form
+					action="/admin/users"
+					method="post"
+					className="flex flex-wrap items-end gap-3"
+				>
+					<div className="flex-1 min-w-32">
+						<label for="create-username" className="mb-1 block text-sm text-gray-600">Username</label>
+						<input
+							id="create-username"
+							name="username"
+							type="text"
+							required
+							className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+						/>
+					</div>
+					<div className="flex-1 min-w-32">
+						<label for="create-password" className="mb-1 block text-sm text-gray-600">Password</label>
+						<input
+							id="create-password"
+							name="password"
+							type="password"
+							required
+							className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+						/>
+					</div>
+					<div>
+						<label for="create-role" className="mb-1 block text-sm text-gray-600">Role</label>
+						<select
+							id="create-role"
+							name="role"
+							className="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+						>
+							<option value="user">user</option>
+							<option value="admin">admin</option>
+						</select>
+					</div>
+					<button
+						type="submit"
+						className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700"
+					>
+						Create User
+					</button>
+				</form>
+			</section>
+		</div>
+	)
+}
+
+const adminRoutes = new Hono<AppBindings>()
+
+adminRoutes.use("*", async (c, next) => {
+	const user = c.get("user")
+	if (user.type !== "authenticated" || user.role !== "admin") {
+		if (c.req.header("HX-Request") === "true") {
+			c.header("HX-Redirect", "/login")
+			return c.body(null, 401)
+		}
+		return c.redirect("/login")
+	}
+	return next()
+})
+
+adminRoutes.get("/users", async (c) => {
+	const { UPLOAD_DIR } = env(c)
+	const uploadDir = UPLOAD_DIR || DEFAULT_UPLOAD_DIR
+	const usersFile = getUsersFilePath(uploadDir)
+	const currentUser = c.get("user") as Extract<typeof c.var.user, { type: "authenticated" }>
+
+	let users: UserConfig[] = []
+	try {
+		users = await loadUsersFromFileWithCache(usersFile)
+	} catch (error) {
+		console.error(error)
+	}
+
+	const error = c.req.query("error")
+	const success = c.req.query("success")
+
+	return c.html(
+		<PageShell user={c.get("user")}>
+			<AdminUsersPage
+				users={users}
+				currentUsername={currentUser.username}
+				error={error}
+				success={success}
+			/>
+		</PageShell>,
+	)
+})
+
+adminRoutes.post("/users", async (c) => {
+	const { UPLOAD_DIR } = env(c)
+	const uploadDir = UPLOAD_DIR || DEFAULT_UPLOAD_DIR
+	const usersFile = getUsersFilePath(uploadDir)
+
+	const formData = await c.req.formData()
+	const username = String(formData.get("username") || "").trim()
+	const password = String(formData.get("password") || "")
+	const role = String(formData.get("role") || "user")
+
+	if (!isValidUsername(username)) {
+		return c.redirect(
+			`/admin/users?error=${encodeURIComponent("Invalid username. Use only lowercase letters, numbers, hyphens, and underscores.")}`,
+		)
+	}
+	if (!password) {
+		return c.redirect(`/admin/users?error=${encodeURIComponent("Password is required.")}`)
+	}
+	if (role !== "admin" && role !== "user") {
+		return c.redirect(`/admin/users?error=${encodeURIComponent("Invalid role.")}`)
+	}
+
+	let users: UserConfig[] = []
+	try {
+		users = await loadUsersFromFileWithCache(usersFile)
+	} catch (error) {
+		console.error(error)
+		return c.redirect(`/admin/users?error=${encodeURIComponent("Failed to load users.")}`)
+	}
+
+	if (users.some((u) => u.username === username)) {
+		return c.redirect(
+			`/admin/users?error=${encodeURIComponent(`User '${username}' already exists.`)}`,
+		)
+	}
+
+	const passwordHash = await Bun.password.hash(password, {
+		algorithm: "bcrypt",
+		cost: 12,
+	})
+
+	await saveUsersToFile(usersFile, [
+		...users,
+		{ username, passwordHash, role: role as "admin" | "user", sessionVersion: 0 },
+	])
+
+	return c.redirect(`/admin/users?success=${encodeURIComponent(`User '${username}' created.`)}`)
+})
+
+adminRoutes.post("/users/:username/role", async (c) => {
+	const { UPLOAD_DIR } = env(c)
+	const uploadDir = UPLOAD_DIR || DEFAULT_UPLOAD_DIR
+	const usersFile = getUsersFilePath(uploadDir)
+	const targetUsername = c.req.param("username")
+
+	if (targetUsername === MASTER_ADMIN_USERNAME) {
+		return c.redirect(
+			`/admin/users?error=${encodeURIComponent("Cannot change role of master admin.")}`,
+		)
+	}
+
+	const formData = await c.req.formData()
+	const newRole = String(formData.get("role") || "")
+	if (newRole !== "admin" && newRole !== "user") {
+		return c.redirect(`/admin/users?error=${encodeURIComponent("Invalid role.")}`)
+	}
+
+	let users: UserConfig[] = []
+	try {
+		users = await loadUsersFromFileWithCache(usersFile)
+	} catch (error) {
+		console.error(error)
+		return c.redirect(`/admin/users?error=${encodeURIComponent("Failed to load users.")}`)
+	}
+
+	const idx = users.findIndex((u) => u.username === targetUsername)
+	if (idx === -1) {
+		return c.redirect(
+			`/admin/users?error=${encodeURIComponent(`User '${targetUsername}' not found.`)}`,
+		)
+	}
+
+	const updated = users.map((u, i) =>
+		i === idx
+			? { ...u, role: newRole as "admin" | "user", sessionVersion: u.sessionVersion + 1 }
+			: u,
+	)
+	await saveUsersToFile(usersFile, updated)
+
+	return c.redirect(
+		`/admin/users?success=${encodeURIComponent(`Role of '${targetUsername}' changed to '${newRole}'.`)}`,
+	)
+})
+
+adminRoutes.post("/users/:username/delete", async (c) => {
+	const { UPLOAD_DIR } = env(c)
+	const uploadDir = UPLOAD_DIR || DEFAULT_UPLOAD_DIR
+	const usersFile = getUsersFilePath(uploadDir)
+	const targetUsername = c.req.param("username")
+
+	if (targetUsername === MASTER_ADMIN_USERNAME) {
+		return c.redirect(
+			`/admin/users?error=${encodeURIComponent("Cannot delete master admin.")}`,
+		)
+	}
+
+	let users: UserConfig[] = []
+	try {
+		users = await loadUsersFromFileWithCache(usersFile)
+	} catch (error) {
+		console.error(error)
+		return c.redirect(`/admin/users?error=${encodeURIComponent("Failed to load users.")}`)
+	}
+
+	const filtered = users.filter((u) => u.username !== targetUsername)
+	if (filtered.length === users.length) {
+		return c.redirect(
+			`/admin/users?error=${encodeURIComponent(`User '${targetUsername}' not found.`)}`,
+		)
+	}
+
+	await saveUsersToFile(usersFile, filtered)
+
+	return c.redirect(
+		`/admin/users?success=${encodeURIComponent(`User '${targetUsername}' deleted.`)}`,
+	)
+})
+
+adminRoutes.post("/users/:username/password", async (c) => {
+	const { UPLOAD_DIR } = env(c)
+	const uploadDir = UPLOAD_DIR || DEFAULT_UPLOAD_DIR
+	const usersFile = getUsersFilePath(uploadDir)
+	const targetUsername = c.req.param("username")
+	const currentUser = c.get("user") as Extract<typeof c.var.user, { type: "authenticated" }>
+
+	if (targetUsername === currentUser.username) {
+		return c.redirect(
+			`/admin/users?error=${encodeURIComponent("Use 'Change My Password' to change your own password.")}`,
+		)
+	}
+
+	const formData = await c.req.formData()
+	const newPassword = String(formData.get("newPassword") || "")
+	if (!newPassword) {
+		return c.redirect(`/admin/users?error=${encodeURIComponent("New password is required.")}`)
+	}
+
+	let users: UserConfig[] = []
+	try {
+		users = await loadUsersFromFileWithCache(usersFile)
+	} catch (error) {
+		console.error(error)
+		return c.redirect(`/admin/users?error=${encodeURIComponent("Failed to load users.")}`)
+	}
+
+	const idx = users.findIndex((u) => u.username === targetUsername)
+	if (idx === -1) {
+		return c.redirect(
+			`/admin/users?error=${encodeURIComponent(`User '${targetUsername}' not found.`)}`,
+		)
+	}
+
+	const newHash = await Bun.password.hash(newPassword, { algorithm: "bcrypt", cost: 12 })
+	const updated = users.map((u, i) =>
+		i === idx ? { ...u, passwordHash: newHash, sessionVersion: u.sessionVersion + 1 } : u,
+	)
+	await saveUsersToFile(usersFile, updated)
+
+	return c.redirect(
+		`/admin/users?success=${encodeURIComponent(`Password of '${targetUsername}' has been reset.`)}`,
+	)
+})
+
+adminRoutes.post("/change-password", async (c) => {
+	const { UPLOAD_DIR, SESSION_SECRET } = env(c)
+	const uploadDir = UPLOAD_DIR || DEFAULT_UPLOAD_DIR
+	const usersFile = getUsersFilePath(uploadDir)
+	const currentUser = c.get("user") as Extract<typeof c.var.user, { type: "authenticated" }>
+
+	if (!SESSION_SECRET) {
+		return c.redirect("/admin/users?error=AuthConfigError")
+	}
+
+	const formData = await c.req.formData()
+	const currentPassword = String(formData.get("currentPassword") || "")
+	const newPassword = String(formData.get("newPassword") || "")
+
+	if (!currentPassword || !newPassword) {
+		return c.redirect(
+			`/admin/users?error=${encodeURIComponent("Both current and new password are required.")}`,
+		)
+	}
+
+	let users: UserConfig[] = []
+	try {
+		users = await loadUsersFromFileWithCache(usersFile)
+	} catch (error) {
+		console.error(error)
+		return c.redirect(`/admin/users?error=${encodeURIComponent("Failed to load users.")}`)
+	}
+
+	const self = users.find((u) => u.username === currentUser.username)
+	if (!self) {
+		return c.redirect(`/admin/users?error=${encodeURIComponent("Current user not found.")}`)
+	}
+
+	const valid = await verifyPassword(currentPassword, self.passwordHash)
+	if (!valid) {
+		return c.redirect(
+			`/admin/users?error=${encodeURIComponent("Current password is incorrect.")}`,
+		)
+	}
+
+	const newHash = await Bun.password.hash(newPassword, { algorithm: "bcrypt", cost: 12 })
+	const newVersion = self.sessionVersion + 1
+	const updated = users.map((u) =>
+		u.username === currentUser.username
+			? { ...u, passwordHash: newHash, sessionVersion: newVersion }
+			: u,
+	)
+	await saveUsersToFile(usersFile, updated)
+
+	const newSession = await signSession(
+		{ username: currentUser.username, sessionVersion: newVersion },
+		SESSION_SECRET,
+	)
+	setCookie(c, SESSION_COOKIE_NAME, newSession, {
+		httpOnly: true,
+		path: "/",
+		sameSite: "Lax",
+		maxAge: SESSION_MAX_AGE_SECONDS,
+	})
+
+	return c.redirect(
+		`/admin/users?success=${encodeURIComponent("Password changed successfully.")}`,
+	)
+})
+
+export default adminRoutes

--- a/projects/file-server/src/routes/auth.tsx
+++ b/projects/file-server/src/routes/auth.tsx
@@ -4,121 +4,123 @@ import { deleteCookie, setCookie } from "hono/cookie"
 import { PageShell } from "../components/PageShell"
 import type { AppBindings } from "../types"
 import {
-  findUser,
-  loadUsersConfig,
-  normalizeReturnTo,
-  SESSION_COOKIE_NAME,
-  SESSION_MAX_AGE_SECONDS,
-  signSession,
-  verifyPassword,
+	DEFAULT_UPLOAD_DIR,
+	findUser,
+	getUsersFilePath,
+	normalizeReturnTo,
+	SESSION_COOKIE_NAME,
+	SESSION_MAX_AGE_SECONDS,
+	signSession,
+	verifyPassword,
 } from "../utils/auth"
+import { loadUsersFromFileWithCache } from "../utils/userConfigCache"
 
 interface LoginPageProps {
-  returnTo: string
-  error?: string
-  username?: string
+	returnTo: string
+	error?: string
+	username?: string
 }
 
 function LoginPage({ returnTo, error, username }: LoginPageProps) {
-  return (
-    <div className="mx-auto max-w-md rounded-xl border border-indigo-200 bg-white p-6 shadow-sm">
-      <h2 className="mb-1 text-xl font-semibold text-gray-900">Login</h2>
-      <p className="mb-4 text-sm text-gray-600">
-        Sign in to access your private files.
-      </p>
-      {error && (
-        <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
-          {error}
-        </div>
-      )}
-      <form action="/login" method="post" className="space-y-4">
-        <input type="hidden" name="returnTo" value={returnTo} />
-        <div>
-          <label
-            for="username"
-            className="mb-1 block text-sm font-medium text-gray-700"
-          >
-            Username
-          </label>
-          <input
-            id="username"
-            name="username"
-            type="text"
-            required
-            value={username}
-            className="w-full rounded-lg border border-gray-300 px-3 py-2 focus:border-indigo-500 focus:outline-none"
-          />
-        </div>
-        <div>
-          <label
-            for="password"
-            className="mb-1 block text-sm font-medium text-gray-700"
-          >
-            Password
-          </label>
-          <div className="relative">
-            <input
-              id="password"
-              name="password"
-              type="password"
-              required
-              className="w-full rounded-lg border border-gray-300 px-3 py-2 pr-10 focus:border-indigo-500 focus:outline-none"
-            />
-            <button
-              id="password-toggle"
-              type="button"
-              aria-label="Show password"
-              aria-controls="password"
-              aria-pressed="false"
-              className="absolute inset-y-0 right-0 inline-flex w-10 items-center justify-center text-gray-500 hover:text-gray-700"
-            >
-              <span id="password-toggle-eye">
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="2"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  className="h-5 w-5"
-                  aria-hidden="true"
-                >
-                  <path d="M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0" />
-                  <circle cx="12" cy="12" r="3" />
-                </svg>
-              </span>
-              <span id="password-toggle-eye-off" className="hidden">
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="2"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  className="h-5 w-5"
-                  aria-hidden="true"
-                >
-                  <path d="M2.458 12C3.732 7.943 7.523 5 12 5c1.97 0 3.807.57 5.354 1.553" />
-                  <path d="M21.542 12C20.268 16.057 16.477 19 12 19c-1.97 0-3.807-.57-5.354-1.553" />
-                  <path d="M9.88 9.88a3 3 0 1 0 4.24 4.24" />
-                  <path d="m3 3 18 18" />
-                </svg>
-              </span>
-            </button>
-          </div>
-        </div>
-        <button
-          type="submit"
-          className="w-full rounded-lg bg-indigo-600 px-4 py-2 font-semibold text-white hover:bg-indigo-700"
-        >
-          Login
-        </button>
-      </form>
-      <script
-        dangerouslySetInnerHTML={{
-          __html: `
+	return (
+		<div className="mx-auto max-w-md rounded-xl border border-indigo-200 bg-white p-6 shadow-sm">
+			<h2 className="mb-1 text-xl font-semibold text-gray-900">Login</h2>
+			<p className="mb-4 text-sm text-gray-600">
+				Sign in to access your private files.
+			</p>
+			{error && (
+				<div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+					{error}
+				</div>
+			)}
+			<form action="/login" method="post" className="space-y-4">
+				<input type="hidden" name="returnTo" value={returnTo} />
+				<div>
+					<label
+						for="username"
+						className="mb-1 block text-sm font-medium text-gray-700"
+					>
+						Username
+					</label>
+					<input
+						id="username"
+						name="username"
+						type="text"
+						required
+						value={username}
+						className="w-full rounded-lg border border-gray-300 px-3 py-2 focus:border-indigo-500 focus:outline-none"
+					/>
+				</div>
+				<div>
+					<label
+						for="password"
+						className="mb-1 block text-sm font-medium text-gray-700"
+					>
+						Password
+					</label>
+					<div className="relative">
+						<input
+							id="password"
+							name="password"
+							type="password"
+							required
+							className="w-full rounded-lg border border-gray-300 px-3 py-2 pr-10 focus:border-indigo-500 focus:outline-none"
+						/>
+						<button
+							id="password-toggle"
+							type="button"
+							aria-label="Show password"
+							aria-controls="password"
+							aria-pressed="false"
+							className="absolute inset-y-0 right-0 inline-flex w-10 items-center justify-center text-gray-500 hover:text-gray-700"
+						>
+							<span id="password-toggle-eye">
+								<svg
+									xmlns="http://www.w3.org/2000/svg"
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									stroke-width="2"
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									className="h-5 w-5"
+									aria-hidden="true"
+								>
+									<path d="M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0" />
+									<circle cx="12" cy="12" r="3" />
+								</svg>
+							</span>
+							<span id="password-toggle-eye-off" className="hidden">
+								<svg
+									xmlns="http://www.w3.org/2000/svg"
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									stroke-width="2"
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									className="h-5 w-5"
+									aria-hidden="true"
+								>
+									<path d="M2.458 12C3.732 7.943 7.523 5 12 5c1.97 0 3.807.57 5.354 1.553" />
+									<path d="M21.542 12C20.268 16.057 16.477 19 12 19c-1.97 0-3.807-.57-5.354-1.553" />
+									<path d="M9.88 9.88a3 3 0 1 0 4.24 4.24" />
+									<path d="m3 3 18 18" />
+								</svg>
+							</span>
+						</button>
+					</div>
+				</div>
+				<button
+					type="submit"
+					className="w-full rounded-lg bg-indigo-600 px-4 py-2 font-semibold text-white hover:bg-indigo-700"
+				>
+					Login
+				</button>
+			</form>
+			<script
+				dangerouslySetInnerHTML={{
+					__html: `
 						(() => {
 							const passwordInput = document.getElementById("password");
 							const toggleButton = document.getElementById("password-toggle");
@@ -137,110 +139,101 @@ function LoginPage({ returnTo, error, username }: LoginPageProps) {
 							});
 						})();
 					`,
-        }}
-      />
-    </div>
-  )
+				}}
+			/>
+		</div>
+	)
 }
 
 const authRoutes = new Hono<AppBindings>()
 
 authRoutes.get("/login", (c) => {
-  const usersFile = env(c).USERS_FILE
-  if (!usersFile) {
-    return c.redirect("/")
-  }
+	const sessionSecret = env(c).SESSION_SECRET
+	if (!sessionSecret) {
+		return c.redirect("/")
+	}
 
-  const user = c.get("user")
-  const returnTo = normalizeReturnTo(c.req.query("returnTo"))
-  if (user.type === "authenticated") {
-    return c.redirect(returnTo)
-  }
+	const user = c.get("user")
+	const returnTo = normalizeReturnTo(c.req.query("returnTo"))
+	if (user.type === "authenticated") {
+		return c.redirect(returnTo)
+	}
 
-  const error = c.req.query("error")
-  return c.html(
-    <PageShell user={user}>
-      <LoginPage returnTo={returnTo} error={error ?? undefined} />
-    </PageShell>,
-  )
+	const error = c.req.query("error")
+	return c.html(
+		<PageShell user={user}>
+			<LoginPage returnTo={returnTo} error={error ?? undefined} />
+		</PageShell>,
+	)
 })
 
 authRoutes.post("/login", async (c) => {
-  const { USERS_FILE, SESSION_SECRET } = env(c)
-  if (!USERS_FILE) {
-    return c.redirect("/")
-  }
-  if (!SESSION_SECRET) {
-    return c.json(
-      {
-        success: false,
-        error: {
-          name: "AuthConfigError",
-          message: "SESSION_SECRET is required when USERS_FILE is set",
-        },
-      },
-      500,
-    )
-  }
+	const { UPLOAD_DIR, SESSION_SECRET } = env(c)
+	if (!SESSION_SECRET) {
+		return c.redirect("/")
+	}
 
-  const formData = await c.req.formData()
-  const username = String(formData.get("username") || "").trim()
-  const password = String(formData.get("password") || "")
-  const returnTo = normalizeReturnTo(String(formData.get("returnTo") || "/"))
+	const uploadDir = UPLOAD_DIR || DEFAULT_UPLOAD_DIR
+	const usersFile = getUsersFilePath(uploadDir)
 
-  let users: Awaited<ReturnType<typeof loadUsersConfig>> = null
-  try {
-    users = await loadUsersConfig(USERS_FILE)
-  } catch (error) {
-    console.error(error)
-    return c.json(
-      {
-        success: false,
-        error: {
-          name: "AuthConfigError",
-          message: "Failed to load users configuration",
-        },
-      },
-      500,
-    )
-  }
+	const formData = await c.req.formData()
+	const username = String(formData.get("username") || "").trim()
+	const password = String(formData.get("password") || "")
+	const returnTo = normalizeReturnTo(String(formData.get("returnTo") || "/"))
 
-  const matchedUser = findUser(users, username)
-  const isValidPassword = matchedUser
-    ? await verifyPassword(password, matchedUser.passwordHash)
-    : false
+	let users: Awaited<ReturnType<typeof loadUsersFromFileWithCache>> | null = null
+	try {
+		users = await loadUsersFromFileWithCache(usersFile)
+	} catch (error) {
+		console.error(error)
+		return c.json(
+			{
+				success: false,
+				error: {
+					name: "AuthConfigError",
+					message: "Failed to load users configuration",
+				},
+			},
+			500,
+		)
+	}
 
-  if (!matchedUser || !isValidPassword) {
-    return c.html(
-      <PageShell user={{ type: "anonymous" }}>
-        <LoginPage
-          returnTo={returnTo}
-          error="Invalid username or password"
-          username={username}
-        />
-      </PageShell>,
-      401,
-    )
-  }
+	const matchedUser = findUser(users, username)
+	const isValidPassword = matchedUser
+		? await verifyPassword(password, matchedUser.passwordHash)
+		: false
 
-  const sessionValue = await signSession(
-    { username: matchedUser.username },
-    SESSION_SECRET,
-  )
-  setCookie(c, SESSION_COOKIE_NAME, sessionValue, {
-    httpOnly: true,
-    path: "/",
-    sameSite: "Lax",
-    maxAge: SESSION_MAX_AGE_SECONDS,
-  })
+	if (!matchedUser || !isValidPassword) {
+		return c.html(
+			<PageShell user={{ type: "anonymous" }}>
+				<LoginPage
+					returnTo={returnTo}
+					error="Invalid username or password"
+					username={username}
+				/>
+			</PageShell>,
+			401,
+		)
+	}
 
-  return c.redirect(returnTo)
+	const sessionValue = await signSession(
+		{ username: matchedUser.username, sessionVersion: matchedUser.sessionVersion },
+		SESSION_SECRET,
+	)
+	setCookie(c, SESSION_COOKIE_NAME, sessionValue, {
+		httpOnly: true,
+		path: "/",
+		sameSite: "Lax",
+		maxAge: SESSION_MAX_AGE_SECONDS,
+	})
+
+	return c.redirect(returnTo)
 })
 
 authRoutes.post("/logout", (c) => {
-  const usersFile = env(c).USERS_FILE
-  deleteCookie(c, SESSION_COOKIE_NAME, { path: "/" })
-  return c.redirect(usersFile ? "/login" : "/")
+	const sessionSecret = env(c).SESSION_SECRET
+	deleteCookie(c, SESSION_COOKIE_NAME, { path: "/" })
+	return c.redirect(sessionSecret ? "/login" : "/")
 })
 
 export default authRoutes

--- a/projects/file-server/src/types.ts
+++ b/projects/file-server/src/types.ts
@@ -12,13 +12,14 @@ export type UserConfig = {
   username: string
   passwordHash: string
   role: UserRole
+  sessionVersion: number
 }
 
 export type AppBindings = {
   Bindings: {
     UPLOAD_DIR: string
     SESSION_SECRET?: string
-    USERS_FILE?: string
+    INITIAL_ADMIN_PASSWORD?: string
   }
   Variables: {
     user: UserState

--- a/projects/file-server/src/utils/auth.ts
+++ b/projects/file-server/src/utils/auth.ts
@@ -1,161 +1,136 @@
 import { createHmac, timingSafeEqual } from "node:crypto"
 import path from "node:path"
 import type { UserConfig, UserState } from "../types"
-import { loadUsersFromFileWithCache } from "./userConfigCache"
 
 const USERNAME_PATTERN = /^[a-z0-9_-]+$/
 const RESERVED_USERNAMES = new Set(["public", "private"])
 export const SESSION_COOKIE_NAME = "session"
 export const SESSION_MAX_AGE_SECONDS = 60 * 60 * 24 * 7
 export const DEFAULT_UPLOAD_DIR = "./tmp"
+export const MASTER_ADMIN_USERNAME = "admin"
 
-export function validateAuthConfig(
-  usersFile: string | undefined,
-  sessionSecret: string | undefined,
-): void {
-  if (usersFile && !sessionSecret) {
-    throw new Error(
-      "[FATAL] SESSION_SECRET is required when USERS_FILE is set.",
-    )
-  }
-
-  if (sessionSecret && sessionSecret.length < 32) {
-    console.warn("[WARN] SESSION_SECRET should be at least 32 characters long.")
-  }
+export function getUsersFilePath(uploadDir: string): string {
+	return path.join(uploadDir, ".auth", "users.json")
 }
 
-export async function loadUsersConfig(
-  usersFile: string | undefined,
-): Promise<UserConfig[] | null> {
-  if (!usersFile) {
-    return null
-  }
-
-  return loadUsersFromFileWithCache(usersFile)
+export function validateAuthConfig(sessionSecret: string | undefined): void {
+	if (sessionSecret && sessionSecret.length < 32) {
+		console.warn("[WARN] SESSION_SECRET should be at least 32 characters long.")
+	}
 }
 
-export function findUser(
-  users: UserConfig[] | null,
-  username: string,
-): UserConfig | null {
-  if (!users) {
-    return null
-  }
-
-  return users.find((user) => user.username === username) ?? null
+export function findUser(users: UserConfig[] | null, username: string): UserConfig | null {
+	if (!users) {
+		return null
+	}
+	return users.find((user) => user.username === username) ?? null
 }
 
 export function isValidUsername(username: string): boolean {
-  return USERNAME_PATTERN.test(username) && !RESERVED_USERNAMES.has(username)
+	return USERNAME_PATTERN.test(username) && !RESERVED_USERNAMES.has(username)
 }
 
-export async function verifyPassword(
-  password: string,
-  hash: string,
-): Promise<boolean> {
-  try {
-    return await Bun.password.verify(password, hash)
-  } catch {
-    return false
-  }
+export async function verifyPassword(password: string, hash: string): Promise<boolean> {
+	try {
+		return await Bun.password.verify(password, hash)
+	} catch {
+		return false
+	}
 }
 
 function signValue(value: string, secret: string): string {
-  return createHmac("sha256", secret).update(value).digest("base64url")
+	return createHmac("sha256", secret).update(value).digest("base64url")
 }
 
 function safeStringEqual(a: string, b: string): boolean {
-  const left = Buffer.from(a)
-  const right = Buffer.from(b)
-  if (left.length !== right.length) {
-    return false
-  }
-
-  return timingSafeEqual(left, right)
+	const left = Buffer.from(a)
+	const right = Buffer.from(b)
+	if (left.length !== right.length) {
+		return false
+	}
+	return timingSafeEqual(left, right)
 }
 
 export async function signSession(
-  payload: { username: string },
-  secret: string,
+	payload: { username: string; sessionVersion: number },
+	secret: string,
 ): Promise<string> {
-  if (!isValidUsername(payload.username)) {
-    throw new Error("Invalid username for session payload.")
-  }
-
-  const signature = signValue(payload.username, secret)
-  return `${payload.username}:${signature}`
+	if (!isValidUsername(payload.username)) {
+		throw new Error("Invalid username for session payload.")
+	}
+	const data = `${payload.username}:${payload.sessionVersion}`
+	const signature = signValue(data, secret)
+	return `${data}:${signature}`
 }
 
 export async function verifySession(
-  cookieValue: string,
-  secret: string,
-): Promise<{ username: string } | null> {
-  const separatorIndex = cookieValue.indexOf(":")
-  if (separatorIndex <= 0 || separatorIndex === cookieValue.length - 1) {
-    return null
-  }
+	cookieValue: string,
+	secret: string,
+): Promise<{ username: string; sessionVersion: number } | null> {
+	const lastColon = cookieValue.lastIndexOf(":")
+	if (lastColon <= 0 || lastColon === cookieValue.length - 1) {
+		return null
+	}
 
-  const username = cookieValue.slice(0, separatorIndex)
-  const signature = cookieValue.slice(separatorIndex + 1)
+	const data = cookieValue.slice(0, lastColon)
+	const signature = cookieValue.slice(lastColon + 1)
 
-  if (!isValidUsername(username)) {
-    return null
-  }
+	const firstColon = data.indexOf(":")
+	if (firstColon <= 0) {
+		return null
+	}
 
-  const expectedSignature = signValue(username, secret)
-  if (!safeStringEqual(signature, expectedSignature)) {
-    return null
-  }
+	const username = data.slice(0, firstColon)
+	const versionStr = data.slice(firstColon + 1)
+	const sessionVersion = Number(versionStr)
 
-  return { username }
+	if (!isValidUsername(username)) {
+		return null
+	}
+	if (!Number.isInteger(sessionVersion) || sessionVersion < 0) {
+		return null
+	}
+
+	const expectedSignature = signValue(data, secret)
+	if (!safeStringEqual(signature, expectedSignature)) {
+		return null
+	}
+
+	return { username, sessionVersion }
 }
 
-export function getUserUploadDir(
-  baseDir: string,
-  userState: UserState,
-): string {
-  if (userState.type === "authenticated" && userState.role === "user") {
-    return path.join(baseDir, "private", userState.username)
-  }
-  return baseDir
+export function getUserUploadDir(baseDir: string, userState: UserState): string {
+	if (userState.type === "authenticated" && userState.role === "user") {
+		return path.join(baseDir, "private", userState.username)
+	}
+	return baseDir
 }
 
 export function getUserHomeVirtualPath(userState: UserState): string | null {
-  if (userState.type !== "authenticated" || userState.role !== "user") {
-    return null
-  }
-
-  return `private/${userState.username}`
+	if (userState.type !== "authenticated" || userState.role !== "user") {
+		return null
+	}
+	return `private/${userState.username}`
 }
 
-export function isUserHomeVirtualPath(
-  userState: UserState,
-  virtualPath: string,
-): boolean {
-  const homePath = getUserHomeVirtualPath(userState)
-  if (!homePath) {
-    return false
-  }
-
-  return (
-    virtualPath === "" || virtualPath === "private" || virtualPath === homePath
-  )
+export function isUserHomeVirtualPath(userState: UserState, virtualPath: string): boolean {
+	const homePath = getUserHomeVirtualPath(userState)
+	if (!homePath) {
+		return false
+	}
+	return virtualPath === "" || virtualPath === "private" || virtualPath === homePath
 }
 
-export function toBrowseLocation(
-  userState: UserState,
-  virtualPath: string,
-): string {
-  return isUserHomeVirtualPath(userState, virtualPath) ? "" : virtualPath
+export function toBrowseLocation(userState: UserState, virtualPath: string): string {
+	return isUserHomeVirtualPath(userState, virtualPath) ? "" : virtualPath
 }
 
 export function normalizeReturnTo(value: string | null | undefined): string {
-  if (!value) {
-    return "/"
-  }
-  if (!value.startsWith("/") || value.startsWith("//")) {
-    return "/"
-  }
-
-  return value
+	if (!value) {
+		return "/"
+	}
+	if (!value.startsWith("/") || value.startsWith("//")) {
+		return "/"
+	}
+	return value
 }

--- a/projects/file-server/src/utils/bootstrap.ts
+++ b/projects/file-server/src/utils/bootstrap.ts
@@ -1,4 +1,4 @@
-import { stat } from "node:fs/promises"
+import { readFile, stat } from "node:fs/promises"
 import { getUsersFilePath, MASTER_ADMIN_USERNAME } from "./auth"
 import { loadUsersFromFileWithCache, saveUsersToFile } from "./userConfigCache"
 
@@ -17,28 +17,29 @@ export async function bootstrapAdminUser(
 	}
 
 	if (fileExists) {
-		let users: Awaited<ReturnType<typeof loadUsersFromFileWithCache>>
-		try {
-			users = await loadUsersFromFileWithCache(usersFile)
-		} catch {
-			// Empty or unparseable file — treat as absent and bootstrap
-			users = []
-		}
+		const raw = await readFile(usersFile, "utf-8")
 
-		if (users.length > 0) {
-			const admin = users.find((u) => u.username === MASTER_ADMIN_USERNAME)
-			if (!admin) {
-				throw new Error(
-					`[FATAL] Users file is non-empty but missing '${MASTER_ADMIN_USERNAME}' user.`,
-				)
+		if (raw.trim() !== "") {
+			// Non-empty file: parse and validate strictly — errors are startup failures
+			const users = await loadUsersFromFileWithCache(usersFile)
+
+			if (users.length > 0) {
+				const admin = users.find((u) => u.username === MASTER_ADMIN_USERNAME)
+				if (!admin) {
+					throw new Error(
+						`[FATAL] Users file is non-empty but missing '${MASTER_ADMIN_USERNAME}' user.`,
+					)
+				}
+				if (admin.role !== "admin") {
+					throw new Error(
+						`[FATAL] '${MASTER_ADMIN_USERNAME}' user must have role 'admin'.`,
+					)
+				}
+				return
 			}
-			if (admin.role !== "admin") {
-				throw new Error(
-					`[FATAL] '${MASTER_ADMIN_USERNAME}' user must have role 'admin'.`,
-				)
-			}
-			return
+			// Valid JSON empty array — fall through to bootstrap
 		}
+		// Empty file (0 bytes or whitespace) — fall through to bootstrap
 	}
 
 	const password = initialAdminPassword ?? generateRandomPassword()

--- a/projects/file-server/src/utils/bootstrap.ts
+++ b/projects/file-server/src/utils/bootstrap.ts
@@ -17,7 +17,13 @@ export async function bootstrapAdminUser(
 	}
 
 	if (fileExists) {
-		const users = await loadUsersFromFileWithCache(usersFile)
+		let users: Awaited<ReturnType<typeof loadUsersFromFileWithCache>>
+		try {
+			users = await loadUsersFromFileWithCache(usersFile)
+		} catch {
+			// Empty or unparseable file — treat as absent and bootstrap
+			users = []
+		}
 
 		if (users.length > 0) {
 			const admin = users.find((u) => u.username === MASTER_ADMIN_USERNAME)

--- a/projects/file-server/src/utils/bootstrap.ts
+++ b/projects/file-server/src/utils/bootstrap.ts
@@ -1,0 +1,64 @@
+import { stat } from "node:fs/promises"
+import { getUsersFilePath, MASTER_ADMIN_USERNAME } from "./auth"
+import { loadUsersFromFileWithCache, saveUsersToFile } from "./userConfigCache"
+
+export async function bootstrapAdminUser(
+	uploadDir: string,
+	initialAdminPassword?: string,
+): Promise<void> {
+	const usersFile = getUsersFilePath(uploadDir)
+
+	let fileExists = false
+	try {
+		await stat(usersFile)
+		fileExists = true
+	} catch {
+		// File doesn't exist
+	}
+
+	if (fileExists) {
+		const users = await loadUsersFromFileWithCache(usersFile)
+
+		if (users.length > 0) {
+			const admin = users.find((u) => u.username === MASTER_ADMIN_USERNAME)
+			if (!admin) {
+				throw new Error(
+					`[FATAL] Users file is non-empty but missing '${MASTER_ADMIN_USERNAME}' user.`,
+				)
+			}
+			if (admin.role !== "admin") {
+				throw new Error(
+					`[FATAL] '${MASTER_ADMIN_USERNAME}' user must have role 'admin'.`,
+				)
+			}
+			return
+		}
+	}
+
+	const password = initialAdminPassword ?? generateRandomPassword()
+	const passwordHash = await Bun.password.hash(password, {
+		algorithm: "bcrypt",
+		cost: 12,
+	})
+
+	await saveUsersToFile(usersFile, [
+		{
+			username: MASTER_ADMIN_USERNAME,
+			passwordHash,
+			role: "admin",
+			sessionVersion: 0,
+		},
+	])
+
+	if (!initialAdminPassword) {
+		console.log(`[BOOTSTRAP] Initial admin password: ${password}`)
+		console.log("[BOOTSTRAP] Change this password after your first login.")
+	}
+}
+
+function generateRandomPassword(): string {
+	const chars = "ABCDEFGHJKLMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz23456789"
+	const bytes = new Uint8Array(16)
+	crypto.getRandomValues(bytes)
+	return Array.from(bytes, (b) => chars[b % chars.length]).join("")
+}

--- a/projects/file-server/src/utils/userConfigCache.ts
+++ b/projects/file-server/src/utils/userConfigCache.ts
@@ -1,4 +1,5 @@
-import { readFile, stat } from "node:fs/promises"
+import { mkdir, readFile, rename, stat, writeFile } from "node:fs/promises"
+import path from "node:path"
 import type { UserConfig, UserRole } from "../types"
 import { isValidUsername } from "./auth"
 
@@ -10,33 +11,32 @@ let cachedPath: string | null = null
 
 function toValidatedUsers(input: unknown): UserConfig[] {
   if (!Array.isArray(input)) {
-    throw new Error("USERS_FILE must be an array of users.")
+    throw new Error("Users file must be an array of users.")
   }
 
   return input.map((item, index) => {
     if (typeof item !== "object" || item === null) {
-      throw new Error(`USERS_FILE entry at index ${index} must be an object.`)
+      throw new Error(`Users file entry at index ${index} must be an object.`)
     }
 
-    const username = (item as { username?: unknown }).username
-    const passwordHash = (item as { passwordHash?: unknown }).passwordHash
-    const role = (item as { role?: unknown }).role
+    const { username, passwordHash, role, sessionVersion } = item as Record<string, unknown>
 
     if (typeof username !== "string" || !isValidUsername(username)) {
-      throw new Error(
-        `USERS_FILE entry at index ${index} has invalid username.`,
-      )
+      throw new Error(`Users file entry at index ${index} has invalid username.`)
     }
     if (typeof passwordHash !== "string" || passwordHash.length === 0) {
-      throw new Error(
-        `USERS_FILE entry at index ${index} has invalid passwordHash.`,
-      )
+      throw new Error(`Users file entry at index ${index} has invalid passwordHash.`)
     }
     if (typeof role !== "string" || !USER_ROLES.has(role)) {
-      throw new Error(`USERS_FILE entry at index ${index} has invalid role.`)
+      throw new Error(`Users file entry at index ${index} has invalid role.`)
     }
 
-    return { username, passwordHash, role: role as UserRole }
+    return {
+      username,
+      passwordHash,
+      role: role as UserRole,
+      sessionVersion: typeof sessionVersion === "number" ? sessionVersion : 0,
+    }
   })
 }
 
@@ -68,6 +68,17 @@ export async function loadUsersFromFileWithCache(
   cachedMtimeMs = fileStat.mtimeMs
 
   return users
+}
+
+export async function saveUsersToFile(usersFile: string, users: UserConfig[]): Promise<void> {
+  const dir = path.dirname(usersFile)
+  await mkdir(dir, { recursive: true })
+  const tmpFile = `${usersFile}.tmp`
+  await writeFile(tmpFile, JSON.stringify(users, null, 2), "utf-8")
+  await rename(tmpFile, usersFile)
+  cachedUsers = null
+  cachedPath = null
+  cachedMtimeMs = null
 }
 
 export function resetUsersCacheForTests() {

--- a/projects/file-server/tests/auth.test.ts
+++ b/projects/file-server/tests/auth.test.ts
@@ -1,512 +1,569 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test"
 import { mkdir, rm, writeFile } from "node:fs/promises"
 import path from "node:path"
-import { validateAuthConfig } from "../src/utils/auth"
+import { getUsersFilePath } from "../src/utils/auth"
 import { isPathTraversal } from "../src/utils/pathTraversal"
+import { resetUsersCacheForTests } from "../src/utils/userConfigCache"
 import { createTestSession } from "./helpers/auth"
 import { createTestApp } from "./helpers/createTestApp"
 
 const UPLOAD_DIR = "./tmp-test-auth"
-const USERS_FILE = path.join(UPLOAD_DIR, "users.json")
 const SESSION_SECRET = "0123456789abcdef0123456789abcdef"
 const zipAvailable = Bun.spawnSync(["which", "zip"]).exitCode === 0
 
 type PlainUser = {
-  username: string
-  password: string
-  role?: "admin" | "user"
+	username: string
+	password: string
+	role?: "admin" | "user"
 }
 
 let app: Awaited<ReturnType<typeof createTestApp>>
 
 async function writeUsers(users: PlainUser[]) {
-  const userConfigs = await Promise.all(
-    users.map(async (user) => ({
-      username: user.username,
-      passwordHash: await Bun.password.hash(user.password, {
-        algorithm: "bcrypt",
-        cost: 4,
-      }),
-      role: user.role ?? "user",
-    })),
-  )
-  await writeFile(USERS_FILE, JSON.stringify(userConfigs), "utf-8")
+	const usersFile = getUsersFilePath(UPLOAD_DIR)
+	const userConfigs = await Promise.all(
+		users.map(async (user) => ({
+			username: user.username,
+			passwordHash: await Bun.password.hash(user.password, {
+				algorithm: "bcrypt",
+				cost: 4,
+			}),
+			role: user.role ?? "user",
+			sessionVersion: 0,
+		})),
+	)
+	await mkdir(path.dirname(usersFile), { recursive: true })
+	await writeFile(usersFile, JSON.stringify(userConfigs), "utf-8")
+	resetUsersCacheForTests()
 }
 
 async function login(
-  username: string,
-  password: string,
-  returnTo = "/",
+	username: string,
+	password: string,
+	returnTo = "/",
 ): Promise<Response> {
-  const body = new URLSearchParams({ username, password, returnTo })
-  return app.request(
-    new Request("http://localhost/login", {
-      method: "POST",
-      body,
-      headers: { "content-type": "application/x-www-form-urlencoded" },
-      redirect: "manual",
-    }),
-  )
+	const body = new URLSearchParams({ username, password, returnTo })
+	return app.request(
+		new Request("http://localhost/login", {
+			method: "POST",
+			body,
+			headers: { "content-type": "application/x-www-form-urlencoded" },
+			redirect: "manual",
+		}),
+	)
 }
 
 describe("auth", () => {
-  beforeEach(async () => {
-    await rm(UPLOAD_DIR, { recursive: true, force: true })
-    app = await createTestApp({
-      uploadDir: UPLOAD_DIR,
-      usersFile: USERS_FILE,
-      sessionSecret: SESSION_SECRET,
-    })
-  })
-
-  afterEach(async () => {
-    await rm(UPLOAD_DIR, { recursive: true, force: true })
-  })
-
-  it("allows access when authentication is disabled", async () => {
-    app = await createTestApp({ uploadDir: UPLOAD_DIR })
-
-    const res = await app.request(
-      new Request("http://localhost/?path=", {
-        redirect: "manual",
-      }),
-    )
-
-    expect(res.status).toBe(200)
-  })
-
-  it("redirects unauthenticated requests to login when auth is enabled", async () => {
-    await writeUsers([{ username: "alice", password: "password1" }])
-
-    const res = await app.request(
-      new Request("http://localhost/?path=", {
-        redirect: "manual",
-      }),
-    )
-
-    expect(res.status).toBe(302)
-    const location = res.headers.get("location")
-    expect(location).toBe("/login?returnTo=%2F%3Fpath%3D")
-  })
-
-  it("sets a session cookie on successful login", async () => {
-    await writeUsers([{ username: "alice", password: "password1" }])
-
-    const res = await login("alice", "password1", "/?path=docs")
-
-    expect(res.status).toBe(302)
-    expect(res.headers.get("location")).toBe("/?path=docs")
-    expect(res.headers.get("set-cookie")).toContain("session=")
-  })
-
-  it("returns 401 on failed login", async () => {
-    await writeUsers([{ username: "alice", password: "password1" }])
-
-    const res = await login("alice", "wrong-password")
-
-    expect(res.status).toBe(401)
-    const body = await res.text()
-    expect(body).toContain("Invalid username or password")
-  })
-
-  it("isolates files by authenticated user directory", async () => {
-    await writeUsers([
-      { username: "alice", password: "password1" },
-      { username: "bob", password: "password2" },
-    ])
-
-    await mkdir(path.join(UPLOAD_DIR, "private", "alice"), { recursive: true })
-    await mkdir(path.join(UPLOAD_DIR, "private", "bob"), { recursive: true })
-    await writeFile(
-      path.join(UPLOAD_DIR, "private", "alice", "alice.txt"),
-      "alice",
-    )
-    await writeFile(path.join(UPLOAD_DIR, "private", "bob", "bob.txt"), "bob")
-
-    const aliceSession = await createTestSession("alice", SESSION_SECRET)
-    const bobSession = await createTestSession("bob", SESSION_SECRET)
-
-    const aliceRes = await app.request(
-      new Request("http://localhost/api/private/alice/", {
-        headers: { cookie: aliceSession.cookie },
-      }),
-    )
-    const bobRes = await app.request(
-      new Request("http://localhost/api/private/bob/", {
-        headers: { cookie: bobSession.cookie },
-      }),
-    )
-
-    const aliceJson = (await aliceRes.json()) as {
-      files: Array<{ name: string }>
-    }
-    const bobJson = (await bobRes.json()) as {
-      files: Array<{ name: string }>
-    }
-
-    expect(aliceRes.status).toBe(200)
-    expect(bobRes.status).toBe(200)
-    expect(aliceJson.files.map((f) => f.name)).toContain("alice.txt")
-    expect(aliceJson.files.map((f) => f.name)).not.toContain("bob.txt")
-    expect(bobJson.files.map((f) => f.name)).toContain("bob.txt")
-    expect(bobJson.files.map((f) => f.name)).not.toContain("alice.txt")
-  })
-
-  it("allows admin to browse the whole upload root", async () => {
-    await writeUsers([
-      { username: "admin", password: "password1", role: "admin" },
-      { username: "alice", password: "password2", role: "user" },
-      { username: "bob", password: "password3", role: "user" },
-    ])
-
-    await mkdir(path.join(UPLOAD_DIR, "private", "alice"), { recursive: true })
-    await mkdir(path.join(UPLOAD_DIR, "private", "bob"), { recursive: true })
-    await writeFile(
-      path.join(UPLOAD_DIR, "private", "alice", "alice.txt"),
-      "alice",
-    )
-    await writeFile(path.join(UPLOAD_DIR, "private", "bob", "bob.txt"), "bob")
-
-    const adminSession = await createTestSession("admin", SESSION_SECRET)
-    const res = await app.request(
-      new Request("http://localhost/api/private/", {
-        headers: { cookie: adminSession.cookie },
-      }),
-    )
-    const body = (await res.json()) as {
-      files: Array<{ name: string; type: "file" | "dir" }>
-    }
-
-    expect(res.status).toBe(200)
-    expect(body.files).toEqual(
-      expect.arrayContaining([
-        { name: "alice", type: "dir" },
-        { name: "bob", type: "dir" },
-      ]),
-    )
-  })
-
-  it("renders / as a home view for regular users", async () => {
-    await writeUsers([{ username: "alice", password: "password1" }])
-    await mkdir(path.join(UPLOAD_DIR, "private", "alice", "docs"), {
-      recursive: true,
-    })
-    await writeFile(
-      path.join(UPLOAD_DIR, "private", "alice", "notes.txt"),
-      "hello",
-    )
-
-    const session = await createTestSession("alice", SESSION_SECRET)
-    const res = await app.request(
-      new Request("http://localhost/?path=", {
-        headers: { cookie: session.cookie },
-      }),
-    )
-    const text = await res.text()
-
-    expect(res.status).toBe(200)
-    expect(text).toContain(">home</a>")
-    expect(text).toContain("Shared")
-    expect(text).toContain('hx-get="/browse?path=public"')
-    expect(text).toContain('hx-get="/browse?path=private%2Falice%2Fdocs"')
-    expect(text).toContain('name="path" value="private/alice"')
-    expect(text).toContain('href="/file/archive?path=private%2Falice"')
-    expect(text).toContain("notes.txt")
-  })
-
-  it("keeps the home view after htmx create operations for regular users", async () => {
-    await writeUsers([{ username: "alice", password: "password1" }])
-    const session = await createTestSession("alice", SESSION_SECRET)
-
-    const body = new URLSearchParams({
-      path: "private/alice",
-      file: "home.txt",
-    })
-    const res = await app.request(
-      new Request("http://localhost/api/file", {
-        method: "POST",
-        body,
-        headers: {
-          cookie: session.cookie,
-          "content-type": "application/x-www-form-urlencoded",
-          "HX-Request": "true",
-        },
-      }),
-    )
-    const text = await res.text()
-
-    expect(res.status).toBe(200)
-    expect(text).toContain(">home</a>")
-    expect(text).toContain("Shared")
-    expect(text).toContain("home.txt")
-    expect(text).toContain('name="path" value="private/alice"')
-  })
-
-  it("hides root action controls for admins", async () => {
-    await writeUsers([
-      { username: "admin", password: "password1", role: "admin" },
-      { username: "alice", password: "password2", role: "user" },
-    ])
-
-    const session = await createTestSession("admin", SESSION_SECRET)
-    const res = await app.request(
-      new Request("http://localhost/?path=", {
-        headers: { cookie: session.cookie },
-      }),
-    )
-    const text = await res.text()
-
-    expect(res.status).toBe(200)
-    expect(text).toContain(">root</a>")
-    expect(text).toContain("public")
-    expect(text).toContain("private")
-    expect(text).not.toContain("New File")
-    expect(text).not.toContain("New Folder")
-    expect(text).not.toContain("Download Zip")
-  })
-
-  it("allows admin to upload to another user's directory", async () => {
-    await writeUsers([
-      { username: "admin", password: "password1", role: "admin" },
-      { username: "bob", password: "password2", role: "user" },
-    ])
-    await mkdir(path.join(UPLOAD_DIR, "private", "bob"), { recursive: true })
-
-    const adminSession = await createTestSession("admin", SESSION_SECRET)
-    const formData = new FormData()
-    formData.append("files", new File(["hello"], "from-admin.txt"))
-    formData.append("path", "private/bob")
-
-    const res = await app.request(
-      new Request("http://localhost/api/upload", {
-        method: "POST",
-        body: formData,
-        headers: { cookie: adminSession.cookie },
-      }),
-    )
-
-    expect(res.status).toBe(200)
-    expect(
-      Bun.file(
-        path.join(UPLOAD_DIR, "private", "bob", "from-admin.txt"),
-      ).text(),
-    ).resolves.toBe("hello")
-  })
-
-  it("rejects path traversal attempts for authenticated users", async () => {
-    await writeUsers([{ username: "alice", password: "password1" }])
-    const session = await createTestSession("alice", SESSION_SECRET)
-
-    const res = await app.request(
-      new Request("http://localhost/?path=../bob", {
-        headers: { cookie: session.cookie },
-      }),
-    )
-
-    expect(res.status).toBe(403)
-    const body = (await res.json()) as {
-      success: boolean
-      error: { name: string; message: string }
-    }
-    expect(body.success).toBe(false)
-    expect(body.error.name).toBe("Forbidden")
-  })
-
-  it("isolates archive downloads by authenticated user directory", async () => {
-    if (!zipAvailable) {
-      return
-    }
-
-    await writeUsers([
-      { username: "alice", password: "password1" },
-      { username: "bob", password: "password2" },
-    ])
-
-    await mkdir(path.join(UPLOAD_DIR, "private", "alice"), { recursive: true })
-    await mkdir(path.join(UPLOAD_DIR, "private", "bob"), { recursive: true })
-    await writeFile(
-      path.join(UPLOAD_DIR, "private", "alice", "alice.txt"),
-      "alice",
-    )
-    await writeFile(path.join(UPLOAD_DIR, "private", "bob", "bob.txt"), "bob")
-
-    const aliceSession = await createTestSession("alice", SESSION_SECRET)
-    const res = await app.request(
-      new Request("http://localhost/file/archive?path=private%2Falice", {
-        headers: { cookie: aliceSession.cookie },
-      }),
-    )
-    const bodyText = Buffer.from(await res.arrayBuffer()).toString("latin1")
-
-    expect(res.status).toBe(200)
-    expect(bodyText).toContain("alice.txt")
-    expect(bodyText).not.toContain("bob.txt")
-  })
-
-  it("rejects archive traversal attempts for authenticated users", async () => {
-    await writeUsers([{ username: "alice", password: "password1" }])
-    const session = await createTestSession("alice", SESSION_SECRET)
-
-    const res = await app.request(
-      new Request("http://localhost/file/archive?path=..%2Fbob", {
-        headers: { cookie: session.cookie },
-      }),
-    )
-    const body = (await res.json()) as {
-      success: boolean
-      error: { name: string; message: string }
-    }
-
-    expect(res.status).toBe(403)
-    expect(body.success).toBe(false)
-    expect(body.error.name).toBe("Forbidden")
-  })
-
-  it("allows admin to archive another user's directory", async () => {
-    if (!zipAvailable) {
-      return
-    }
-
-    await writeUsers([
-      { username: "admin", password: "password1", role: "admin" },
-      { username: "alice", password: "password2", role: "user" },
-    ])
-    await mkdir(path.join(UPLOAD_DIR, "private", "alice"), { recursive: true })
-    await writeFile(
-      path.join(UPLOAD_DIR, "private", "alice", "alice.txt"),
-      "alice",
-    )
-
-    const adminSession = await createTestSession("admin", SESSION_SECRET)
-    const res = await app.request(
-      new Request("http://localhost/file/archive?path=private%2Falice", {
-        headers: { cookie: adminSession.cookie },
-      }),
-    )
-    const bodyText = Buffer.from(await res.arrayBuffer()).toString("latin1")
-
-    expect(res.status).toBe(200)
-    expect(bodyText).toContain("alice.txt")
-  })
-
-  it("rejects path traversal attempts for admins", async () => {
-    await writeUsers([
-      { username: "admin", password: "password1", role: "admin" },
-    ])
-    const adminSession = await createTestSession("admin", SESSION_SECRET)
-
-    const res = await app.request(
-      new Request("http://localhost/?path=../etc", {
-        headers: { cookie: adminSession.cookie },
-      }),
-    )
-    const body = (await res.json()) as {
-      success: boolean
-      error: { name: string; message: string }
-    }
-
-    expect(res.status).toBe(403)
-    expect(body.success).toBe(false)
-    expect(body.error.name).toBe("Forbidden")
-  })
-
-  it("clears the session cookie on logout", async () => {
-    await writeUsers([{ username: "alice", password: "password1" }])
-    const session = await createTestSession("alice", SESSION_SECRET)
-
-    const res = await app.request(
-      new Request("http://localhost/logout", {
-        method: "POST",
-        headers: { cookie: session.cookie },
-        redirect: "manual",
-      }),
-    )
-
-    expect(res.status).toBe(302)
-    expect(res.headers.get("location")).toBe("/login")
-    expect(res.headers.get("set-cookie")).toContain("session=;")
-  })
-
-  it("reloads users from USERS_FILE when file changes", async () => {
-    await writeUsers([{ username: "alice", password: "oldpass" }])
-    const oldLogin = await login("alice", "oldpass")
-    expect(oldLogin.status).toBe(302)
-
-    await new Promise((resolve) => setTimeout(resolve, 20))
-    await writeUsers([{ username: "alice", password: "newpass" }])
-
-    const rejectedOldLogin = await login("alice", "oldpass")
-    const acceptedNewLogin = await login("alice", "newpass")
-
-    expect(rejectedOldLogin.status).toBe(401)
-    expect(acceptedNewLogin.status).toBe(302)
-  })
-
-  it("validates startup auth config requirements", () => {
-    expect(() => validateAuthConfig("users.json", undefined)).toThrow(
-      "SESSION_SECRET",
-    )
-  })
-
-  it("handles precise path traversal checks", () => {
-    expect(isPathTraversal("../../etc/passwd")).toBe(true)
-    expect(isPathTraversal("../bob/file.txt")).toBe(true)
-    expect(isPathTraversal("/etc/passwd")).toBe(true)
-    expect(isPathTraversal("file..name.txt")).toBe(false)
-    expect(isPathTraversal("docs..")).toBe(false)
-    expect(isPathTraversal("")).toBe(false)
-  })
-
-  it("rejects invalid username entries in USERS_FILE", async () => {
-    await writeFile(
-      USERS_FILE,
-      JSON.stringify([
-        { username: "alice/root", passwordHash: "dummy", role: "user" },
-      ]),
-      "utf-8",
-    )
-
-    const res = await app.request(new Request("http://localhost/login"))
-    expect(res.status).toBe(500)
-  })
-
-  it("rejects invalid role entries in USERS_FILE", async () => {
-    await writeFile(
-      USERS_FILE,
-      JSON.stringify([
-        { username: "alice", passwordHash: "dummy", role: "super-admin" },
-      ]),
-      "utf-8",
-    )
-
-    const res = await app.request(new Request("http://localhost/login"))
-    expect(res.status).toBe(500)
-  })
-
-  it("keeps file write access inside user directory", async () => {
-    await writeUsers([{ username: "alice", password: "password1" }])
-    const session = await createTestSession("alice", SESSION_SECRET)
-
-    const formData = new FormData()
-    formData.append("files", new File(["hello"], "safe.txt"))
-    formData.append("path", "../../outside.txt")
-
-    const res = await app.request(
-      new Request("http://localhost/api/upload", {
-        method: "POST",
-        body: formData,
-        headers: { cookie: session.cookie },
-      }),
-    )
-    const body = (await res.json()) as {
-      success: boolean
-      error: { name: string }
-    }
-
-    expect(res.status).toBe(403)
-    expect(body.success).toBe(false)
-    expect(body.error.name).toBe("Forbidden")
-    const outsidePath = path.join(UPLOAD_DIR, "outside.txt")
-    expect(Bun.file(outsidePath).exists()).resolves.toBe(false)
-  })
+	beforeEach(async () => {
+		await rm(UPLOAD_DIR, { recursive: true, force: true })
+		app = await createTestApp({
+			uploadDir: UPLOAD_DIR,
+			sessionSecret: SESSION_SECRET,
+			initialAdminPassword: "initial-admin-pass",
+		})
+	})
+
+	afterEach(async () => {
+		await rm(UPLOAD_DIR, { recursive: true, force: true })
+	})
+
+	it("allows access when authentication is disabled", async () => {
+		app = await createTestApp({ uploadDir: UPLOAD_DIR })
+
+		const res = await app.request(
+			new Request("http://localhost/?path=", {
+				redirect: "manual",
+			}),
+		)
+
+		expect(res.status).toBe(200)
+	})
+
+	it("redirects unauthenticated requests to login when auth is enabled", async () => {
+		const res = await app.request(
+			new Request("http://localhost/?path=", {
+				redirect: "manual",
+			}),
+		)
+
+		expect(res.status).toBe(302)
+		const location = res.headers.get("location")
+		expect(location).toBe("/login?returnTo=%2F%3Fpath%3D")
+	})
+
+	it("sets a session cookie on successful login", async () => {
+		await writeUsers([{ username: "alice", password: "password1" }])
+
+		const res = await login("alice", "password1", "/?path=docs")
+
+		expect(res.status).toBe(302)
+		expect(res.headers.get("location")).toBe("/?path=docs")
+		expect(res.headers.get("set-cookie")).toContain("session=")
+	})
+
+	it("returns 401 on failed login", async () => {
+		await writeUsers([{ username: "alice", password: "password1" }])
+
+		const res = await login("alice", "wrong-password")
+
+		expect(res.status).toBe(401)
+		const body = await res.text()
+		expect(body).toContain("Invalid username or password")
+	})
+
+	it("isolates files by authenticated user directory", async () => {
+		await writeUsers([
+			{ username: "alice", password: "password1" },
+			{ username: "bob", password: "password2" },
+		])
+
+		await mkdir(path.join(UPLOAD_DIR, "private", "alice"), { recursive: true })
+		await mkdir(path.join(UPLOAD_DIR, "private", "bob"), { recursive: true })
+		await writeFile(
+			path.join(UPLOAD_DIR, "private", "alice", "alice.txt"),
+			"alice",
+		)
+		await writeFile(path.join(UPLOAD_DIR, "private", "bob", "bob.txt"), "bob")
+
+		const aliceSession = await createTestSession("alice", SESSION_SECRET)
+		const bobSession = await createTestSession("bob", SESSION_SECRET)
+
+		const aliceRes = await app.request(
+			new Request("http://localhost/api/private/alice/", {
+				headers: { cookie: aliceSession.cookie },
+			}),
+		)
+		const bobRes = await app.request(
+			new Request("http://localhost/api/private/bob/", {
+				headers: { cookie: bobSession.cookie },
+			}),
+		)
+
+		const aliceJson = (await aliceRes.json()) as {
+			files: Array<{ name: string }>
+		}
+		const bobJson = (await bobRes.json()) as {
+			files: Array<{ name: string }>
+		}
+
+		expect(aliceRes.status).toBe(200)
+		expect(bobRes.status).toBe(200)
+		expect(aliceJson.files.map((f) => f.name)).toContain("alice.txt")
+		expect(aliceJson.files.map((f) => f.name)).not.toContain("bob.txt")
+		expect(bobJson.files.map((f) => f.name)).toContain("bob.txt")
+		expect(bobJson.files.map((f) => f.name)).not.toContain("alice.txt")
+	})
+
+	it("allows admin to browse the whole upload root", async () => {
+		await writeUsers([
+			{ username: "admin", password: "password1", role: "admin" },
+			{ username: "alice", password: "password2", role: "user" },
+			{ username: "bob", password: "password3", role: "user" },
+		])
+
+		await mkdir(path.join(UPLOAD_DIR, "private", "alice"), { recursive: true })
+		await mkdir(path.join(UPLOAD_DIR, "private", "bob"), { recursive: true })
+		await writeFile(
+			path.join(UPLOAD_DIR, "private", "alice", "alice.txt"),
+			"alice",
+		)
+		await writeFile(path.join(UPLOAD_DIR, "private", "bob", "bob.txt"), "bob")
+
+		const adminSession = await createTestSession("admin", SESSION_SECRET)
+		const res = await app.request(
+			new Request("http://localhost/api/private/", {
+				headers: { cookie: adminSession.cookie },
+			}),
+		)
+		const body = (await res.json()) as {
+			files: Array<{ name: string; type: "file" | "dir" }>
+		}
+
+		expect(res.status).toBe(200)
+		expect(body.files).toEqual(
+			expect.arrayContaining([
+				{ name: "alice", type: "dir" },
+				{ name: "bob", type: "dir" },
+			]),
+		)
+	})
+
+	it("renders / as a home view for regular users", async () => {
+		await writeUsers([{ username: "alice", password: "password1" }])
+		await mkdir(path.join(UPLOAD_DIR, "private", "alice", "docs"), {
+			recursive: true,
+		})
+		await writeFile(
+			path.join(UPLOAD_DIR, "private", "alice", "notes.txt"),
+			"hello",
+		)
+
+		const session = await createTestSession("alice", SESSION_SECRET)
+		const res = await app.request(
+			new Request("http://localhost/?path=", {
+				headers: { cookie: session.cookie },
+			}),
+		)
+		const text = await res.text()
+
+		expect(res.status).toBe(200)
+		expect(text).toContain(">home</a>")
+		expect(text).toContain("Shared")
+		expect(text).toContain('hx-get="/browse?path=public"')
+		expect(text).toContain('hx-get="/browse?path=private%2Falice%2Fdocs"')
+		expect(text).toContain('name="path" value="private/alice"')
+		expect(text).toContain('href="/file/archive?path=private%2Falice"')
+		expect(text).toContain("notes.txt")
+	})
+
+	it("keeps the home view after htmx create operations for regular users", async () => {
+		await writeUsers([{ username: "alice", password: "password1" }])
+		const session = await createTestSession("alice", SESSION_SECRET)
+
+		const body = new URLSearchParams({
+			path: "private/alice",
+			file: "home.txt",
+		})
+		const res = await app.request(
+			new Request("http://localhost/api/file", {
+				method: "POST",
+				body,
+				headers: {
+					cookie: session.cookie,
+					"content-type": "application/x-www-form-urlencoded",
+					"HX-Request": "true",
+				},
+			}),
+		)
+		const text = await res.text()
+
+		expect(res.status).toBe(200)
+		expect(text).toContain(">home</a>")
+		expect(text).toContain("Shared")
+		expect(text).toContain("home.txt")
+		expect(text).toContain('name="path" value="private/alice"')
+	})
+
+	it("hides root action controls for admins", async () => {
+		await writeUsers([
+			{ username: "admin", password: "password1", role: "admin" },
+			{ username: "alice", password: "password2", role: "user" },
+		])
+
+		const session = await createTestSession("admin", SESSION_SECRET)
+		const res = await app.request(
+			new Request("http://localhost/?path=", {
+				headers: { cookie: session.cookie },
+			}),
+		)
+		const text = await res.text()
+
+		expect(res.status).toBe(200)
+		expect(text).toContain(">root</a>")
+		expect(text).toContain("public")
+		expect(text).toContain("private")
+		expect(text).not.toContain("New File")
+		expect(text).not.toContain("New Folder")
+		expect(text).not.toContain("Download Zip")
+	})
+
+	it("allows admin to upload to another user's directory", async () => {
+		await writeUsers([
+			{ username: "admin", password: "password1", role: "admin" },
+			{ username: "bob", password: "password2", role: "user" },
+		])
+		await mkdir(path.join(UPLOAD_DIR, "private", "bob"), { recursive: true })
+
+		const adminSession = await createTestSession("admin", SESSION_SECRET)
+		const formData = new FormData()
+		formData.append("files", new File(["hello"], "from-admin.txt"))
+		formData.append("path", "private/bob")
+
+		const res = await app.request(
+			new Request("http://localhost/api/upload", {
+				method: "POST",
+				body: formData,
+				headers: { cookie: adminSession.cookie },
+			}),
+		)
+
+		expect(res.status).toBe(200)
+		expect(
+			Bun.file(
+				path.join(UPLOAD_DIR, "private", "bob", "from-admin.txt"),
+			).text(),
+		).resolves.toBe("hello")
+	})
+
+	it("rejects path traversal attempts for authenticated users", async () => {
+		await writeUsers([{ username: "alice", password: "password1" }])
+		const session = await createTestSession("alice", SESSION_SECRET)
+
+		const res = await app.request(
+			new Request("http://localhost/?path=../bob", {
+				headers: { cookie: session.cookie },
+			}),
+		)
+
+		expect(res.status).toBe(403)
+		const body = (await res.json()) as {
+			success: boolean
+			error: { name: string; message: string }
+		}
+		expect(body.success).toBe(false)
+		expect(body.error.name).toBe("Forbidden")
+	})
+
+	it("isolates archive downloads by authenticated user directory", async () => {
+		if (!zipAvailable) {
+			return
+		}
+
+		await writeUsers([
+			{ username: "alice", password: "password1" },
+			{ username: "bob", password: "password2" },
+		])
+
+		await mkdir(path.join(UPLOAD_DIR, "private", "alice"), { recursive: true })
+		await mkdir(path.join(UPLOAD_DIR, "private", "bob"), { recursive: true })
+		await writeFile(
+			path.join(UPLOAD_DIR, "private", "alice", "alice.txt"),
+			"alice",
+		)
+		await writeFile(path.join(UPLOAD_DIR, "private", "bob", "bob.txt"), "bob")
+
+		const aliceSession = await createTestSession("alice", SESSION_SECRET)
+		const res = await app.request(
+			new Request("http://localhost/file/archive?path=private%2Falice", {
+				headers: { cookie: aliceSession.cookie },
+			}),
+		)
+		const bodyText = Buffer.from(await res.arrayBuffer()).toString("latin1")
+
+		expect(res.status).toBe(200)
+		expect(bodyText).toContain("alice.txt")
+		expect(bodyText).not.toContain("bob.txt")
+	})
+
+	it("rejects archive traversal attempts for authenticated users", async () => {
+		await writeUsers([{ username: "alice", password: "password1" }])
+		const session = await createTestSession("alice", SESSION_SECRET)
+
+		const res = await app.request(
+			new Request("http://localhost/file/archive?path=..%2Fbob", {
+				headers: { cookie: session.cookie },
+			}),
+		)
+		const body = (await res.json()) as {
+			success: boolean
+			error: { name: string; message: string }
+		}
+
+		expect(res.status).toBe(403)
+		expect(body.success).toBe(false)
+		expect(body.error.name).toBe("Forbidden")
+	})
+
+	it("allows admin to archive another user's directory", async () => {
+		if (!zipAvailable) {
+			return
+		}
+
+		await writeUsers([
+			{ username: "admin", password: "password1", role: "admin" },
+			{ username: "alice", password: "password2", role: "user" },
+		])
+		await mkdir(path.join(UPLOAD_DIR, "private", "alice"), { recursive: true })
+		await writeFile(
+			path.join(UPLOAD_DIR, "private", "alice", "alice.txt"),
+			"alice",
+		)
+
+		const adminSession = await createTestSession("admin", SESSION_SECRET)
+		const res = await app.request(
+			new Request("http://localhost/file/archive?path=private%2Falice", {
+				headers: { cookie: adminSession.cookie },
+			}),
+		)
+		const bodyText = Buffer.from(await res.arrayBuffer()).toString("latin1")
+
+		expect(res.status).toBe(200)
+		expect(bodyText).toContain("alice.txt")
+	})
+
+	it("rejects path traversal attempts for admins", async () => {
+		await writeUsers([
+			{ username: "admin", password: "password1", role: "admin" },
+		])
+		const adminSession = await createTestSession("admin", SESSION_SECRET)
+
+		const res = await app.request(
+			new Request("http://localhost/?path=../etc", {
+				headers: { cookie: adminSession.cookie },
+			}),
+		)
+		const body = (await res.json()) as {
+			success: boolean
+			error: { name: string; message: string }
+		}
+
+		expect(res.status).toBe(403)
+		expect(body.success).toBe(false)
+		expect(body.error.name).toBe("Forbidden")
+	})
+
+	it("clears the session cookie on logout", async () => {
+		await writeUsers([{ username: "alice", password: "password1" }])
+		const session = await createTestSession("alice", SESSION_SECRET)
+
+		const res = await app.request(
+			new Request("http://localhost/logout", {
+				method: "POST",
+				headers: { cookie: session.cookie },
+				redirect: "manual",
+			}),
+		)
+
+		expect(res.status).toBe(302)
+		expect(res.headers.get("location")).toBe("/login")
+		expect(res.headers.get("set-cookie")).toContain("session=;")
+	})
+
+	it("reloads users when the users file changes", async () => {
+		await writeUsers([{ username: "alice", password: "oldpass" }])
+		const oldLogin = await login("alice", "oldpass")
+		expect(oldLogin.status).toBe(302)
+
+		await new Promise((resolve) => setTimeout(resolve, 20))
+		await writeUsers([{ username: "alice", password: "newpass" }])
+
+		const rejectedOldLogin = await login("alice", "oldpass")
+		const acceptedNewLogin = await login("alice", "newpass")
+
+		expect(rejectedOldLogin.status).toBe(401)
+		expect(acceptedNewLogin.status).toBe(302)
+	})
+
+	it("bootstraps admin on first startup with SESSION_SECRET", async () => {
+		const adminLogin = await login("admin", "initial-admin-pass")
+		expect(adminLogin.status).toBe(302)
+	})
+
+	it("fails to start if users file exists but has no admin", async () => {
+		const usersFile = getUsersFilePath(UPLOAD_DIR)
+		await writeFile(
+			usersFile,
+			JSON.stringify([
+				{
+					username: "alice",
+					passwordHash: "dummy",
+					role: "user",
+					sessionVersion: 0,
+				},
+			]),
+			"utf-8",
+		)
+
+		await expect(
+			createTestApp({ uploadDir: UPLOAD_DIR, sessionSecret: SESSION_SECRET }),
+		).rejects.toThrow()
+	})
+
+	it("handles precise path traversal checks", () => {
+		expect(isPathTraversal("../../etc/passwd")).toBe(true)
+		expect(isPathTraversal("../bob/file.txt")).toBe(true)
+		expect(isPathTraversal("/etc/passwd")).toBe(true)
+		expect(isPathTraversal("file..name.txt")).toBe(false)
+		expect(isPathTraversal("docs..")).toBe(false)
+		expect(isPathTraversal("")).toBe(false)
+	})
+
+	it("rejects invalid username entries in users file", async () => {
+		const usersFile = getUsersFilePath(UPLOAD_DIR)
+		await writeFile(
+			usersFile,
+			JSON.stringify([
+				{ username: "alice/root", passwordHash: "dummy", role: "user", sessionVersion: 0 },
+			]),
+			"utf-8",
+		)
+		resetUsersCacheForTests()
+
+		const res = await app.request(new Request("http://localhost/login"))
+		expect(res.status).toBe(500)
+	})
+
+	it("rejects invalid role entries in users file", async () => {
+		const usersFile = getUsersFilePath(UPLOAD_DIR)
+		await writeFile(
+			usersFile,
+			JSON.stringify([
+				{ username: "alice", passwordHash: "dummy", role: "super-admin", sessionVersion: 0 },
+			]),
+			"utf-8",
+		)
+		resetUsersCacheForTests()
+
+		const res = await app.request(new Request("http://localhost/login"))
+		expect(res.status).toBe(500)
+	})
+
+	it("invalidates session after sessionVersion mismatch", async () => {
+		await writeUsers([{ username: "alice", password: "password1" }])
+
+		const staleSession = await createTestSession("alice", SESSION_SECRET, 0)
+
+		// Simulate version increment (e.g., password change)
+		const usersFile = getUsersFilePath(UPLOAD_DIR)
+		const userConfigs = [
+			{
+				username: "alice",
+				passwordHash: await Bun.password.hash("newpass", {
+					algorithm: "bcrypt",
+					cost: 4,
+				}),
+				role: "user",
+				sessionVersion: 1,
+			},
+		]
+		await writeFile(usersFile, JSON.stringify(userConfigs), "utf-8")
+		resetUsersCacheForTests()
+
+		const res = await app.request(
+			new Request("http://localhost/?path=", {
+				headers: { cookie: staleSession.cookie },
+				redirect: "manual",
+			}),
+		)
+
+		expect(res.status).toBe(302)
+		expect(res.headers.get("location")).toContain("/login")
+	})
+
+	it("keeps file write access inside user directory", async () => {
+		await writeUsers([{ username: "alice", password: "password1" }])
+		const session = await createTestSession("alice", SESSION_SECRET)
+
+		const formData = new FormData()
+		formData.append("files", new File(["hello"], "safe.txt"))
+		formData.append("path", "../../outside.txt")
+
+		const res = await app.request(
+			new Request("http://localhost/api/upload", {
+				method: "POST",
+				body: formData,
+				headers: { cookie: session.cookie },
+			}),
+		)
+		const body = (await res.json()) as {
+			success: boolean
+			error: { name: string }
+		}
+
+		expect(res.status).toBe(403)
+		expect(body.success).toBe(false)
+		expect(body.error.name).toBe("Forbidden")
+		const outsidePath = path.join(UPLOAD_DIR, "outside.txt")
+		expect(Bun.file(outsidePath).exists()).resolves.toBe(false)
+	})
 })

--- a/projects/file-server/tests/auth.test.ts
+++ b/projects/file-server/tests/auth.test.ts
@@ -567,6 +567,15 @@ describe("auth", () => {
 		expect(Bun.file(outsidePath).exists()).resolves.toBe(false)
 	})
 
+	it("fails to start if users file contains broken JSON", async () => {
+		const usersFile = getUsersFilePath(UPLOAD_DIR)
+		await writeFile(usersFile, "{ broken json", "utf-8")
+
+		await expect(
+			createTestApp({ uploadDir: UPLOAD_DIR, sessionSecret: SESSION_SECRET }),
+		).rejects.toThrow()
+	})
+
 	it("bootstraps admin when users file is empty (0 bytes)", async () => {
 		const usersFile = getUsersFilePath(UPLOAD_DIR)
 		await mkdir(path.dirname(usersFile), { recursive: true })

--- a/projects/file-server/tests/auth.test.ts
+++ b/projects/file-server/tests/auth.test.ts
@@ -566,4 +566,41 @@ describe("auth", () => {
 		const outsidePath = path.join(UPLOAD_DIR, "outside.txt")
 		expect(Bun.file(outsidePath).exists()).resolves.toBe(false)
 	})
+
+	it("bootstraps admin when users file is empty (0 bytes)", async () => {
+		const usersFile = getUsersFilePath(UPLOAD_DIR)
+		await mkdir(path.dirname(usersFile), { recursive: true })
+		await writeFile(usersFile, "", "utf-8")
+
+		app = await createTestApp({
+			uploadDir: UPLOAD_DIR,
+			sessionSecret: SESSION_SECRET,
+			initialAdminPassword: "initial-admin-pass",
+		})
+
+		const res = await login("admin", "initial-admin-pass")
+		expect(res.status).toBe(302)
+	})
+
+	it("blocks master admin password reset via /admin/users/:username/password", async () => {
+		const adminSession = await createTestSession("admin", SESSION_SECRET)
+
+		const body = new URLSearchParams({ newPassword: "hacked" })
+		const res = await app.request(
+			new Request("http://localhost/admin/users/admin/password", {
+				method: "POST",
+				body,
+				headers: {
+					"content-type": "application/x-www-form-urlencoded",
+					cookie: adminSession.cookie,
+				},
+				redirect: "manual",
+			}),
+		)
+
+		expect(res.status).toBe(302)
+		const location = res.headers.get("location") ?? ""
+		expect(location).toContain("error")
+		expect(location).toContain("master%20admin")
+	})
 })

--- a/projects/file-server/tests/helpers/auth.ts
+++ b/projects/file-server/tests/helpers/auth.ts
@@ -1,17 +1,18 @@
 import { SESSION_COOKIE_NAME, signSession } from "../../src/utils/auth"
 
 export interface TestSession {
-  cookie: string
-  username: string
+	cookie: string
+	username: string
 }
 
 export async function createTestSession(
-  username: string,
-  secret: string,
+	username: string,
+	secret: string,
+	sessionVersion = 0,
 ): Promise<TestSession> {
-  const sessionValue = await signSession({ username }, secret)
-  return {
-    cookie: `${SESSION_COOKIE_NAME}=${sessionValue}`,
-    username,
-  }
+	const sessionValue = await signSession({ username, sessionVersion }, secret)
+	return {
+		cookie: `${SESSION_COOKIE_NAME}=${sessionValue}`,
+		username,
+	}
 }

--- a/projects/file-server/tests/helpers/createTestApp.ts
+++ b/projects/file-server/tests/helpers/createTestApp.ts
@@ -1,34 +1,60 @@
+import { mkdir, writeFile } from "node:fs/promises"
+import path from "node:path"
 import type { Hono } from "hono"
 import { createApp } from "../../src/app"
 import type { AppBindings } from "../../src/types"
+import { getUsersFilePath } from "../../src/utils/auth"
 import { resetUsersCacheForTests } from "../../src/utils/userConfigCache"
 
 export interface TestAppOptions {
-  uploadDir: string
-  usersFile?: string
-  sessionSecret?: string
+	uploadDir: string
+	sessionSecret?: string
+	initialAdminPassword?: string
+	seedUsers?: Array<{
+		username: string
+		password: string
+		role?: "admin" | "user"
+	}>
 }
 
 export async function createTestApp(
-  options: TestAppOptions,
+	options: TestAppOptions,
 ): Promise<Hono<AppBindings>> {
-  process.env.UPLOAD_DIR = options.uploadDir
-  if (options.usersFile) {
-    process.env.USERS_FILE = options.usersFile
-  } else {
-    delete process.env.USERS_FILE
-  }
-  if (options.sessionSecret) {
-    process.env.SESSION_SECRET = options.sessionSecret
-  } else {
-    delete process.env.SESSION_SECRET
-  }
+	process.env.UPLOAD_DIR = options.uploadDir
+	delete process.env.USERS_FILE
+	if (options.sessionSecret) {
+		process.env.SESSION_SECRET = options.sessionSecret
+	} else {
+		delete process.env.SESSION_SECRET
+	}
+	if (options.initialAdminPassword) {
+		process.env.INITIAL_ADMIN_PASSWORD = options.initialAdminPassword
+	} else {
+		delete process.env.INITIAL_ADMIN_PASSWORD
+	}
 
-  resetUsersCacheForTests()
+	resetUsersCacheForTests()
 
-  return createApp({
-    uploadDir: options.uploadDir,
-    usersFile: options.usersFile,
-    sessionSecret: options.sessionSecret,
-  })
+	if (options.seedUsers && options.seedUsers.length > 0) {
+		const usersFile = getUsersFilePath(options.uploadDir)
+		await mkdir(path.dirname(usersFile), { recursive: true })
+		const userConfigs = await Promise.all(
+			options.seedUsers.map(async (user) => ({
+				username: user.username,
+				passwordHash: await Bun.password.hash(user.password, {
+					algorithm: "bcrypt",
+					cost: 4,
+				}),
+				role: user.role ?? "user",
+				sessionVersion: 0,
+			})),
+		)
+		await writeFile(usersFile, JSON.stringify(userConfigs), "utf-8")
+	}
+
+	return createApp({
+		uploadDir: options.uploadDir,
+		sessionSecret: options.sessionSecret,
+		initialAdminPassword: options.initialAdminPassword,
+	})
 }

--- a/projects/file-server/tests/public-route.test.ts
+++ b/projects/file-server/tests/public-route.test.ts
@@ -153,24 +153,10 @@ describe("GET /public/*", () => {
   })
 
   it("is accessible without a session cookie when auth is enabled", async () => {
-    const USERS_FILE = path.join(UPLOAD_DIR, "users.json")
-    await writeFile(
-      USERS_FILE,
-      JSON.stringify([
-        {
-          username: "alice",
-          passwordHash: await Bun.password.hash("pw", {
-            algorithm: "bcrypt",
-            cost: 4,
-          }),
-          role: "user",
-        },
-      ]),
-    )
     app = await createTestApp({
       uploadDir: UPLOAD_DIR,
-      usersFile: USERS_FILE,
       sessionSecret: "0123456789abcdef0123456789abcdef",
+      initialAdminPassword: "test-admin-pass",
     })
 
     await writeFile(

--- a/projects/file-server/tests/rename.test.ts
+++ b/projects/file-server/tests/rename.test.ts
@@ -1,17 +1,19 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test"
 import { mkdir, readFile, rm, stat, writeFile } from "node:fs/promises"
 import path from "node:path"
+import { getUsersFilePath } from "../src/utils/auth"
+import { resetUsersCacheForTests } from "../src/utils/userConfigCache"
 import { createTestSession } from "./helpers/auth"
 import { createTestApp } from "./helpers/createTestApp"
 
 const UPLOAD_DIR = "./tmp-test-rename"
-const USERS_FILE = path.join(UPLOAD_DIR, "users.json")
 const SESSION_SECRET = "0123456789abcdef0123456789abcdef"
 let app: Awaited<ReturnType<typeof createTestApp>>
 
 type PlainUser = { username: string; password: string; role?: "admin" | "user" }
 
 async function writeUsers(users: PlainUser[]) {
+  const usersFile = getUsersFilePath(UPLOAD_DIR)
   const userConfigs = await Promise.all(
     users.map(async (u) => ({
       username: u.username,
@@ -20,9 +22,12 @@ async function writeUsers(users: PlainUser[]) {
         cost: 4,
       }),
       role: u.role ?? "user",
+      sessionVersion: 0,
     })),
   )
-  await writeFile(USERS_FILE, JSON.stringify(userConfigs), "utf-8")
+  await mkdir(path.dirname(usersFile), { recursive: true })
+  await writeFile(usersFile, JSON.stringify(userConfigs), "utf-8")
+  resetUsersCacheForTests()
 }
 
 beforeEach(async () => {
@@ -301,7 +306,6 @@ describe("POST /api/rename", () => {
   it("prevents authenticated users from renaming outside their scope (path traversal)", async () => {
     app = await createTestApp({
       uploadDir: UPLOAD_DIR,
-      usersFile: USERS_FILE,
       sessionSecret: SESSION_SECRET,
     })
     await writeUsers([{ username: "alice", password: "password1" }])
@@ -330,7 +334,6 @@ describe("POST /api/rename", () => {
   it("allows admins to rename items in private area", async () => {
     app = await createTestApp({
       uploadDir: UPLOAD_DIR,
-      usersFile: USERS_FILE,
       sessionSecret: SESSION_SECRET,
     })
     await writeUsers([


### PR DESCRIPTION
## Issues

- Close #814

## Why

本番運用で、事前にコマンドでパスワードを発行し JSON を手動編集する手順を不要にするため。
初回起動後は `admin` でログインし、GUI からユーザー管理を完結できる状態を目指した。

## Summary

`SESSION_SECRET` を設定するだけで認証が有効化され、初回起動時に `admin` ユーザーが自動 bootstrap される。
ログイン後は `/admin/users` からユーザーの作成・削除・ロール変更・パスワード変更をすべて GUI で行える。
セッションに `sessionVersion` を導入し、認証情報の変更時に古いセッションを失効させる。

## Changes

- `SESSION_SECRET` を認証有効化の起点に変更（`USERS_FILE` を廃止）
- 起動時に `UPLOAD_DIR/.auth/users.json` へ `admin` ユーザーを bootstrap（`INITIAL_ADMIN_PASSWORD` 未設定時はランダムパスワードを stdout に一度だけ出力）
- `admin` ユーザーは削除不可・ロール変更不可・自己パスワード変更時は現在パスワード必須
- `UserConfig` に `sessionVersion` を追加し、パスワード変更・ロール変更時にインクリメント（既存セッション失効）
- `saveUsersToFile` で atomic write（tmp → rename）を実装
- `src/routes/admin.tsx` 新規作成: `/admin/users` GUI（作成・ロール変更・PW リセット・削除・自己 PW 変更）
- ヘッダーに admin 向け「User Management」リンクを追加
- `createTestApp` ヘルパーを新方式に対応、`usersFile` オプションを廃止
- `AGENTS.md` / `.env.example` を新しい認証運用に合わせて更新

## Checklist

- [x] `SESSION_SECRET` のみで認証有効化・初回 bootstrap 動作
- [x] `INITIAL_ADMIN_PASSWORD` 未設定時にランダムパスワードがログ出力される
- [x] 起動時 users file が非空で `admin` 不在の場合は起動失敗
- [x] `admin` の削除・ロール変更が拒否される
- [x] 自己パスワード変更時に現在パスワードが必須・成功後に新しいセッション Cookie が発行される
- [x] ユーザー削除後も `private/<username>/` のファイルは残る（削除処理はアカウント定義のみ）
- [x] `sessionVersion` 不一致でセッションが失効する
- [x] `bun run lint` 通過
- [x] `bun test` 全 115 テスト通過
- [x] AGENTS.md / `.env.example` 更新済み
