### PR TITLE
[file-server] AUTH_DIRベースで認証設定を一本化する

### DIFF
--- a/projects/file-server/.dockerignore
+++ b/projects/file-server/.dockerignore
@@ -1,3 +1,4 @@
 node_modules
 tmp
 tmp-test
+auth

--- a/projects/file-server/.env.example
+++ b/projects/file-server/.env.example
@@ -1,11 +1,11 @@
 # File storage base directory
 UPLOAD_DIR=./tmp
 
-# Enable authentication by setting SESSION_SECRET (32+ characters).
-# Users are stored at UPLOAD_DIR/.auth/users.json.
+# Enable authentication by setting AUTH_DIR.
+# AUTH_DIR/users.json and AUTH_DIR/session-secret are created automatically.
 # On first startup an 'admin' user is bootstrapped automatically.
 # Bun loads .env automatically for `bun run`.
-SESSION_SECRET=replace-with-32+chars-secret
+AUTH_DIR=./auth
 
 # Optional: set the initial admin password on first bootstrap.
 # If unset, a random password is printed once to stdout.

--- a/projects/file-server/.env.example
+++ b/projects/file-server/.env.example
@@ -7,6 +7,7 @@ UPLOAD_DIR=./tmp
 # Bun loads .env automatically for `bun run`.
 AUTH_DIR=./auth
 
-# Optional: set the initial admin password on first bootstrap.
+# Optional: set the initial admin password on first bootstrap only.
+# If users.json already has a valid admin, this value is ignored.
 # If unset, a random password is printed once to stdout.
 # INITIAL_ADMIN_PASSWORD=changeme

--- a/projects/file-server/.gitignore
+++ b/projects/file-server/.gitignore
@@ -2,6 +2,7 @@
 node_modules/
 tmp/
 tmp-test/
+auth/
 users.dev.json
 
 .env

--- a/projects/file-server/AGENTS.md
+++ b/projects/file-server/AGENTS.md
@@ -33,7 +33,7 @@ Current features include empty file creation, per-directory Zip download via `/f
 ## Environment Variables
 
 - `UPLOAD_DIR` - File storage root directory (default: `./tmp`)
-- `SESSION_SECRET` - Session signing secret (32+ chars). Setting this enables authentication.
+- `AUTH_DIR` - Authentication metadata directory. Setting this enables authentication and stores `users.json` plus `session-secret`.
 - `INITIAL_ADMIN_PASSWORD` - Password for the `admin` user on first bootstrap. If unset, a random password is printed to stdout once at startup.
 - Use `.env.example` as a template and set values in `.env` for local development (`bun run` loads `.env` automatically)
 
@@ -51,9 +51,9 @@ UPLOAD_DIR/
 
 `createApp()` creates both directories at startup if they do not exist.
 
-When `SESSION_SECRET` is set, `createApp()` also creates `UPLOAD_DIR/.auth/users.json` with a bootstrapped `admin` user if the file is absent or empty. On subsequent startups the file is validated (must contain `admin` with `role: "admin"`).
+When `AUTH_DIR` is set, `createApp()` also creates `AUTH_DIR/users.json` plus `AUTH_DIR/session-secret`. `users.json` is bootstrapped with an `admin` user if the file is absent or empty. On subsequent startups the file is validated (must contain `admin` with `role: "admin"`).
 
-**Docker / Docker Compose**: mount `UPLOAD_DIR` as a persistent volume so `UPLOAD_DIR/.auth/users.json` survives container restarts.
+**Docker / Docker Compose**: mount `AUTH_DIR` as a persistent volume so `users.json` and `session-secret` survive container restarts.
 
 ## Virtual Path Resolution
 
@@ -77,7 +77,7 @@ All browse/API requests use a virtual path that maps to one of two scopes:
 
 ## Authentication
 
-Authentication is enabled when `SESSION_SECRET` is set. Users are stored in `UPLOAD_DIR/.auth/users.json`.
+Authentication is enabled when `AUTH_DIR` is set. Users are stored in `AUTH_DIR/users.json`, and the session signing key is stored in `AUTH_DIR/session-secret`.
 
 ### Roles
 
@@ -88,7 +88,7 @@ Authentication is enabled when `SESSION_SECRET` is set. Users are stored in `UPL
 
 - Username `admin` is the master admin: deletion-protected and role-change-protected.
 - Changing `admin`'s own password requires the current password.
-- `UPLOAD_DIR/.auth/users.json` must always contain `admin` with `role: "admin"` when non-empty; otherwise startup fails.
+- `AUTH_DIR/users.json` must always contain `admin` with `role: "admin"` when non-empty; otherwise startup fails.
 
 ### Session Versioning
 

--- a/projects/file-server/AGENTS.md
+++ b/projects/file-server/AGENTS.md
@@ -34,7 +34,7 @@ Current features include empty file creation, per-directory Zip download via `/f
 
 - `UPLOAD_DIR` - File storage root directory (default: `./tmp`)
 - `AUTH_DIR` - Authentication metadata directory. Setting this enables authentication and stores `users.json` plus `session-secret`.
-- `INITIAL_ADMIN_PASSWORD` - Password for the `admin` user on first bootstrap. If unset, a random password is printed to stdout once at startup.
+- `INITIAL_ADMIN_PASSWORD` - Password for the `admin` user on first bootstrap only. If `users.json` already contains a valid `admin`, this value is ignored. If unset, a random password is printed to stdout once at startup.
 - Use `.env.example` as a template and set values in `.env` for local development (`bun run` loads `.env` automatically)
 
 ## Directory Layout
@@ -51,7 +51,7 @@ UPLOAD_DIR/
 
 `createApp()` creates both directories at startup if they do not exist.
 
-When `AUTH_DIR` is set, `createApp()` also creates `AUTH_DIR/users.json` plus `AUTH_DIR/session-secret`. `users.json` is bootstrapped with an `admin` user if the file is absent or empty. On subsequent startups the file is validated (must contain `admin` with `role: "admin"`).
+When `AUTH_DIR` is set, `createApp()` also creates `AUTH_DIR/users.json` plus `AUTH_DIR/session-secret`. `users.json` is bootstrapped with an `admin` user if the file is absent or empty. On subsequent startups the file is validated (must contain `admin` with `role: "admin"`), and `INITIAL_ADMIN_PASSWORD` is ignored once a valid admin already exists.
 
 **Docker / Docker Compose**: mount `AUTH_DIR` as a persistent volume so `users.json` and `session-secret` survive container restarts.
 

--- a/projects/file-server/Dockerfile
+++ b/projects/file-server/Dockerfile
@@ -46,8 +46,8 @@ COPY --from=builder /app/node_modules ./node_modules
 COPY src ./src
 COPY tsconfig.json ./tsconfig.json
 
-RUN mkdir -p $UPLOAD_DIR && \
-    chown -R node:node $UPLOAD_DIR
+RUN mkdir -p $UPLOAD_DIR /app/auth && \
+    chown -R node:node $UPLOAD_DIR /app/auth
 
 USER node
 

--- a/projects/file-server/README.md
+++ b/projects/file-server/README.md
@@ -166,7 +166,7 @@ bun run hash-password 'your-password'
 |------|------|-----------|
 | `UPLOAD_DIR` | ファイル保存ルートディレクトリ | `./tmp` |
 | `AUTH_DIR` | 認証メタデータ保存ディレクトリ。設定時に認証有効 | 未設定 |
-| `INITIAL_ADMIN_PASSWORD` | 初回 bootstrap 時の `admin` パスワード | 未設定 |
+| `INITIAL_ADMIN_PASSWORD` | 初回 bootstrap 時のみ使う `admin` パスワード。既存の有効な `admin` がいる場合は無視 | 未設定 |
 
 `AUTH_DIR` を設定すると、初回起動時に次の2ファイルが自動作成される。
 
@@ -178,6 +178,7 @@ AUTH_DIR/
 
 - `users.json`: ユーザー定義。存在しない、空、または空配列なら `admin` ユーザーを bootstrap する
 - `session-secret`: セッション署名鍵。再起動後も同じ値が再利用される
+- `INITIAL_ADMIN_PASSWORD`: `users.json` に有効な `admin` がまだ無い初回 bootstrap 時だけ適用される
 
 ### `users.json` 例
 

--- a/projects/file-server/README.md
+++ b/projects/file-server/README.md
@@ -244,16 +244,17 @@ bun run hash-password 'alice-password'
 - `users.json` を更新すると次回リクエストから再読込される
 - `session-secret` を失うか差し替えると既存セッションはすべて失効する
 
-Docker 例:
+このリポジトリには `compose.yaml` のサンプルが含まれており、`AUTH_DIR` と `UPLOAD_DIR` を別々の named volume に永続化する。
 
 ```bash
-docker run -p 3000:3000 \
-  -e AUTH_DIR='/app/auth' \
-  -e UPLOAD_DIR='/app/uploads' \
-  file-server
+docker compose up -d --build
 ```
 
-必要に応じて `/app/auth` と `/app/uploads` を volume mount する。
+停止時:
+
+```bash
+docker compose down
+```
 
 ## 破壊的変更とマイグレーション
 
@@ -287,15 +288,10 @@ APIパスも変更されている:
 
 現在のランタイムイメージでは `zip` コマンドをインストールしており、`/file/archive` はその `zip` コマンドを使って表示中ディレクトリ配下の子要素だけをアーカイブする。
 
+同梱の `compose.yaml` を使う場合は、次のコマンドで起動できる。
+
 ```bash
-# ビルド
-docker build -t file-server .
-
-# テスト実行
-docker build --target=test .
-
-# 実行
-docker run -p 3000:3000 -e UPLOAD_DIR=/app/uploads -v $(pwd)/data:/app/uploads file-server
+docker compose up -d --build
 ```
 
 ### Dockerfileの構成（マルチステージ）

--- a/projects/file-server/README.md
+++ b/projects/file-server/README.md
@@ -165,10 +165,21 @@ bun run hash-password 'your-password'
 | 変数 | 説明 | デフォルト |
 |------|------|-----------|
 | `UPLOAD_DIR` | ファイル保存ルートディレクトリ | `./tmp` |
-| `USERS_FILE` | ユーザー設定JSONファイルへのパス（設定時に認証有効） | 未設定 |
-| `SESSION_SECRET` | セッション署名シークレット（`USERS_FILE` 設定時は必須） | 未設定 |
+| `AUTH_DIR` | 認証メタデータ保存ディレクトリ。設定時に認証有効 | 未設定 |
+| `INITIAL_ADMIN_PASSWORD` | 初回 bootstrap 時の `admin` パスワード | 未設定 |
 
-### `USERS_FILE` 例
+`AUTH_DIR` を設定すると、初回起動時に次の2ファイルが自動作成される。
+
+```text
+AUTH_DIR/
+├── users.json
+└── session-secret
+```
+
+- `users.json`: ユーザー定義。存在しない、空、または空配列なら `admin` ユーザーを bootstrap する
+- `session-secret`: セッション署名鍵。再起動後も同じ値が再利用される
+
+### `users.json` 例
 
 ```json
 [
@@ -187,16 +198,29 @@ bun run hash-password 'your-password'
 
 `role` は必須で、`"user"` または `"admin"` のみ指定できる。不正な値は設定エラーとして扱われる。
 `public` と `private` はシステム予約語のため、ユーザー名に使用できない。
+`SESSION_SECRET` と `USERS_FILE` は廃止されており、設定すると起動エラーになる。
 
 ### 開発時にユーザー認証を有効化する手順
 
-1. パスワードハッシュを生成する。
+1. `.env` を作成して `AUTH_DIR` を設定する。
+
+```bash
+cp .env.example .env
+# .env を編集して AUTH_DIR と必要なら INITIAL_ADMIN_PASSWORD を設定
+```
+
+2. 開発サーバーを起動する。
+
+```bash
+bun run dev
+```
+
+3. 初回起動後、`AUTH_DIR/users.json` と `AUTH_DIR/session-secret` が作成される。
+4. 追加ユーザーを手で投入したい場合は、パスワードハッシュを生成して `AUTH_DIR/users.json` を編集する。
 
 ```bash
 bun run hash-password 'alice-password'
 ```
-
-2. プロジェクトルートに `users.dev.json` を作成し、ユーザーを設定する。
 
 ```json
 [
@@ -208,42 +232,28 @@ bun run hash-password 'alice-password'
 ]
 ```
 
-3. `.env` に環境変数を設定して開発サーバーを起動する。
-
-```bash
-cp .env.example .env
-# .env を編集して USERS_FILE と SESSION_SECRET を設定
-bun run dev
-```
-
 認証時のパスとスコープの対応:
 - `role: "user"`: `private/<username>/` のみアクセス可
 - `role: "admin"`: 全スコープにアクセス可
 
 `bun run` 実行時は Bun が `.env` を自動で読み込む。
 
-### 本番環境での `SESSION_SECRET` 運用
+### `AUTH_DIR` の永続化
 
-- `SESSION_SECRET` は 32 文字以上の十分に長いランダム値を使う（推奨: 64 バイト相当）。
-- ソースコードや Git にコミットしない。環境変数として注入する。
-- 複数インスタンス運用時は、同一サービスで同じ `SESSION_SECRET` を共有する。
-- 定期ローテーションを行う（切り替え時は既存セッション失効を想定）。
-
-生成例:
-
-```bash
-openssl rand -base64 48
-```
+- 認証を継続利用する場合、`AUTH_DIR` は永続化ストレージに置く
+- `users.json` を更新すると次回リクエストから再読込される
+- `session-secret` を失うか差し替えると既存セッションはすべて失効する
 
 Docker 例:
 
 ```bash
 docker run -p 3000:3000 \
-  -e SESSION_SECRET='generated-secret' \
-  -e USERS_FILE='/app/users.json' \
+  -e AUTH_DIR='/app/auth' \
   -e UPLOAD_DIR='/app/uploads' \
   file-server
 ```
+
+必要に応じて `/app/auth` と `/app/uploads` を volume mount する。
 
 ## 破壊的変更とマイグレーション
 

--- a/projects/file-server/compose.yaml
+++ b/projects/file-server/compose.yaml
@@ -1,0 +1,16 @@
+services:
+  file-server:
+    build: .
+    ports:
+      - "3000:3000"
+    environment:
+      AUTH_DIR: /app/auth
+      UPLOAD_DIR: /app/uploads
+    volumes:
+      - file_server_auth:/app/auth
+      - file_server_uploads:/app/uploads
+    restart: unless-stopped
+
+volumes:
+  file_server_auth:
+  file_server_uploads:

--- a/projects/file-server/src/app.ts
+++ b/projects/file-server/src/app.ts
@@ -13,6 +13,7 @@ import {
   DEFAULT_UPLOAD_DIR,
   ensureSessionSecret,
   resolveAuthConfig,
+  validateLegacyAuthEnv,
 } from "./utils/auth"
 import { bootstrapAdminUser } from "./utils/bootstrap"
 
@@ -27,11 +28,13 @@ export async function createApp(
 ): Promise<Hono<AppBindings>> {
   const uploadDir =
     options.uploadDir ?? process.env.UPLOAD_DIR ?? DEFAULT_UPLOAD_DIR
-  const authConfig = resolveAuthConfig({
+  const authEnv = {
     AUTH_DIR: options.authDir ?? process.env.AUTH_DIR,
     SESSION_SECRET: process.env.SESSION_SECRET,
     USERS_FILE: process.env.USERS_FILE,
-  })
+  }
+  validateLegacyAuthEnv(authEnv)
+  const authConfig = resolveAuthConfig(authEnv)
   const initialAdminPassword =
     options.initialAdminPassword ?? process.env.INITIAL_ADMIN_PASSWORD
 

--- a/projects/file-server/src/app.ts
+++ b/projects/file-server/src/app.ts
@@ -9,44 +9,51 @@ import browseRoutes from "./routes/browse"
 import fileRoutes from "./routes/file"
 import publicRoutes from "./routes/public"
 import type { AppBindings } from "./types"
-import { DEFAULT_UPLOAD_DIR, validateAuthConfig } from "./utils/auth"
+import {
+  DEFAULT_UPLOAD_DIR,
+  ensureSessionSecret,
+  resolveAuthConfig,
+} from "./utils/auth"
 import { bootstrapAdminUser } from "./utils/bootstrap"
 
 export interface CreateAppOptions {
-	uploadDir?: string
-	sessionSecret?: string
-	initialAdminPassword?: string
+  uploadDir?: string
+  authDir?: string
+  initialAdminPassword?: string
 }
 
 export async function createApp(
-	options: CreateAppOptions = {},
+  options: CreateAppOptions = {},
 ): Promise<Hono<AppBindings>> {
-	const uploadDir =
-		options.uploadDir ?? process.env.UPLOAD_DIR ?? DEFAULT_UPLOAD_DIR
-	const sessionSecret = options.sessionSecret ?? process.env.SESSION_SECRET
-	const initialAdminPassword =
-		options.initialAdminPassword ?? process.env.INITIAL_ADMIN_PASSWORD
+  const uploadDir =
+    options.uploadDir ?? process.env.UPLOAD_DIR ?? DEFAULT_UPLOAD_DIR
+  const authConfig = resolveAuthConfig({
+    AUTH_DIR: options.authDir ?? process.env.AUTH_DIR,
+    SESSION_SECRET: process.env.SESSION_SECRET,
+    USERS_FILE: process.env.USERS_FILE,
+  })
+  const initialAdminPassword =
+    options.initialAdminPassword ?? process.env.INITIAL_ADMIN_PASSWORD
 
-	validateAuthConfig(sessionSecret)
+  await mkdir(path.join(uploadDir, "public"), { recursive: true })
+  await mkdir(path.join(uploadDir, "private"), { recursive: true })
 
-	await mkdir(path.join(uploadDir, "public"), { recursive: true })
-	await mkdir(path.join(uploadDir, "private"), { recursive: true })
+  if (authConfig.authDir) {
+    await bootstrapAdminUser(authConfig.authDir, initialAdminPassword)
+    await ensureSessionSecret(authConfig.authDir)
+  }
 
-	if (sessionSecret) {
-		await bootstrapAdminUser(uploadDir, initialAdminPassword)
-	}
+  const app = new Hono<AppBindings>()
 
-	const app = new Hono<AppBindings>()
+  app.use("*", authMiddleware)
+  app.use("*", requireAuthMiddleware)
 
-	app.use("*", authMiddleware)
-	app.use("*", requireAuthMiddleware)
+  app.route("/", authRoutes)
+  app.route("/public", publicRoutes)
+  app.route("/api", apiRoutes)
+  app.route("/admin", adminRoutes)
+  app.route("/", browseRoutes)
+  app.route("/file", fileRoutes)
 
-	app.route("/", authRoutes)
-	app.route("/public", publicRoutes)
-	app.route("/api", apiRoutes)
-	app.route("/admin", adminRoutes)
-	app.route("/", browseRoutes)
-	app.route("/file", fileRoutes)
-
-	return app
+  return app
 }

--- a/projects/file-server/src/middleware/auth.ts
+++ b/projects/file-server/src/middleware/auth.ts
@@ -9,17 +9,13 @@ import {
   loadSessionSecretWithCache,
   normalizeReturnTo,
   type ResolvedAuthConfig,
+  type RuntimeAuthEnv,
   resolveAuthConfig,
   SESSION_COOKIE_NAME,
   verifySession,
 } from "../utils/auth"
 import { errorResponse } from "../utils/requestUtils"
 import { loadUsersFromFileWithCache } from "../utils/userConfigCache"
-
-type RuntimeAuthEnv = AppBindings["Bindings"] & {
-  SESSION_SECRET?: string
-  USERS_FILE?: string
-}
 
 function getRequestPathWithQuery(c: Context<AppBindings>): string {
   const url = new URL(c.req.url)
@@ -42,19 +38,7 @@ export async function authMiddleware(c: Context<AppBindings>, next: Next) {
   const runtimeEnv = env(c) as RuntimeAuthEnv
   const { UPLOAD_DIR } = runtimeEnv
   const uploadBaseDir = UPLOAD_DIR || DEFAULT_UPLOAD_DIR
-  let authConfig: ResolvedAuthConfig
-
-  try {
-    authConfig = resolveAuthConfig(runtimeEnv)
-  } catch (error) {
-    console.error(error)
-    return errorResponse(
-      c,
-      "AuthConfigError",
-      "Invalid authentication configuration",
-      500,
-    )
-  }
+  const authConfig: ResolvedAuthConfig = resolveAuthConfig(runtimeEnv)
 
   if (!authConfig.enabled || !authConfig.usersFile || !authConfig.authDir) {
     return next()
@@ -125,18 +109,7 @@ export async function requireAuthMiddleware(
   next: Next,
 ) {
   const runtimeEnv = env(c) as RuntimeAuthEnv
-  let authConfig: ResolvedAuthConfig
-  try {
-    authConfig = resolveAuthConfig(runtimeEnv)
-  } catch (error) {
-    console.error(error)
-    return errorResponse(
-      c,
-      "AuthConfigError",
-      "Invalid authentication configuration",
-      500,
-    )
-  }
+  const authConfig: ResolvedAuthConfig = resolveAuthConfig(runtimeEnv)
 
   if (!authConfig.enabled) {
     return next()

--- a/projects/file-server/src/middleware/auth.ts
+++ b/projects/file-server/src/middleware/auth.ts
@@ -5,127 +5,159 @@ import { env } from "hono/adapter"
 import { getCookie } from "hono/cookie"
 import type { AppBindings } from "../types"
 import {
-	DEFAULT_UPLOAD_DIR,
-	getUsersFilePath,
-	normalizeReturnTo,
-	SESSION_COOKIE_NAME,
-	validateAuthConfig,
-	verifySession,
+  DEFAULT_UPLOAD_DIR,
+  loadSessionSecretWithCache,
+  normalizeReturnTo,
+  type ResolvedAuthConfig,
+  resolveAuthConfig,
+  SESSION_COOKIE_NAME,
+  verifySession,
 } from "../utils/auth"
-import { loadUsersFromFileWithCache } from "../utils/userConfigCache"
 import { errorResponse } from "../utils/requestUtils"
+import { loadUsersFromFileWithCache } from "../utils/userConfigCache"
+
+type RuntimeAuthEnv = AppBindings["Bindings"] & {
+  SESSION_SECRET?: string
+  USERS_FILE?: string
+}
 
 function getRequestPathWithQuery(c: Context<AppBindings>): string {
-	const url = new URL(c.req.url)
-	const pathWithQuery = `${url.pathname}${url.search}`
-	return normalizeReturnTo(pathWithQuery)
+  const url = new URL(c.req.url)
+  const pathWithQuery = `${url.pathname}${url.search}`
+  return normalizeReturnTo(pathWithQuery)
 }
 
 function isPublicPath(pathname: string): boolean {
-	return (
-		pathname === "/login" ||
-		pathname === "/logout" ||
-		pathname.startsWith("/public/") ||
-		pathname === "/public"
-	)
+  return (
+    pathname === "/login" ||
+    pathname === "/logout" ||
+    pathname.startsWith("/public/") ||
+    pathname === "/public"
+  )
 }
 
 export async function authMiddleware(c: Context<AppBindings>, next: Next) {
-	c.set("user", { type: "anonymous" })
+  c.set("user", { type: "anonymous" })
 
-	const { UPLOAD_DIR, SESSION_SECRET } = env(c)
-	const uploadBaseDir = UPLOAD_DIR || DEFAULT_UPLOAD_DIR
+  const runtimeEnv = env(c) as RuntimeAuthEnv
+  const { UPLOAD_DIR } = runtimeEnv
+  const uploadBaseDir = UPLOAD_DIR || DEFAULT_UPLOAD_DIR
+  let authConfig: ResolvedAuthConfig
 
-	try {
-		validateAuthConfig(SESSION_SECRET)
-	} catch (error) {
-		console.error(error)
-		return errorResponse(
-			c,
-			"AuthConfigError",
-			"Invalid authentication configuration",
-			500,
-		)
-	}
+  try {
+    authConfig = resolveAuthConfig(runtimeEnv)
+  } catch (error) {
+    console.error(error)
+    return errorResponse(
+      c,
+      "AuthConfigError",
+      "Invalid authentication configuration",
+      500,
+    )
+  }
 
-	if (!SESSION_SECRET) {
-		return next()
-	}
+  if (!authConfig.enabled || !authConfig.usersFile || !authConfig.authDir) {
+    return next()
+  }
 
-	const usersFile = getUsersFilePath(uploadBaseDir)
-	let users: Awaited<ReturnType<typeof loadUsersFromFileWithCache>>
-	try {
-		users = await loadUsersFromFileWithCache(usersFile)
-	} catch (error) {
-		console.error(error)
-		return errorResponse(
-			c,
-			"AuthConfigError",
-			"Failed to load users configuration",
-			500,
-		)
-	}
+  let users: Awaited<ReturnType<typeof loadUsersFromFileWithCache>>
+  try {
+    users = await loadUsersFromFileWithCache(authConfig.usersFile)
+  } catch (error) {
+    console.error(error)
+    return errorResponse(
+      c,
+      "AuthConfigError",
+      "Failed to load users configuration",
+      500,
+    )
+  }
 
-	const session = getCookie(c, SESSION_COOKIE_NAME)
-	if (!session) {
-		return next()
-	}
+  const session = getCookie(c, SESSION_COOKIE_NAME)
+  if (!session) {
+    return next()
+  }
 
-	const payload = await verifySession(session, SESSION_SECRET)
-	if (!payload) {
-		return next()
-	}
+  let payload: Awaited<ReturnType<typeof verifySession>>
+  try {
+    const sessionSecret = await loadSessionSecretWithCache(authConfig.authDir)
+    payload = await verifySession(session, sessionSecret)
+  } catch (error) {
+    console.error(error)
+    return errorResponse(
+      c,
+      "AuthConfigError",
+      "Failed to load session secret",
+      500,
+    )
+  }
+  if (!payload) {
+    return next()
+  }
 
-	const user = users.find((entry) => entry.username === payload.username)
-	if (!user) {
-		return next()
-	}
+  const user = users.find((entry) => entry.username === payload.username)
+  if (!user) {
+    return next()
+  }
 
-	if (user.sessionVersion !== payload.sessionVersion) {
-		return next()
-	}
+  if (user.sessionVersion !== payload.sessionVersion) {
+    return next()
+  }
 
-	const authenticated = {
-		type: "authenticated" as const,
-		username: user.username,
-		role: user.role,
-	}
-	c.set("user", authenticated)
+  const authenticated = {
+    type: "authenticated" as const,
+    username: user.username,
+    role: user.role,
+  }
+  c.set("user", authenticated)
 
-	if (authenticated.role === "user") {
-		await mkdir(path.join(uploadBaseDir, "private", authenticated.username), {
-			recursive: true,
-		})
-	}
+  if (authenticated.role === "user") {
+    await mkdir(path.join(uploadBaseDir, "private", authenticated.username), {
+      recursive: true,
+    })
+  }
 
-	return next()
+  return next()
 }
 
 export async function requireAuthMiddleware(
-	c: Context<AppBindings>,
-	next: Next,
+  c: Context<AppBindings>,
+  next: Next,
 ) {
-	const { SESSION_SECRET } = env(c)
-	if (!SESSION_SECRET) {
-		return next()
-	}
+  const runtimeEnv = env(c) as RuntimeAuthEnv
+  let authConfig: ResolvedAuthConfig
+  try {
+    authConfig = resolveAuthConfig(runtimeEnv)
+  } catch (error) {
+    console.error(error)
+    return errorResponse(
+      c,
+      "AuthConfigError",
+      "Invalid authentication configuration",
+      500,
+    )
+  }
 
-	if (isPublicPath(c.req.path)) {
-		return next()
-	}
+  if (!authConfig.enabled) {
+    return next()
+  }
 
-	const user = c.get("user")
-	if (user.type === "authenticated") {
-		return next()
-	}
+  if (isPublicPath(c.req.path)) {
+    return next()
+  }
 
-	const returnTo = encodeURIComponent(getRequestPathWithQuery(c))
-	const loginUrl = `/login?returnTo=${returnTo}`
+  const user = c.get("user")
+  if (user.type === "authenticated") {
+    return next()
+  }
 
-	if (c.req.header("HX-Request") === "true") {
-		c.header("HX-Redirect", loginUrl)
-		return c.body(null, 401)
-	}
+  const returnTo = encodeURIComponent(getRequestPathWithQuery(c))
+  const loginUrl = `/login?returnTo=${returnTo}`
 
-	return c.redirect(loginUrl)
+  if (c.req.header("HX-Request") === "true") {
+    c.header("HX-Redirect", loginUrl)
+    return c.body(null, 401)
+  }
+
+  return c.redirect(loginUrl)
 }

--- a/projects/file-server/src/routes/admin.tsx
+++ b/projects/file-server/src/routes/admin.tsx
@@ -7,6 +7,7 @@ import {
   isValidUsername,
   loadSessionSecretWithCache,
   MASTER_ADMIN_USERNAME,
+  type RuntimeAuthEnv,
   resolveAuthConfig,
   SESSION_COOKIE_NAME,
   SESSION_MAX_AGE_SECONDS,
@@ -260,11 +261,6 @@ function AdminUsersPage({
       </section>
     </div>
   )
-}
-
-type RuntimeAuthEnv = AppBindings["Bindings"] & {
-  SESSION_SECRET?: string
-  USERS_FILE?: string
 }
 
 function getAuthConfig(c: Context<AppBindings>) {

--- a/projects/file-server/src/routes/admin.tsx
+++ b/projects/file-server/src/routes/admin.tsx
@@ -1,512 +1,606 @@
-import { Hono } from "hono"
+import { type Context, Hono } from "hono"
 import { env } from "hono/adapter"
 import { setCookie } from "hono/cookie"
 import { PageShell } from "../components/PageShell"
 import type { AppBindings, UserConfig } from "../types"
 import {
-	DEFAULT_UPLOAD_DIR,
-	getUsersFilePath,
-	isValidUsername,
-	MASTER_ADMIN_USERNAME,
-	SESSION_COOKIE_NAME,
-	SESSION_MAX_AGE_SECONDS,
-	signSession,
-	verifyPassword,
+  isValidUsername,
+  loadSessionSecretWithCache,
+  MASTER_ADMIN_USERNAME,
+  resolveAuthConfig,
+  SESSION_COOKIE_NAME,
+  SESSION_MAX_AGE_SECONDS,
+  signSession,
+  verifyPassword,
 } from "../utils/auth"
-import { loadUsersFromFileWithCache, saveUsersToFile } from "../utils/userConfigCache"
+import {
+  loadUsersFromFileWithCache,
+  saveUsersToFile,
+} from "../utils/userConfigCache"
 
 interface AdminUsersPageProps {
-	users: UserConfig[]
-	currentUsername: string
-	error?: string
-	success?: string
+  users: UserConfig[]
+  currentUsername: string
+  error?: string
+  success?: string
 }
 
-function AdminUsersPage({ users, currentUsername, error, success }: AdminUsersPageProps) {
-	return (
-		<div className="space-y-6">
-			<div className="flex flex-wrap items-center justify-between gap-3">
-				<h2 className="text-xl font-semibold text-gray-900">User Management</h2>
-				<a
-					href="/"
-					className="rounded-md bg-gray-100 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-200"
-				>
-					← Back
-				</a>
-			</div>
+function AdminUsersPage({
+  users,
+  currentUsername,
+  error,
+  success,
+}: AdminUsersPageProps) {
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <h2 className="text-xl font-semibold text-gray-900">User Management</h2>
+        <a
+          href="/"
+          className="rounded-md bg-gray-100 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-200"
+        >
+          ← Back
+        </a>
+      </div>
 
-			{error && (
-				<div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-					{error}
-				</div>
-			)}
-			{success && (
-				<div className="rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700">
-					{success}
-				</div>
-			)}
+      {error && (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+      {success && (
+        <div className="rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700">
+          {success}
+        </div>
+      )}
 
-			<section className="rounded-xl border border-indigo-100 bg-white p-5">
-				<h3 className="mb-3 font-medium text-gray-800">Change My Password</h3>
-				<form
-					action="/admin/change-password"
-					method="post"
-					className="flex flex-wrap items-end gap-3"
-				>
-					<div className="flex-1 min-w-36">
-						<label for="change-current-password" className="mb-1 block text-sm text-gray-600">Current password</label>
-						<input
-							id="change-current-password"
-							name="currentPassword"
-							type="password"
-							required
-							className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
-						/>
-					</div>
-					<div className="flex-1 min-w-36">
-						<label for="change-new-password" className="mb-1 block text-sm text-gray-600">New password</label>
-						<input
-							id="change-new-password"
-							name="newPassword"
-							type="password"
-							required
-							className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
-						/>
-					</div>
-					<button
-						type="submit"
-						className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700"
-					>
-						Change
-					</button>
-				</form>
-			</section>
+      <section className="rounded-xl border border-indigo-100 bg-white p-5">
+        <h3 className="mb-3 font-medium text-gray-800">Change My Password</h3>
+        <form
+          action="/admin/change-password"
+          method="post"
+          className="flex flex-wrap items-end gap-3"
+        >
+          <div className="flex-1 min-w-36">
+            <label
+              for="change-current-password"
+              className="mb-1 block text-sm text-gray-600"
+            >
+              Current password
+            </label>
+            <input
+              id="change-current-password"
+              name="currentPassword"
+              type="password"
+              required
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+            />
+          </div>
+          <div className="flex-1 min-w-36">
+            <label
+              for="change-new-password"
+              className="mb-1 block text-sm text-gray-600"
+            >
+              New password
+            </label>
+            <input
+              id="change-new-password"
+              name="newPassword"
+              type="password"
+              required
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+            />
+          </div>
+          <button
+            type="submit"
+            className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700"
+          >
+            Change
+          </button>
+        </form>
+      </section>
 
-			<section className="rounded-xl border border-indigo-100 bg-white p-5">
-				<h3 className="mb-3 font-medium text-gray-800">Users</h3>
-				<div className="overflow-x-auto">
-					<table className="w-full text-sm">
-						<thead>
-							<tr className="border-b border-gray-200 text-left text-xs font-medium uppercase tracking-wide text-gray-500">
-								<th className="pb-2 pr-4">Username</th>
-								<th className="pb-2 pr-4">Role</th>
-								<th className="pb-2">Actions</th>
-							</tr>
-						</thead>
-						<tbody className="divide-y divide-gray-100">
-							{users.map((user) => (
-								<tr key={user.username}>
-									<td className="py-3 pr-4 font-medium text-gray-800">
-										{user.username}
-										{user.username === currentUsername && (
-											<span className="ml-2 text-xs text-gray-400">(you)</span>
-										)}
-									</td>
-									<td className="py-3 pr-4 text-gray-600">{user.role}</td>
-									<td className="py-3">
-										{user.username === MASTER_ADMIN_USERNAME ? (
-											<span className="text-xs text-gray-400">Protected</span>
-										) : (
-											<div className="flex flex-wrap items-center gap-2">
-												<form
-													action={`/admin/users/${user.username}/role`}
-													method="post"
-													className="flex items-center gap-1"
-												>
-													<select
-														name="role"
-														className="rounded border border-gray-300 px-2 py-1 text-xs focus:border-indigo-500 focus:outline-none"
-													>
-														<option value="user" selected={user.role === "user"}>
-															user
-														</option>
-														<option value="admin" selected={user.role === "admin"}>
-															admin
-														</option>
-													</select>
-													<button
-														type="submit"
-														className="rounded bg-gray-100 px-2 py-1 text-xs font-medium text-gray-700 hover:bg-gray-200"
-													>
-														Change Role
-													</button>
-												</form>
-												{user.username !== currentUsername && (
-													<form
-														action={`/admin/users/${user.username}/password`}
-														method="post"
-														className="flex items-center gap-1"
-													>
-														<input
-															name="newPassword"
-															type="password"
-															required
-															placeholder="New password"
-															className="rounded border border-gray-300 px-2 py-1 text-xs focus:border-indigo-500 focus:outline-none"
-														/>
-														<button
-															type="submit"
-															className="rounded bg-gray-100 px-2 py-1 text-xs font-medium text-gray-700 hover:bg-gray-200"
-														>
-															Reset PW
-														</button>
-													</form>
-												)}
-												<form
-													action={`/admin/users/${user.username}/delete`}
-													method="post"
-												>
-													<button
-														type="submit"
-														className="rounded bg-red-50 px-2 py-1 text-xs font-medium text-red-600 hover:bg-red-100"
-													>
-														Delete
-													</button>
-												</form>
-											</div>
-										)}
-									</td>
-								</tr>
-							))}
-						</tbody>
-					</table>
-				</div>
-			</section>
+      <section className="rounded-xl border border-indigo-100 bg-white p-5">
+        <h3 className="mb-3 font-medium text-gray-800">Users</h3>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-gray-200 text-left text-xs font-medium uppercase tracking-wide text-gray-500">
+                <th className="pb-2 pr-4">Username</th>
+                <th className="pb-2 pr-4">Role</th>
+                <th className="pb-2">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {users.map((user) => (
+                <tr key={user.username}>
+                  <td className="py-3 pr-4 font-medium text-gray-800">
+                    {user.username}
+                    {user.username === currentUsername && (
+                      <span className="ml-2 text-xs text-gray-400">(you)</span>
+                    )}
+                  </td>
+                  <td className="py-3 pr-4 text-gray-600">{user.role}</td>
+                  <td className="py-3">
+                    {user.username === MASTER_ADMIN_USERNAME ? (
+                      <span className="text-xs text-gray-400">Protected</span>
+                    ) : (
+                      <div className="flex flex-wrap items-center gap-2">
+                        <form
+                          action={`/admin/users/${user.username}/role`}
+                          method="post"
+                          className="flex items-center gap-1"
+                        >
+                          <select
+                            name="role"
+                            className="rounded border border-gray-300 px-2 py-1 text-xs focus:border-indigo-500 focus:outline-none"
+                          >
+                            <option
+                              value="user"
+                              selected={user.role === "user"}
+                            >
+                              user
+                            </option>
+                            <option
+                              value="admin"
+                              selected={user.role === "admin"}
+                            >
+                              admin
+                            </option>
+                          </select>
+                          <button
+                            type="submit"
+                            className="rounded bg-gray-100 px-2 py-1 text-xs font-medium text-gray-700 hover:bg-gray-200"
+                          >
+                            Change Role
+                          </button>
+                        </form>
+                        {user.username !== currentUsername && (
+                          <form
+                            action={`/admin/users/${user.username}/password`}
+                            method="post"
+                            className="flex items-center gap-1"
+                          >
+                            <input
+                              name="newPassword"
+                              type="password"
+                              required
+                              placeholder="New password"
+                              className="rounded border border-gray-300 px-2 py-1 text-xs focus:border-indigo-500 focus:outline-none"
+                            />
+                            <button
+                              type="submit"
+                              className="rounded bg-gray-100 px-2 py-1 text-xs font-medium text-gray-700 hover:bg-gray-200"
+                            >
+                              Reset PW
+                            </button>
+                          </form>
+                        )}
+                        <form
+                          action={`/admin/users/${user.username}/delete`}
+                          method="post"
+                        >
+                          <button
+                            type="submit"
+                            className="rounded bg-red-50 px-2 py-1 text-xs font-medium text-red-600 hover:bg-red-100"
+                          >
+                            Delete
+                          </button>
+                        </form>
+                      </div>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
 
-			<section className="rounded-xl border border-indigo-100 bg-white p-5">
-				<h3 className="mb-3 font-medium text-gray-800">Create User</h3>
-				<form
-					action="/admin/users"
-					method="post"
-					className="flex flex-wrap items-end gap-3"
-				>
-					<div className="flex-1 min-w-32">
-						<label for="create-username" className="mb-1 block text-sm text-gray-600">Username</label>
-						<input
-							id="create-username"
-							name="username"
-							type="text"
-							required
-							className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
-						/>
-					</div>
-					<div className="flex-1 min-w-32">
-						<label for="create-password" className="mb-1 block text-sm text-gray-600">Password</label>
-						<input
-							id="create-password"
-							name="password"
-							type="password"
-							required
-							className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
-						/>
-					</div>
-					<div>
-						<label for="create-role" className="mb-1 block text-sm text-gray-600">Role</label>
-						<select
-							id="create-role"
-							name="role"
-							className="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
-						>
-							<option value="user">user</option>
-							<option value="admin">admin</option>
-						</select>
-					</div>
-					<button
-						type="submit"
-						className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700"
-					>
-						Create User
-					</button>
-				</form>
-			</section>
-		</div>
-	)
+      <section className="rounded-xl border border-indigo-100 bg-white p-5">
+        <h3 className="mb-3 font-medium text-gray-800">Create User</h3>
+        <form
+          action="/admin/users"
+          method="post"
+          className="flex flex-wrap items-end gap-3"
+        >
+          <div className="flex-1 min-w-32">
+            <label
+              for="create-username"
+              className="mb-1 block text-sm text-gray-600"
+            >
+              Username
+            </label>
+            <input
+              id="create-username"
+              name="username"
+              type="text"
+              required
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+            />
+          </div>
+          <div className="flex-1 min-w-32">
+            <label
+              for="create-password"
+              className="mb-1 block text-sm text-gray-600"
+            >
+              Password
+            </label>
+            <input
+              id="create-password"
+              name="password"
+              type="password"
+              required
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+            />
+          </div>
+          <div>
+            <label
+              for="create-role"
+              className="mb-1 block text-sm text-gray-600"
+            >
+              Role
+            </label>
+            <select
+              id="create-role"
+              name="role"
+              className="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+            >
+              <option value="user">user</option>
+              <option value="admin">admin</option>
+            </select>
+          </div>
+          <button
+            type="submit"
+            className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700"
+          >
+            Create User
+          </button>
+        </form>
+      </section>
+    </div>
+  )
+}
+
+type RuntimeAuthEnv = AppBindings["Bindings"] & {
+  SESSION_SECRET?: string
+  USERS_FILE?: string
+}
+
+function getAuthConfig(c: Context<AppBindings>) {
+  return resolveAuthConfig(env(c) as RuntimeAuthEnv)
+}
+
+function getUsersFile(c: Context<AppBindings>): string {
+  const authConfig = getAuthConfig(c)
+  if (!authConfig.usersFile) {
+    throw new Error("Authentication is not enabled.")
+  }
+  return authConfig.usersFile
 }
 
 const adminRoutes = new Hono<AppBindings>()
 
 adminRoutes.use("*", async (c, next) => {
-	const user = c.get("user")
-	if (user.type !== "authenticated" || user.role !== "admin") {
-		if (c.req.header("HX-Request") === "true") {
-			c.header("HX-Redirect", "/login")
-			return c.body(null, 401)
-		}
-		return c.redirect("/login")
-	}
-	return next()
+  const user = c.get("user")
+  if (user.type !== "authenticated" || user.role !== "admin") {
+    if (c.req.header("HX-Request") === "true") {
+      c.header("HX-Redirect", "/login")
+      return c.body(null, 401)
+    }
+    return c.redirect("/login")
+  }
+  return next()
 })
 
 adminRoutes.get("/users", async (c) => {
-	const { UPLOAD_DIR } = env(c)
-	const uploadDir = UPLOAD_DIR || DEFAULT_UPLOAD_DIR
-	const usersFile = getUsersFilePath(uploadDir)
-	const currentUser = c.get("user") as Extract<typeof c.var.user, { type: "authenticated" }>
+  const usersFile = getUsersFile(c)
+  const currentUser = c.get("user") as Extract<
+    typeof c.var.user,
+    { type: "authenticated" }
+  >
 
-	let users: UserConfig[] = []
-	try {
-		users = await loadUsersFromFileWithCache(usersFile)
-	} catch (error) {
-		console.error(error)
-	}
+  let users: UserConfig[] = []
+  try {
+    users = await loadUsersFromFileWithCache(usersFile)
+  } catch (error) {
+    console.error(error)
+  }
 
-	const error = c.req.query("error")
-	const success = c.req.query("success")
+  const error = c.req.query("error")
+  const success = c.req.query("success")
 
-	return c.html(
-		<PageShell user={c.get("user")}>
-			<AdminUsersPage
-				users={users}
-				currentUsername={currentUser.username}
-				error={error}
-				success={success}
-			/>
-		</PageShell>,
-	)
+  return c.html(
+    <PageShell user={c.get("user")}>
+      <AdminUsersPage
+        users={users}
+        currentUsername={currentUser.username}
+        error={error}
+        success={success}
+      />
+    </PageShell>,
+  )
 })
 
 adminRoutes.post("/users", async (c) => {
-	const { UPLOAD_DIR } = env(c)
-	const uploadDir = UPLOAD_DIR || DEFAULT_UPLOAD_DIR
-	const usersFile = getUsersFilePath(uploadDir)
+  const usersFile = getUsersFile(c)
 
-	const formData = await c.req.formData()
-	const username = String(formData.get("username") || "").trim()
-	const password = String(formData.get("password") || "")
-	const role = String(formData.get("role") || "user")
+  const formData = await c.req.formData()
+  const username = String(formData.get("username") || "").trim()
+  const password = String(formData.get("password") || "")
+  const role = String(formData.get("role") || "user")
 
-	if (!isValidUsername(username)) {
-		return c.redirect(
-			`/admin/users?error=${encodeURIComponent("Invalid username. Use only lowercase letters, numbers, hyphens, and underscores.")}`,
-		)
-	}
-	if (!password) {
-		return c.redirect(`/admin/users?error=${encodeURIComponent("Password is required.")}`)
-	}
-	if (role !== "admin" && role !== "user") {
-		return c.redirect(`/admin/users?error=${encodeURIComponent("Invalid role.")}`)
-	}
+  if (!isValidUsername(username)) {
+    return c.redirect(
+      `/admin/users?error=${encodeURIComponent("Invalid username. Use only lowercase letters, numbers, hyphens, and underscores.")}`,
+    )
+  }
+  if (!password) {
+    return c.redirect(
+      `/admin/users?error=${encodeURIComponent("Password is required.")}`,
+    )
+  }
+  if (role !== "admin" && role !== "user") {
+    return c.redirect(
+      `/admin/users?error=${encodeURIComponent("Invalid role.")}`,
+    )
+  }
 
-	let users: UserConfig[] = []
-	try {
-		users = await loadUsersFromFileWithCache(usersFile)
-	} catch (error) {
-		console.error(error)
-		return c.redirect(`/admin/users?error=${encodeURIComponent("Failed to load users.")}`)
-	}
+  let users: UserConfig[] = []
+  try {
+    users = await loadUsersFromFileWithCache(usersFile)
+  } catch (error) {
+    console.error(error)
+    return c.redirect(
+      `/admin/users?error=${encodeURIComponent("Failed to load users.")}`,
+    )
+  }
 
-	if (users.some((u) => u.username === username)) {
-		return c.redirect(
-			`/admin/users?error=${encodeURIComponent(`User '${username}' already exists.`)}`,
-		)
-	}
+  if (users.some((u) => u.username === username)) {
+    return c.redirect(
+      `/admin/users?error=${encodeURIComponent(`User '${username}' already exists.`)}`,
+    )
+  }
 
-	const passwordHash = await Bun.password.hash(password, {
-		algorithm: "bcrypt",
-		cost: 12,
-	})
+  const passwordHash = await Bun.password.hash(password, {
+    algorithm: "bcrypt",
+    cost: 12,
+  })
 
-	await saveUsersToFile(usersFile, [
-		...users,
-		{ username, passwordHash, role: role as "admin" | "user", sessionVersion: 0 },
-	])
+  await saveUsersToFile(usersFile, [
+    ...users,
+    {
+      username,
+      passwordHash,
+      role: role as "admin" | "user",
+      sessionVersion: 0,
+    },
+  ])
 
-	return c.redirect(`/admin/users?success=${encodeURIComponent(`User '${username}' created.`)}`)
+  return c.redirect(
+    `/admin/users?success=${encodeURIComponent(`User '${username}' created.`)}`,
+  )
 })
 
 adminRoutes.post("/users/:username/role", async (c) => {
-	const { UPLOAD_DIR } = env(c)
-	const uploadDir = UPLOAD_DIR || DEFAULT_UPLOAD_DIR
-	const usersFile = getUsersFilePath(uploadDir)
-	const targetUsername = c.req.param("username")
+  const usersFile = getUsersFile(c)
+  const targetUsername = c.req.param("username")
 
-	if (targetUsername === MASTER_ADMIN_USERNAME) {
-		return c.redirect(
-			`/admin/users?error=${encodeURIComponent("Cannot change role of master admin.")}`,
-		)
-	}
+  if (targetUsername === MASTER_ADMIN_USERNAME) {
+    return c.redirect(
+      `/admin/users?error=${encodeURIComponent("Cannot change role of master admin.")}`,
+    )
+  }
 
-	const formData = await c.req.formData()
-	const newRole = String(formData.get("role") || "")
-	if (newRole !== "admin" && newRole !== "user") {
-		return c.redirect(`/admin/users?error=${encodeURIComponent("Invalid role.")}`)
-	}
+  const formData = await c.req.formData()
+  const newRole = String(formData.get("role") || "")
+  if (newRole !== "admin" && newRole !== "user") {
+    return c.redirect(
+      `/admin/users?error=${encodeURIComponent("Invalid role.")}`,
+    )
+  }
 
-	let users: UserConfig[] = []
-	try {
-		users = await loadUsersFromFileWithCache(usersFile)
-	} catch (error) {
-		console.error(error)
-		return c.redirect(`/admin/users?error=${encodeURIComponent("Failed to load users.")}`)
-	}
+  let users: UserConfig[] = []
+  try {
+    users = await loadUsersFromFileWithCache(usersFile)
+  } catch (error) {
+    console.error(error)
+    return c.redirect(
+      `/admin/users?error=${encodeURIComponent("Failed to load users.")}`,
+    )
+  }
 
-	const idx = users.findIndex((u) => u.username === targetUsername)
-	if (idx === -1) {
-		return c.redirect(
-			`/admin/users?error=${encodeURIComponent(`User '${targetUsername}' not found.`)}`,
-		)
-	}
+  const idx = users.findIndex((u) => u.username === targetUsername)
+  if (idx === -1) {
+    return c.redirect(
+      `/admin/users?error=${encodeURIComponent(`User '${targetUsername}' not found.`)}`,
+    )
+  }
 
-	const updated = users.map((u, i) =>
-		i === idx
-			? { ...u, role: newRole as "admin" | "user", sessionVersion: u.sessionVersion + 1 }
-			: u,
-	)
-	await saveUsersToFile(usersFile, updated)
+  const updated = users.map((u, i) =>
+    i === idx
+      ? {
+          ...u,
+          role: newRole as "admin" | "user",
+          sessionVersion: u.sessionVersion + 1,
+        }
+      : u,
+  )
+  await saveUsersToFile(usersFile, updated)
 
-	return c.redirect(
-		`/admin/users?success=${encodeURIComponent(`Role of '${targetUsername}' changed to '${newRole}'.`)}`,
-	)
+  return c.redirect(
+    `/admin/users?success=${encodeURIComponent(`Role of '${targetUsername}' changed to '${newRole}'.`)}`,
+  )
 })
 
 adminRoutes.post("/users/:username/delete", async (c) => {
-	const { UPLOAD_DIR } = env(c)
-	const uploadDir = UPLOAD_DIR || DEFAULT_UPLOAD_DIR
-	const usersFile = getUsersFilePath(uploadDir)
-	const targetUsername = c.req.param("username")
+  const usersFile = getUsersFile(c)
+  const targetUsername = c.req.param("username")
 
-	if (targetUsername === MASTER_ADMIN_USERNAME) {
-		return c.redirect(
-			`/admin/users?error=${encodeURIComponent("Cannot delete master admin.")}`,
-		)
-	}
+  if (targetUsername === MASTER_ADMIN_USERNAME) {
+    return c.redirect(
+      `/admin/users?error=${encodeURIComponent("Cannot delete master admin.")}`,
+    )
+  }
 
-	let users: UserConfig[] = []
-	try {
-		users = await loadUsersFromFileWithCache(usersFile)
-	} catch (error) {
-		console.error(error)
-		return c.redirect(`/admin/users?error=${encodeURIComponent("Failed to load users.")}`)
-	}
+  let users: UserConfig[] = []
+  try {
+    users = await loadUsersFromFileWithCache(usersFile)
+  } catch (error) {
+    console.error(error)
+    return c.redirect(
+      `/admin/users?error=${encodeURIComponent("Failed to load users.")}`,
+    )
+  }
 
-	const filtered = users.filter((u) => u.username !== targetUsername)
-	if (filtered.length === users.length) {
-		return c.redirect(
-			`/admin/users?error=${encodeURIComponent(`User '${targetUsername}' not found.`)}`,
-		)
-	}
+  const filtered = users.filter((u) => u.username !== targetUsername)
+  if (filtered.length === users.length) {
+    return c.redirect(
+      `/admin/users?error=${encodeURIComponent(`User '${targetUsername}' not found.`)}`,
+    )
+  }
 
-	await saveUsersToFile(usersFile, filtered)
+  await saveUsersToFile(usersFile, filtered)
 
-	return c.redirect(
-		`/admin/users?success=${encodeURIComponent(`User '${targetUsername}' deleted.`)}`,
-	)
+  return c.redirect(
+    `/admin/users?success=${encodeURIComponent(`User '${targetUsername}' deleted.`)}`,
+  )
 })
 
 adminRoutes.post("/users/:username/password", async (c) => {
-	const { UPLOAD_DIR } = env(c)
-	const uploadDir = UPLOAD_DIR || DEFAULT_UPLOAD_DIR
-	const usersFile = getUsersFilePath(uploadDir)
-	const targetUsername = c.req.param("username")
-	const currentUser = c.get("user") as Extract<typeof c.var.user, { type: "authenticated" }>
+  const usersFile = getUsersFile(c)
+  const targetUsername = c.req.param("username")
+  const currentUser = c.get("user") as Extract<
+    typeof c.var.user,
+    { type: "authenticated" }
+  >
 
-	if (targetUsername === MASTER_ADMIN_USERNAME) {
-		return c.redirect(
-			`/admin/users?error=${encodeURIComponent("Cannot reset master admin password via this endpoint. Use 'Change My Password'.")}`,
-		)
-	}
+  if (targetUsername === MASTER_ADMIN_USERNAME) {
+    return c.redirect(
+      `/admin/users?error=${encodeURIComponent("Cannot reset master admin password via this endpoint. Use 'Change My Password'.")}`,
+    )
+  }
 
-	if (targetUsername === currentUser.username) {
-		return c.redirect(
-			`/admin/users?error=${encodeURIComponent("Use 'Change My Password' to change your own password.")}`,
-		)
-	}
+  if (targetUsername === currentUser.username) {
+    return c.redirect(
+      `/admin/users?error=${encodeURIComponent("Use 'Change My Password' to change your own password.")}`,
+    )
+  }
 
-	const formData = await c.req.formData()
-	const newPassword = String(formData.get("newPassword") || "")
-	if (!newPassword) {
-		return c.redirect(`/admin/users?error=${encodeURIComponent("New password is required.")}`)
-	}
+  const formData = await c.req.formData()
+  const newPassword = String(formData.get("newPassword") || "")
+  if (!newPassword) {
+    return c.redirect(
+      `/admin/users?error=${encodeURIComponent("New password is required.")}`,
+    )
+  }
 
-	let users: UserConfig[] = []
-	try {
-		users = await loadUsersFromFileWithCache(usersFile)
-	} catch (error) {
-		console.error(error)
-		return c.redirect(`/admin/users?error=${encodeURIComponent("Failed to load users.")}`)
-	}
+  let users: UserConfig[] = []
+  try {
+    users = await loadUsersFromFileWithCache(usersFile)
+  } catch (error) {
+    console.error(error)
+    return c.redirect(
+      `/admin/users?error=${encodeURIComponent("Failed to load users.")}`,
+    )
+  }
 
-	const idx = users.findIndex((u) => u.username === targetUsername)
-	if (idx === -1) {
-		return c.redirect(
-			`/admin/users?error=${encodeURIComponent(`User '${targetUsername}' not found.`)}`,
-		)
-	}
+  const idx = users.findIndex((u) => u.username === targetUsername)
+  if (idx === -1) {
+    return c.redirect(
+      `/admin/users?error=${encodeURIComponent(`User '${targetUsername}' not found.`)}`,
+    )
+  }
 
-	const newHash = await Bun.password.hash(newPassword, { algorithm: "bcrypt", cost: 12 })
-	const updated = users.map((u, i) =>
-		i === idx ? { ...u, passwordHash: newHash, sessionVersion: u.sessionVersion + 1 } : u,
-	)
-	await saveUsersToFile(usersFile, updated)
+  const newHash = await Bun.password.hash(newPassword, {
+    algorithm: "bcrypt",
+    cost: 12,
+  })
+  const updated = users.map((u, i) =>
+    i === idx
+      ? { ...u, passwordHash: newHash, sessionVersion: u.sessionVersion + 1 }
+      : u,
+  )
+  await saveUsersToFile(usersFile, updated)
 
-	return c.redirect(
-		`/admin/users?success=${encodeURIComponent(`Password of '${targetUsername}' has been reset.`)}`,
-	)
+  return c.redirect(
+    `/admin/users?success=${encodeURIComponent(`Password of '${targetUsername}' has been reset.`)}`,
+  )
 })
 
 adminRoutes.post("/change-password", async (c) => {
-	const { UPLOAD_DIR, SESSION_SECRET } = env(c)
-	const uploadDir = UPLOAD_DIR || DEFAULT_UPLOAD_DIR
-	const usersFile = getUsersFilePath(uploadDir)
-	const currentUser = c.get("user") as Extract<typeof c.var.user, { type: "authenticated" }>
+  const authConfig = getAuthConfig(c)
+  const usersFile = getUsersFile(c)
+  const currentUser = c.get("user") as Extract<
+    typeof c.var.user,
+    { type: "authenticated" }
+  >
 
-	if (!SESSION_SECRET) {
-		return c.redirect("/admin/users?error=AuthConfigError")
-	}
+  if (!authConfig.authDir) {
+    return c.redirect("/admin/users?error=AuthConfigError")
+  }
 
-	const formData = await c.req.formData()
-	const currentPassword = String(formData.get("currentPassword") || "")
-	const newPassword = String(formData.get("newPassword") || "")
+  const formData = await c.req.formData()
+  const currentPassword = String(formData.get("currentPassword") || "")
+  const newPassword = String(formData.get("newPassword") || "")
 
-	if (!currentPassword || !newPassword) {
-		return c.redirect(
-			`/admin/users?error=${encodeURIComponent("Both current and new password are required.")}`,
-		)
-	}
+  if (!currentPassword || !newPassword) {
+    return c.redirect(
+      `/admin/users?error=${encodeURIComponent("Both current and new password are required.")}`,
+    )
+  }
 
-	let users: UserConfig[] = []
-	try {
-		users = await loadUsersFromFileWithCache(usersFile)
-	} catch (error) {
-		console.error(error)
-		return c.redirect(`/admin/users?error=${encodeURIComponent("Failed to load users.")}`)
-	}
+  let users: UserConfig[] = []
+  try {
+    users = await loadUsersFromFileWithCache(usersFile)
+  } catch (error) {
+    console.error(error)
+    return c.redirect(
+      `/admin/users?error=${encodeURIComponent("Failed to load users.")}`,
+    )
+  }
 
-	const self = users.find((u) => u.username === currentUser.username)
-	if (!self) {
-		return c.redirect(`/admin/users?error=${encodeURIComponent("Current user not found.")}`)
-	}
+  const self = users.find((u) => u.username === currentUser.username)
+  if (!self) {
+    return c.redirect(
+      `/admin/users?error=${encodeURIComponent("Current user not found.")}`,
+    )
+  }
 
-	const valid = await verifyPassword(currentPassword, self.passwordHash)
-	if (!valid) {
-		return c.redirect(
-			`/admin/users?error=${encodeURIComponent("Current password is incorrect.")}`,
-		)
-	}
+  const valid = await verifyPassword(currentPassword, self.passwordHash)
+  if (!valid) {
+    return c.redirect(
+      `/admin/users?error=${encodeURIComponent("Current password is incorrect.")}`,
+    )
+  }
 
-	const newHash = await Bun.password.hash(newPassword, { algorithm: "bcrypt", cost: 12 })
-	const newVersion = self.sessionVersion + 1
-	const updated = users.map((u) =>
-		u.username === currentUser.username
-			? { ...u, passwordHash: newHash, sessionVersion: newVersion }
-			: u,
-	)
-	await saveUsersToFile(usersFile, updated)
+  const newHash = await Bun.password.hash(newPassword, {
+    algorithm: "bcrypt",
+    cost: 12,
+  })
+  const newVersion = self.sessionVersion + 1
+  const updated = users.map((u) =>
+    u.username === currentUser.username
+      ? { ...u, passwordHash: newHash, sessionVersion: newVersion }
+      : u,
+  )
+  await saveUsersToFile(usersFile, updated)
 
-	const newSession = await signSession(
-		{ username: currentUser.username, sessionVersion: newVersion },
-		SESSION_SECRET,
-	)
-	setCookie(c, SESSION_COOKIE_NAME, newSession, {
-		httpOnly: true,
-		path: "/",
-		sameSite: "Lax",
-		maxAge: SESSION_MAX_AGE_SECONDS,
-	})
+  const sessionSecret = await loadSessionSecretWithCache(authConfig.authDir)
+  const newSession = await signSession(
+    { username: currentUser.username, sessionVersion: newVersion },
+    sessionSecret,
+  )
+  setCookie(c, SESSION_COOKIE_NAME, newSession, {
+    httpOnly: true,
+    path: "/",
+    sameSite: "Lax",
+    maxAge: SESSION_MAX_AGE_SECONDS,
+  })
 
-	return c.redirect(
-		`/admin/users?success=${encodeURIComponent("Password changed successfully.")}`,
-	)
+  return c.redirect(
+    `/admin/users?success=${encodeURIComponent("Password changed successfully.")}`,
+  )
 })
 
 export default adminRoutes

--- a/projects/file-server/src/routes/auth.tsx
+++ b/projects/file-server/src/routes/auth.tsx
@@ -1,126 +1,126 @@
-import { Hono } from "hono"
+import { type Context, Hono } from "hono"
 import { env } from "hono/adapter"
 import { deleteCookie, setCookie } from "hono/cookie"
 import { PageShell } from "../components/PageShell"
 import type { AppBindings } from "../types"
 import {
-	DEFAULT_UPLOAD_DIR,
-	findUser,
-	getUsersFilePath,
-	normalizeReturnTo,
-	SESSION_COOKIE_NAME,
-	SESSION_MAX_AGE_SECONDS,
-	signSession,
-	verifyPassword,
+  findUser,
+  loadSessionSecretWithCache,
+  normalizeReturnTo,
+  resolveAuthConfig,
+  SESSION_COOKIE_NAME,
+  SESSION_MAX_AGE_SECONDS,
+  signSession,
+  verifyPassword,
 } from "../utils/auth"
 import { loadUsersFromFileWithCache } from "../utils/userConfigCache"
 
 interface LoginPageProps {
-	returnTo: string
-	error?: string
-	username?: string
+  returnTo: string
+  error?: string
+  username?: string
 }
 
 function LoginPage({ returnTo, error, username }: LoginPageProps) {
-	return (
-		<div className="mx-auto max-w-md rounded-xl border border-indigo-200 bg-white p-6 shadow-sm">
-			<h2 className="mb-1 text-xl font-semibold text-gray-900">Login</h2>
-			<p className="mb-4 text-sm text-gray-600">
-				Sign in to access your private files.
-			</p>
-			{error && (
-				<div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
-					{error}
-				</div>
-			)}
-			<form action="/login" method="post" className="space-y-4">
-				<input type="hidden" name="returnTo" value={returnTo} />
-				<div>
-					<label
-						for="username"
-						className="mb-1 block text-sm font-medium text-gray-700"
-					>
-						Username
-					</label>
-					<input
-						id="username"
-						name="username"
-						type="text"
-						required
-						value={username}
-						className="w-full rounded-lg border border-gray-300 px-3 py-2 focus:border-indigo-500 focus:outline-none"
-					/>
-				</div>
-				<div>
-					<label
-						for="password"
-						className="mb-1 block text-sm font-medium text-gray-700"
-					>
-						Password
-					</label>
-					<div className="relative">
-						<input
-							id="password"
-							name="password"
-							type="password"
-							required
-							className="w-full rounded-lg border border-gray-300 px-3 py-2 pr-10 focus:border-indigo-500 focus:outline-none"
-						/>
-						<button
-							id="password-toggle"
-							type="button"
-							aria-label="Show password"
-							aria-controls="password"
-							aria-pressed="false"
-							className="absolute inset-y-0 right-0 inline-flex w-10 items-center justify-center text-gray-500 hover:text-gray-700"
-						>
-							<span id="password-toggle-eye">
-								<svg
-									xmlns="http://www.w3.org/2000/svg"
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="currentColor"
-									stroke-width="2"
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									className="h-5 w-5"
-									aria-hidden="true"
-								>
-									<path d="M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0" />
-									<circle cx="12" cy="12" r="3" />
-								</svg>
-							</span>
-							<span id="password-toggle-eye-off" className="hidden">
-								<svg
-									xmlns="http://www.w3.org/2000/svg"
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="currentColor"
-									stroke-width="2"
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									className="h-5 w-5"
-									aria-hidden="true"
-								>
-									<path d="M2.458 12C3.732 7.943 7.523 5 12 5c1.97 0 3.807.57 5.354 1.553" />
-									<path d="M21.542 12C20.268 16.057 16.477 19 12 19c-1.97 0-3.807-.57-5.354-1.553" />
-									<path d="M9.88 9.88a3 3 0 1 0 4.24 4.24" />
-									<path d="m3 3 18 18" />
-								</svg>
-							</span>
-						</button>
-					</div>
-				</div>
-				<button
-					type="submit"
-					className="w-full rounded-lg bg-indigo-600 px-4 py-2 font-semibold text-white hover:bg-indigo-700"
-				>
-					Login
-				</button>
-			</form>
-			<script
-				dangerouslySetInnerHTML={{
-					__html: `
+  return (
+    <div className="mx-auto max-w-md rounded-xl border border-indigo-200 bg-white p-6 shadow-sm">
+      <h2 className="mb-1 text-xl font-semibold text-gray-900">Login</h2>
+      <p className="mb-4 text-sm text-gray-600">
+        Sign in to access your private files.
+      </p>
+      {error && (
+        <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+      <form action="/login" method="post" className="space-y-4">
+        <input type="hidden" name="returnTo" value={returnTo} />
+        <div>
+          <label
+            for="username"
+            className="mb-1 block text-sm font-medium text-gray-700"
+          >
+            Username
+          </label>
+          <input
+            id="username"
+            name="username"
+            type="text"
+            required
+            value={username}
+            className="w-full rounded-lg border border-gray-300 px-3 py-2 focus:border-indigo-500 focus:outline-none"
+          />
+        </div>
+        <div>
+          <label
+            for="password"
+            className="mb-1 block text-sm font-medium text-gray-700"
+          >
+            Password
+          </label>
+          <div className="relative">
+            <input
+              id="password"
+              name="password"
+              type="password"
+              required
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 pr-10 focus:border-indigo-500 focus:outline-none"
+            />
+            <button
+              id="password-toggle"
+              type="button"
+              aria-label="Show password"
+              aria-controls="password"
+              aria-pressed="false"
+              className="absolute inset-y-0 right-0 inline-flex w-10 items-center justify-center text-gray-500 hover:text-gray-700"
+            >
+              <span id="password-toggle-eye">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  className="h-5 w-5"
+                  aria-hidden="true"
+                >
+                  <path d="M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0" />
+                  <circle cx="12" cy="12" r="3" />
+                </svg>
+              </span>
+              <span id="password-toggle-eye-off" className="hidden">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  className="h-5 w-5"
+                  aria-hidden="true"
+                >
+                  <path d="M2.458 12C3.732 7.943 7.523 5 12 5c1.97 0 3.807.57 5.354 1.553" />
+                  <path d="M21.542 12C20.268 16.057 16.477 19 12 19c-1.97 0-3.807-.57-5.354-1.553" />
+                  <path d="M9.88 9.88a3 3 0 1 0 4.24 4.24" />
+                  <path d="m3 3 18 18" />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </div>
+        <button
+          type="submit"
+          className="w-full rounded-lg bg-indigo-600 px-4 py-2 font-semibold text-white hover:bg-indigo-700"
+        >
+          Login
+        </button>
+      </form>
+      <script
+        dangerouslySetInnerHTML={{
+          __html: `
 						(() => {
 							const passwordInput = document.getElementById("password");
 							const toggleButton = document.getElementById("password-toggle");
@@ -139,101 +139,128 @@ function LoginPage({ returnTo, error, username }: LoginPageProps) {
 							});
 						})();
 					`,
-				}}
-			/>
-		</div>
-	)
+        }}
+      />
+    </div>
+  )
+}
+
+type RuntimeAuthEnv = AppBindings["Bindings"] & {
+  SESSION_SECRET?: string
+  USERS_FILE?: string
+}
+
+function getAuthConfig(c: Context<AppBindings>) {
+  return resolveAuthConfig(env(c) as RuntimeAuthEnv)
 }
 
 const authRoutes = new Hono<AppBindings>()
 
 authRoutes.get("/login", (c) => {
-	const sessionSecret = env(c).SESSION_SECRET
-	if (!sessionSecret) {
-		return c.redirect("/")
-	}
+  const authConfig = getAuthConfig(c)
+  if (!authConfig.enabled) {
+    return c.redirect("/")
+  }
 
-	const user = c.get("user")
-	const returnTo = normalizeReturnTo(c.req.query("returnTo"))
-	if (user.type === "authenticated") {
-		return c.redirect(returnTo)
-	}
+  const user = c.get("user")
+  const returnTo = normalizeReturnTo(c.req.query("returnTo"))
+  if (user.type === "authenticated") {
+    return c.redirect(returnTo)
+  }
 
-	const error = c.req.query("error")
-	return c.html(
-		<PageShell user={user}>
-			<LoginPage returnTo={returnTo} error={error ?? undefined} />
-		</PageShell>,
-	)
+  const error = c.req.query("error")
+  return c.html(
+    <PageShell user={user}>
+      <LoginPage returnTo={returnTo} error={error ?? undefined} />
+    </PageShell>,
+  )
 })
 
 authRoutes.post("/login", async (c) => {
-	const { UPLOAD_DIR, SESSION_SECRET } = env(c)
-	if (!SESSION_SECRET) {
-		return c.redirect("/")
-	}
+  const authConfig = getAuthConfig(c)
+  if (!authConfig.enabled || !authConfig.usersFile || !authConfig.authDir) {
+    return c.redirect("/")
+  }
 
-	const uploadDir = UPLOAD_DIR || DEFAULT_UPLOAD_DIR
-	const usersFile = getUsersFilePath(uploadDir)
+  const formData = await c.req.formData()
+  const username = String(formData.get("username") || "").trim()
+  const password = String(formData.get("password") || "")
+  const returnTo = normalizeReturnTo(String(formData.get("returnTo") || "/"))
 
-	const formData = await c.req.formData()
-	const username = String(formData.get("username") || "").trim()
-	const password = String(formData.get("password") || "")
-	const returnTo = normalizeReturnTo(String(formData.get("returnTo") || "/"))
+  let users: Awaited<ReturnType<typeof loadUsersFromFileWithCache>> | null =
+    null
+  try {
+    users = await loadUsersFromFileWithCache(authConfig.usersFile)
+  } catch (error) {
+    console.error(error)
+    return c.json(
+      {
+        success: false,
+        error: {
+          name: "AuthConfigError",
+          message: "Failed to load users configuration",
+        },
+      },
+      500,
+    )
+  }
 
-	let users: Awaited<ReturnType<typeof loadUsersFromFileWithCache>> | null = null
-	try {
-		users = await loadUsersFromFileWithCache(usersFile)
-	} catch (error) {
-		console.error(error)
-		return c.json(
-			{
-				success: false,
-				error: {
-					name: "AuthConfigError",
-					message: "Failed to load users configuration",
-				},
-			},
-			500,
-		)
-	}
+  let sessionSecret: string
+  try {
+    sessionSecret = await loadSessionSecretWithCache(authConfig.authDir)
+  } catch (error) {
+    console.error(error)
+    return c.json(
+      {
+        success: false,
+        error: {
+          name: "AuthConfigError",
+          message: "Failed to load session secret",
+        },
+      },
+      500,
+    )
+  }
 
-	const matchedUser = findUser(users, username)
-	const isValidPassword = matchedUser
-		? await verifyPassword(password, matchedUser.passwordHash)
-		: false
+  const matchedUser = findUser(users, username)
+  const isValidPassword = matchedUser
+    ? await verifyPassword(password, matchedUser.passwordHash)
+    : false
 
-	if (!matchedUser || !isValidPassword) {
-		return c.html(
-			<PageShell user={{ type: "anonymous" }}>
-				<LoginPage
-					returnTo={returnTo}
-					error="Invalid username or password"
-					username={username}
-				/>
-			</PageShell>,
-			401,
-		)
-	}
+  if (!matchedUser || !isValidPassword) {
+    return c.html(
+      <PageShell user={{ type: "anonymous" }}>
+        <LoginPage
+          returnTo={returnTo}
+          error="Invalid username or password"
+          username={username}
+        />
+      </PageShell>,
+      401,
+    )
+  }
 
-	const sessionValue = await signSession(
-		{ username: matchedUser.username, sessionVersion: matchedUser.sessionVersion },
-		SESSION_SECRET,
-	)
-	setCookie(c, SESSION_COOKIE_NAME, sessionValue, {
-		httpOnly: true,
-		path: "/",
-		sameSite: "Lax",
-		maxAge: SESSION_MAX_AGE_SECONDS,
-	})
+  const sessionValue = await signSession(
+    {
+      username: matchedUser.username,
+      sessionVersion: matchedUser.sessionVersion,
+    },
+    sessionSecret,
+  )
+  setCookie(c, SESSION_COOKIE_NAME, sessionValue, {
+    httpOnly: true,
+    path: "/",
+    sameSite: "Lax",
+    maxAge: SESSION_MAX_AGE_SECONDS,
+  })
 
-	return c.redirect(returnTo)
+  return c.redirect(returnTo)
 })
 
 authRoutes.post("/logout", (c) => {
-	const sessionSecret = env(c).SESSION_SECRET
-	deleteCookie(c, SESSION_COOKIE_NAME, { path: "/" })
-	return c.redirect(sessionSecret ? "/login" : "/")
+  const authConfig = getAuthConfig(c)
+  deleteCookie(c, SESSION_COOKIE_NAME, { path: "/" })
+  return c.redirect(authConfig.enabled ? "/login" : "/")
 })
 
 export default authRoutes

--- a/projects/file-server/src/routes/auth.tsx
+++ b/projects/file-server/src/routes/auth.tsx
@@ -7,6 +7,7 @@ import {
   findUser,
   loadSessionSecretWithCache,
   normalizeReturnTo,
+  type RuntimeAuthEnv,
   resolveAuthConfig,
   SESSION_COOKIE_NAME,
   SESSION_MAX_AGE_SECONDS,
@@ -143,11 +144,6 @@ function LoginPage({ returnTo, error, username }: LoginPageProps) {
       />
     </div>
   )
-}
-
-type RuntimeAuthEnv = AppBindings["Bindings"] & {
-  SESSION_SECRET?: string
-  USERS_FILE?: string
 }
 
 function getAuthConfig(c: Context<AppBindings>) {

--- a/projects/file-server/src/types.ts
+++ b/projects/file-server/src/types.ts
@@ -17,8 +17,8 @@ export type UserConfig = {
 
 export type AppBindings = {
   Bindings: {
+    AUTH_DIR?: string
     UPLOAD_DIR: string
-    SESSION_SECRET?: string
     INITIAL_ADMIN_PASSWORD?: string
   }
   Variables: {

--- a/projects/file-server/src/utils/auth.ts
+++ b/projects/file-server/src/utils/auth.ts
@@ -1,136 +1,262 @@
-import { createHmac, timingSafeEqual } from "node:crypto"
+import { createHmac, randomBytes, timingSafeEqual } from "node:crypto"
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises"
 import path from "node:path"
 import type { UserConfig, UserState } from "../types"
 
 const USERNAME_PATTERN = /^[a-z0-9_-]+$/
 const RESERVED_USERNAMES = new Set(["public", "private"])
+const USERS_FILENAME = "users.json"
+const SESSION_SECRET_FILENAME = "session-secret"
 export const SESSION_COOKIE_NAME = "session"
 export const SESSION_MAX_AGE_SECONDS = 60 * 60 * 24 * 7
 export const DEFAULT_UPLOAD_DIR = "./tmp"
 export const MASTER_ADMIN_USERNAME = "admin"
 
-export function getUsersFilePath(uploadDir: string): string {
-	return path.join(uploadDir, ".auth", "users.json")
+export type AuthEnv = {
+  AUTH_DIR?: string
+  SESSION_SECRET?: string
+  USERS_FILE?: string
 }
 
-export function validateAuthConfig(sessionSecret: string | undefined): void {
-	if (sessionSecret && sessionSecret.length < 32) {
-		console.warn("[WARN] SESSION_SECRET should be at least 32 characters long.")
-	}
+export type ResolvedAuthConfig = {
+  enabled: boolean
+  authDir: string | null
+  usersFile: string | null
 }
 
-export function findUser(users: UserConfig[] | null, username: string): UserConfig | null {
-	if (!users) {
-		return null
-	}
-	return users.find((user) => user.username === username) ?? null
+let cachedSessionSecret: string | null = null
+let cachedSessionSecretPath: string | null = null
+let cachedSessionSecretMtimeMs: number | null = null
+
+export function getUsersFilePath(authDir: string): string {
+  return path.join(authDir, USERS_FILENAME)
+}
+
+export function getSessionSecretFilePath(authDir: string): string {
+  return path.join(authDir, SESSION_SECRET_FILENAME)
+}
+
+function normalizeOptionalPath(
+  value: string | undefined | null,
+): string | null {
+  const normalized = value?.trim()
+  return normalized ? normalized : null
+}
+
+export function validateLegacyAuthEnv(
+  env: Pick<AuthEnv, "SESSION_SECRET" | "USERS_FILE">,
+): void {
+  if (env.SESSION_SECRET) {
+    throw new Error("SESSION_SECRET has been removed. Use AUTH_DIR instead.")
+  }
+  if (env.USERS_FILE) {
+    throw new Error("USERS_FILE has been removed. Use AUTH_DIR instead.")
+  }
+}
+
+export function resolveAuthConfig(env: AuthEnv): ResolvedAuthConfig {
+  validateLegacyAuthEnv(env)
+
+  const authDir = normalizeOptionalPath(env.AUTH_DIR)
+
+  return {
+    enabled: authDir !== null,
+    authDir,
+    usersFile: authDir ? getUsersFilePath(authDir) : null,
+  }
+}
+
+function resetSessionSecretCache(): void {
+  cachedSessionSecret = null
+  cachedSessionSecretPath = null
+  cachedSessionSecretMtimeMs = null
+}
+
+export async function ensureSessionSecret(authDir: string): Promise<string> {
+  await mkdir(authDir, { recursive: true })
+
+  const sessionSecretFile = getSessionSecretFilePath(authDir)
+
+  try {
+    const existingSecret = (await readFile(sessionSecretFile, "utf-8")).trim()
+    if (existingSecret) {
+      return existingSecret
+    }
+  } catch (error) {
+    const errno = error as NodeJS.ErrnoException
+    if (errno.code !== "ENOENT") {
+      throw error
+    }
+  }
+
+  const sessionSecret = randomBytes(48).toString("base64url")
+  await writeFile(sessionSecretFile, `${sessionSecret}\n`, {
+    encoding: "utf-8",
+    mode: 0o600,
+  })
+  resetSessionSecretCache()
+  return sessionSecret
+}
+
+export async function loadSessionSecretWithCache(
+  authDir: string,
+): Promise<string> {
+  const sessionSecretFile = getSessionSecretFilePath(authDir)
+  const fileStat = await stat(sessionSecretFile)
+
+  if (
+    cachedSessionSecret &&
+    cachedSessionSecretPath === sessionSecretFile &&
+    cachedSessionSecretMtimeMs === fileStat.mtimeMs
+  ) {
+    return cachedSessionSecret
+  }
+
+  const sessionSecret = (await readFile(sessionSecretFile, "utf-8")).trim()
+  if (!sessionSecret) {
+    throw new Error("session-secret file is empty.")
+  }
+
+  cachedSessionSecret = sessionSecret
+  cachedSessionSecretPath = sessionSecretFile
+  cachedSessionSecretMtimeMs = fileStat.mtimeMs
+
+  return sessionSecret
+}
+
+export function resetSessionSecretCacheForTests(): void {
+  resetSessionSecretCache()
+}
+
+export function findUser(
+  users: UserConfig[] | null,
+  username: string,
+): UserConfig | null {
+  if (!users) {
+    return null
+  }
+  return users.find((user) => user.username === username) ?? null
 }
 
 export function isValidUsername(username: string): boolean {
-	return USERNAME_PATTERN.test(username) && !RESERVED_USERNAMES.has(username)
+  return USERNAME_PATTERN.test(username) && !RESERVED_USERNAMES.has(username)
 }
 
-export async function verifyPassword(password: string, hash: string): Promise<boolean> {
-	try {
-		return await Bun.password.verify(password, hash)
-	} catch {
-		return false
-	}
+export async function verifyPassword(
+  password: string,
+  hash: string,
+): Promise<boolean> {
+  try {
+    return await Bun.password.verify(password, hash)
+  } catch {
+    return false
+  }
 }
 
 function signValue(value: string, secret: string): string {
-	return createHmac("sha256", secret).update(value).digest("base64url")
+  return createHmac("sha256", secret).update(value).digest("base64url")
 }
 
 function safeStringEqual(a: string, b: string): boolean {
-	const left = Buffer.from(a)
-	const right = Buffer.from(b)
-	if (left.length !== right.length) {
-		return false
-	}
-	return timingSafeEqual(left, right)
+  const left = Buffer.from(a)
+  const right = Buffer.from(b)
+  if (left.length !== right.length) {
+    return false
+  }
+  return timingSafeEqual(left, right)
 }
 
 export async function signSession(
-	payload: { username: string; sessionVersion: number },
-	secret: string,
+  payload: { username: string; sessionVersion: number },
+  secret: string,
 ): Promise<string> {
-	if (!isValidUsername(payload.username)) {
-		throw new Error("Invalid username for session payload.")
-	}
-	const data = `${payload.username}:${payload.sessionVersion}`
-	const signature = signValue(data, secret)
-	return `${data}:${signature}`
+  if (!isValidUsername(payload.username)) {
+    throw new Error("Invalid username for session payload.")
+  }
+  const data = `${payload.username}:${payload.sessionVersion}`
+  const signature = signValue(data, secret)
+  return `${data}:${signature}`
 }
 
 export async function verifySession(
-	cookieValue: string,
-	secret: string,
+  cookieValue: string,
+  secret: string,
 ): Promise<{ username: string; sessionVersion: number } | null> {
-	const lastColon = cookieValue.lastIndexOf(":")
-	if (lastColon <= 0 || lastColon === cookieValue.length - 1) {
-		return null
-	}
+  const lastColon = cookieValue.lastIndexOf(":")
+  if (lastColon <= 0 || lastColon === cookieValue.length - 1) {
+    return null
+  }
 
-	const data = cookieValue.slice(0, lastColon)
-	const signature = cookieValue.slice(lastColon + 1)
+  const data = cookieValue.slice(0, lastColon)
+  const signature = cookieValue.slice(lastColon + 1)
 
-	const firstColon = data.indexOf(":")
-	if (firstColon <= 0) {
-		return null
-	}
+  const firstColon = data.indexOf(":")
+  if (firstColon <= 0) {
+    return null
+  }
 
-	const username = data.slice(0, firstColon)
-	const versionStr = data.slice(firstColon + 1)
-	const sessionVersion = Number(versionStr)
+  const username = data.slice(0, firstColon)
+  const versionStr = data.slice(firstColon + 1)
+  const sessionVersion = Number(versionStr)
 
-	if (!isValidUsername(username)) {
-		return null
-	}
-	if (!Number.isInteger(sessionVersion) || sessionVersion < 0) {
-		return null
-	}
+  if (!isValidUsername(username)) {
+    return null
+  }
+  if (!Number.isInteger(sessionVersion) || sessionVersion < 0) {
+    return null
+  }
 
-	const expectedSignature = signValue(data, secret)
-	if (!safeStringEqual(signature, expectedSignature)) {
-		return null
-	}
+  const expectedSignature = signValue(data, secret)
+  if (!safeStringEqual(signature, expectedSignature)) {
+    return null
+  }
 
-	return { username, sessionVersion }
+  return { username, sessionVersion }
 }
 
-export function getUserUploadDir(baseDir: string, userState: UserState): string {
-	if (userState.type === "authenticated" && userState.role === "user") {
-		return path.join(baseDir, "private", userState.username)
-	}
-	return baseDir
+export function getUserUploadDir(
+  baseDir: string,
+  userState: UserState,
+): string {
+  if (userState.type === "authenticated" && userState.role === "user") {
+    return path.join(baseDir, "private", userState.username)
+  }
+  return baseDir
 }
 
 export function getUserHomeVirtualPath(userState: UserState): string | null {
-	if (userState.type !== "authenticated" || userState.role !== "user") {
-		return null
-	}
-	return `private/${userState.username}`
+  if (userState.type !== "authenticated" || userState.role !== "user") {
+    return null
+  }
+  return `private/${userState.username}`
 }
 
-export function isUserHomeVirtualPath(userState: UserState, virtualPath: string): boolean {
-	const homePath = getUserHomeVirtualPath(userState)
-	if (!homePath) {
-		return false
-	}
-	return virtualPath === "" || virtualPath === "private" || virtualPath === homePath
+export function isUserHomeVirtualPath(
+  userState: UserState,
+  virtualPath: string,
+): boolean {
+  const homePath = getUserHomeVirtualPath(userState)
+  if (!homePath) {
+    return false
+  }
+  return (
+    virtualPath === "" || virtualPath === "private" || virtualPath === homePath
+  )
 }
 
-export function toBrowseLocation(userState: UserState, virtualPath: string): string {
-	return isUserHomeVirtualPath(userState, virtualPath) ? "" : virtualPath
+export function toBrowseLocation(
+  userState: UserState,
+  virtualPath: string,
+): string {
+  return isUserHomeVirtualPath(userState, virtualPath) ? "" : virtualPath
 }
 
 export function normalizeReturnTo(value: string | null | undefined): string {
-	if (!value) {
-		return "/"
-	}
-	if (!value.startsWith("/") || value.startsWith("//")) {
-		return "/"
-	}
-	return value
+  if (!value) {
+    return "/"
+  }
+  if (!value.startsWith("/") || value.startsWith("//")) {
+    return "/"
+  }
+  return value
 }

--- a/projects/file-server/src/utils/auth.ts
+++ b/projects/file-server/src/utils/auth.ts
@@ -1,7 +1,7 @@
 import { createHmac, randomBytes, timingSafeEqual } from "node:crypto"
 import { mkdir, readFile, stat, writeFile } from "node:fs/promises"
 import path from "node:path"
-import type { UserConfig, UserState } from "../types"
+import type { AppBindings, UserConfig, UserState } from "../types"
 
 const USERNAME_PATTERN = /^[a-z0-9_-]+$/
 const RESERVED_USERNAMES = new Set(["public", "private"])
@@ -17,6 +17,9 @@ export type AuthEnv = {
   SESSION_SECRET?: string
   USERS_FILE?: string
 }
+
+export type RuntimeAuthEnv = AppBindings["Bindings"] &
+  Pick<AuthEnv, "SESSION_SECRET" | "USERS_FILE">
 
 export type ResolvedAuthConfig = {
   enabled: boolean
@@ -54,9 +57,9 @@ export function validateLegacyAuthEnv(
   }
 }
 
-export function resolveAuthConfig(env: AuthEnv): ResolvedAuthConfig {
-  validateLegacyAuthEnv(env)
-
+export function resolveAuthConfig(
+  env: Pick<AuthEnv, "AUTH_DIR">,
+): ResolvedAuthConfig {
   const authDir = normalizeOptionalPath(env.AUTH_DIR)
 
   return {
@@ -72,30 +75,52 @@ function resetSessionSecretCache(): void {
   cachedSessionSecretMtimeMs = null
 }
 
+async function readSessionSecretIfPresent(
+  sessionSecretFile: string,
+): Promise<string | null> {
+  try {
+    const sessionSecret = (await readFile(sessionSecretFile, "utf-8")).trim()
+    return sessionSecret || null
+  } catch (error) {
+    const errno = error as NodeJS.ErrnoException
+    if (errno.code === "ENOENT") {
+      return null
+    }
+    throw error
+  }
+}
+
 export async function ensureSessionSecret(authDir: string): Promise<string> {
   await mkdir(authDir, { recursive: true })
 
   const sessionSecretFile = getSessionSecretFilePath(authDir)
+  const existingSecret = await readSessionSecretIfPresent(sessionSecretFile)
+  if (existingSecret) {
+    return existingSecret
+  }
 
+  const sessionSecret = randomBytes(48).toString("base64url")
   try {
-    const existingSecret = (await readFile(sessionSecretFile, "utf-8")).trim()
-    if (existingSecret) {
-      return existingSecret
-    }
+    // Use exclusive create so concurrent first startups converge on one secret.
+    await writeFile(sessionSecretFile, `${sessionSecret}\n`, {
+      encoding: "utf-8",
+      mode: 0o600,
+      flag: "wx",
+    })
+    resetSessionSecretCache()
+    return sessionSecret
   } catch (error) {
     const errno = error as NodeJS.ErrnoException
-    if (errno.code !== "ENOENT") {
+    if (errno.code !== "EEXIST") {
       throw error
     }
   }
 
-  const sessionSecret = randomBytes(48).toString("base64url")
-  await writeFile(sessionSecretFile, `${sessionSecret}\n`, {
-    encoding: "utf-8",
-    mode: 0o600,
-  })
-  resetSessionSecretCache()
-  return sessionSecret
+  const concurrentSecret = await readSessionSecretIfPresent(sessionSecretFile)
+  if (!concurrentSecret) {
+    throw new Error("session-secret file is empty.")
+  }
+  return concurrentSecret
 }
 
 export async function loadSessionSecretWithCache(

--- a/projects/file-server/src/utils/bootstrap.ts
+++ b/projects/file-server/src/utils/bootstrap.ts
@@ -35,6 +35,11 @@ export async function bootstrapAdminUser(
             `[FATAL] '${MASTER_ADMIN_USERNAME}' user must have role 'admin'.`,
           )
         }
+        if (initialAdminPassword) {
+          console.log(
+            "[BOOTSTRAP] INITIAL_ADMIN_PASSWORD is ignored because users.json already contains a valid admin user.",
+          )
+        }
         return
       }
       // Valid JSON empty array — fall through to bootstrap

--- a/projects/file-server/src/utils/bootstrap.ts
+++ b/projects/file-server/src/utils/bootstrap.ts
@@ -3,69 +3,69 @@ import { getUsersFilePath, MASTER_ADMIN_USERNAME } from "./auth"
 import { loadUsersFromFileWithCache, saveUsersToFile } from "./userConfigCache"
 
 export async function bootstrapAdminUser(
-	uploadDir: string,
-	initialAdminPassword?: string,
+  authDir: string,
+  initialAdminPassword?: string,
 ): Promise<void> {
-	const usersFile = getUsersFilePath(uploadDir)
+  const usersFile = getUsersFilePath(authDir)
 
-	let fileExists = false
-	try {
-		await stat(usersFile)
-		fileExists = true
-	} catch {
-		// File doesn't exist
-	}
+  let fileExists = false
+  try {
+    await stat(usersFile)
+    fileExists = true
+  } catch {
+    // File doesn't exist
+  }
 
-	if (fileExists) {
-		const raw = await readFile(usersFile, "utf-8")
+  if (fileExists) {
+    const raw = await readFile(usersFile, "utf-8")
 
-		if (raw.trim() !== "") {
-			// Non-empty file: parse and validate strictly — errors are startup failures
-			const users = await loadUsersFromFileWithCache(usersFile)
+    if (raw.trim() !== "") {
+      // Non-empty file: parse and validate strictly — errors are startup failures
+      const users = await loadUsersFromFileWithCache(usersFile)
 
-			if (users.length > 0) {
-				const admin = users.find((u) => u.username === MASTER_ADMIN_USERNAME)
-				if (!admin) {
-					throw new Error(
-						`[FATAL] Users file is non-empty but missing '${MASTER_ADMIN_USERNAME}' user.`,
-					)
-				}
-				if (admin.role !== "admin") {
-					throw new Error(
-						`[FATAL] '${MASTER_ADMIN_USERNAME}' user must have role 'admin'.`,
-					)
-				}
-				return
-			}
-			// Valid JSON empty array — fall through to bootstrap
-		}
-		// Empty file (0 bytes or whitespace) — fall through to bootstrap
-	}
+      if (users.length > 0) {
+        const admin = users.find((u) => u.username === MASTER_ADMIN_USERNAME)
+        if (!admin) {
+          throw new Error(
+            `[FATAL] Users file is non-empty but missing '${MASTER_ADMIN_USERNAME}' user.`,
+          )
+        }
+        if (admin.role !== "admin") {
+          throw new Error(
+            `[FATAL] '${MASTER_ADMIN_USERNAME}' user must have role 'admin'.`,
+          )
+        }
+        return
+      }
+      // Valid JSON empty array — fall through to bootstrap
+    }
+    // Empty file (0 bytes or whitespace) — fall through to bootstrap
+  }
 
-	const password = initialAdminPassword ?? generateRandomPassword()
-	const passwordHash = await Bun.password.hash(password, {
-		algorithm: "bcrypt",
-		cost: 12,
-	})
+  const password = initialAdminPassword ?? generateRandomPassword()
+  const passwordHash = await Bun.password.hash(password, {
+    algorithm: "bcrypt",
+    cost: 12,
+  })
 
-	await saveUsersToFile(usersFile, [
-		{
-			username: MASTER_ADMIN_USERNAME,
-			passwordHash,
-			role: "admin",
-			sessionVersion: 0,
-		},
-	])
+  await saveUsersToFile(usersFile, [
+    {
+      username: MASTER_ADMIN_USERNAME,
+      passwordHash,
+      role: "admin",
+      sessionVersion: 0,
+    },
+  ])
 
-	if (!initialAdminPassword) {
-		console.log(`[BOOTSTRAP] Initial admin password: ${password}`)
-		console.log("[BOOTSTRAP] Change this password after your first login.")
-	}
+  if (!initialAdminPassword) {
+    console.log(`[BOOTSTRAP] Initial admin password: ${password}`)
+    console.log("[BOOTSTRAP] Change this password after your first login.")
+  }
 }
 
 function generateRandomPassword(): string {
-	const chars = "ABCDEFGHJKLMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz23456789"
-	const bytes = new Uint8Array(16)
-	crypto.getRandomValues(bytes)
-	return Array.from(bytes, (b) => chars[b % chars.length]).join("")
+  const chars = "ABCDEFGHJKLMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz23456789"
+  const bytes = new Uint8Array(16)
+  crypto.getRandomValues(bytes)
+  return Array.from(bytes, (b) => chars[b % chars.length]).join("")
 }

--- a/projects/file-server/src/utils/userConfigCache.ts
+++ b/projects/file-server/src/utils/userConfigCache.ts
@@ -84,7 +84,10 @@ export async function saveUsersToFile(
   const dir = path.dirname(usersFile)
   await mkdir(dir, { recursive: true })
   const tmpFile = `${usersFile}.tmp`
-  await writeFile(tmpFile, JSON.stringify(users, null, 2), "utf-8")
+  await writeFile(tmpFile, JSON.stringify(users, null, 2), {
+    encoding: "utf-8",
+    mode: 0o600,
+  })
   await rename(tmpFile, usersFile)
   cachedUsers = null
   cachedPath = null

--- a/projects/file-server/src/utils/userConfigCache.ts
+++ b/projects/file-server/src/utils/userConfigCache.ts
@@ -19,13 +19,20 @@ function toValidatedUsers(input: unknown): UserConfig[] {
       throw new Error(`Users file entry at index ${index} must be an object.`)
     }
 
-    const { username, passwordHash, role, sessionVersion } = item as Record<string, unknown>
+    const { username, passwordHash, role, sessionVersion } = item as Record<
+      string,
+      unknown
+    >
 
     if (typeof username !== "string" || !isValidUsername(username)) {
-      throw new Error(`Users file entry at index ${index} has invalid username.`)
+      throw new Error(
+        `Users file entry at index ${index} has invalid username.`,
+      )
     }
     if (typeof passwordHash !== "string" || passwordHash.length === 0) {
-      throw new Error(`Users file entry at index ${index} has invalid passwordHash.`)
+      throw new Error(
+        `Users file entry at index ${index} has invalid passwordHash.`,
+      )
     }
     if (typeof role !== "string" || !USER_ROLES.has(role)) {
       throw new Error(`Users file entry at index ${index} has invalid role.`)
@@ -58,7 +65,7 @@ export async function loadUsersFromFileWithCache(
   try {
     parsed = JSON.parse(content)
   } catch {
-    throw new Error("USERS_FILE is not valid JSON.")
+    throw new Error("users.json is not valid JSON.")
   }
 
   const users = toValidatedUsers(parsed)
@@ -70,7 +77,10 @@ export async function loadUsersFromFileWithCache(
   return users
 }
 
-export async function saveUsersToFile(usersFile: string, users: UserConfig[]): Promise<void> {
+export async function saveUsersToFile(
+  usersFile: string,
+  users: UserConfig[],
+): Promise<void> {
   const dir = path.dirname(usersFile)
   await mkdir(dir, { recursive: true })
   const tmpFile = `${usersFile}.tmp`

--- a/projects/file-server/tests/auth.test.ts
+++ b/projects/file-server/tests/auth.test.ts
@@ -1,615 +1,677 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test"
 import { mkdir, rm, writeFile } from "node:fs/promises"
 import path from "node:path"
-import { getUsersFilePath } from "../src/utils/auth"
+import { createApp } from "../src/app"
+import { getSessionSecretFilePath, getUsersFilePath } from "../src/utils/auth"
 import { isPathTraversal } from "../src/utils/pathTraversal"
 import { resetUsersCacheForTests } from "../src/utils/userConfigCache"
 import { createTestSession } from "./helpers/auth"
 import { createTestApp } from "./helpers/createTestApp"
 
 const UPLOAD_DIR = "./tmp-test-auth"
+const AUTH_DIR = path.join(UPLOAD_DIR, ".auth")
 const SESSION_SECRET = "0123456789abcdef0123456789abcdef"
 const zipAvailable = Bun.spawnSync(["which", "zip"]).exitCode === 0
 
 type PlainUser = {
-	username: string
-	password: string
-	role?: "admin" | "user"
+  username: string
+  password: string
+  role?: "admin" | "user"
 }
 
 let app: Awaited<ReturnType<typeof createTestApp>>
 
 async function writeUsers(users: PlainUser[]) {
-	const usersFile = getUsersFilePath(UPLOAD_DIR)
-	const userConfigs = await Promise.all(
-		users.map(async (user) => ({
-			username: user.username,
-			passwordHash: await Bun.password.hash(user.password, {
-				algorithm: "bcrypt",
-				cost: 4,
-			}),
-			role: user.role ?? "user",
-			sessionVersion: 0,
-		})),
-	)
-	await mkdir(path.dirname(usersFile), { recursive: true })
-	await writeFile(usersFile, JSON.stringify(userConfigs), "utf-8")
-	resetUsersCacheForTests()
+  const usersFile = getUsersFilePath(AUTH_DIR)
+  const userConfigs = await Promise.all(
+    users.map(async (user) => ({
+      username: user.username,
+      passwordHash: await Bun.password.hash(user.password, {
+        algorithm: "bcrypt",
+        cost: 4,
+      }),
+      role: user.role ?? "user",
+      sessionVersion: 0,
+    })),
+  )
+  await mkdir(path.dirname(usersFile), { recursive: true })
+  await writeFile(usersFile, JSON.stringify(userConfigs), "utf-8")
+  resetUsersCacheForTests()
 }
 
 async function login(
-	username: string,
-	password: string,
-	returnTo = "/",
+  username: string,
+  password: string,
+  returnTo = "/",
 ): Promise<Response> {
-	const body = new URLSearchParams({ username, password, returnTo })
-	return app.request(
-		new Request("http://localhost/login", {
-			method: "POST",
-			body,
-			headers: { "content-type": "application/x-www-form-urlencoded" },
-			redirect: "manual",
-		}),
-	)
+  const body = new URLSearchParams({ username, password, returnTo })
+  return app.request(
+    new Request("http://localhost/login", {
+      method: "POST",
+      body,
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      redirect: "manual",
+    }),
+  )
 }
 
 describe("auth", () => {
-	beforeEach(async () => {
-		await rm(UPLOAD_DIR, { recursive: true, force: true })
-		app = await createTestApp({
-			uploadDir: UPLOAD_DIR,
-			sessionSecret: SESSION_SECRET,
-			initialAdminPassword: "initial-admin-pass",
-		})
-	})
-
-	afterEach(async () => {
-		await rm(UPLOAD_DIR, { recursive: true, force: true })
-	})
-
-	it("allows access when authentication is disabled", async () => {
-		app = await createTestApp({ uploadDir: UPLOAD_DIR })
-
-		const res = await app.request(
-			new Request("http://localhost/?path=", {
-				redirect: "manual",
-			}),
-		)
-
-		expect(res.status).toBe(200)
-	})
-
-	it("redirects unauthenticated requests to login when auth is enabled", async () => {
-		const res = await app.request(
-			new Request("http://localhost/?path=", {
-				redirect: "manual",
-			}),
-		)
-
-		expect(res.status).toBe(302)
-		const location = res.headers.get("location")
-		expect(location).toBe("/login?returnTo=%2F%3Fpath%3D")
-	})
-
-	it("sets a session cookie on successful login", async () => {
-		await writeUsers([{ username: "alice", password: "password1" }])
-
-		const res = await login("alice", "password1", "/?path=docs")
-
-		expect(res.status).toBe(302)
-		expect(res.headers.get("location")).toBe("/?path=docs")
-		expect(res.headers.get("set-cookie")).toContain("session=")
-	})
-
-	it("returns 401 on failed login", async () => {
-		await writeUsers([{ username: "alice", password: "password1" }])
-
-		const res = await login("alice", "wrong-password")
-
-		expect(res.status).toBe(401)
-		const body = await res.text()
-		expect(body).toContain("Invalid username or password")
-	})
-
-	it("isolates files by authenticated user directory", async () => {
-		await writeUsers([
-			{ username: "alice", password: "password1" },
-			{ username: "bob", password: "password2" },
-		])
-
-		await mkdir(path.join(UPLOAD_DIR, "private", "alice"), { recursive: true })
-		await mkdir(path.join(UPLOAD_DIR, "private", "bob"), { recursive: true })
-		await writeFile(
-			path.join(UPLOAD_DIR, "private", "alice", "alice.txt"),
-			"alice",
-		)
-		await writeFile(path.join(UPLOAD_DIR, "private", "bob", "bob.txt"), "bob")
-
-		const aliceSession = await createTestSession("alice", SESSION_SECRET)
-		const bobSession = await createTestSession("bob", SESSION_SECRET)
-
-		const aliceRes = await app.request(
-			new Request("http://localhost/api/private/alice/", {
-				headers: { cookie: aliceSession.cookie },
-			}),
-		)
-		const bobRes = await app.request(
-			new Request("http://localhost/api/private/bob/", {
-				headers: { cookie: bobSession.cookie },
-			}),
-		)
-
-		const aliceJson = (await aliceRes.json()) as {
-			files: Array<{ name: string }>
-		}
-		const bobJson = (await bobRes.json()) as {
-			files: Array<{ name: string }>
-		}
-
-		expect(aliceRes.status).toBe(200)
-		expect(bobRes.status).toBe(200)
-		expect(aliceJson.files.map((f) => f.name)).toContain("alice.txt")
-		expect(aliceJson.files.map((f) => f.name)).not.toContain("bob.txt")
-		expect(bobJson.files.map((f) => f.name)).toContain("bob.txt")
-		expect(bobJson.files.map((f) => f.name)).not.toContain("alice.txt")
-	})
-
-	it("allows admin to browse the whole upload root", async () => {
-		await writeUsers([
-			{ username: "admin", password: "password1", role: "admin" },
-			{ username: "alice", password: "password2", role: "user" },
-			{ username: "bob", password: "password3", role: "user" },
-		])
-
-		await mkdir(path.join(UPLOAD_DIR, "private", "alice"), { recursive: true })
-		await mkdir(path.join(UPLOAD_DIR, "private", "bob"), { recursive: true })
-		await writeFile(
-			path.join(UPLOAD_DIR, "private", "alice", "alice.txt"),
-			"alice",
-		)
-		await writeFile(path.join(UPLOAD_DIR, "private", "bob", "bob.txt"), "bob")
-
-		const adminSession = await createTestSession("admin", SESSION_SECRET)
-		const res = await app.request(
-			new Request("http://localhost/api/private/", {
-				headers: { cookie: adminSession.cookie },
-			}),
-		)
-		const body = (await res.json()) as {
-			files: Array<{ name: string; type: "file" | "dir" }>
-		}
-
-		expect(res.status).toBe(200)
-		expect(body.files).toEqual(
-			expect.arrayContaining([
-				{ name: "alice", type: "dir" },
-				{ name: "bob", type: "dir" },
-			]),
-		)
-	})
-
-	it("renders / as a home view for regular users", async () => {
-		await writeUsers([{ username: "alice", password: "password1" }])
-		await mkdir(path.join(UPLOAD_DIR, "private", "alice", "docs"), {
-			recursive: true,
-		})
-		await writeFile(
-			path.join(UPLOAD_DIR, "private", "alice", "notes.txt"),
-			"hello",
-		)
-
-		const session = await createTestSession("alice", SESSION_SECRET)
-		const res = await app.request(
-			new Request("http://localhost/?path=", {
-				headers: { cookie: session.cookie },
-			}),
-		)
-		const text = await res.text()
-
-		expect(res.status).toBe(200)
-		expect(text).toContain(">home</a>")
-		expect(text).toContain("Shared")
-		expect(text).toContain('hx-get="/browse?path=public"')
-		expect(text).toContain('hx-get="/browse?path=private%2Falice%2Fdocs"')
-		expect(text).toContain('name="path" value="private/alice"')
-		expect(text).toContain('href="/file/archive?path=private%2Falice"')
-		expect(text).toContain("notes.txt")
-	})
-
-	it("keeps the home view after htmx create operations for regular users", async () => {
-		await writeUsers([{ username: "alice", password: "password1" }])
-		const session = await createTestSession("alice", SESSION_SECRET)
-
-		const body = new URLSearchParams({
-			path: "private/alice",
-			file: "home.txt",
-		})
-		const res = await app.request(
-			new Request("http://localhost/api/file", {
-				method: "POST",
-				body,
-				headers: {
-					cookie: session.cookie,
-					"content-type": "application/x-www-form-urlencoded",
-					"HX-Request": "true",
-				},
-			}),
-		)
-		const text = await res.text()
-
-		expect(res.status).toBe(200)
-		expect(text).toContain(">home</a>")
-		expect(text).toContain("Shared")
-		expect(text).toContain("home.txt")
-		expect(text).toContain('name="path" value="private/alice"')
-	})
-
-	it("hides root action controls for admins", async () => {
-		await writeUsers([
-			{ username: "admin", password: "password1", role: "admin" },
-			{ username: "alice", password: "password2", role: "user" },
-		])
-
-		const session = await createTestSession("admin", SESSION_SECRET)
-		const res = await app.request(
-			new Request("http://localhost/?path=", {
-				headers: { cookie: session.cookie },
-			}),
-		)
-		const text = await res.text()
-
-		expect(res.status).toBe(200)
-		expect(text).toContain(">root</a>")
-		expect(text).toContain("public")
-		expect(text).toContain("private")
-		expect(text).not.toContain("New File")
-		expect(text).not.toContain("New Folder")
-		expect(text).not.toContain("Download Zip")
-	})
-
-	it("allows admin to upload to another user's directory", async () => {
-		await writeUsers([
-			{ username: "admin", password: "password1", role: "admin" },
-			{ username: "bob", password: "password2", role: "user" },
-		])
-		await mkdir(path.join(UPLOAD_DIR, "private", "bob"), { recursive: true })
-
-		const adminSession = await createTestSession("admin", SESSION_SECRET)
-		const formData = new FormData()
-		formData.append("files", new File(["hello"], "from-admin.txt"))
-		formData.append("path", "private/bob")
-
-		const res = await app.request(
-			new Request("http://localhost/api/upload", {
-				method: "POST",
-				body: formData,
-				headers: { cookie: adminSession.cookie },
-			}),
-		)
-
-		expect(res.status).toBe(200)
-		expect(
-			Bun.file(
-				path.join(UPLOAD_DIR, "private", "bob", "from-admin.txt"),
-			).text(),
-		).resolves.toBe("hello")
-	})
-
-	it("rejects path traversal attempts for authenticated users", async () => {
-		await writeUsers([{ username: "alice", password: "password1" }])
-		const session = await createTestSession("alice", SESSION_SECRET)
-
-		const res = await app.request(
-			new Request("http://localhost/?path=../bob", {
-				headers: { cookie: session.cookie },
-			}),
-		)
-
-		expect(res.status).toBe(403)
-		const body = (await res.json()) as {
-			success: boolean
-			error: { name: string; message: string }
-		}
-		expect(body.success).toBe(false)
-		expect(body.error.name).toBe("Forbidden")
-	})
-
-	it("isolates archive downloads by authenticated user directory", async () => {
-		if (!zipAvailable) {
-			return
-		}
-
-		await writeUsers([
-			{ username: "alice", password: "password1" },
-			{ username: "bob", password: "password2" },
-		])
-
-		await mkdir(path.join(UPLOAD_DIR, "private", "alice"), { recursive: true })
-		await mkdir(path.join(UPLOAD_DIR, "private", "bob"), { recursive: true })
-		await writeFile(
-			path.join(UPLOAD_DIR, "private", "alice", "alice.txt"),
-			"alice",
-		)
-		await writeFile(path.join(UPLOAD_DIR, "private", "bob", "bob.txt"), "bob")
-
-		const aliceSession = await createTestSession("alice", SESSION_SECRET)
-		const res = await app.request(
-			new Request("http://localhost/file/archive?path=private%2Falice", {
-				headers: { cookie: aliceSession.cookie },
-			}),
-		)
-		const bodyText = Buffer.from(await res.arrayBuffer()).toString("latin1")
-
-		expect(res.status).toBe(200)
-		expect(bodyText).toContain("alice.txt")
-		expect(bodyText).not.toContain("bob.txt")
-	})
-
-	it("rejects archive traversal attempts for authenticated users", async () => {
-		await writeUsers([{ username: "alice", password: "password1" }])
-		const session = await createTestSession("alice", SESSION_SECRET)
-
-		const res = await app.request(
-			new Request("http://localhost/file/archive?path=..%2Fbob", {
-				headers: { cookie: session.cookie },
-			}),
-		)
-		const body = (await res.json()) as {
-			success: boolean
-			error: { name: string; message: string }
-		}
-
-		expect(res.status).toBe(403)
-		expect(body.success).toBe(false)
-		expect(body.error.name).toBe("Forbidden")
-	})
-
-	it("allows admin to archive another user's directory", async () => {
-		if (!zipAvailable) {
-			return
-		}
-
-		await writeUsers([
-			{ username: "admin", password: "password1", role: "admin" },
-			{ username: "alice", password: "password2", role: "user" },
-		])
-		await mkdir(path.join(UPLOAD_DIR, "private", "alice"), { recursive: true })
-		await writeFile(
-			path.join(UPLOAD_DIR, "private", "alice", "alice.txt"),
-			"alice",
-		)
-
-		const adminSession = await createTestSession("admin", SESSION_SECRET)
-		const res = await app.request(
-			new Request("http://localhost/file/archive?path=private%2Falice", {
-				headers: { cookie: adminSession.cookie },
-			}),
-		)
-		const bodyText = Buffer.from(await res.arrayBuffer()).toString("latin1")
-
-		expect(res.status).toBe(200)
-		expect(bodyText).toContain("alice.txt")
-	})
-
-	it("rejects path traversal attempts for admins", async () => {
-		await writeUsers([
-			{ username: "admin", password: "password1", role: "admin" },
-		])
-		const adminSession = await createTestSession("admin", SESSION_SECRET)
-
-		const res = await app.request(
-			new Request("http://localhost/?path=../etc", {
-				headers: { cookie: adminSession.cookie },
-			}),
-		)
-		const body = (await res.json()) as {
-			success: boolean
-			error: { name: string; message: string }
-		}
-
-		expect(res.status).toBe(403)
-		expect(body.success).toBe(false)
-		expect(body.error.name).toBe("Forbidden")
-	})
-
-	it("clears the session cookie on logout", async () => {
-		await writeUsers([{ username: "alice", password: "password1" }])
-		const session = await createTestSession("alice", SESSION_SECRET)
-
-		const res = await app.request(
-			new Request("http://localhost/logout", {
-				method: "POST",
-				headers: { cookie: session.cookie },
-				redirect: "manual",
-			}),
-		)
-
-		expect(res.status).toBe(302)
-		expect(res.headers.get("location")).toBe("/login")
-		expect(res.headers.get("set-cookie")).toContain("session=;")
-	})
-
-	it("reloads users when the users file changes", async () => {
-		await writeUsers([{ username: "alice", password: "oldpass" }])
-		const oldLogin = await login("alice", "oldpass")
-		expect(oldLogin.status).toBe(302)
-
-		await new Promise((resolve) => setTimeout(resolve, 20))
-		await writeUsers([{ username: "alice", password: "newpass" }])
-
-		const rejectedOldLogin = await login("alice", "oldpass")
-		const acceptedNewLogin = await login("alice", "newpass")
-
-		expect(rejectedOldLogin.status).toBe(401)
-		expect(acceptedNewLogin.status).toBe(302)
-	})
-
-	it("bootstraps admin on first startup with SESSION_SECRET", async () => {
-		const adminLogin = await login("admin", "initial-admin-pass")
-		expect(adminLogin.status).toBe(302)
-	})
-
-	it("fails to start if users file exists but has no admin", async () => {
-		const usersFile = getUsersFilePath(UPLOAD_DIR)
-		await writeFile(
-			usersFile,
-			JSON.stringify([
-				{
-					username: "alice",
-					passwordHash: "dummy",
-					role: "user",
-					sessionVersion: 0,
-				},
-			]),
-			"utf-8",
-		)
-
-		await expect(
-			createTestApp({ uploadDir: UPLOAD_DIR, sessionSecret: SESSION_SECRET }),
-		).rejects.toThrow()
-	})
-
-	it("handles precise path traversal checks", () => {
-		expect(isPathTraversal("../../etc/passwd")).toBe(true)
-		expect(isPathTraversal("../bob/file.txt")).toBe(true)
-		expect(isPathTraversal("/etc/passwd")).toBe(true)
-		expect(isPathTraversal("file..name.txt")).toBe(false)
-		expect(isPathTraversal("docs..")).toBe(false)
-		expect(isPathTraversal("")).toBe(false)
-	})
-
-	it("rejects invalid username entries in users file", async () => {
-		const usersFile = getUsersFilePath(UPLOAD_DIR)
-		await writeFile(
-			usersFile,
-			JSON.stringify([
-				{ username: "alice/root", passwordHash: "dummy", role: "user", sessionVersion: 0 },
-			]),
-			"utf-8",
-		)
-		resetUsersCacheForTests()
-
-		const res = await app.request(new Request("http://localhost/login"))
-		expect(res.status).toBe(500)
-	})
-
-	it("rejects invalid role entries in users file", async () => {
-		const usersFile = getUsersFilePath(UPLOAD_DIR)
-		await writeFile(
-			usersFile,
-			JSON.stringify([
-				{ username: "alice", passwordHash: "dummy", role: "super-admin", sessionVersion: 0 },
-			]),
-			"utf-8",
-		)
-		resetUsersCacheForTests()
-
-		const res = await app.request(new Request("http://localhost/login"))
-		expect(res.status).toBe(500)
-	})
-
-	it("invalidates session after sessionVersion mismatch", async () => {
-		await writeUsers([{ username: "alice", password: "password1" }])
-
-		const staleSession = await createTestSession("alice", SESSION_SECRET, 0)
-
-		// Simulate version increment (e.g., password change)
-		const usersFile = getUsersFilePath(UPLOAD_DIR)
-		const userConfigs = [
-			{
-				username: "alice",
-				passwordHash: await Bun.password.hash("newpass", {
-					algorithm: "bcrypt",
-					cost: 4,
-				}),
-				role: "user",
-				sessionVersion: 1,
-			},
-		]
-		await writeFile(usersFile, JSON.stringify(userConfigs), "utf-8")
-		resetUsersCacheForTests()
-
-		const res = await app.request(
-			new Request("http://localhost/?path=", {
-				headers: { cookie: staleSession.cookie },
-				redirect: "manual",
-			}),
-		)
-
-		expect(res.status).toBe(302)
-		expect(res.headers.get("location")).toContain("/login")
-	})
-
-	it("keeps file write access inside user directory", async () => {
-		await writeUsers([{ username: "alice", password: "password1" }])
-		const session = await createTestSession("alice", SESSION_SECRET)
-
-		const formData = new FormData()
-		formData.append("files", new File(["hello"], "safe.txt"))
-		formData.append("path", "../../outside.txt")
-
-		const res = await app.request(
-			new Request("http://localhost/api/upload", {
-				method: "POST",
-				body: formData,
-				headers: { cookie: session.cookie },
-			}),
-		)
-		const body = (await res.json()) as {
-			success: boolean
-			error: { name: string }
-		}
-
-		expect(res.status).toBe(403)
-		expect(body.success).toBe(false)
-		expect(body.error.name).toBe("Forbidden")
-		const outsidePath = path.join(UPLOAD_DIR, "outside.txt")
-		expect(Bun.file(outsidePath).exists()).resolves.toBe(false)
-	})
-
-	it("fails to start if users file contains broken JSON", async () => {
-		const usersFile = getUsersFilePath(UPLOAD_DIR)
-		await writeFile(usersFile, "{ broken json", "utf-8")
-
-		await expect(
-			createTestApp({ uploadDir: UPLOAD_DIR, sessionSecret: SESSION_SECRET }),
-		).rejects.toThrow()
-	})
-
-	it("bootstraps admin when users file is empty (0 bytes)", async () => {
-		const usersFile = getUsersFilePath(UPLOAD_DIR)
-		await mkdir(path.dirname(usersFile), { recursive: true })
-		await writeFile(usersFile, "", "utf-8")
-
-		app = await createTestApp({
-			uploadDir: UPLOAD_DIR,
-			sessionSecret: SESSION_SECRET,
-			initialAdminPassword: "initial-admin-pass",
-		})
-
-		const res = await login("admin", "initial-admin-pass")
-		expect(res.status).toBe(302)
-	})
-
-	it("blocks master admin password reset via /admin/users/:username/password", async () => {
-		const adminSession = await createTestSession("admin", SESSION_SECRET)
-
-		const body = new URLSearchParams({ newPassword: "hacked" })
-		const res = await app.request(
-			new Request("http://localhost/admin/users/admin/password", {
-				method: "POST",
-				body,
-				headers: {
-					"content-type": "application/x-www-form-urlencoded",
-					cookie: adminSession.cookie,
-				},
-				redirect: "manual",
-			}),
-		)
-
-		expect(res.status).toBe(302)
-		const location = res.headers.get("location") ?? ""
-		expect(location).toContain("error")
-		expect(location).toContain("master%20admin")
-	})
+  beforeEach(async () => {
+    await rm(UPLOAD_DIR, { recursive: true, force: true })
+    app = await createTestApp({
+      uploadDir: UPLOAD_DIR,
+      authDir: AUTH_DIR,
+      sessionSecret: SESSION_SECRET,
+      initialAdminPassword: "initial-admin-pass",
+    })
+  })
+
+  afterEach(async () => {
+    await rm(UPLOAD_DIR, { recursive: true, force: true })
+  })
+
+  it("allows access when authentication is disabled", async () => {
+    app = await createTestApp({ uploadDir: UPLOAD_DIR })
+
+    const res = await app.request(
+      new Request("http://localhost/?path=", {
+        redirect: "manual",
+      }),
+    )
+
+    expect(res.status).toBe(200)
+  })
+
+  it("redirects unauthenticated requests to login when auth is enabled", async () => {
+    const res = await app.request(
+      new Request("http://localhost/?path=", {
+        redirect: "manual",
+      }),
+    )
+
+    expect(res.status).toBe(302)
+    const location = res.headers.get("location")
+    expect(location).toBe("/login?returnTo=%2F%3Fpath%3D")
+  })
+
+  it("sets a session cookie on successful login", async () => {
+    await writeUsers([{ username: "alice", password: "password1" }])
+
+    const res = await login("alice", "password1", "/?path=docs")
+
+    expect(res.status).toBe(302)
+    expect(res.headers.get("location")).toBe("/?path=docs")
+    expect(res.headers.get("set-cookie")).toContain("session=")
+  })
+
+  it("returns 401 on failed login", async () => {
+    await writeUsers([{ username: "alice", password: "password1" }])
+
+    const res = await login("alice", "wrong-password")
+
+    expect(res.status).toBe(401)
+    const body = await res.text()
+    expect(body).toContain("Invalid username or password")
+  })
+
+  it("isolates files by authenticated user directory", async () => {
+    await writeUsers([
+      { username: "alice", password: "password1" },
+      { username: "bob", password: "password2" },
+    ])
+
+    await mkdir(path.join(UPLOAD_DIR, "private", "alice"), { recursive: true })
+    await mkdir(path.join(UPLOAD_DIR, "private", "bob"), { recursive: true })
+    await writeFile(
+      path.join(UPLOAD_DIR, "private", "alice", "alice.txt"),
+      "alice",
+    )
+    await writeFile(path.join(UPLOAD_DIR, "private", "bob", "bob.txt"), "bob")
+
+    const aliceSession = await createTestSession("alice", SESSION_SECRET)
+    const bobSession = await createTestSession("bob", SESSION_SECRET)
+
+    const aliceRes = await app.request(
+      new Request("http://localhost/api/private/alice/", {
+        headers: { cookie: aliceSession.cookie },
+      }),
+    )
+    const bobRes = await app.request(
+      new Request("http://localhost/api/private/bob/", {
+        headers: { cookie: bobSession.cookie },
+      }),
+    )
+
+    const aliceJson = (await aliceRes.json()) as {
+      files: Array<{ name: string }>
+    }
+    const bobJson = (await bobRes.json()) as {
+      files: Array<{ name: string }>
+    }
+
+    expect(aliceRes.status).toBe(200)
+    expect(bobRes.status).toBe(200)
+    expect(aliceJson.files.map((f) => f.name)).toContain("alice.txt")
+    expect(aliceJson.files.map((f) => f.name)).not.toContain("bob.txt")
+    expect(bobJson.files.map((f) => f.name)).toContain("bob.txt")
+    expect(bobJson.files.map((f) => f.name)).not.toContain("alice.txt")
+  })
+
+  it("allows admin to browse the whole upload root", async () => {
+    await writeUsers([
+      { username: "admin", password: "password1", role: "admin" },
+      { username: "alice", password: "password2", role: "user" },
+      { username: "bob", password: "password3", role: "user" },
+    ])
+
+    await mkdir(path.join(UPLOAD_DIR, "private", "alice"), { recursive: true })
+    await mkdir(path.join(UPLOAD_DIR, "private", "bob"), { recursive: true })
+    await writeFile(
+      path.join(UPLOAD_DIR, "private", "alice", "alice.txt"),
+      "alice",
+    )
+    await writeFile(path.join(UPLOAD_DIR, "private", "bob", "bob.txt"), "bob")
+
+    const adminSession = await createTestSession("admin", SESSION_SECRET)
+    const res = await app.request(
+      new Request("http://localhost/api/private/", {
+        headers: { cookie: adminSession.cookie },
+      }),
+    )
+    const body = (await res.json()) as {
+      files: Array<{ name: string; type: "file" | "dir" }>
+    }
+
+    expect(res.status).toBe(200)
+    expect(body.files).toEqual(
+      expect.arrayContaining([
+        { name: "alice", type: "dir" },
+        { name: "bob", type: "dir" },
+      ]),
+    )
+  })
+
+  it("renders / as a home view for regular users", async () => {
+    await writeUsers([{ username: "alice", password: "password1" }])
+    await mkdir(path.join(UPLOAD_DIR, "private", "alice", "docs"), {
+      recursive: true,
+    })
+    await writeFile(
+      path.join(UPLOAD_DIR, "private", "alice", "notes.txt"),
+      "hello",
+    )
+
+    const session = await createTestSession("alice", SESSION_SECRET)
+    const res = await app.request(
+      new Request("http://localhost/?path=", {
+        headers: { cookie: session.cookie },
+      }),
+    )
+    const text = await res.text()
+
+    expect(res.status).toBe(200)
+    expect(text).toContain(">home</a>")
+    expect(text).toContain("Shared")
+    expect(text).toContain('hx-get="/browse?path=public"')
+    expect(text).toContain('hx-get="/browse?path=private%2Falice%2Fdocs"')
+    expect(text).toContain('name="path" value="private/alice"')
+    expect(text).toContain('href="/file/archive?path=private%2Falice"')
+    expect(text).toContain("notes.txt")
+  })
+
+  it("keeps the home view after htmx create operations for regular users", async () => {
+    await writeUsers([{ username: "alice", password: "password1" }])
+    const session = await createTestSession("alice", SESSION_SECRET)
+
+    const body = new URLSearchParams({
+      path: "private/alice",
+      file: "home.txt",
+    })
+    const res = await app.request(
+      new Request("http://localhost/api/file", {
+        method: "POST",
+        body,
+        headers: {
+          cookie: session.cookie,
+          "content-type": "application/x-www-form-urlencoded",
+          "HX-Request": "true",
+        },
+      }),
+    )
+    const text = await res.text()
+
+    expect(res.status).toBe(200)
+    expect(text).toContain(">home</a>")
+    expect(text).toContain("Shared")
+    expect(text).toContain("home.txt")
+    expect(text).toContain('name="path" value="private/alice"')
+  })
+
+  it("hides root action controls for admins", async () => {
+    await writeUsers([
+      { username: "admin", password: "password1", role: "admin" },
+      { username: "alice", password: "password2", role: "user" },
+    ])
+
+    const session = await createTestSession("admin", SESSION_SECRET)
+    const res = await app.request(
+      new Request("http://localhost/?path=", {
+        headers: { cookie: session.cookie },
+      }),
+    )
+    const text = await res.text()
+
+    expect(res.status).toBe(200)
+    expect(text).toContain(">root</a>")
+    expect(text).toContain("public")
+    expect(text).toContain("private")
+    expect(text).not.toContain("New File")
+    expect(text).not.toContain("New Folder")
+    expect(text).not.toContain("Download Zip")
+  })
+
+  it("allows admin to upload to another user's directory", async () => {
+    await writeUsers([
+      { username: "admin", password: "password1", role: "admin" },
+      { username: "bob", password: "password2", role: "user" },
+    ])
+    await mkdir(path.join(UPLOAD_DIR, "private", "bob"), { recursive: true })
+
+    const adminSession = await createTestSession("admin", SESSION_SECRET)
+    const formData = new FormData()
+    formData.append("files", new File(["hello"], "from-admin.txt"))
+    formData.append("path", "private/bob")
+
+    const res = await app.request(
+      new Request("http://localhost/api/upload", {
+        method: "POST",
+        body: formData,
+        headers: { cookie: adminSession.cookie },
+      }),
+    )
+
+    expect(res.status).toBe(200)
+    expect(
+      Bun.file(
+        path.join(UPLOAD_DIR, "private", "bob", "from-admin.txt"),
+      ).text(),
+    ).resolves.toBe("hello")
+  })
+
+  it("rejects path traversal attempts for authenticated users", async () => {
+    await writeUsers([{ username: "alice", password: "password1" }])
+    const session = await createTestSession("alice", SESSION_SECRET)
+
+    const res = await app.request(
+      new Request("http://localhost/?path=../bob", {
+        headers: { cookie: session.cookie },
+      }),
+    )
+
+    expect(res.status).toBe(403)
+    const body = (await res.json()) as {
+      success: boolean
+      error: { name: string; message: string }
+    }
+    expect(body.success).toBe(false)
+    expect(body.error.name).toBe("Forbidden")
+  })
+
+  it("isolates archive downloads by authenticated user directory", async () => {
+    if (!zipAvailable) {
+      return
+    }
+
+    await writeUsers([
+      { username: "alice", password: "password1" },
+      { username: "bob", password: "password2" },
+    ])
+
+    await mkdir(path.join(UPLOAD_DIR, "private", "alice"), { recursive: true })
+    await mkdir(path.join(UPLOAD_DIR, "private", "bob"), { recursive: true })
+    await writeFile(
+      path.join(UPLOAD_DIR, "private", "alice", "alice.txt"),
+      "alice",
+    )
+    await writeFile(path.join(UPLOAD_DIR, "private", "bob", "bob.txt"), "bob")
+
+    const aliceSession = await createTestSession("alice", SESSION_SECRET)
+    const res = await app.request(
+      new Request("http://localhost/file/archive?path=private%2Falice", {
+        headers: { cookie: aliceSession.cookie },
+      }),
+    )
+    const bodyText = Buffer.from(await res.arrayBuffer()).toString("latin1")
+
+    expect(res.status).toBe(200)
+    expect(bodyText).toContain("alice.txt")
+    expect(bodyText).not.toContain("bob.txt")
+  })
+
+  it("rejects archive traversal attempts for authenticated users", async () => {
+    await writeUsers([{ username: "alice", password: "password1" }])
+    const session = await createTestSession("alice", SESSION_SECRET)
+
+    const res = await app.request(
+      new Request("http://localhost/file/archive?path=..%2Fbob", {
+        headers: { cookie: session.cookie },
+      }),
+    )
+    const body = (await res.json()) as {
+      success: boolean
+      error: { name: string; message: string }
+    }
+
+    expect(res.status).toBe(403)
+    expect(body.success).toBe(false)
+    expect(body.error.name).toBe("Forbidden")
+  })
+
+  it("allows admin to archive another user's directory", async () => {
+    if (!zipAvailable) {
+      return
+    }
+
+    await writeUsers([
+      { username: "admin", password: "password1", role: "admin" },
+      { username: "alice", password: "password2", role: "user" },
+    ])
+    await mkdir(path.join(UPLOAD_DIR, "private", "alice"), { recursive: true })
+    await writeFile(
+      path.join(UPLOAD_DIR, "private", "alice", "alice.txt"),
+      "alice",
+    )
+
+    const adminSession = await createTestSession("admin", SESSION_SECRET)
+    const res = await app.request(
+      new Request("http://localhost/file/archive?path=private%2Falice", {
+        headers: { cookie: adminSession.cookie },
+      }),
+    )
+    const bodyText = Buffer.from(await res.arrayBuffer()).toString("latin1")
+
+    expect(res.status).toBe(200)
+    expect(bodyText).toContain("alice.txt")
+  })
+
+  it("rejects path traversal attempts for admins", async () => {
+    await writeUsers([
+      { username: "admin", password: "password1", role: "admin" },
+    ])
+    const adminSession = await createTestSession("admin", SESSION_SECRET)
+
+    const res = await app.request(
+      new Request("http://localhost/?path=../etc", {
+        headers: { cookie: adminSession.cookie },
+      }),
+    )
+    const body = (await res.json()) as {
+      success: boolean
+      error: { name: string; message: string }
+    }
+
+    expect(res.status).toBe(403)
+    expect(body.success).toBe(false)
+    expect(body.error.name).toBe("Forbidden")
+  })
+
+  it("clears the session cookie on logout", async () => {
+    await writeUsers([{ username: "alice", password: "password1" }])
+    const session = await createTestSession("alice", SESSION_SECRET)
+
+    const res = await app.request(
+      new Request("http://localhost/logout", {
+        method: "POST",
+        headers: { cookie: session.cookie },
+        redirect: "manual",
+      }),
+    )
+
+    expect(res.status).toBe(302)
+    expect(res.headers.get("location")).toBe("/login")
+    expect(res.headers.get("set-cookie")).toContain("session=;")
+  })
+
+  it("reloads users when the users file changes", async () => {
+    await writeUsers([{ username: "alice", password: "oldpass" }])
+    const oldLogin = await login("alice", "oldpass")
+    expect(oldLogin.status).toBe(302)
+
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    await writeUsers([{ username: "alice", password: "newpass" }])
+
+    const rejectedOldLogin = await login("alice", "oldpass")
+    const acceptedNewLogin = await login("alice", "newpass")
+
+    expect(rejectedOldLogin.status).toBe(401)
+    expect(acceptedNewLogin.status).toBe(302)
+  })
+
+  it("bootstraps admin on first startup with AUTH_DIR", async () => {
+    const adminLogin = await login("admin", "initial-admin-pass")
+    expect(adminLogin.status).toBe(302)
+  })
+
+  it("creates session-secret on first startup", async () => {
+    const secret = await Bun.file(getSessionSecretFilePath(AUTH_DIR)).text()
+    expect(secret.trim().length).toBeGreaterThan(0)
+  })
+
+  it("keeps existing sessions valid after restart with the same AUTH_DIR", async () => {
+    const adminLogin = await login("admin", "initial-admin-pass")
+    const sessionCookie =
+      adminLogin.headers.get("set-cookie")?.split(";")[0] ?? ""
+
+    app = await createTestApp({
+      uploadDir: UPLOAD_DIR,
+      authDir: AUTH_DIR,
+    })
+
+    const res = await app.request(
+      new Request("http://localhost/?path=", {
+        headers: { cookie: sessionCookie },
+      }),
+    )
+
+    expect(res.status).toBe(200)
+  })
+
+  it("fails to start if SESSION_SECRET is still set", async () => {
+    process.env.SESSION_SECRET = SESSION_SECRET
+    await expect(
+      createApp({ uploadDir: UPLOAD_DIR, authDir: AUTH_DIR }),
+    ).rejects.toThrow("SESSION_SECRET")
+    delete process.env.SESSION_SECRET
+  })
+
+  it("fails to start if USERS_FILE is still set", async () => {
+    process.env.USERS_FILE = "./legacy-users.json"
+    await expect(
+      createApp({ uploadDir: UPLOAD_DIR, authDir: AUTH_DIR }),
+    ).rejects.toThrow("USERS_FILE")
+    delete process.env.USERS_FILE
+  })
+
+  it("fails to start if users file exists but has no admin", async () => {
+    const usersFile = getUsersFilePath(AUTH_DIR)
+    await writeFile(
+      usersFile,
+      JSON.stringify([
+        {
+          username: "alice",
+          passwordHash: "dummy",
+          role: "user",
+          sessionVersion: 0,
+        },
+      ]),
+      "utf-8",
+    )
+
+    await expect(
+      createTestApp({
+        uploadDir: UPLOAD_DIR,
+        authDir: AUTH_DIR,
+        sessionSecret: SESSION_SECRET,
+      }),
+    ).rejects.toThrow()
+  })
+
+  it("handles precise path traversal checks", () => {
+    expect(isPathTraversal("../../etc/passwd")).toBe(true)
+    expect(isPathTraversal("../bob/file.txt")).toBe(true)
+    expect(isPathTraversal("/etc/passwd")).toBe(true)
+    expect(isPathTraversal("file..name.txt")).toBe(false)
+    expect(isPathTraversal("docs..")).toBe(false)
+    expect(isPathTraversal("")).toBe(false)
+  })
+
+  it("rejects invalid username entries in users file", async () => {
+    const usersFile = getUsersFilePath(AUTH_DIR)
+    await writeFile(
+      usersFile,
+      JSON.stringify([
+        {
+          username: "alice/root",
+          passwordHash: "dummy",
+          role: "user",
+          sessionVersion: 0,
+        },
+      ]),
+      "utf-8",
+    )
+    resetUsersCacheForTests()
+
+    const res = await app.request(new Request("http://localhost/login"))
+    expect(res.status).toBe(500)
+  })
+
+  it("rejects invalid role entries in users file", async () => {
+    const usersFile = getUsersFilePath(AUTH_DIR)
+    await writeFile(
+      usersFile,
+      JSON.stringify([
+        {
+          username: "alice",
+          passwordHash: "dummy",
+          role: "super-admin",
+          sessionVersion: 0,
+        },
+      ]),
+      "utf-8",
+    )
+    resetUsersCacheForTests()
+
+    const res = await app.request(new Request("http://localhost/login"))
+    expect(res.status).toBe(500)
+  })
+
+  it("invalidates session after sessionVersion mismatch", async () => {
+    await writeUsers([{ username: "alice", password: "password1" }])
+
+    const staleSession = await createTestSession("alice", SESSION_SECRET, 0)
+
+    // Simulate version increment (e.g., password change)
+    const usersFile = getUsersFilePath(AUTH_DIR)
+    const userConfigs = [
+      {
+        username: "alice",
+        passwordHash: await Bun.password.hash("newpass", {
+          algorithm: "bcrypt",
+          cost: 4,
+        }),
+        role: "user",
+        sessionVersion: 1,
+      },
+    ]
+    await writeFile(usersFile, JSON.stringify(userConfigs), "utf-8")
+    resetUsersCacheForTests()
+
+    const res = await app.request(
+      new Request("http://localhost/?path=", {
+        headers: { cookie: staleSession.cookie },
+        redirect: "manual",
+      }),
+    )
+
+    expect(res.status).toBe(302)
+    expect(res.headers.get("location")).toContain("/login")
+  })
+
+  it("keeps file write access inside user directory", async () => {
+    await writeUsers([{ username: "alice", password: "password1" }])
+    const session = await createTestSession("alice", SESSION_SECRET)
+
+    const formData = new FormData()
+    formData.append("files", new File(["hello"], "safe.txt"))
+    formData.append("path", "../../outside.txt")
+
+    const res = await app.request(
+      new Request("http://localhost/api/upload", {
+        method: "POST",
+        body: formData,
+        headers: { cookie: session.cookie },
+      }),
+    )
+    const body = (await res.json()) as {
+      success: boolean
+      error: { name: string }
+    }
+
+    expect(res.status).toBe(403)
+    expect(body.success).toBe(false)
+    expect(body.error.name).toBe("Forbidden")
+    const outsidePath = path.join(UPLOAD_DIR, "outside.txt")
+    expect(Bun.file(outsidePath).exists()).resolves.toBe(false)
+  })
+
+  it("fails to start if users file contains broken JSON", async () => {
+    const usersFile = getUsersFilePath(AUTH_DIR)
+    await writeFile(usersFile, "{ broken json", "utf-8")
+
+    await expect(
+      createTestApp({
+        uploadDir: UPLOAD_DIR,
+        authDir: AUTH_DIR,
+        sessionSecret: SESSION_SECRET,
+      }),
+    ).rejects.toThrow()
+  })
+
+  it("bootstraps admin when users file is empty (0 bytes)", async () => {
+    const usersFile = getUsersFilePath(AUTH_DIR)
+    await mkdir(path.dirname(usersFile), { recursive: true })
+    await writeFile(usersFile, "", "utf-8")
+
+    app = await createTestApp({
+      uploadDir: UPLOAD_DIR,
+      authDir: AUTH_DIR,
+      sessionSecret: SESSION_SECRET,
+      initialAdminPassword: "initial-admin-pass",
+    })
+
+    const res = await login("admin", "initial-admin-pass")
+    expect(res.status).toBe(302)
+  })
+
+  it("blocks master admin password reset via /admin/users/:username/password", async () => {
+    const adminSession = await createTestSession("admin", SESSION_SECRET)
+
+    const body = new URLSearchParams({ newPassword: "hacked" })
+    const res = await app.request(
+      new Request("http://localhost/admin/users/admin/password", {
+        method: "POST",
+        body,
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          cookie: adminSession.cookie,
+        },
+        redirect: "manual",
+      }),
+    )
+
+    expect(res.status).toBe(302)
+    const location = res.headers.get("location") ?? ""
+    expect(location).toContain("error")
+    expect(location).toContain("master%20admin")
+  })
 })

--- a/projects/file-server/tests/auth.test.ts
+++ b/projects/file-server/tests/auth.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test"
-import { mkdir, rm, writeFile } from "node:fs/promises"
+import { mkdir, rm, stat, writeFile } from "node:fs/promises"
 import path from "node:path"
 import { createApp } from "../src/app"
 import { getSessionSecretFilePath, getUsersFilePath } from "../src/utils/auth"
@@ -457,10 +457,20 @@ describe("auth", () => {
     expect(secret.trim().length).toBeGreaterThan(0)
   })
 
+  it("writes users.json with restricted permissions", async () => {
+    const usersFile = getUsersFilePath(AUTH_DIR)
+    const fileStat = await stat(usersFile)
+
+    expect(fileStat.mode & 0o777).toBe(0o600)
+  })
+
   it("keeps existing sessions valid after restart with the same AUTH_DIR", async () => {
     const adminLogin = await login("admin", "initial-admin-pass")
     const sessionCookie =
       adminLogin.headers.get("set-cookie")?.split(";")[0] ?? ""
+    const originalSecret = await Bun.file(
+      getSessionSecretFilePath(AUTH_DIR),
+    ).text()
 
     app = await createTestApp({
       uploadDir: UPLOAD_DIR,
@@ -474,6 +484,9 @@ describe("auth", () => {
     )
 
     expect(res.status).toBe(200)
+    await expect(
+      Bun.file(getSessionSecretFilePath(AUTH_DIR)).text(),
+    ).resolves.toBe(originalSecret)
   })
 
   it("fails to start if SESSION_SECRET is still set", async () => {
@@ -651,6 +664,28 @@ describe("auth", () => {
 
     const res = await login("admin", "initial-admin-pass")
     expect(res.status).toBe(302)
+  })
+
+  it("logs when INITIAL_ADMIN_PASSWORD is ignored for an existing admin", async () => {
+    const messages: string[] = []
+    const originalConsoleLog = console.log
+    console.log = (...args: unknown[]) => {
+      messages.push(args.join(" "))
+    }
+
+    try {
+      app = await createTestApp({
+        uploadDir: UPLOAD_DIR,
+        authDir: AUTH_DIR,
+        initialAdminPassword: "ignored-admin-pass",
+      })
+    } finally {
+      console.log = originalConsoleLog
+    }
+
+    expect(messages).toContain(
+      "[BOOTSTRAP] INITIAL_ADMIN_PASSWORD is ignored because users.json already contains a valid admin user.",
+    )
   })
 
   it("blocks master admin password reset via /admin/users/:username/password", async () => {

--- a/projects/file-server/tests/helpers/auth.ts
+++ b/projects/file-server/tests/helpers/auth.ts
@@ -1,18 +1,18 @@
 import { SESSION_COOKIE_NAME, signSession } from "../../src/utils/auth"
 
 export interface TestSession {
-	cookie: string
-	username: string
+  cookie: string
+  username: string
 }
 
 export async function createTestSession(
-	username: string,
-	secret: string,
-	sessionVersion = 0,
+  username: string,
+  secret: string,
+  sessionVersion = 0,
 ): Promise<TestSession> {
-	const sessionValue = await signSession({ username, sessionVersion }, secret)
-	return {
-		cookie: `${SESSION_COOKIE_NAME}=${sessionValue}`,
-		username,
-	}
+  const sessionValue = await signSession({ username, sessionVersion }, secret)
+  return {
+    cookie: `${SESSION_COOKIE_NAME}=${sessionValue}`,
+    username,
+  }
 }

--- a/projects/file-server/tests/helpers/createTestApp.ts
+++ b/projects/file-server/tests/helpers/createTestApp.ts
@@ -3,58 +3,80 @@ import path from "node:path"
 import type { Hono } from "hono"
 import { createApp } from "../../src/app"
 import type { AppBindings } from "../../src/types"
-import { getUsersFilePath } from "../../src/utils/auth"
+import {
+  getSessionSecretFilePath,
+  getUsersFilePath,
+  resetSessionSecretCacheForTests,
+} from "../../src/utils/auth"
 import { resetUsersCacheForTests } from "../../src/utils/userConfigCache"
 
 export interface TestAppOptions {
-	uploadDir: string
-	sessionSecret?: string
-	initialAdminPassword?: string
-	seedUsers?: Array<{
-		username: string
-		password: string
-		role?: "admin" | "user"
-	}>
+  uploadDir: string
+  authDir?: string
+  sessionSecret?: string
+  initialAdminPassword?: string
+  seedUsers?: Array<{
+    username: string
+    password: string
+    role?: "admin" | "user"
+  }>
 }
 
 export async function createTestApp(
-	options: TestAppOptions,
+  options: TestAppOptions,
 ): Promise<Hono<AppBindings>> {
-	process.env.UPLOAD_DIR = options.uploadDir
-	delete process.env.USERS_FILE
-	if (options.sessionSecret) {
-		process.env.SESSION_SECRET = options.sessionSecret
-	} else {
-		delete process.env.SESSION_SECRET
-	}
-	if (options.initialAdminPassword) {
-		process.env.INITIAL_ADMIN_PASSWORD = options.initialAdminPassword
-	} else {
-		delete process.env.INITIAL_ADMIN_PASSWORD
-	}
+  const authDir =
+    options.authDir ??
+    (options.sessionSecret || options.seedUsers || options.initialAdminPassword
+      ? path.join(options.uploadDir, ".auth")
+      : undefined)
 
-	resetUsersCacheForTests()
+  process.env.UPLOAD_DIR = options.uploadDir
+  if (authDir) {
+    process.env.AUTH_DIR = authDir
+  } else {
+    delete process.env.AUTH_DIR
+  }
+  delete process.env.USERS_FILE
+  delete process.env.SESSION_SECRET
+  if (options.initialAdminPassword) {
+    process.env.INITIAL_ADMIN_PASSWORD = options.initialAdminPassword
+  } else {
+    delete process.env.INITIAL_ADMIN_PASSWORD
+  }
 
-	if (options.seedUsers && options.seedUsers.length > 0) {
-		const usersFile = getUsersFilePath(options.uploadDir)
-		await mkdir(path.dirname(usersFile), { recursive: true })
-		const userConfigs = await Promise.all(
-			options.seedUsers.map(async (user) => ({
-				username: user.username,
-				passwordHash: await Bun.password.hash(user.password, {
-					algorithm: "bcrypt",
-					cost: 4,
-				}),
-				role: user.role ?? "user",
-				sessionVersion: 0,
-			})),
-		)
-		await writeFile(usersFile, JSON.stringify(userConfigs), "utf-8")
-	}
+  resetUsersCacheForTests()
+  resetSessionSecretCacheForTests()
 
-	return createApp({
-		uploadDir: options.uploadDir,
-		sessionSecret: options.sessionSecret,
-		initialAdminPassword: options.initialAdminPassword,
-	})
+  if (authDir && options.sessionSecret) {
+    await mkdir(authDir, { recursive: true })
+    await writeFile(
+      getSessionSecretFilePath(authDir),
+      `${options.sessionSecret}\n`,
+      "utf-8",
+    )
+  }
+
+  if (authDir && options.seedUsers && options.seedUsers.length > 0) {
+    const usersFile = getUsersFilePath(authDir)
+    await mkdir(path.dirname(usersFile), { recursive: true })
+    const userConfigs = await Promise.all(
+      options.seedUsers.map(async (user) => ({
+        username: user.username,
+        passwordHash: await Bun.password.hash(user.password, {
+          algorithm: "bcrypt",
+          cost: 4,
+        }),
+        role: user.role ?? "user",
+        sessionVersion: 0,
+      })),
+    )
+    await writeFile(usersFile, JSON.stringify(userConfigs), "utf-8")
+  }
+
+  return createApp({
+    uploadDir: options.uploadDir,
+    authDir,
+    initialAdminPassword: options.initialAdminPassword,
+  })
 }

--- a/projects/file-server/tests/public-route.test.ts
+++ b/projects/file-server/tests/public-route.test.ts
@@ -4,6 +4,7 @@ import path from "node:path"
 import { createTestApp } from "./helpers/createTestApp"
 
 const UPLOAD_DIR = "./tmp-test-public-route"
+const AUTH_DIR = path.join(UPLOAD_DIR, ".auth")
 let app: Awaited<ReturnType<typeof createTestApp>>
 
 beforeEach(async () => {
@@ -155,6 +156,7 @@ describe("GET /public/*", () => {
   it("is accessible without a session cookie when auth is enabled", async () => {
     app = await createTestApp({
       uploadDir: UPLOAD_DIR,
+      authDir: AUTH_DIR,
       sessionSecret: "0123456789abcdef0123456789abcdef",
       initialAdminPassword: "test-admin-pass",
     })

--- a/projects/file-server/tests/rename.test.ts
+++ b/projects/file-server/tests/rename.test.ts
@@ -7,13 +7,14 @@ import { createTestSession } from "./helpers/auth"
 import { createTestApp } from "./helpers/createTestApp"
 
 const UPLOAD_DIR = "./tmp-test-rename"
+const AUTH_DIR = path.join(UPLOAD_DIR, ".auth")
 const SESSION_SECRET = "0123456789abcdef0123456789abcdef"
 let app: Awaited<ReturnType<typeof createTestApp>>
 
 type PlainUser = { username: string; password: string; role?: "admin" | "user" }
 
 async function writeUsers(users: PlainUser[]) {
-  const usersFile = getUsersFilePath(UPLOAD_DIR)
+  const usersFile = getUsersFilePath(AUTH_DIR)
   const userConfigs = await Promise.all(
     users.map(async (u) => ({
       username: u.username,
@@ -306,6 +307,7 @@ describe("POST /api/rename", () => {
   it("prevents authenticated users from renaming outside their scope (path traversal)", async () => {
     app = await createTestApp({
       uploadDir: UPLOAD_DIR,
+      authDir: AUTH_DIR,
       sessionSecret: SESSION_SECRET,
     })
     await writeUsers([{ username: "alice", password: "password1" }])
@@ -334,6 +336,7 @@ describe("POST /api/rename", () => {
   it("allows admins to rename items in private area", async () => {
     app = await createTestApp({
       uploadDir: UPLOAD_DIR,
+      authDir: AUTH_DIR,
       sessionSecret: SESSION_SECRET,
     })
     await writeUsers([


### PR DESCRIPTION
## Issues

- Close #818

## Why

`file-server` の認証有効化が `SESSION_SECRET` と `USERS_FILE` の組み合わせに依存していて、利用時に設定が煩雑でした。永続化ディレクトリを 1 つ指定するだけで認証を有効化できるようにして、実装とドキュメントのずれも解消します。

## Summary

認証設定を `AUTH_DIR` のみに一本化し、`AUTH_DIR/users.json` と `AUTH_DIR/session-secret` を自動管理するようにしました。あわせて auth middleware・routes・テスト・README / AGENTS / .env.example を新仕様へ更新しています。

## Changes

- `AUTH_DIR` ベースの認証設定解決と `session-secret` 自動生成を追加
- `SESSION_SECRET` / `USERS_FILE` を廃止し、設定時は起動エラーに変更
- auth middleware、`/login`、`/admin/users`、テストヘルパーを `AUTH_DIR` 前提へ更新
- README、AGENTS、`.env.example` を新しい運用に合わせて更新

## Checklist

- [x] `bun run lint`
- [x] `bun run format`
- [x] `bun test`

