### PR TITLE
feat(file-server): restrict /file/raw to safe preview, add /file/download (#813)

### DIFF
--- a/projects/file-server/AGENTS.md
+++ b/projects/file-server/AGENTS.md
@@ -3,6 +3,12 @@
 Web-based file server built with Bun + Hono + HTMX.
 Current features include empty file creation, per-directory Zip download via `/file/archive`, unauthenticated public file serving via `GET /public/*`, and GUI-based user management via `/admin/users`.
 
+## File Raw and Download Routes
+
+- `GET /file/raw` — preview-only route. Blocks `text/html`, `application/xhtml+xml`, `image/svg+xml`, and extensions `.html`, `.htm`, `.xhtml`, `.svg` with `403`. SVG is treated as source view (not embedded image) and is also blocked. Existing image/video/PDF preview behavior is preserved.
+- `GET /file/download` — download route. Always returns `Content-Disposition: attachment`. Supports all file types including HTML and SVG. Applies the same path validation and authorization rules as other file routes.
+- `/public/*` HTML/XHTML/SVG delivery is out of scope for this feature and is tracked in issue #816.
+
 ## Commands
 
 - `bun install` - Install dependencies

--- a/projects/file-server/README.md
+++ b/projects/file-server/README.md
@@ -129,7 +129,8 @@ tests/
 | GET | `/` | ディレクトリブラウズ（メインUI） |
 | GET | `/browse` | ディレクトリ一覧（HTMX部分更新用） |
 | GET | `/file` | ファイルビューアー表示 |
-| GET | `/file/raw` | ファイルの生データ配信 |
+| GET | `/file/raw` | ファイルのプレビュー配信（HTML/XHTML/SVG は 403 ブロック） |
+| GET | `/file/download` | ファイルをダウンロード（`Content-Disposition: attachment`、全ファイル種別対応） |
 | GET | `/file/archive` | 表示中ディレクトリ配下を Zip でダウンロード |
 | GET | `/login` | ログイン画面 |
 | POST | `/login` | ログイン処理 |

--- a/projects/file-server/src/components/file-viewer/FileViewerModal.tsx
+++ b/projects/file-server/src/components/file-viewer/FileViewerModal.tsx
@@ -34,7 +34,7 @@ export const FileViewerModal: FC<FileViewerModalProps> = ({
 
   const downloadButton = path ? (
     <a
-      href={`/file/raw?path=${encodedPath}`}
+      href={`/file/download?path=${encodedPath}`}
       download={fileName || true}
       className={secondaryIconButtonClassName}
     >

--- a/projects/file-server/src/routes/file.tsx
+++ b/projects/file-server/src/routes/file.tsx
@@ -7,6 +7,7 @@ import { toBrowseLocation } from "../utils/auth"
 import {
   archiveFileName,
   createDirectoryArchive,
+  isActiveContent,
   isPreviewableBinary,
   isTextMime,
   notADirectoryResponse,
@@ -102,7 +103,35 @@ fileRoutes.get("/raw", async (c) => {
     return notAFileResponse(c)
   }
 
+  if (isActiveContent(resolved.resolvedPath, resolved.mimeType)) {
+    return errorResponse(
+      c,
+      "ActiveContentNotAllowed",
+      "Active content cannot be served via /file/raw",
+      403,
+    )
+  }
+
   return readBinaryFileResponse(resolved.resolvedPath, resolved.mimeType)
+})
+
+fileRoutes.get("/download", async (c) => {
+  const resolved = await resolveRequestedFile(c, "File does not exist")
+  if ("response" in resolved) {
+    return resolved.response
+  }
+
+  if (!resolved.stat.isFile()) {
+    return notAFileResponse(c)
+  }
+
+  const contentBuffer = await readFile(resolved.resolvedPath)
+  return new Response(toArrayBuffer(contentBuffer), {
+    headers: {
+      "Content-Type": resolved.mimeType,
+      "Content-Disposition": `attachment; filename*=UTF-8''${encodeURIComponent(path.basename(resolved.resolvedPath))}`,
+    },
+  })
 })
 
 fileRoutes.get("/archive", async (c) => {

--- a/projects/file-server/src/routes/public.tsx
+++ b/projects/file-server/src/routes/public.tsx
@@ -4,24 +4,9 @@ import * as mime from "mime-types"
 import type { AppBindings } from "../types"
 import { isPathTraversal } from "../utils/pathTraversal"
 import { errorResponse, getUploadDir } from "../utils/requestUtils"
+import { isActiveContent } from "../utils/fileRouteUtils"
 
 const publicRoutes = new Hono<AppBindings>()
-
-const ACTIVE_MIME_TYPES = new Set([
-  "text/html",
-  "application/xhtml+xml",
-  "image/svg+xml",
-])
-
-const ACTIVE_EXTENSIONS = new Set([".html", ".htm", ".xhtml", ".svg"])
-
-function isActiveContent(filePath: string, mimeType: string): boolean {
-  if (ACTIVE_MIME_TYPES.has(mimeType)) {
-    return true
-  }
-  const ext = path.extname(filePath).toLowerCase()
-  return ACTIVE_EXTENSIONS.has(ext)
-}
 
 publicRoutes.get("/*", async (c) => {
   const baseDir = getUploadDir(c)

--- a/projects/file-server/src/utils/fileRouteUtils.tsx
+++ b/projects/file-server/src/utils/fileRouteUtils.tsx
@@ -6,6 +6,22 @@ import type { AppBindings } from "../types"
 import { errorResponse, getRequestPath, getUploadDir } from "./requestUtils"
 import { resolveVirtualPath } from "./virtualPath"
 
+const ACTIVE_MIME_TYPES = new Set([
+	"text/html",
+	"application/xhtml+xml",
+	"image/svg+xml",
+])
+
+const ACTIVE_EXTENSIONS = new Set([".html", ".htm", ".xhtml", ".svg"])
+
+export function isActiveContent(filePath: string, mimeType: string): boolean {
+	if (ACTIVE_MIME_TYPES.has(mimeType)) {
+		return true
+	}
+	const ext = path.extname(filePath).toLowerCase()
+	return ACTIVE_EXTENSIONS.has(ext)
+}
+
 const EMPTY_ZIP_ARCHIVE = new Uint8Array([
   0x50, 0x4b, 0x05, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
   0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,

--- a/projects/file-server/tests/file-raw-download.test.ts
+++ b/projects/file-server/tests/file-raw-download.test.ts
@@ -1,0 +1,316 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { mkdir, rm } from "node:fs/promises"
+import * as path from "node:path"
+import { createTestApp } from "./helpers/createTestApp"
+import { createTestSession } from "./helpers/auth"
+
+const SESSION_SECRET = "test-secret-for-raw-download"
+
+describe("GET /file/raw - active content blocking", () => {
+	const UPLOAD_DIR = "./tmp-test-raw-block"
+	let app: Awaited<ReturnType<typeof createTestApp>>
+
+	beforeEach(async () => {
+		await rm(UPLOAD_DIR, { recursive: true, force: true })
+		app = await createTestApp({ uploadDir: UPLOAD_DIR })
+	})
+
+	afterEach(async () => {
+		await rm(UPLOAD_DIR, { recursive: true, force: true })
+	})
+
+	it("should return 403 for HTML file in public", async () => {
+		await Bun.write(
+			path.join(UPLOAD_DIR, "public", "page.html"),
+			"<html><body>hello</body></html>",
+		)
+		const res = await app.request(
+			new Request("http://localhost/file/raw?path=public%2Fpage.html"),
+		)
+		expect(res.status).toBe(403)
+		const data = (await res.json()) as { error: { name: string } }
+		expect(data.error.name).toBe("ActiveContentNotAllowed")
+	})
+
+	it("should return 403 for .htm file", async () => {
+		await Bun.write(
+			path.join(UPLOAD_DIR, "public", "page.htm"),
+			"<html>hello</html>",
+		)
+		const res = await app.request(
+			new Request("http://localhost/file/raw?path=public%2Fpage.htm"),
+		)
+		expect(res.status).toBe(403)
+		const data = (await res.json()) as { error: { name: string } }
+		expect(data.error.name).toBe("ActiveContentNotAllowed")
+	})
+
+	it("should return 403 for .xhtml file", async () => {
+		await Bun.write(
+			path.join(UPLOAD_DIR, "public", "page.xhtml"),
+			'<?xml version="1.0"?><html xmlns="http://www.w3.org/1999/xhtml"></html>',
+		)
+		const res = await app.request(
+			new Request("http://localhost/file/raw?path=public%2Fpage.xhtml"),
+		)
+		expect(res.status).toBe(403)
+		const data = (await res.json()) as { error: { name: string } }
+		expect(data.error.name).toBe("ActiveContentNotAllowed")
+	})
+
+	it("should return 403 for SVG file", async () => {
+		await Bun.write(
+			path.join(UPLOAD_DIR, "public", "image.svg"),
+			'<svg xmlns="http://www.w3.org/2000/svg"><circle r="10"/></svg>',
+		)
+		const res = await app.request(
+			new Request("http://localhost/file/raw?path=public%2Fimage.svg"),
+		)
+		expect(res.status).toBe(403)
+		const data = (await res.json()) as { error: { name: string } }
+		expect(data.error.name).toBe("ActiveContentNotAllowed")
+	})
+
+	it("should serve PNG image without block", async () => {
+		const pngBytes = new Uint8Array([
+			0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+		])
+		await Bun.write(path.join(UPLOAD_DIR, "public", "image.png"), pngBytes)
+		const res = await app.request(
+			new Request("http://localhost/file/raw?path=public%2Fimage.png"),
+		)
+		expect(res.status).toBe(200)
+		expect(res.headers.get("Content-Type")).toContain("image/png")
+	})
+
+	it("should serve text file without block", async () => {
+		await Bun.write(path.join(UPLOAD_DIR, "public", "note.txt"), "hello world")
+		const res = await app.request(
+			new Request("http://localhost/file/raw?path=public%2Fnote.txt"),
+		)
+		expect(res.status).toBe(200)
+	})
+
+	it("should return 403 for HTML in private dir (auth disabled)", async () => {
+		await mkdir(path.join(UPLOAD_DIR, "private"), { recursive: true })
+		await Bun.write(
+			path.join(UPLOAD_DIR, "private", "secret.html"),
+			"<html>secret</html>",
+		)
+		const res = await app.request(
+			new Request("http://localhost/file/raw?path=private%2Fsecret.html"),
+		)
+		expect(res.status).toBe(403)
+		const data = (await res.json()) as { error: { name: string } }
+		expect(data.error.name).toBe("ActiveContentNotAllowed")
+	})
+})
+
+describe("GET /file/raw - active content blocking with auth", () => {
+	const UPLOAD_DIR = "./tmp-test-raw-block-auth"
+	let app: Awaited<ReturnType<typeof createTestApp>>
+
+	beforeEach(async () => {
+		await rm(UPLOAD_DIR, { recursive: true, force: true })
+		app = await createTestApp({
+			uploadDir: UPLOAD_DIR,
+			sessionSecret: SESSION_SECRET,
+			seedUsers: [
+				{ username: "admin", password: "pass", role: "admin" },
+				{ username: "alice", password: "pass", role: "user" },
+			],
+		})
+	})
+
+	afterEach(async () => {
+		await rm(UPLOAD_DIR, { recursive: true, force: true })
+	})
+
+	it("should return 403 for SVG in private dir even with valid session", async () => {
+		const session = await createTestSession("alice", SESSION_SECRET)
+		await mkdir(path.join(UPLOAD_DIR, "private", "alice"), { recursive: true })
+		await Bun.write(
+			path.join(UPLOAD_DIR, "private", "alice", "chart.svg"),
+			'<svg xmlns="http://www.w3.org/2000/svg"></svg>',
+		)
+		const res = await app.request(
+			new Request(
+				"http://localhost/file/raw?path=private%2Falice%2Fchart.svg",
+				{ headers: { Cookie: session.cookie } },
+			),
+		)
+		expect(res.status).toBe(403)
+		const data = (await res.json()) as { error: { name: string } }
+		expect(data.error.name).toBe("ActiveContentNotAllowed")
+	})
+
+	it("should deny access to other user private file (403 Forbidden)", async () => {
+		const session = await createTestSession("alice", SESSION_SECRET)
+		await mkdir(path.join(UPLOAD_DIR, "private", "admin"), { recursive: true })
+		await Bun.write(
+			path.join(UPLOAD_DIR, "private", "admin", "secret.png"),
+			new Uint8Array([0x89, 0x50, 0x4e, 0x47]),
+		)
+		const res = await app.request(
+			new Request(
+				"http://localhost/file/raw?path=private%2Fadmin%2Fsecret.png",
+				{ headers: { Cookie: session.cookie } },
+			),
+		)
+		expect(res.status).toBe(403)
+	})
+})
+
+describe("GET /file/download", () => {
+	const UPLOAD_DIR = "./tmp-test-download"
+	let app: Awaited<ReturnType<typeof createTestApp>>
+
+	beforeEach(async () => {
+		await rm(UPLOAD_DIR, { recursive: true, force: true })
+		app = await createTestApp({ uploadDir: UPLOAD_DIR })
+	})
+
+	afterEach(async () => {
+		await rm(UPLOAD_DIR, { recursive: true, force: true })
+	})
+
+	it("should download HTML file with attachment disposition", async () => {
+		await Bun.write(
+			path.join(UPLOAD_DIR, "public", "page.html"),
+			"<html><body>hello</body></html>",
+		)
+		const res = await app.request(
+			new Request("http://localhost/file/download?path=public%2Fpage.html"),
+		)
+		expect(res.status).toBe(200)
+		const disposition = res.headers.get("Content-Disposition")
+		expect(disposition).toContain("attachment")
+		expect(disposition).toContain("page.html")
+	})
+
+	it("should download SVG file with attachment disposition", async () => {
+		await Bun.write(
+			path.join(UPLOAD_DIR, "public", "image.svg"),
+			'<svg xmlns="http://www.w3.org/2000/svg"></svg>',
+		)
+		const res = await app.request(
+			new Request("http://localhost/file/download?path=public%2Fimage.svg"),
+		)
+		expect(res.status).toBe(200)
+		const disposition = res.headers.get("Content-Disposition")
+		expect(disposition).toContain("attachment")
+		expect(disposition).toContain("image.svg")
+	})
+
+	it("should download PNG file with attachment disposition", async () => {
+		const pngBytes = new Uint8Array([
+			0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+		])
+		await Bun.write(path.join(UPLOAD_DIR, "public", "photo.png"), pngBytes)
+		const res = await app.request(
+			new Request("http://localhost/file/download?path=public%2Fphoto.png"),
+		)
+		expect(res.status).toBe(200)
+		const disposition = res.headers.get("Content-Disposition")
+		expect(disposition).toContain("attachment")
+		expect(disposition).toContain("photo.png")
+	})
+
+	it("should download text file with attachment disposition", async () => {
+		await Bun.write(
+			path.join(UPLOAD_DIR, "public", "note.txt"),
+			"some text content",
+		)
+		const res = await app.request(
+			new Request("http://localhost/file/download?path=public%2Fnote.txt"),
+		)
+		expect(res.status).toBe(200)
+		const disposition = res.headers.get("Content-Disposition")
+		expect(disposition).toContain("attachment")
+		expect(disposition).toContain("note.txt")
+	})
+
+	it("should return 400 for non-existent file", async () => {
+		const res = await app.request(
+			new Request("http://localhost/file/download?path=public%2Fnotfound.bin"),
+		)
+		expect(res.status).toBe(400)
+		const data = (await res.json()) as { error: { name: string } }
+		expect(data.error.name).toBe("NotFound")
+	})
+
+	it("should return 400 for directory path", async () => {
+		await mkdir(path.join(UPLOAD_DIR, "public", "subdir"), { recursive: true })
+		const res = await app.request(
+			new Request("http://localhost/file/download?path=public%2Fsubdir"),
+		)
+		expect(res.status).toBe(400)
+		const data = (await res.json()) as { error: { name: string } }
+		expect(data.error.name).toBe("NotAFile")
+	})
+
+	it("should reject path traversal", async () => {
+		const res = await app.request(
+			new Request("http://localhost/file/download?path=../secret"),
+		)
+		expect(res.status).toBe(403)
+		const data = (await res.json()) as { error: { name: string } }
+		expect(data.error.name).toBe("Forbidden")
+	})
+})
+
+describe("GET /file/download - with auth", () => {
+	const UPLOAD_DIR = "./tmp-test-download-auth"
+	let app: Awaited<ReturnType<typeof createTestApp>>
+
+	beforeEach(async () => {
+		await rm(UPLOAD_DIR, { recursive: true, force: true })
+		app = await createTestApp({
+			uploadDir: UPLOAD_DIR,
+			sessionSecret: SESSION_SECRET,
+			seedUsers: [
+				{ username: "admin", password: "pass", role: "admin" },
+				{ username: "alice", password: "pass", role: "user" },
+			],
+		})
+	})
+
+	afterEach(async () => {
+		await rm(UPLOAD_DIR, { recursive: true, force: true })
+	})
+
+	it("should allow user to download own private file", async () => {
+		const session = await createTestSession("alice", SESSION_SECRET)
+		await mkdir(path.join(UPLOAD_DIR, "private", "alice"), { recursive: true })
+		await Bun.write(
+			path.join(UPLOAD_DIR, "private", "alice", "report.html"),
+			"<html>report</html>",
+		)
+		const res = await app.request(
+			new Request(
+				"http://localhost/file/download?path=private%2Falice%2Freport.html",
+				{ headers: { Cookie: session.cookie } },
+			),
+		)
+		expect(res.status).toBe(200)
+		const disposition = res.headers.get("Content-Disposition")
+		expect(disposition).toContain("attachment")
+		expect(disposition).toContain("report.html")
+	})
+
+	it("should deny download of other user private file", async () => {
+		const session = await createTestSession("alice", SESSION_SECRET)
+		await mkdir(path.join(UPLOAD_DIR, "private", "admin"), { recursive: true })
+		await Bun.write(
+			path.join(UPLOAD_DIR, "private", "admin", "secret.txt"),
+			"top secret",
+		)
+		const res = await app.request(
+			new Request(
+				"http://localhost/file/download?path=private%2Fadmin%2Fsecret.txt",
+				{ headers: { Cookie: session.cookie } },
+			),
+		)
+		expect(res.status).toBe(403)
+	})
+})

--- a/projects/file-server/tests/file-raw-download.test.ts
+++ b/projects/file-server/tests/file-raw-download.test.ts
@@ -314,3 +314,81 @@ describe("GET /file/download - with auth", () => {
 		expect(res.status).toBe(403)
 	})
 })
+
+describe("GET /file - viewer routing regression", () => {
+	const UPLOAD_DIR = "./tmp-test-file-viewer-regression"
+	let app: Awaited<ReturnType<typeof createTestApp>>
+
+	beforeEach(async () => {
+		await rm(UPLOAD_DIR, { recursive: true, force: true })
+		app = await createTestApp({ uploadDir: UPLOAD_DIR })
+	})
+
+	afterEach(async () => {
+		await rm(UPLOAD_DIR, { recursive: true, force: true })
+	})
+
+	it("should render SVG as source view (text viewer), not image viewer", async () => {
+		await Bun.write(
+			path.join(UPLOAD_DIR, "public", "chart.svg"),
+			'<svg xmlns="http://www.w3.org/2000/svg"><circle r="10"/></svg>',
+		)
+		const res = await app.request(
+			new Request("http://localhost/file?path=public%2Fchart.svg", {
+				headers: { "HX-Request": "true" },
+			}),
+		)
+		expect(res.status).toBe(200)
+		const text = await res.text()
+		expect(text).toMatch(/<pre[^>]*>/)
+		expect(text).not.toContain("<img")
+	})
+
+	it("should render HTML as source view (text viewer), not image viewer", async () => {
+		await Bun.write(
+			path.join(UPLOAD_DIR, "public", "page.html"),
+			"<html><body>hello</body></html>",
+		)
+		const res = await app.request(
+			new Request("http://localhost/file?path=public%2Fpage.html", {
+				headers: { "HX-Request": "true" },
+			}),
+		)
+		expect(res.status).toBe(200)
+		const text = await res.text()
+		expect(text).toMatch(/<pre[^>]*>/)
+		expect(text).not.toContain("<img")
+	})
+
+	it("should render PNG as image viewer, not source view", async () => {
+		const pngBytes = new Uint8Array([
+			0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+		])
+		await Bun.write(path.join(UPLOAD_DIR, "public", "photo.png"), pngBytes)
+		const res = await app.request(
+			new Request("http://localhost/file?path=public%2Fphoto.png", {
+				headers: { "HX-Request": "true" },
+			}),
+		)
+		expect(res.status).toBe(200)
+		const text = await res.text()
+		expect(text).toContain("<img")
+		expect(text).not.toMatch(/<pre[^>]*>/)
+	})
+
+	it("should render PDF as PDF viewer (iframe), not source view", async () => {
+		await Bun.write(
+			path.join(UPLOAD_DIR, "public", "doc.pdf"),
+			"%PDF-1.4 fake pdf content",
+		)
+		const res = await app.request(
+			new Request("http://localhost/file?path=public%2Fdoc.pdf", {
+				headers: { "HX-Request": "true" },
+			}),
+		)
+		expect(res.status).toBe(200)
+		const text = await res.text()
+		expect(text).toContain("<iframe")
+		expect(text).not.toMatch(/<pre[^>]*>/)
+	})
+})


### PR DESCRIPTION
## Issues

- Close #813

## Why

`/file/raw` は HTML や SVG などのアクティブコンテンツもそのまま返せる状態であり、ファイルビューアのダウンロードボタンもこのルートを流用していた。プレビュー用途とダウンロード用途が分離されていないため、セキュリティ上の抜け道が存在していた。

## Summary

`/file/raw` をプレビュー専用に制限し、HTML/XHTML/SVG を 403 でブロックする。ダウンロードは新設した `/file/download` に分離し、`Content-Disposition: attachment` で全ファイル種別を安全に返す。

## Changes

- `fileRouteUtils.tsx` に `isActiveContent` を追加し、`public.tsx` と共有化
- `/file/raw` で `text/html` / `application/xhtml+xml` / `image/svg+xml` および `.html` `.htm` `.xhtml` `.svg` を 403 ブロック
- `/file/download` ルートを新設（全ファイル種別を `Content-Disposition: attachment` で返す）
- ファイルビューアのダウンロードボタンを `/file/raw` → `/file/download` に切り替え
- `tests/file-raw-download.test.ts` に 18 件のテストを追加（auth あり/なし両方）
- `README.md` / `AGENTS.md` に各ルートの役割を明記

## Checklist

- [x] `bun run lint` が通ること
- [x] `bun test` が通ること（142 件）
- [x] `/file/raw` が HTML/XHTML/SVG に対して 403 を返すこと
- [x] `/file/download` が全ファイル種別を attachment で返すこと
- [x] auth 有効時のアクセス制御が維持されること
- [x] PNG・動画・PDF の既存プレビュー挙動が退行していないこと
- [x] README.md / AGENTS.md を更新したこと
