### PR TITLE
fix(deploy): persist file-server auth data

### DIFF
--- a/deploy/file-server.yml
+++ b/deploy/file-server.yml
@@ -9,8 +9,12 @@ services:
     restart: always
     ports:
       - 8010:3000
+    environment:
+      - AUTH_DIR=/app/auth
     volumes:
       - file-server:/app/uploads
+      - file-server-auth:/app/auth
 
 volumes:
   file-server:
+  file-server-auth:


### PR DESCRIPTION
## Why

`file-server` の認証は `AUTH_DIR` を設定したときだけ有効になります。現行の `deploy/file-server.yml` は `/app/uploads` しか永続化しておらず、認証を有効化できず、`users.json` と `session-secret` も保持できません。

## Summary

デプロイ設定を現行仕様に合わせ、`/app/auth` を永続化します。

## Changes

- `AUTH_DIR=/app/auth` を設定して認証モードを有効化
- `/app/auth` 用の named volume を追加
- 既存の `/app/uploads` 永続化は維持

## Checklist

- [x] `docker compose -f deploy/file-server.yml config`
