### PR TITLE
feat(file-server): add server-side validation for public HTML/SVG (#815)

### DIFF
--- a/projects/file-server/AGENTS.md
+++ b/projects/file-server/AGENTS.md
@@ -126,6 +126,18 @@ API paths also change:
 - Old: `GET /api/` (admin) → all user dirs
 - New: `GET /api/private/` (admin) → all user dirs
 
+## Public HTML/SVG Validation (Issue #815)
+
+`POST /api/upload` and `POST /api/update` apply server-side validation when saving HTML/XHTML/SVG files (`.html`, `.htm`, `.xhtml`, `.svg`) to the `public/` scope.
+
+- This is a **trusted content** guardrail. It is not a mechanism to safely host untrusted content on the same origin.
+- Validation is implemented in `src/utils/htmlValidation.ts` (`validatePublicHtml`).
+- The following are rejected: `<script>`, `on*` event handler attributes, `javascript:` URLs, `<iframe>`, `<object>`, `<embed>`, `meta[http-equiv]`, `<foreignObject>`.
+- On upload failure, the file appears in the `failed` array with a `reason` field.
+- On update failure, a `400 ValidationError` response is returned.
+- Files in `private/` scope are not validated.
+- Non-HTML/SVG files are not validated regardless of scope.
+
 ## Important
 
 - Path validation prevents directory traversal. Do not bypass this mechanism.

--- a/projects/file-server/README.md
+++ b/projects/file-server/README.md
@@ -81,6 +81,7 @@ src/
     ├── fileListing.ts     # ファイル一覧取得
     ├── fileUtils.ts       # パス検証、ソート
     ├── formatters.ts      # サイズ・日時フォーマット
+    ├── htmlValidation.ts  # public HTML/SVG バリデーション
     ├── pathTraversal.ts   # ディレクトリトラバーサル判定
     ├── requestUtils.tsx   # リクエストユーティリティ
     ├── userConfigCache.ts # ユーザー設定キャッシュ
@@ -99,6 +100,7 @@ tests/
 ├── mkdir.test.ts          # ディレクトリ作成テスト
 ├── rename.test.ts         # リネームテスト
 ├── update.test.ts         # ファイル更新テスト
+├── html-validation.test.ts # public HTML/SVG バリデーションテスト
 └── public-route.test.ts   # 外部公開ルートテスト
 ```
 
@@ -257,6 +259,57 @@ docker compose up -d --build
 ```bash
 docker compose down
 ```
+
+## Internal API 経由の public HTML/SVG 配置
+
+`POST /api/upload` および `POST /api/update` 経由で `public/` スコープに HTML/XHTML/SVG を保存する場合、サーバー側バリデーションが実行される。
+
+### 前提
+
+- この機能は **trusted content** を公開する用途を想定している。LLM 生成物や自動化フローの出力を人間が確認した上でデプロイするフローのガードレールとして機能する。
+- **untrusted content を same-origin で安全に公開する機能ではない。** そのようなユースケースには別設計が必要。
+
+### バリデーションルール
+
+以下を含むコンテンツは reject される:
+
+| 拒否対象 | 説明 |
+|---|---|
+| `<script>` | スクリプトタグ（大文字小文字不問） |
+| `on*` 属性 | `onload`・`onclick` 等のイベントハンドラ属性 |
+| `javascript:` URL | `href`・`src` 等の javascript: スキーム |
+| `<iframe>` | インラインフレーム |
+| `<object>` | オブジェクト埋め込み |
+| `<embed>` | プラグインコンテンツ埋め込み |
+| `meta[http-equiv]` | リダイレクト等を誘発する meta タグ |
+| `<foreignObject>` | SVG 内 HTML 埋め込み要素 |
+
+### エラー応答
+
+バリデーション失敗時は、拒否理由を含むエラーが返される。
+
+**upload (`POST /api/upload`)**: ファイル単位で `failed` 配列に拒否理由が入る。
+```json
+{
+  "success": false,
+  "uploaded": [],
+  "failed": [{ "name": "page.html", "reason": "Prohibited content: <script>" }]
+}
+```
+
+**update (`POST /api/update`)**: 400 レスポンスで `ValidationError` が返される。
+```json
+{
+  "success": false,
+  "error": { "name": "ValidationError", "message": "Prohibited content: <script>" }
+}
+```
+
+### 適用範囲
+
+- バリデーションは `public/` スコープの `.html`、`.htm`、`.xhtml`、`.svg` ファイルにのみ適用される。
+- `private/` スコープへの保存にはバリデーションは実行されない。
+- バリデーション追加前から存在するファイルは対象外（読み取り/配信には影響しない）。
 
 ## 破壊的変更とマイグレーション
 

--- a/projects/file-server/src/api/handlers.tsx
+++ b/projects/file-server/src/api/handlers.tsx
@@ -16,6 +16,11 @@ import {
 } from "../utils/apiHelpers"
 import { getFileList } from "../utils/fileListing"
 import { normalizeRelativePath, resolveUploadPath } from "../utils/fileUtils"
+import {
+  isPublicHtmlFile,
+  isPublicScope,
+  validatePublicHtml,
+} from "../utils/htmlValidation"
 import { isPathTraversal } from "../utils/pathTraversal"
 import {
   errorResponse,
@@ -114,6 +119,16 @@ export async function uploadFileHandler(c: Context<AppBindings>) {
       const savePath = path.join(baseDir, relativePath)
       await mkdir(path.dirname(savePath), { recursive: true })
       const buffer = await file.arrayBuffer()
+
+      if (isPublicScope(virtualPath) && isPublicHtmlFile(file.name)) {
+        const text = Buffer.from(buffer).toString("utf-8")
+        const validation = validatePublicHtml(text)
+        if (!validation.ok) {
+          results.failed.push({ name: file.name, reason: validation.reason })
+          continue
+        }
+      }
+
       await writeFile(savePath, Buffer.from(buffer))
       results.success.push(file.name)
     } catch (err) {
@@ -331,6 +346,13 @@ export async function updateFileHandler(c: Context<AppBindings>) {
       return errorResponse(c, "FileNotFound", "File does not exist", 400)
     }
     throw err
+  }
+
+  if (isPublicScope(filePathParam) && isPublicHtmlFile(filePathParam)) {
+    const validation = validatePublicHtml(content)
+    if (!validation.ok) {
+      return errorResponse(c, "ValidationError", validation.reason, 400)
+    }
   }
 
   await writeFile(targetPath, content, "utf-8")

--- a/projects/file-server/src/api/handlers.tsx
+++ b/projects/file-server/src/api/handlers.tsx
@@ -120,7 +120,7 @@ export async function uploadFileHandler(c: Context<AppBindings>) {
       await mkdir(path.dirname(savePath), { recursive: true })
       const buffer = await file.arrayBuffer()
 
-      if (isPublicScope(virtualPath) && isPublicHtmlFile(file.name)) {
+      if (isPublicScope(relativePath) && isPublicHtmlFile(relativePath)) {
         const text = Buffer.from(buffer).toString("utf-8")
         const validation = validatePublicHtml(text)
         if (!validation.ok) {
@@ -310,6 +310,17 @@ export async function renameHandler(c: Context<AppBindings>) {
   } catch (err: unknown) {
     if (!isNodeErrorCode(err, "ENOENT")) {
       throw err
+    }
+  }
+
+  if (
+    isPublicScope(destinationRelativePath) &&
+    isPublicHtmlFile(destinationRelativePath)
+  ) {
+    const sourceContent = await readFile(sourcePath, "utf-8")
+    const validation = validatePublicHtml(sourceContent)
+    if (!validation.ok) {
+      return errorResponse(c, "ValidationError", validation.reason, 400)
     }
   }
 

--- a/projects/file-server/src/utils/htmlValidation.ts
+++ b/projects/file-server/src/utils/htmlValidation.ts
@@ -1,0 +1,34 @@
+import * as path from "node:path"
+
+const PUBLIC_HTML_EXTENSIONS = new Set([".html", ".htm", ".xhtml", ".svg"])
+
+export function isPublicHtmlFile(fileName: string): boolean {
+	const ext = path.extname(fileName).toLowerCase()
+	return PUBLIC_HTML_EXTENSIONS.has(ext)
+}
+
+export function isPublicScope(virtualPath: string): boolean {
+	return virtualPath === "public" || virtualPath.startsWith("public/")
+}
+
+export type HtmlValidationResult = { ok: true } | { ok: false; reason: string }
+
+const DENIED_PATTERNS: Array<{ pattern: RegExp; label: string }> = [
+	{ pattern: /<script\b/i, label: "<script>" },
+	{ pattern: /\bon\w+\s*=/i, label: "event handler attribute" },
+	{ pattern: /javascript\s*:/i, label: "javascript: URL" },
+	{ pattern: /<iframe\b/i, label: "<iframe>" },
+	{ pattern: /<object\b/i, label: "<object>" },
+	{ pattern: /<embed\b/i, label: "<embed>" },
+	{ pattern: /<meta[^>]+http-equiv/i, label: "meta[http-equiv]" },
+	{ pattern: /<foreignObject\b/i, label: "<foreignObject>" },
+]
+
+export function validatePublicHtml(content: string): HtmlValidationResult {
+	for (const { pattern, label } of DENIED_PATTERNS) {
+		if (pattern.test(content)) {
+			return { ok: false, reason: `Prohibited content: ${label}` }
+		}
+	}
+	return { ok: true }
+}

--- a/projects/file-server/src/utils/htmlValidation.ts
+++ b/projects/file-server/src/utils/htmlValidation.ts
@@ -24,9 +24,18 @@ const DENIED_PATTERNS: Array<{ pattern: RegExp; label: string }> = [
 	{ pattern: /<foreignObject\b/i, label: "<foreignObject>" },
 ]
 
+function decodeHtmlEntities(content: string): string {
+	return content
+		.replace(/&#x([0-9a-f]+);/gi, (_, hex) =>
+			String.fromCodePoint(Number.parseInt(hex, 16)),
+		)
+		.replace(/&#(\d+);/g, (_, dec) => String.fromCodePoint(Number(dec)))
+}
+
 export function validatePublicHtml(content: string): HtmlValidationResult {
+	const decoded = decodeHtmlEntities(content)
 	for (const { pattern, label } of DENIED_PATTERNS) {
-		if (pattern.test(content)) {
+		if (pattern.test(content) || pattern.test(decoded)) {
 			return { ok: false, reason: `Prohibited content: ${label}` }
 		}
 	}

--- a/projects/file-server/tests/html-validation.test.ts
+++ b/projects/file-server/tests/html-validation.test.ts
@@ -1,0 +1,470 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { mkdir, rm, writeFile } from "node:fs/promises"
+import * as path from "node:path"
+import {
+	isPublicHtmlFile,
+	isPublicScope,
+	validatePublicHtml,
+} from "../src/utils/htmlValidation"
+import { createTestApp } from "./helpers/createTestApp"
+
+describe("validatePublicHtml", () => {
+	it("allows minimal safe HTML", () => {
+		const result = validatePublicHtml(
+			"<!DOCTYPE html><html><head><title>Hi</title></head><body><p>Hello</p></body></html>",
+		)
+		expect(result.ok).toBe(true)
+	})
+
+	it("allows safe SVG", () => {
+		const result = validatePublicHtml(
+			'<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"><circle cx="50" cy="50" r="40" fill="red"/></svg>',
+		)
+		expect(result.ok).toBe(true)
+	})
+
+	it("rejects <script> tag", () => {
+		const result = validatePublicHtml("<html><body><script>alert(1)</script></body></html>")
+		expect(result.ok).toBe(false)
+		if (!result.ok) expect(result.reason).toContain("<script>")
+	})
+
+	it("rejects <SCRIPT> (case insensitive)", () => {
+		const result = validatePublicHtml("<SCRIPT>alert(1)</SCRIPT>")
+		expect(result.ok).toBe(false)
+	})
+
+	it("rejects onload event handler attribute", () => {
+		const result = validatePublicHtml('<body onload="alert(1)">')
+		expect(result.ok).toBe(false)
+		if (!result.ok) expect(result.reason).toContain("event handler attribute")
+	})
+
+	it("rejects onclick attribute", () => {
+		const result = validatePublicHtml('<button onclick="alert(1)">Click</button>')
+		expect(result.ok).toBe(false)
+	})
+
+	it("rejects javascript: URL", () => {
+		const result = validatePublicHtml('<a href="javascript:alert(1)">link</a>')
+		expect(result.ok).toBe(false)
+		if (!result.ok) expect(result.reason).toContain("javascript: URL")
+	})
+
+	it("rejects javascript: with spaces", () => {
+		const result = validatePublicHtml('<a href="javascript :alert(1)">link</a>')
+		expect(result.ok).toBe(false)
+	})
+
+	it("rejects <iframe>", () => {
+		const result = validatePublicHtml('<iframe src="https://evil.com"></iframe>')
+		expect(result.ok).toBe(false)
+		if (!result.ok) expect(result.reason).toContain("<iframe>")
+	})
+
+	it("rejects <object>", () => {
+		const result = validatePublicHtml('<object data="evil.swf"></object>')
+		expect(result.ok).toBe(false)
+		if (!result.ok) expect(result.reason).toContain("<object>")
+	})
+
+	it("rejects <embed>", () => {
+		const result = validatePublicHtml('<embed src="evil.swf">')
+		expect(result.ok).toBe(false)
+		if (!result.ok) expect(result.reason).toContain("<embed>")
+	})
+
+	it("rejects meta[http-equiv]", () => {
+		const result = validatePublicHtml(
+			'<meta http-equiv="refresh" content="0; url=https://evil.com">',
+		)
+		expect(result.ok).toBe(false)
+		if (!result.ok) expect(result.reason).toContain("meta[http-equiv]")
+	})
+
+	it("rejects <foreignObject> in SVG", () => {
+		const result = validatePublicHtml(
+			'<svg><foreignObject><html><body><p>hi</p></body></html></foreignObject></svg>',
+		)
+		expect(result.ok).toBe(false)
+		if (!result.ok) expect(result.reason).toContain("<foreignObject>")
+	})
+
+	it("returns the first matching reason", () => {
+		const result = validatePublicHtml(
+			'<script>alert(1)</script><body onload="x()">',
+		)
+		expect(result.ok).toBe(false)
+		if (!result.ok) expect(result.reason).toContain("<script>")
+	})
+})
+
+describe("isPublicHtmlFile", () => {
+	it.each([".html", ".htm", ".xhtml", ".svg"])("returns true for %s", (ext) => {
+		expect(isPublicHtmlFile(`file${ext}`)).toBe(true)
+	})
+
+	it.each([".txt", ".png", ".pdf", ".js"])("returns false for %s", (ext) => {
+		expect(isPublicHtmlFile(`file${ext}`)).toBe(false)
+	})
+
+	it("is case insensitive", () => {
+		expect(isPublicHtmlFile("file.HTML")).toBe(true)
+		expect(isPublicHtmlFile("file.SVG")).toBe(true)
+	})
+})
+
+describe("isPublicScope", () => {
+	it("returns true for 'public'", () => {
+		expect(isPublicScope("public")).toBe(true)
+	})
+
+	it("returns true for paths starting with 'public/'", () => {
+		expect(isPublicScope("public/foo/bar.html")).toBe(true)
+	})
+
+	it("returns false for private paths", () => {
+		expect(isPublicScope("private/user/file.html")).toBe(false)
+	})
+
+	it("returns false for empty string", () => {
+		expect(isPublicScope("")).toBe(false)
+	})
+})
+
+describe("upload HTML/SVG validation via API", () => {
+	const UPLOAD_DIR = "./tmp-test-html-validation"
+	let app: Awaited<ReturnType<typeof createTestApp>>
+
+	beforeEach(async () => {
+		await rm(UPLOAD_DIR, { recursive: true, force: true })
+		app = await createTestApp({ uploadDir: UPLOAD_DIR })
+	})
+
+	afterEach(async () => {
+		await rm(UPLOAD_DIR, { recursive: true, force: true })
+	})
+
+	it("allows uploading safe HTML to public", async () => {
+		const safeHtml =
+			"<!DOCTYPE html><html><head><title>Safe</title></head><body><p>Hello</p></body></html>"
+		const formData = new FormData()
+		formData.append("files", new File([safeHtml], "safe.html", { type: "text/html" }))
+		formData.append("path", "public")
+
+		const res = await app.request(
+			new Request("http://localhost/api/upload", { method: "POST", body: formData }),
+		)
+		expect(res.status).toBe(200)
+		const data = (await res.json()) as { success: boolean; uploaded: string[] }
+		expect(data.success).toBe(true)
+		expect(data.uploaded).toContain("safe.html")
+	})
+
+	it("allows uploading safe SVG to public", async () => {
+		const safeSvg =
+			'<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"><circle cx="50" cy="50" r="40" fill="blue"/></svg>'
+		const formData = new FormData()
+		formData.append("files", new File([safeSvg], "image.svg", { type: "image/svg+xml" }))
+		formData.append("path", "public")
+
+		const res = await app.request(
+			new Request("http://localhost/api/upload", { method: "POST", body: formData }),
+		)
+		expect(res.status).toBe(200)
+		const data = (await res.json()) as { success: boolean; uploaded: string[] }
+		expect(data.success).toBe(true)
+		expect(data.uploaded).toContain("image.svg")
+	})
+
+	it("rejects HTML with <script> to public", async () => {
+		const dangerousHtml = "<html><body><script>alert(1)</script></body></html>"
+		const formData = new FormData()
+		formData.append("files", new File([dangerousHtml], "evil.html", { type: "text/html" }))
+		formData.append("path", "public")
+
+		const res = await app.request(
+			new Request("http://localhost/api/upload", { method: "POST", body: formData }),
+		)
+		expect(res.status).toBe(200)
+		const data = (await res.json()) as {
+			success: boolean
+			failed: { name: string; reason: string }[]
+		}
+		expect(data.success).toBe(false)
+		expect(data.failed).toHaveLength(1)
+		expect(data.failed[0].name).toBe("evil.html")
+		expect(data.failed[0].reason).toContain("<script>")
+	})
+
+	it("rejects HTML with event handler to public", async () => {
+		const dangerousHtml = '<body onload="alert(1)"><p>Hi</p></body>'
+		const formData = new FormData()
+		formData.append("files", new File([dangerousHtml], "evil.html", { type: "text/html" }))
+		formData.append("path", "public")
+
+		const res = await app.request(
+			new Request("http://localhost/api/upload", { method: "POST", body: formData }),
+		)
+		const data = (await res.json()) as {
+			success: boolean
+			failed: { name: string; reason: string }[]
+		}
+		expect(data.success).toBe(false)
+		expect(data.failed[0].reason).toContain("event handler attribute")
+	})
+
+	it("rejects SVG with <script> to public", async () => {
+		const dangerousSvg =
+			'<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>'
+		const formData = new FormData()
+		formData.append(
+			"files",
+			new File([dangerousSvg], "evil.svg", { type: "image/svg+xml" }),
+		)
+		formData.append("path", "public")
+
+		const res = await app.request(
+			new Request("http://localhost/api/upload", { method: "POST", body: formData }),
+		)
+		const data = (await res.json()) as {
+			success: boolean
+			failed: { name: string; reason: string }[]
+		}
+		expect(data.success).toBe(false)
+		expect(data.failed[0].reason).toContain("<script>")
+	})
+
+	it("rejects SVG with javascript: href to public", async () => {
+		const dangerousSvg =
+			'<svg xmlns="http://www.w3.org/2000/svg"><a href="javascript:alert(1)"><text>click</text></a></svg>'
+		const formData = new FormData()
+		formData.append(
+			"files",
+			new File([dangerousSvg], "evil.svg", { type: "image/svg+xml" }),
+		)
+		formData.append("path", "public")
+
+		const res = await app.request(
+			new Request("http://localhost/api/upload", { method: "POST", body: formData }),
+		)
+		const data = (await res.json()) as {
+			success: boolean
+			failed: { name: string; reason: string }[]
+		}
+		expect(data.success).toBe(false)
+		expect(data.failed[0].reason).toContain("javascript: URL")
+	})
+
+	it("rejects SVG with <foreignObject> to public", async () => {
+		const dangerousSvg =
+			"<svg><foreignObject><html><body><p>hi</p></body></html></foreignObject></svg>"
+		const formData = new FormData()
+		formData.append(
+			"files",
+			new File([dangerousSvg], "evil.svg", { type: "image/svg+xml" }),
+		)
+		formData.append("path", "public")
+
+		const res = await app.request(
+			new Request("http://localhost/api/upload", { method: "POST", body: formData }),
+		)
+		const data = (await res.json()) as {
+			success: boolean
+			failed: { name: string; reason: string }[]
+		}
+		expect(data.success).toBe(false)
+		expect(data.failed[0].reason).toContain("<foreignObject>")
+	})
+
+	it("does not validate HTML uploaded to private scope", async () => {
+		const dangerousHtml = "<html><body><script>alert(1)</script></body></html>"
+		const formData = new FormData()
+		formData.append("files", new File([dangerousHtml], "evil.html", { type: "text/html" }))
+		formData.append("path", "private")
+
+		const res = await app.request(
+			new Request("http://localhost/api/upload", { method: "POST", body: formData }),
+		)
+		expect(res.status).toBe(200)
+		const data = (await res.json()) as { success: boolean; uploaded: string[] }
+		expect(data.success).toBe(true)
+		expect(data.uploaded).toContain("evil.html")
+	})
+
+	it("does not validate non-HTML files in public scope", async () => {
+		const content = "alert(1)"
+		const formData = new FormData()
+		formData.append(
+			"files",
+			new File([content], "script.js", { type: "application/javascript" }),
+		)
+		formData.append("path", "public")
+
+		const res = await app.request(
+			new Request("http://localhost/api/upload", { method: "POST", body: formData }),
+		)
+		const data = (await res.json()) as { success: boolean; uploaded: string[] }
+		expect(data.success).toBe(true)
+		expect(data.uploaded).toContain("script.js")
+	})
+
+	it("allows one safe file and rejects one dangerous file in the same upload", async () => {
+		const safeHtml = "<html><body><p>Safe</p></body></html>"
+		const dangerousHtml = "<html><body><script>alert(1)</script></body></html>"
+		const formData = new FormData()
+		formData.append("files", new File([safeHtml], "safe.html", { type: "text/html" }))
+		formData.append("files", new File([dangerousHtml], "evil.html", { type: "text/html" }))
+		formData.append("path", "public")
+
+		const res = await app.request(
+			new Request("http://localhost/api/upload", { method: "POST", body: formData }),
+		)
+		const data = (await res.json()) as {
+			success: boolean
+			uploaded: string[]
+			failed: { name: string; reason: string }[]
+		}
+		expect(data.success).toBe(false)
+		expect(data.uploaded).toContain("safe.html")
+		expect(data.failed).toHaveLength(1)
+		expect(data.failed[0].name).toBe("evil.html")
+	})
+})
+
+describe("update HTML/SVG validation via API", () => {
+	const UPLOAD_DIR = "./tmp-test-html-validation-update"
+	let app: Awaited<ReturnType<typeof createTestApp>>
+
+	beforeEach(async () => {
+		await rm(UPLOAD_DIR, { recursive: true, force: true })
+		app = await createTestApp({ uploadDir: UPLOAD_DIR })
+		await mkdir(path.join(UPLOAD_DIR, "public"), { recursive: true })
+		await mkdir(path.join(UPLOAD_DIR, "private"), { recursive: true })
+	})
+
+	afterEach(async () => {
+		await rm(UPLOAD_DIR, { recursive: true, force: true })
+	})
+
+	it("allows updating public HTML with safe content", async () => {
+		await writeFile(path.join(UPLOAD_DIR, "public", "page.html"), "<p>Old</p>", "utf-8")
+
+		const formData = new FormData()
+		formData.append("path", "public/page.html")
+		formData.append("content", "<html><body><p>Safe content</p></body></html>")
+
+		const res = await app.request(
+			new Request("http://localhost/api/update", { method: "POST", body: formData }),
+		)
+		expect(res.status).toBe(200)
+		const data = (await res.json()) as { success: boolean }
+		expect(data.success).toBe(true)
+	})
+
+	it("rejects updating public HTML with <script>", async () => {
+		await writeFile(path.join(UPLOAD_DIR, "public", "page.html"), "<p>Old</p>", "utf-8")
+
+		const formData = new FormData()
+		formData.append("path", "public/page.html")
+		formData.append("content", "<html><body><script>alert(1)</script></body></html>")
+
+		const res = await app.request(
+			new Request("http://localhost/api/update", { method: "POST", body: formData }),
+		)
+		expect(res.status).toBe(400)
+		const data = (await res.json()) as { success: boolean; error: { name: string; message: string } }
+		expect(data.success).toBe(false)
+		expect(data.error.name).toBe("ValidationError")
+		expect(data.error.message).toContain("<script>")
+	})
+
+	it("rejects updating public HTML with event handler", async () => {
+		await writeFile(path.join(UPLOAD_DIR, "public", "page.html"), "<p>Old</p>", "utf-8")
+
+		const formData = new FormData()
+		formData.append("path", "public/page.html")
+		formData.append("content", '<body onload="evil()"><p>Hi</p></body>')
+
+		const res = await app.request(
+			new Request("http://localhost/api/update", { method: "POST", body: formData }),
+		)
+		expect(res.status).toBe(400)
+		const data = (await res.json()) as { success: boolean; error: { name: string; message: string } }
+		expect(data.error.name).toBe("ValidationError")
+		expect(data.error.message).toContain("event handler attribute")
+	})
+
+	it("rejects updating public SVG with javascript: URL", async () => {
+		await writeFile(path.join(UPLOAD_DIR, "public", "image.svg"), "<svg></svg>", "utf-8")
+
+		const formData = new FormData()
+		formData.append("path", "public/image.svg")
+		formData.append(
+			"content",
+			'<svg><a href="javascript:alert(1)"><text>click</text></a></svg>',
+		)
+
+		const res = await app.request(
+			new Request("http://localhost/api/update", { method: "POST", body: formData }),
+		)
+		expect(res.status).toBe(400)
+		const data = (await res.json()) as { success: boolean; error: { name: string; message: string } }
+		expect(data.error.name).toBe("ValidationError")
+		expect(data.error.message).toContain("javascript: URL")
+	})
+
+	it("rejects updating public SVG with <foreignObject>", async () => {
+		await writeFile(path.join(UPLOAD_DIR, "public", "image.svg"), "<svg></svg>", "utf-8")
+
+		const formData = new FormData()
+		formData.append("path", "public/image.svg")
+		formData.append(
+			"content",
+			"<svg><foreignObject><html><body>evil</body></html></foreignObject></svg>",
+		)
+
+		const res = await app.request(
+			new Request("http://localhost/api/update", { method: "POST", body: formData }),
+		)
+		expect(res.status).toBe(400)
+		const data = (await res.json()) as { success: boolean; error: { name: string; message: string } }
+		expect(data.error.name).toBe("ValidationError")
+		expect(data.error.message).toContain("<foreignObject>")
+	})
+
+	it("does not validate HTML in private scope", async () => {
+		await mkdir(path.join(UPLOAD_DIR, "private", "user"), { recursive: true })
+		await writeFile(
+			path.join(UPLOAD_DIR, "private", "user", "page.html"),
+			"<p>Old</p>",
+			"utf-8",
+		)
+
+		const formData = new FormData()
+		formData.append("path", "private/user/page.html")
+		formData.append("content", "<html><body><script>alert(1)</script></body></html>")
+
+		const res = await app.request(
+			new Request("http://localhost/api/update", { method: "POST", body: formData }),
+		)
+		expect(res.status).toBe(200)
+		const data = (await res.json()) as { success: boolean }
+		expect(data.success).toBe(true)
+	})
+
+	it("does not validate non-HTML files in public scope", async () => {
+		await writeFile(path.join(UPLOAD_DIR, "public", "script.js"), "", "utf-8")
+
+		const formData = new FormData()
+		formData.append("path", "public/script.js")
+		formData.append("content", "alert(1)")
+
+		const res = await app.request(
+			new Request("http://localhost/api/update", { method: "POST", body: formData }),
+		)
+		expect(res.status).toBe(200)
+		const data = (await res.json()) as { success: boolean }
+		expect(data.success).toBe(true)
+	})
+})

--- a/projects/file-server/tests/html-validation.test.ts
+++ b/projects/file-server/tests/html-validation.test.ts
@@ -97,6 +97,17 @@ describe("validatePublicHtml", () => {
 		expect(result.ok).toBe(false)
 		if (!result.ok) expect(result.reason).toContain("<script>")
 	})
+
+	it("rejects javascript: via hex entity-encoded colon (&#x3a;)", () => {
+		const result = validatePublicHtml('<a href="javascript&#x3a;alert(1)">link</a>')
+		expect(result.ok).toBe(false)
+		if (!result.ok) expect(result.reason).toContain("javascript: URL")
+	})
+
+	it("rejects javascript: via decimal entity-encoded colon (&#58;)", () => {
+		const result = validatePublicHtml('<a href="javascript&#58;alert(1)">link</a>')
+		expect(result.ok).toBe(false)
+	})
 })
 
 describe("isPublicHtmlFile", () => {
@@ -275,6 +286,47 @@ describe("upload HTML/SVG validation via API", () => {
 		}
 		expect(data.success).toBe(false)
 		expect(data.failed[0].reason).toContain("<foreignObject>")
+	})
+
+	it("rejects dangerous content when path param is public/evil.svg but file.name is safe.txt", async () => {
+		const dangerousSvg =
+			'<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>'
+		const formData = new FormData()
+		formData.append(
+			"files",
+			new File([dangerousSvg], "safe.txt", { type: "text/plain" }),
+		)
+		formData.append("path", "public/evil.svg")
+
+		const res = await app.request(
+			new Request("http://localhost/api/upload", { method: "POST", body: formData }),
+		)
+		const data = (await res.json()) as {
+			success: boolean
+			failed: { name: string; reason: string }[]
+		}
+		expect(data.success).toBe(false)
+		expect(data.failed[0].reason).toContain("<script>")
+	})
+
+	it("rejects javascript: via HTML entity in uploaded SVG", async () => {
+		const dangerousSvg = '<svg><a href="javascript&#x3a;alert(1)"><text>x</text></a></svg>'
+		const formData = new FormData()
+		formData.append(
+			"files",
+			new File([dangerousSvg], "image.svg", { type: "image/svg+xml" }),
+		)
+		formData.append("path", "public")
+
+		const res = await app.request(
+			new Request("http://localhost/api/upload", { method: "POST", body: formData }),
+		)
+		const data = (await res.json()) as {
+			success: boolean
+			failed: { name: string; reason: string }[]
+		}
+		expect(data.success).toBe(false)
+		expect(data.failed[0].reason).toContain("javascript: URL")
 	})
 
 	it("does not validate HTML uploaded to private scope", async () => {
@@ -466,5 +518,93 @@ describe("update HTML/SVG validation via API", () => {
 		expect(res.status).toBe(200)
 		const data = (await res.json()) as { success: boolean }
 		expect(data.success).toBe(true)
+	})
+})
+
+describe("rename HTML/SVG validation via API", () => {
+	const UPLOAD_DIR = "./tmp-test-html-validation-rename"
+	let app: Awaited<ReturnType<typeof createTestApp>>
+
+	beforeEach(async () => {
+		await rm(UPLOAD_DIR, { recursive: true, force: true })
+		app = await createTestApp({ uploadDir: UPLOAD_DIR })
+		await mkdir(path.join(UPLOAD_DIR, "public"), { recursive: true })
+	})
+
+	afterEach(async () => {
+		await rm(UPLOAD_DIR, { recursive: true, force: true })
+	})
+
+	it("allows renaming safe content to public HTML", async () => {
+		await writeFile(
+			path.join(UPLOAD_DIR, "public", "page.txt"),
+			"<html><body><p>Safe</p></body></html>",
+			"utf-8",
+		)
+
+		const formData = new FormData()
+		formData.append("path", "public/page.txt")
+		formData.append("name", "page.html")
+
+		const res = await app.request(
+			new Request("http://localhost/api/rename", { method: "POST", body: formData }),
+		)
+		expect(res.status).toBe(301)
+	})
+
+	it("rejects renaming file with <script> content to public HTML", async () => {
+		await writeFile(
+			path.join(UPLOAD_DIR, "public", "evil.txt"),
+			"<html><body><script>alert(1)</script></body></html>",
+			"utf-8",
+		)
+
+		const formData = new FormData()
+		formData.append("path", "public/evil.txt")
+		formData.append("name", "evil.html")
+
+		const res = await app.request(
+			new Request("http://localhost/api/rename", { method: "POST", body: formData }),
+		)
+		expect(res.status).toBe(400)
+		const data = (await res.json()) as { success: boolean; error: { name: string; message: string } }
+		expect(data.error.name).toBe("ValidationError")
+		expect(data.error.message).toContain("<script>")
+	})
+
+	it("rejects renaming file with javascript: content to public SVG", async () => {
+		await writeFile(
+			path.join(UPLOAD_DIR, "public", "evil.txt"),
+			'<svg><a href="javascript:alert(1)"><text>x</text></a></svg>',
+			"utf-8",
+		)
+
+		const formData = new FormData()
+		formData.append("path", "public/evil.txt")
+		formData.append("name", "evil.svg")
+
+		const res = await app.request(
+			new Request("http://localhost/api/rename", { method: "POST", body: formData }),
+		)
+		expect(res.status).toBe(400)
+		const data = (await res.json()) as { success: boolean; error: { name: string; message: string } }
+		expect(data.error.name).toBe("ValidationError")
+	})
+
+	it("does not validate when renaming to non-HTML extension", async () => {
+		await writeFile(
+			path.join(UPLOAD_DIR, "public", "old.html"),
+			"<script>alert(1)</script>",
+			"utf-8",
+		)
+
+		const formData = new FormData()
+		formData.append("path", "public/old.html")
+		formData.append("name", "old.txt")
+
+		const res = await app.request(
+			new Request("http://localhost/api/rename", { method: "POST", body: formData }),
+		)
+		expect(res.status).toBe(301)
 	})
 })


### PR DESCRIPTION
## Issues

- Close #815

## Why

Internal API 経由で LLM 生成物や自動化フローの出力を `public/` スコープに保存する際、人間の目視確認だけでは `<script>` やイベントハンドラ属性、`javascript:` URL などを見落とす可能性がある。サーバー側でガードレールを設けることで、trusted publish フローの安全性を高める。

## Summary

`POST /api/upload` と `POST /api/update` に対して、`public/` スコープの HTML/XHTML/SVG ファイルへの保存時にサーバー側バリデーションを追加した。危険なコンテンツを含む場合は保存前に reject し、拒否理由をエラー応答として返す。

## Changes

- `src/utils/htmlValidation.ts` を新規作成（`validatePublicHtml`・`isPublicHtmlFile`・`isPublicScope`）
- `src/api/handlers.tsx` の `uploadFileHandler`・`updateFileHandler` にバリデーションを統合
- `tests/html-validation.test.ts` を追加（44 件: 単体テスト + upload/update 統合テスト）
- `README.md` に Internal API 経由の public HTML/SVG 配置セクションを追記
- `AGENTS.md` にバリデーションルールと適用範囲を追記

## Checklist

- [x] `<script>` タグを reject できる
- [x] `on*` イベントハンドラ属性を reject できる
- [x] `javascript:` URL を reject できる
- [x] `<iframe>`・`<object>`・`<embed>` を reject できる
- [x] `meta[http-equiv]` を reject できる
- [x] `<foreignObject>` を reject できる
- [x] 安全な HTML/SVG は既存フローを壊さず保存できる
- [x] `private/` スコープと非 HTML/SVG ファイルはバリデーション対象外
- [x] `bun run lint` パス
- [x] `bun test`（190 件）パス

## Details

### バリデーション適用範囲

- 対象スコープ: `public/` のみ（`private/` は対象外）
- 対象拡張子: `.html`・`.htm`・`.xhtml`・`.svg`
- この機能は **trusted content** のガードレールであり、untrusted content を same-origin で安全公開する機能ではない

### エラー応答形式

upload 失敗時はファイル単位で `failed[].reason` に拒否理由が入る。update 失敗時は `400 ValidationError` で `error.message` に理由が入る。
