### PR TITLE
feat(portfolio): add chat generated-code upload to file-server

### DIFF
--- a/projects/file-server/.env.example
+++ b/projects/file-server/.env.example
@@ -5,6 +5,10 @@ UPLOAD_DIR=./tmp
 # AUTH_DIR/users.json and AUTH_DIR/session-secret are created automatically.
 # On first startup an 'admin' user is bootstrapped automatically.
 # Bun loads .env automatically for `bun run`.
+# 注意: portfolio から file-server 連携を使う場合は、portfolio 側にも
+# この AUTH_DIR で bootstrap された admin credentials
+# (FILE_SERVER_ADMIN_USERNAME / FILE_SERVER_ADMIN_PASSWORD) を
+# 設定する必要がある。
 AUTH_DIR=./auth
 
 # Optional: set the initial admin password on first bootstrap only.

--- a/projects/portfolio/.env.example
+++ b/projects/portfolio/.env.example
@@ -7,3 +7,9 @@ COOKIE_NAME=sid
 COOKIE_EXPIRES=1d
 DATABASE_URL=postgresql://{{ user }}:{{ password }}@localhost:5432/{{ database }}
 CHAT_CONVERSATION_ENABLED=TRUE
+
+# File-server 連携（assistant 生成コードの保存先）。
+# AUTH_DIR 有効時のみ動作。空なら連携を無効化する。
+# FILE_SERVER_URL=http://localhost:3001
+# FILE_SERVER_ADMIN_USERNAME=admin
+# FILE_SERVER_ADMIN_PASSWORD=changeme

--- a/projects/portfolio/src/client/components/chat/assistant-code-block.tsx
+++ b/projects/portfolio/src/client/components/chat/assistant-code-block.tsx
@@ -1,0 +1,156 @@
+import { CodeBlockRenderer } from '#/client/components/chat/code-block-renderer'
+import type { GeneratedCodeFile } from '#/types'
+import { createContext, type HTMLAttributes, type ReactNode, useContext, useState } from 'react'
+
+export type SaveGeneratedFileRequest = {
+  blockIndex: number
+  language: string
+  content: string
+}
+
+export interface AssistantCodeBlockContextValue {
+  messageId: string | null
+  conversationId: string | null
+  generatedFiles: GeneratedCodeFile[]
+  cursor: { current: number }
+  onSave: (params: SaveGeneratedFileRequest) => Promise<GeneratedCodeFile | null>
+}
+
+export const AssistantCodeBlockContext = createContext<AssistantCodeBlockContextValue | null>(null)
+
+const SUPPORTED_LANGUAGES = new Set(['html', 'htm', 'xhtml', 'svg'])
+
+function isSupportedLanguage(language: string | undefined): boolean {
+  if (!language) {
+    return false
+  }
+  return SUPPORTED_LANGUAGES.has(language.toLowerCase())
+}
+
+type AssistantAwareCodeBlockProps = HTMLAttributes<HTMLElement> & {
+  children?: ReactNode | string
+}
+
+export function AssistantAwareCodeBlock({ className, children, ...rest }: AssistantAwareCodeBlockProps) {
+  const detectedLanguage = className?.split('-')[1]
+  const code = typeof children === 'string' ? children : Array.isArray(children) ? children.join('') : ''
+  const isBlock = detectedLanguage !== undefined || (typeof children === 'string' && code.includes('\n'))
+
+  if (!isBlock) {
+    return (
+      <CodeBlockRenderer className={className} {...rest}>
+        {children}
+      </CodeBlockRenderer>
+    )
+  }
+
+  return (
+    <AssistantSavableCodeBlock className={className} detectedLanguage={detectedLanguage} code={code} {...rest}>
+      {children}
+    </AssistantSavableCodeBlock>
+  )
+}
+
+type AssistantSavableCodeBlockProps = HTMLAttributes<HTMLElement> & {
+  children?: ReactNode | string
+  detectedLanguage?: string
+  code: string
+}
+
+function AssistantSavableCodeBlock({
+  className,
+  children,
+  detectedLanguage,
+  code,
+  ...rest
+}: AssistantSavableCodeBlockProps) {
+  const ctx = useContext(AssistantCodeBlockContext)
+
+  // 保存可能な context が無い場合（stream 中や user メッセージなど）は通常描画のみ
+  if (!ctx || !ctx.messageId || !ctx.conversationId) {
+    return (
+      <CodeBlockRenderer className={className} {...rest}>
+        {children}
+      </CodeBlockRenderer>
+    )
+  }
+
+  // render のたびに cursor を進めることで fenced code block に順序 index を割り当てる
+  const blockIndex = ctx.cursor.current
+  ctx.cursor.current += 1
+
+  const existing = ctx.generatedFiles.find((f) => f.blockIndex === blockIndex)
+  const supported = isSupportedLanguage(detectedLanguage)
+
+  return (
+    <div>
+      <CodeBlockRenderer className={className} {...rest}>
+        {children}
+      </CodeBlockRenderer>
+      {supported && (
+        <GeneratedFileActions
+          existing={existing}
+          onSave={() =>
+            ctx.onSave({
+              blockIndex,
+              language: detectedLanguage ?? '',
+              content: code,
+            })
+          }
+        />
+      )}
+    </div>
+  )
+}
+
+interface GeneratedFileActionsProps {
+  existing: GeneratedCodeFile | undefined
+  onSave: () => Promise<GeneratedCodeFile | null>
+}
+
+function GeneratedFileActions({ existing, onSave }: GeneratedFileActionsProps) {
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  if (existing) {
+    return (
+      <div className='mt-1 flex items-center gap-2 text-xs'>
+        <a
+          href={existing.previewUrl}
+          target='_blank'
+          rel='noopener noreferrer'
+          className='rounded-md border border-gray-200 bg-gray-50 px-2 py-1 text-gray-700 hover:bg-gray-100 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600'
+        >
+          プレビュー
+        </a>
+        <span className='text-gray-400 dark:text-gray-500'>{existing.fileName}</span>
+      </div>
+    )
+  }
+
+  const handleClick = async () => {
+    setSaving(true)
+    setError(null)
+    try {
+      await onSave()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className='mt-1 flex items-center gap-2 text-xs'>
+      <button
+        type='button'
+        onClick={handleClick}
+        disabled={saving}
+        className='cursor-pointer rounded-md border border-gray-200 bg-gray-50 px-2 py-1 text-gray-700 hover:bg-gray-100 disabled:cursor-default disabled:opacity-60 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600'
+      >
+        {saving ? '生成中…' : '生成'}
+      </button>
+      {error && <span className='text-red-500'>{error}</span>}
+    </div>
+  )
+}

--- a/projects/portfolio/src/client/components/chat/assistant-code-block.tsx
+++ b/projects/portfolio/src/client/components/chat/assistant-code-block.tsx
@@ -13,6 +13,7 @@ export interface AssistantCodeBlockContextValue {
   conversationId: string | null
   generatedFiles: GeneratedCodeFile[]
   cursor: { current: number }
+  disabled?: boolean
   onSave: (params: SaveGeneratedFileRequest) => Promise<GeneratedCodeFile | null>
 }
 
@@ -90,6 +91,7 @@ function AssistantSavableCodeBlock({
       {supported && (
         <GeneratedFileActions
           existing={existing}
+          disabled={ctx.disabled}
           onSave={() =>
             ctx.onSave({
               blockIndex,
@@ -105,10 +107,11 @@ function AssistantSavableCodeBlock({
 
 interface GeneratedFileActionsProps {
   existing: GeneratedCodeFile | undefined
+  disabled?: boolean
   onSave: () => Promise<GeneratedCodeFile | null>
 }
 
-function GeneratedFileActions({ existing, onSave }: GeneratedFileActionsProps) {
+function GeneratedFileActions({ existing, disabled, onSave }: GeneratedFileActionsProps) {
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -145,7 +148,7 @@ function GeneratedFileActions({ existing, onSave }: GeneratedFileActionsProps) {
       <button
         type='button'
         onClick={handleClick}
-        disabled={saving}
+        disabled={saving || disabled}
         className='cursor-pointer rounded-md border border-gray-200 bg-gray-50 px-2 py-1 text-gray-700 hover:bg-gray-100 disabled:cursor-default disabled:opacity-60 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600'
       >
         {saving ? '生成中…' : '生成'}

--- a/projects/portfolio/src/client/components/chat/assistant-code-block.tsx
+++ b/projects/portfolio/src/client/components/chat/assistant-code-block.tsx
@@ -14,6 +14,7 @@ export interface AssistantCodeBlockContextValue {
   generatedFiles: GeneratedCodeFile[]
   cursor: { current: number }
   disabled?: boolean
+  canSaveGeneratedFile?: boolean
   onSave: (params: SaveGeneratedFileRequest) => Promise<GeneratedCodeFile | null>
 }
 
@@ -82,16 +83,18 @@ function AssistantSavableCodeBlock({
 
   const existing = ctx.generatedFiles.find((f) => f.blockIndex === blockIndex)
   const supported = isSupportedLanguage(detectedLanguage)
+  const canShowActions = supported && (!!existing || ctx.canSaveGeneratedFile)
 
   return (
     <div>
       <CodeBlockRenderer className={className} {...rest}>
         {children}
       </CodeBlockRenderer>
-      {supported && (
+      {canShowActions && (
         <GeneratedFileActions
           existing={existing}
           disabled={ctx.disabled}
+          canSave={ctx.canSaveGeneratedFile}
           onSave={() =>
             ctx.onSave({
               blockIndex,
@@ -108,10 +111,11 @@ function AssistantSavableCodeBlock({
 interface GeneratedFileActionsProps {
   existing: GeneratedCodeFile | undefined
   disabled?: boolean
+  canSave?: boolean
   onSave: () => Promise<GeneratedCodeFile | null>
 }
 
-function GeneratedFileActions({ existing, disabled, onSave }: GeneratedFileActionsProps) {
+function GeneratedFileActions({ existing, disabled, canSave, onSave }: GeneratedFileActionsProps) {
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -129,6 +133,10 @@ function GeneratedFileActions({ existing, disabled, onSave }: GeneratedFileActio
         <span className='text-gray-400 dark:text-gray-500'>{existing.fileName}</span>
       </div>
     )
+  }
+
+  if (!canSave) {
+    return null
   }
 
   const handleClick = async () => {

--- a/projects/portfolio/src/client/components/chat/chat-main.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-main.tsx
@@ -21,6 +21,7 @@ interface Props {
   initTrigger?: number
   settings: Settings
   currentConversation?: Conversation | null
+  canSaveGeneratedFile?: boolean
   onSubmitting?: (submitting: boolean) => void
   onConversationChange?: (conversation: Conversation) => Promise<void> | void
   onDeleteMessages?: (messageIds: string[], isConversationEmpty: boolean) => void
@@ -30,6 +31,7 @@ export function ChatMain({
   initTrigger,
   settings,
   currentConversation,
+  canSaveGeneratedFile,
   onSubmitting,
   onConversationChange,
   onDeleteMessages,
@@ -203,6 +205,10 @@ export function ChatMain({
 
   const handleSaveGeneratedFile = useCallback(
     async (messageIndex: number, params: SaveGeneratedFileRequest): Promise<GeneratedCodeFile | null> => {
+      if (!canSaveGeneratedFile) {
+        return null
+      }
+
       const target = messages[messageIndex]
       if (!target || target.role !== 'assistant' || !target.id || !conversationId) {
         return null
@@ -243,7 +249,7 @@ export function ChatMain({
       )
       return payload.file
     },
-    [conversationId, messages]
+    [canSaveGeneratedFile, conversationId, messages]
   )
 
   const handleClickDeleteMessage = useCallback(
@@ -337,6 +343,7 @@ export function ChatMain({
           <ChatMessageList
             messages={messages}
             conversationId={conversationId}
+            canSaveGeneratedFile={canSaveGeneratedFile}
             markdownPreview={settings.markdownPreview}
             loading={loading}
             stream={stream}

--- a/projects/portfolio/src/client/components/chat/chat-main.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-main.tsx
@@ -22,7 +22,7 @@ interface Props {
   settings: Settings
   currentConversation?: Conversation | null
   onSubmitting?: (submitting: boolean) => void
-  onConversationChange?: (conversation: Conversation) => void
+  onConversationChange?: (conversation: Conversation) => Promise<void> | void
   onDeleteMessages?: (messageIds: string[], isConversationEmpty: boolean) => void
 }
 
@@ -38,6 +38,7 @@ export function ChatMain({
 
   const [conversationId, setConversationId] = useState<string | null>(null)
   const [messages, setMessages] = useState<Message[]>([])
+  const [isSavingConversation, setIsSavingConversation] = useState(false)
   const {
     input,
     uploadImages,
@@ -122,7 +123,7 @@ export function ChatMain({
         temperature: form.temperature,
         maxTokens: form.maxTokens,
         reasoningEffort: settings.reasoningEffortEnabled ? settings.reasoningEffort : undefined,
-      }).then(({ result, responseTimeMs }) => {
+      }).then(async ({ result, responseTimeMs }) => {
         const userContent = params.draftUserMessage.content
 
         // assistant メッセージを state に追加（ドメイン型で保持）
@@ -159,11 +160,16 @@ export function ChatMain({
           })()
 
         // 親コンポーネントに更新されたメッセージを通知（ドメイン型をそのまま渡す）
-        onConversationChange?.({
-          id: currentConversationId,
-          title: typeof userContent === 'string' ? userContent.slice(0, CONVERSATION_TITLE_MAX_LENGTH) : '',
-          messages: finalMessages,
-        })
+        setIsSavingConversation(true)
+        try {
+          await onConversationChange?.({
+            id: currentConversationId,
+            title: typeof userContent === 'string' ? userContent.slice(0, CONVERSATION_TITLE_MAX_LENGTH) : '',
+            messages: finalMessages,
+          })
+        } finally {
+          setIsSavingConversation(false)
+        }
       })
     },
     [
@@ -335,6 +341,7 @@ export function ChatMain({
             loading={loading}
             stream={stream}
             copiedId={copiedId}
+            savingConversation={isSavingConversation}
             messageEndRef={messageEndRef}
             onCopyMessage={copyMessage}
             onDeleteMessage={handleClickDeleteMessage}

--- a/projects/portfolio/src/client/components/chat/chat-main.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-main.tsx
@@ -1,3 +1,4 @@
+import type { SaveGeneratedFileRequest } from '#/client/components/chat/assistant-code-block'
 import { ChatInput } from '#/client/components/chat/chat-input'
 import { ChatMessageList } from '#/client/components/chat/chat-message-list'
 import { useChatForm } from '#/client/components/chat/hooks/use-chat-form'
@@ -10,7 +11,7 @@ import { ArrowUpIcon } from '#/client/components/svg/arrow-up-icon'
 import { StopIcon } from '#/client/components/svg/stop-icon'
 import { UploadIcon } from '#/client/components/svg/upload-icon'
 import type { Settings } from '#/client/storage/remote-storage-settings'
-import type { Conversation, Message } from '#/types'
+import type { Conversation, GeneratedCodeFile, Message } from '#/types'
 import { type FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { uuidv7 } from 'uuidv7'
 
@@ -194,6 +195,51 @@ export function ChatMain({
     [setTemplateInput]
   )
 
+  const handleSaveGeneratedFile = useCallback(
+    async (messageIndex: number, params: SaveGeneratedFileRequest): Promise<GeneratedCodeFile | null> => {
+      const target = messages[messageIndex]
+      if (!target || target.role !== 'assistant' || !target.id || !conversationId) {
+        return null
+      }
+
+      const res = await fetch('/api/conversations/messages/generated-files', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          conversationId,
+          messageId: target.id,
+          blockIndex: params.blockIndex,
+          language: params.language,
+          content: params.content,
+        }),
+      })
+      if (!res.ok) {
+        const err = (await res.json().catch(() => ({}))) as { error?: string }
+        throw new Error(err.error ?? `Request failed: ${res.status}`)
+      }
+      const payload = (await res.json()) as { file: GeneratedCodeFile; alreadyExisted?: boolean }
+
+      setMessages((prev) =>
+        prev.map((msg, idx) => {
+          if (idx !== messageIndex || msg.role !== 'assistant') {
+            return msg
+          }
+          const existingFiles = msg.metadata.generatedFiles ?? []
+          const withoutSame = existingFiles.filter((f) => f.blockIndex !== payload.file.blockIndex)
+          return {
+            ...msg,
+            metadata: {
+              ...msg.metadata,
+              generatedFiles: [...withoutSame, payload.file],
+            },
+          }
+        })
+      )
+      return payload.file
+    },
+    [conversationId, messages]
+  )
+
   const handleClickDeleteMessage = useCallback(
     (index: number) => {
       if (confirm('本当に削除しますか？')) {
@@ -284,6 +330,7 @@ export function ChatMain({
         {!emptyMessage && (
           <ChatMessageList
             messages={messages}
+            conversationId={conversationId}
             markdownPreview={settings.markdownPreview}
             loading={loading}
             stream={stream}
@@ -291,6 +338,7 @@ export function ChatMain({
             messageEndRef={messageEndRef}
             onCopyMessage={copyMessage}
             onDeleteMessage={handleClickDeleteMessage}
+            onSaveGeneratedFile={handleSaveGeneratedFile}
           />
         )}
       </div>

--- a/projects/portfolio/src/client/components/chat/chat-message-list.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-message-list.tsx
@@ -1,10 +1,11 @@
+import type { SaveGeneratedFileRequest } from '#/client/components/chat/assistant-code-block'
 import { CodeBlockRenderer, MarkdownLink } from '#/client/components/chat/code-block-renderer'
 import type { ChatStreamState } from '#/client/components/chat/hooks/chat-response'
 import { MessageRenderer } from '#/client/components/chat/message-renderer'
 import { ReasoningSection } from '#/client/components/chat/reasoning-section'
 import { ChatbotIcon } from '#/client/components/svg/chatbot-icon'
 import { SpinnerIcon } from '#/client/components/svg/spinner-icon'
-import type { Message } from '#/types'
+import type { GeneratedCodeFile, Message } from '#/types'
 import { memo, type ReactNode, type RefObject } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
@@ -18,6 +19,7 @@ const markdownComponents = {
 
 interface ChatMessageListProps {
   messages: Message[]
+  conversationId: string | null
   markdownPreview: boolean
   loading: boolean
   stream: ChatStreamState | null
@@ -25,10 +27,12 @@ interface ChatMessageListProps {
   messageEndRef: RefObject<HTMLDivElement | null>
   onCopyMessage: (message: string, index: number) => void
   onDeleteMessage: (index: number) => void
+  onSaveGeneratedFile?: (messageIndex: number, params: SaveGeneratedFileRequest) => Promise<GeneratedCodeFile | null>
 }
 
 export function ChatMessageList({
   messages,
+  conversationId,
   markdownPreview,
   loading,
   stream,
@@ -36,17 +40,20 @@ export function ChatMessageList({
   messageEndRef,
   onCopyMessage,
   onDeleteMessage,
+  onSaveGeneratedFile,
 }: ChatMessageListProps) {
   return (
     <div className='container mx-auto mt-4 max-w-(--breakpoint-lg) px-4'>
       <div className='message-list'>
         <MessageHistory
           messages={messages}
+          conversationId={conversationId}
           markdownPreview={markdownPreview}
           copiedId={copiedId}
           disabled={loading || !!stream}
           onCopyMessage={onCopyMessage}
           onDeleteMessage={onDeleteMessage}
+          onSaveGeneratedFile={onSaveGeneratedFile}
         />
         {loading && (
           <div className='flex align-item'>
@@ -85,31 +92,37 @@ export function ChatMessageList({
 
 interface MessageHistoryProps {
   messages: Message[]
+  conversationId: string | null
   markdownPreview: boolean
   copiedId: string
   disabled: boolean
   onCopyMessage: (message: string, index: number) => void
   onDeleteMessage: (index: number) => void
+  onSaveGeneratedFile?: (messageIndex: number, params: SaveGeneratedFileRequest) => Promise<GeneratedCodeFile | null>
 }
 
 const MessageHistory = memo(function MessageHistory({
   messages,
+  conversationId,
   markdownPreview,
   copiedId,
   disabled,
   onCopyMessage,
   onDeleteMessage,
+  onSaveGeneratedFile,
 }: MessageHistoryProps) {
   return messages.map((message, index) => (
     <MessageRenderer
       key={message.id ?? `chat_${index}`}
       message={message}
       index={index}
+      conversationId={conversationId}
       markdownPreview={markdownPreview}
       copied={copiedId === `chat_${index}`}
       disabled={disabled}
       onCopyMessage={onCopyMessage}
       onDeleteMessage={onDeleteMessage}
+      onSaveGeneratedFile={onSaveGeneratedFile}
     />
   ))
 })

--- a/projects/portfolio/src/client/components/chat/chat-message-list.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-message-list.tsx
@@ -24,6 +24,7 @@ interface ChatMessageListProps {
   loading: boolean
   stream: ChatStreamState | null
   copiedId: string
+  savingConversation?: boolean
   messageEndRef: RefObject<HTMLDivElement | null>
   onCopyMessage: (message: string, index: number) => void
   onDeleteMessage: (index: number) => void
@@ -37,6 +38,7 @@ export function ChatMessageList({
   loading,
   stream,
   copiedId,
+  savingConversation,
   messageEndRef,
   onCopyMessage,
   onDeleteMessage,
@@ -51,6 +53,7 @@ export function ChatMessageList({
           markdownPreview={markdownPreview}
           copiedId={copiedId}
           disabled={loading || !!stream}
+          savingConversation={savingConversation}
           onCopyMessage={onCopyMessage}
           onDeleteMessage={onDeleteMessage}
           onSaveGeneratedFile={onSaveGeneratedFile}
@@ -96,6 +99,7 @@ interface MessageHistoryProps {
   markdownPreview: boolean
   copiedId: string
   disabled: boolean
+  savingConversation?: boolean
   onCopyMessage: (message: string, index: number) => void
   onDeleteMessage: (index: number) => void
   onSaveGeneratedFile?: (messageIndex: number, params: SaveGeneratedFileRequest) => Promise<GeneratedCodeFile | null>
@@ -107,6 +111,7 @@ const MessageHistory = memo(function MessageHistory({
   markdownPreview,
   copiedId,
   disabled,
+  savingConversation,
   onCopyMessage,
   onDeleteMessage,
   onSaveGeneratedFile,
@@ -120,6 +125,7 @@ const MessageHistory = memo(function MessageHistory({
       markdownPreview={markdownPreview}
       copied={copiedId === `chat_${index}`}
       disabled={disabled}
+      savingConversation={savingConversation}
       onCopyMessage={onCopyMessage}
       onDeleteMessage={onDeleteMessage}
       onSaveGeneratedFile={onSaveGeneratedFile}

--- a/projects/portfolio/src/client/components/chat/chat-message-list.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-message-list.tsx
@@ -20,6 +20,7 @@ const markdownComponents = {
 interface ChatMessageListProps {
   messages: Message[]
   conversationId: string | null
+  canSaveGeneratedFile?: boolean
   markdownPreview: boolean
   loading: boolean
   stream: ChatStreamState | null
@@ -34,6 +35,7 @@ interface ChatMessageListProps {
 export function ChatMessageList({
   messages,
   conversationId,
+  canSaveGeneratedFile,
   markdownPreview,
   loading,
   stream,
@@ -50,6 +52,7 @@ export function ChatMessageList({
         <MessageHistory
           messages={messages}
           conversationId={conversationId}
+          canSaveGeneratedFile={canSaveGeneratedFile}
           markdownPreview={markdownPreview}
           copiedId={copiedId}
           disabled={loading || !!stream}
@@ -96,6 +99,7 @@ export function ChatMessageList({
 interface MessageHistoryProps {
   messages: Message[]
   conversationId: string | null
+  canSaveGeneratedFile?: boolean
   markdownPreview: boolean
   copiedId: string
   disabled: boolean
@@ -108,6 +112,7 @@ interface MessageHistoryProps {
 const MessageHistory = memo(function MessageHistory({
   messages,
   conversationId,
+  canSaveGeneratedFile,
   markdownPreview,
   copiedId,
   disabled,
@@ -122,6 +127,7 @@ const MessageHistory = memo(function MessageHistory({
       message={message}
       index={index}
       conversationId={conversationId}
+      canSaveGeneratedFile={canSaveGeneratedFile}
       markdownPreview={markdownPreview}
       copied={copiedId === `chat_${index}`}
       disabled={disabled}

--- a/projects/portfolio/src/client/components/chat/message-renderer.tsx
+++ b/projects/portfolio/src/client/components/chat/message-renderer.tsx
@@ -29,6 +29,7 @@ interface MessageRendererProps {
   message: Message
   index: number
   conversationId: string | null
+  canSaveGeneratedFile?: boolean
   markdownPreview: boolean
   copied: boolean
   disabled?: boolean
@@ -99,6 +100,7 @@ function MessageRendererComponent({
   message,
   index,
   conversationId,
+  canSaveGeneratedFile,
   markdownPreview,
   copied,
   disabled,
@@ -163,6 +165,7 @@ function MessageRendererComponent({
           generatedFiles,
           cursor: cursorRef.current,
           disabled: savingConversation,
+          canSaveGeneratedFile,
           onSave: (params: SaveGeneratedFileRequest) => onSaveGeneratedFile(index, params),
         }
       : null
@@ -206,6 +209,7 @@ export const MessageRenderer = memo(
     prevProps.message === nextProps.message &&
     prevProps.index === nextProps.index &&
     prevProps.conversationId === nextProps.conversationId &&
+    prevProps.canSaveGeneratedFile === nextProps.canSaveGeneratedFile &&
     prevProps.markdownPreview === nextProps.markdownPreview &&
     prevProps.copied === nextProps.copied &&
     prevProps.disabled === nextProps.disabled &&

--- a/projects/portfolio/src/client/components/chat/message-renderer.tsx
+++ b/projects/portfolio/src/client/components/chat/message-renderer.tsx
@@ -1,13 +1,18 @@
+import {
+  AssistantAwareCodeBlock,
+  AssistantCodeBlockContext,
+  type SaveGeneratedFileRequest,
+} from '#/client/components/chat/assistant-code-block'
 import { ChatResults } from '#/client/components/chat/chat-results'
-import { CodeBlockRenderer, MarkdownLink } from '#/client/components/chat/code-block-renderer'
+import { MarkdownLink } from '#/client/components/chat/code-block-renderer'
 import { ReasoningSection } from '#/client/components/chat/reasoning-section'
 import { ChatbotIcon } from '#/client/components/svg/chatbot-icon'
 import { CheckIcon } from '#/client/components/svg/check-icon'
 import { CopyIcon } from '#/client/components/svg/copy-icon'
 import { DeleteIcon } from '#/client/components/svg/delete-icon'
-import type { Message } from '#/types'
+import type { GeneratedCodeFile, Message } from '#/types'
 import { isImageContentArray } from '#/types'
-import { Fragment, memo, type ReactNode } from 'react'
+import { Fragment, memo, type ReactNode, useRef } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkCjkFriendly from 'remark-cjk-friendly'
 import remarkCjkFriendlyGfmStrikethrough from 'remark-cjk-friendly-gfm-strikethrough'
@@ -16,18 +21,20 @@ import remarkGfm from 'remark-gfm'
 const markdownRemarkPlugins = [remarkGfm, remarkCjkFriendly, remarkCjkFriendlyGfmStrikethrough]
 const markdownComponents = {
   a: MarkdownLink,
-  code: CodeBlockRenderer,
+  code: AssistantAwareCodeBlock,
   pre: ({ children }: { children?: ReactNode }) => <>{children}</>,
 }
 
 interface MessageRendererProps {
   message: Message
   index: number
+  conversationId: string | null
   markdownPreview: boolean
   copied: boolean
   disabled?: boolean
   onCopyMessage: (message: string, index: number) => void
   onDeleteMessage?: (index: number) => void
+  onSaveGeneratedFile?: (messageIndex: number, params: SaveGeneratedFileRequest) => Promise<GeneratedCodeFile | null>
 }
 
 interface MessageActionBarProps {
@@ -90,12 +97,19 @@ function CopyMessageButton({ copied, onClick }: CopyMessageButtonProps) {
 function MessageRendererComponent({
   message,
   index,
+  conversationId,
   markdownPreview,
   copied,
   disabled,
   onCopyMessage,
   onDeleteMessage,
+  onSaveGeneratedFile,
 }: MessageRendererProps) {
+  // fenced code block 用の cursor。render のたびに 0 にリセットし、
+  // 子の AssistantAwareCodeBlock が順序どおり blockIndex を取得できるようにする。
+  const cursorRef = useRef({ current: 0 })
+  cursorRef.current.current = 0
+
   if (message.role === 'system') {
     return null
   }
@@ -138,6 +152,24 @@ function MessageRendererComponent({
     )
   }
 
+  const generatedFiles = message.role === 'assistant' ? (message.metadata.generatedFiles ?? []) : []
+  const assistantContextValue =
+    message.role === 'assistant' && message.id && conversationId && onSaveGeneratedFile
+      ? {
+          messageId: message.id,
+          conversationId,
+          generatedFiles,
+          cursor: cursorRef.current,
+          onSave: (params: SaveGeneratedFileRequest) => onSaveGeneratedFile(index, params),
+        }
+      : null
+
+  const markdownBody = (
+    <ReactMarkdown remarkPlugins={markdownRemarkPlugins} components={markdownComponents}>
+      {message.content}
+    </ReactMarkdown>
+  )
+
   return (
     <div className='flex'>
       <div className='flex h-8 w-8 justify-center rounded-full border border-gray-300 bg-white align-center dark:border-gray-600 dark:bg-gray-800'>
@@ -147,9 +179,9 @@ function MessageRendererComponent({
         {message.reasoningContent && <ReasoningSection content={message.reasoningContent} />}
         {markdownPreview ? (
           <div className='prose mt-1 max-w-(--breakpoint-md) break-all'>
-            <ReactMarkdown remarkPlugins={markdownRemarkPlugins} components={markdownComponents}>
-              {message.content}
-            </ReactMarkdown>
+            <AssistantCodeBlockContext.Provider value={assistantContextValue}>
+              {markdownBody}
+            </AssistantCodeBlockContext.Provider>
           </div>
         ) : (
           <div className='message text-left'>
@@ -170,9 +202,11 @@ export const MessageRenderer = memo(
   (prevProps, nextProps) =>
     prevProps.message === nextProps.message &&
     prevProps.index === nextProps.index &&
+    prevProps.conversationId === nextProps.conversationId &&
     prevProps.markdownPreview === nextProps.markdownPreview &&
     prevProps.copied === nextProps.copied &&
     prevProps.disabled === nextProps.disabled &&
     prevProps.onCopyMessage === nextProps.onCopyMessage &&
-    prevProps.onDeleteMessage === nextProps.onDeleteMessage
+    prevProps.onDeleteMessage === nextProps.onDeleteMessage &&
+    prevProps.onSaveGeneratedFile === nextProps.onSaveGeneratedFile
 )

--- a/projects/portfolio/src/client/components/chat/message-renderer.tsx
+++ b/projects/portfolio/src/client/components/chat/message-renderer.tsx
@@ -32,6 +32,7 @@ interface MessageRendererProps {
   markdownPreview: boolean
   copied: boolean
   disabled?: boolean
+  savingConversation?: boolean
   onCopyMessage: (message: string, index: number) => void
   onDeleteMessage?: (index: number) => void
   onSaveGeneratedFile?: (messageIndex: number, params: SaveGeneratedFileRequest) => Promise<GeneratedCodeFile | null>
@@ -101,6 +102,7 @@ function MessageRendererComponent({
   markdownPreview,
   copied,
   disabled,
+  savingConversation,
   onCopyMessage,
   onDeleteMessage,
   onSaveGeneratedFile,
@@ -160,6 +162,7 @@ function MessageRendererComponent({
           conversationId,
           generatedFiles,
           cursor: cursorRef.current,
+          disabled: savingConversation,
           onSave: (params: SaveGeneratedFileRequest) => onSaveGeneratedFile(index, params),
         }
       : null
@@ -206,6 +209,7 @@ export const MessageRenderer = memo(
     prevProps.markdownPreview === nextProps.markdownPreview &&
     prevProps.copied === nextProps.copied &&
     prevProps.disabled === nextProps.disabled &&
+    prevProps.savingConversation === nextProps.savingConversation &&
     prevProps.onCopyMessage === nextProps.onCopyMessage &&
     prevProps.onDeleteMessage === nextProps.onDeleteMessage &&
     prevProps.onSaveGeneratedFile === nextProps.onSaveGeneratedFile

--- a/projects/portfolio/src/client/pages/chat/index.tsx
+++ b/projects/portfolio/src/client/pages/chat/index.tsx
@@ -30,6 +30,7 @@ export function Chat() {
   } = useChatPageState()
 
   const { email } = useMetaProps()
+  const isAuthenticated = !!email
 
   const query = useQuery({
     queryKey: ['conversations'],
@@ -149,6 +150,7 @@ export function Chat() {
       <ChatMain
         initTrigger={newChatTrigger}
         settings={settings}
+        canSaveGeneratedFile={isAuthenticated}
         onSubmitting={setSubmitting}
         currentConversation={currentConversation}
         onConversationChange={handleConversationChange}

--- a/projects/portfolio/src/client/pages/chat/index.tsx
+++ b/projects/portfolio/src/client/pages/chat/index.tsx
@@ -94,27 +94,21 @@ export function Chat() {
       })
   }
 
-  const handleConversationChange = (conversation: Conversation) => {
+  const handleConversationChange = async (conversation: Conversation): Promise<void> => {
     // カレントの会話IDを更新
     selectConversation(conversation.id)
 
-    if (!email) {
-      return
-    }
+    if (!email) return
 
-    client.api.conversations
-      .$post({
-        json: conversation,
-      })
-      .then((res) => {
-        if (res.status === 200) {
-          // 成功した場合は、会話履歴を再取得
-          query.refetch()
-        }
-      })
-      .catch((error) => {
-        console.error('Error updating conversation:', error)
-      })
+    try {
+      const res = await client.api.conversations.$post({ json: conversation })
+      if (res.status === 200) {
+        // 成功した場合は、会話履歴を再取得
+        query.refetch()
+      }
+    } catch (error) {
+      console.error('Error updating conversation:', error)
+    }
   }
 
   return (

--- a/projects/portfolio/src/server/features/chat-conversations/file-server-client.ts
+++ b/projects/portfolio/src/server/features/chat-conversations/file-server-client.ts
@@ -84,7 +84,7 @@ export async function loginToFileServer(config: FileServerConfig): Promise<strin
 
 /**
  * file-server に POST /api/upload する。
- * path は virtual path（例: public/portfolio/xxx）で、file は { fileName, content, contentType }。
+ * path は virtual path で、ディレクトリまたは保存先ファイルパスを指定する。
  */
 export async function uploadFileToFileServer(
   config: FileServerConfig,

--- a/projects/portfolio/src/server/features/chat-conversations/file-server-client.ts
+++ b/projects/portfolio/src/server/features/chat-conversations/file-server-client.ts
@@ -1,0 +1,127 @@
+import { logger } from '#/server/lib/logger'
+
+export interface FileServerCredentials {
+  username: string
+  password: string
+}
+
+export interface FileServerConfig {
+  baseUrl: string
+  credentials: FileServerCredentials
+}
+
+export interface FileServerEnv {
+  FILE_SERVER_URL?: string
+  FILE_SERVER_ADMIN_USERNAME?: string
+  FILE_SERVER_ADMIN_PASSWORD?: string
+}
+
+/**
+ * file-server の設定を env から解決する。
+ * 現時点では固定 admin credentials を使うが、将来 portfolio user と
+ * file-server user の対応付けに差し替えられるよう helper で閉じ込める。
+ */
+export function resolveFileServerConfig(env: FileServerEnv): FileServerConfig | null {
+  const baseUrl = (env.FILE_SERVER_URL ?? '').trim()
+  const username = (env.FILE_SERVER_ADMIN_USERNAME ?? '').trim()
+  const password = env.FILE_SERVER_ADMIN_PASSWORD ?? ''
+
+  if (!baseUrl || !username || !password) {
+    return null
+  }
+
+  return {
+    baseUrl: baseUrl.replace(/\/$/, ''),
+    credentials: { username, password },
+  }
+}
+
+const SESSION_COOKIE_NAME = 'session'
+
+function extractSessionCookie(setCookieHeader: string | null): string | null {
+  if (!setCookieHeader) {
+    return null
+  }
+  const cookies = setCookieHeader.split(/,(?=\s*[^;]+=)/)
+  for (const raw of cookies) {
+    const [pair] = raw.split(';')
+    const [name, ...rest] = pair.trim().split('=')
+    if (name === SESSION_COOKIE_NAME) {
+      return rest.join('=')
+    }
+  }
+  return null
+}
+
+/**
+ * file-server に POST /login して session cookie の値を取得する。
+ */
+export async function loginToFileServer(config: FileServerConfig): Promise<string> {
+  const form = new URLSearchParams()
+  form.set('username', config.credentials.username)
+  form.set('password', config.credentials.password)
+  form.set('returnTo', '/')
+
+  const res = await fetch(`${config.baseUrl}/login`, {
+    method: 'POST',
+    body: form,
+    redirect: 'manual',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+  })
+
+  if (res.status !== 302 && res.status !== 303 && !res.ok) {
+    const text = await res.text().catch(() => '')
+    logger.warn({ status: res.status, body: text.slice(0, 200) }, 'file-server login failed')
+    throw new Error(`file-server login failed: ${res.status}`)
+  }
+
+  const session = extractSessionCookie(res.headers.get('set-cookie'))
+  if (!session) {
+    throw new Error('file-server login did not return session cookie')
+  }
+  return session
+}
+
+/**
+ * file-server に POST /api/upload する。
+ * path は virtual path（例: public/portfolio/xxx）で、file は { fileName, content, contentType }。
+ */
+export async function uploadFileToFileServer(
+  config: FileServerConfig,
+  session: string,
+  params: {
+    fileName: string
+    content: string | ArrayBuffer
+    contentType: string
+    path: string
+  }
+): Promise<void> {
+  const form = new FormData()
+  const blob = new Blob([params.content], { type: params.contentType })
+  form.set('files', blob, params.fileName)
+  form.set('path', params.path)
+
+  const res = await fetch(`${config.baseUrl}/api/upload`, {
+    method: 'POST',
+    body: form,
+    headers: {
+      cookie: `${SESSION_COOKIE_NAME}=${session}`,
+    },
+  })
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    logger.warn({ status: res.status, body: text.slice(0, 200) }, 'file-server upload failed')
+    throw new Error(`file-server upload failed: ${res.status}`)
+  }
+
+  const payload = (await res.json().catch(() => null)) as {
+    success?: boolean
+    uploaded?: string[]
+    failed?: Array<{ name: string; reason: string }>
+  } | null
+  if (payload && payload.success === false) {
+    const reason = payload.failed?.[0]?.reason ?? 'unknown'
+    throw new Error(`file-server upload rejected: ${reason}`)
+  }
+}

--- a/projects/portfolio/src/server/features/chat-conversations/repository.ts
+++ b/projects/portfolio/src/server/features/chat-conversations/repository.ts
@@ -1,8 +1,17 @@
 import { deleteConversations } from '#/server/features/chat-conversations/delete-conversations'
 import { deleteMessages } from '#/server/features/chat-conversations/delete-messages'
+import type { FileServerConfig } from '#/server/features/chat-conversations/file-server-client'
 import { readConversations } from '#/server/features/chat-conversations/read-conversations'
+import {
+  saveGeneratedFile,
+  type SaveGeneratedFileResult,
+} from '#/server/features/chat-conversations/save-generated-file'
+import {
+  updateMessageMetadata,
+  type UpdateMessageMetadataResult,
+} from '#/server/features/chat-conversations/update-message-metadata'
 import { upsertConversation } from '#/server/features/chat-conversations/upsert-conversation'
-import type { Conversation } from '#/types'
+import type { AssistantMetadata, Conversation } from '#/types'
 
 interface ChatConversationRepository {
   read(databaseUrl: string, email: string): Promise<Conversation[] | null>
@@ -22,6 +31,27 @@ interface ChatConversationRepository {
     failedMessageIds: string[]
     deletedConversationIds: string[]
   }>
+  updateMessageMetadata(
+    databaseUrl: string,
+    email: string,
+    params: {
+      conversationId: string
+      messageId: string
+      metadataPatch: Partial<AssistantMetadata>
+    }
+  ): Promise<UpdateMessageMetadataResult>
+  saveGeneratedFile(
+    databaseUrl: string,
+    email: string,
+    params: {
+      conversationId: string
+      messageId: string
+      blockIndex: number
+      language: string
+      content: string
+    },
+    fileServerConfig: FileServerConfig | null
+  ): Promise<SaveGeneratedFileResult>
 }
 
 export const chatConversationRepository: ChatConversationRepository = {
@@ -49,5 +79,11 @@ export const chatConversationRepository: ChatConversationRepository = {
     deletedConversationIds: string[]
   }> {
     return deleteMessages(databaseUrl, email, messageIds)
+  },
+  async updateMessageMetadata(databaseUrl, email, params) {
+    return updateMessageMetadata(databaseUrl, email, params)
+  },
+  async saveGeneratedFile(databaseUrl, email, params, fileServerConfig) {
+    return saveGeneratedFile(databaseUrl, email, params, fileServerConfig)
   },
 }

--- a/projects/portfolio/src/server/features/chat-conversations/save-generated-file.ts
+++ b/projects/portfolio/src/server/features/chat-conversations/save-generated-file.ts
@@ -1,0 +1,158 @@
+import { getDatabase } from '#/db'
+import { conversationsTable, messagesTable, usersTable } from '#/db/schema'
+import {
+  type FileServerConfig,
+  loginToFileServer,
+  uploadFileToFileServer,
+} from '#/server/features/chat-conversations/file-server-client'
+import { logger } from '#/server/lib/logger'
+import type { AssistantMetadata, GeneratedCodeFile } from '#/types'
+import { and, eq } from 'drizzle-orm'
+
+export type SaveGeneratedFileResult =
+  | { ok: true; file: GeneratedCodeFile; alreadyExisted: boolean }
+  | {
+      ok: false
+      reason:
+        | 'user-not-found'
+        | 'message-not-found'
+        | 'forbidden'
+        | 'invalid-role'
+        | 'file-server-unavailable'
+        | 'upload-failed'
+    }
+
+interface SaveGeneratedFileParams {
+  conversationId: string
+  messageId: string
+  blockIndex: number
+  language: string
+  content: string
+}
+
+const LANGUAGE_EXTENSION_MAP: Record<string, { ext: string; contentType: string }> = {
+  html: { ext: 'html', contentType: 'text/html; charset=utf-8' },
+  htm: { ext: 'html', contentType: 'text/html; charset=utf-8' },
+  xhtml: { ext: 'xhtml', contentType: 'application/xhtml+xml; charset=utf-8' },
+  svg: { ext: 'svg', contentType: 'image/svg+xml; charset=utf-8' },
+}
+
+export function resolveExtension(language: string): { ext: string; contentType: string } | null {
+  const key = language.toLowerCase()
+  return LANGUAGE_EXTENSION_MAP[key] ?? null
+}
+
+function deserializeMetadata(value: unknown): Record<string, unknown> {
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value)
+      return parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : {}
+    } catch {
+      return {}
+    }
+  }
+  if (value && typeof value === 'object') {
+    return value as Record<string, unknown>
+  }
+  return {}
+}
+
+export async function saveGeneratedFile(
+  databaseUrl: string,
+  email: string,
+  params: SaveGeneratedFileParams,
+  fileServerConfig: FileServerConfig | null
+): Promise<SaveGeneratedFileResult> {
+  if (!fileServerConfig) {
+    return { ok: false, reason: 'file-server-unavailable' }
+  }
+
+  const extension = resolveExtension(params.language)
+  if (!extension) {
+    return { ok: false, reason: 'invalid-role' }
+  }
+
+  const db = getDatabase(databaseUrl)
+
+  const users = await db.select().from(usersTable).where(eq(usersTable.email, email))
+  if (users.length <= 0) {
+    logger.warn({ email }, 'No users found')
+    return { ok: false, reason: 'user-not-found' }
+  }
+  const userId = users[0].id
+
+  const rows = await db
+    .select({
+      messageId: messagesTable.id,
+      role: messagesTable.role,
+      metadata: messagesTable.metadata,
+      conversationUserId: conversationsTable.userId,
+    })
+    .from(messagesTable)
+    .innerJoin(conversationsTable, eq(messagesTable.conversationId, conversationsTable.id))
+    .where(and(eq(messagesTable.id, params.messageId), eq(messagesTable.conversationId, params.conversationId)))
+
+  if (rows.length === 0) {
+    return { ok: false, reason: 'message-not-found' }
+  }
+
+  const row = rows[0]
+  if (row.conversationUserId !== userId) {
+    return { ok: false, reason: 'forbidden' }
+  }
+  if (row.role !== 'assistant') {
+    return { ok: false, reason: 'invalid-role' }
+  }
+
+  const existingMetadata = deserializeMetadata(row.metadata)
+  const existingFiles: GeneratedCodeFile[] = Array.isArray(existingMetadata.generatedFiles)
+    ? (existingMetadata.generatedFiles as GeneratedCodeFile[])
+    : []
+
+  // 既に同じ blockIndex で保存済みなら再 upload せずそのまま返す
+  const existing = existingFiles.find((f) => f.blockIndex === params.blockIndex)
+  if (existing) {
+    return { ok: true, file: existing, alreadyExisted: true }
+  }
+
+  const fileName = `${params.messageId}-block-${params.blockIndex}.${extension.ext}`
+  const virtualDir = `public/portfolio/${params.conversationId}`
+  const publicPath = `/public/portfolio/${params.conversationId}/${fileName}`
+
+  try {
+    const session = await loginToFileServer(fileServerConfig)
+    await uploadFileToFileServer(fileServerConfig, session, {
+      fileName,
+      content: params.content,
+      contentType: extension.contentType,
+      path: virtualDir,
+    })
+  } catch (error) {
+    logger.error({ err: error }, 'failed to upload generated file to file-server')
+    return { ok: false, reason: 'upload-failed' }
+  }
+
+  const createdAt = new Date().toISOString()
+  const previewUrl = `${fileServerConfig.baseUrl}${publicPath}`
+  const file: GeneratedCodeFile = {
+    blockIndex: params.blockIndex,
+    language: params.language,
+    fileName,
+    publicPath,
+    previewUrl,
+    contentType: extension.contentType,
+    createdAt,
+  }
+
+  const mergedFiles = [...existingFiles, file]
+  const mergedMetadata: Record<string, unknown> = {
+    ...existingMetadata,
+    generatedFiles: mergedFiles,
+  }
+
+  await db.update(messagesTable).set({ metadata: mergedMetadata }).where(eq(messagesTable.id, params.messageId))
+
+  return { ok: true, file, alreadyExisted: false }
+}
+
+export type { AssistantMetadata }

--- a/projects/portfolio/src/server/features/chat-conversations/save-generated-file.ts
+++ b/projects/portfolio/src/server/features/chat-conversations/save-generated-file.ts
@@ -116,7 +116,7 @@ export async function saveGeneratedFile(
   }
 
   const fileName = `${params.messageId}-block-${params.blockIndex}.${extension.ext}`
-  const virtualDir = `public/portfolio/${params.conversationId}`
+  const virtualPath = `public/portfolio/${params.conversationId}/${fileName}`
   const publicPath = `/public/portfolio/${params.conversationId}/${fileName}`
 
   try {
@@ -125,7 +125,7 @@ export async function saveGeneratedFile(
       fileName,
       content: params.content,
       contentType: extension.contentType,
-      path: virtualDir,
+      path: virtualPath,
     })
   } catch (error) {
     logger.error({ err: error }, 'failed to upload generated file to file-server')

--- a/projects/portfolio/src/server/features/chat-conversations/update-message-metadata.ts
+++ b/projects/portfolio/src/server/features/chat-conversations/update-message-metadata.ts
@@ -70,7 +70,19 @@ export async function updateMessageMetadata(
   }
 
   const existing = deserializeMetadata(row.metadata)
-  const merged = { ...existing, ...params.metadataPatch } as Record<string, unknown>
+  const { usage: patchUsage, ...restPatch } = params.metadataPatch
+  const merged = {
+    ...existing,
+    ...restPatch,
+    ...(patchUsage !== undefined
+      ? {
+          usage: {
+            ...(typeof existing.usage === 'object' && existing.usage ? (existing.usage as object) : {}),
+            ...patchUsage,
+          },
+        }
+      : {}),
+  } as Record<string, unknown>
 
   await db.update(messagesTable).set({ metadata: merged }).where(eq(messagesTable.id, params.messageId))
 

--- a/projects/portfolio/src/server/features/chat-conversations/update-message-metadata.ts
+++ b/projects/portfolio/src/server/features/chat-conversations/update-message-metadata.ts
@@ -1,0 +1,78 @@
+import { getDatabase } from '#/db'
+import { conversationsTable, messagesTable, usersTable } from '#/db/schema'
+import { logger } from '#/server/lib/logger'
+import type { AssistantMetadata } from '#/types'
+import { and, eq } from 'drizzle-orm'
+
+export type UpdateMessageMetadataResult =
+  | { ok: true; metadata: AssistantMetadata }
+  | { ok: false; reason: 'user-not-found' | 'message-not-found' | 'forbidden' | 'invalid-role' }
+
+function deserializeMetadata(value: unknown): Record<string, unknown> {
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value)
+      return parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : {}
+    } catch {
+      return {}
+    }
+  }
+  if (value && typeof value === 'object') {
+    return value as Record<string, unknown>
+  }
+  return {}
+}
+
+/**
+ * assistant message の metadata を部分更新する。
+ * 既存 metadata と shallow merge して保存し、
+ * 保存後の完全な metadata を返す。
+ */
+export async function updateMessageMetadata(
+  databaseUrl: string,
+  email: string,
+  params: {
+    conversationId: string
+    messageId: string
+    metadataPatch: Partial<AssistantMetadata>
+  }
+): Promise<UpdateMessageMetadataResult> {
+  const db = getDatabase(databaseUrl)
+
+  const users = await db.select().from(usersTable).where(eq(usersTable.email, email))
+  if (users.length <= 0) {
+    logger.warn({ email }, 'No users found')
+    return { ok: false, reason: 'user-not-found' }
+  }
+  const userId = users[0].id
+
+  const rows = await db
+    .select({
+      messageId: messagesTable.id,
+      role: messagesTable.role,
+      metadata: messagesTable.metadata,
+      conversationUserId: conversationsTable.userId,
+    })
+    .from(messagesTable)
+    .innerJoin(conversationsTable, eq(messagesTable.conversationId, conversationsTable.id))
+    .where(and(eq(messagesTable.id, params.messageId), eq(messagesTable.conversationId, params.conversationId)))
+
+  if (rows.length === 0) {
+    return { ok: false, reason: 'message-not-found' }
+  }
+
+  const row = rows[0]
+  if (row.conversationUserId !== userId) {
+    return { ok: false, reason: 'forbidden' }
+  }
+  if (row.role !== 'assistant') {
+    return { ok: false, reason: 'invalid-role' }
+  }
+
+  const existing = deserializeMetadata(row.metadata)
+  const merged = { ...existing, ...params.metadataPatch } as Record<string, unknown>
+
+  await db.update(messagesTable).set({ metadata: merged }).where(eq(messagesTable.id, params.messageId))
+
+  return { ok: true, metadata: merged as AssistantMetadata }
+}

--- a/projects/portfolio/src/server/features/chat-conversations/upsert-conversation.ts
+++ b/projects/portfolio/src/server/features/chat-conversations/upsert-conversation.ts
@@ -50,7 +50,7 @@ export async function upsertConversation(databaseUrl: string, email: string, { i
     // index を ms 単位でずらすことで元の配列順序を createdAt に反映し、
     // DB から読み戻したときの ORDER BY createdAt で順序が保たれるようにする
     const messageValues = messages.map((message, index) => ({
-      id: uuidv7(),
+      id: message.id ?? uuidv7(),
       conversationId: id,
       role: message.role,
       content: serializeContent(message.content),

--- a/projects/portfolio/src/server/routes/conversations.ts
+++ b/projects/portfolio/src/server/routes/conversations.ts
@@ -1,6 +1,7 @@
+import { resolveFileServerConfig } from '#/server/features/chat-conversations/file-server-client'
 import { chatConversationRepository } from '#/server/features/chat-conversations/repository'
 import { requireAuth } from '#/server/middleware/auth'
-import { ConversationSchema } from '#/types'
+import { ConversationSchema, GeneratedCodeFileSchema } from '#/types'
 import { sValidator } from '@hono/standard-validator'
 import { Hono } from 'hono'
 import { z } from 'zod'
@@ -9,6 +10,37 @@ import { getServerEnv } from './shared'
 
 const ConversationIdsQuerySchema = z.object({
   ids: z.union([z.string(), z.array(z.string())]).transform((value) => (Array.isArray(value) ? value : [value])),
+})
+
+const AssistantMetadataPatchSchema = z
+  .object({
+    model: z.string().optional(),
+    finishReason: z.string().optional(),
+    responseTimeMs: z.number().optional(),
+    usage: z
+      .object({
+        completionTokens: z.number().optional(),
+        promptTokens: z.number().optional(),
+        totalTokens: z.number().optional(),
+        reasoningTokens: z.number().optional(),
+      })
+      .optional(),
+    generatedFiles: z.array(GeneratedCodeFileSchema).optional(),
+  })
+  .strict()
+
+const UpdateMessageMetadataBodySchema = z.object({
+  conversationId: z.string().min(1),
+  messageId: z.string().min(1),
+  metadata: AssistantMetadataPatchSchema,
+})
+
+const SaveGeneratedFileBodySchema = z.object({
+  conversationId: z.string().min(1),
+  messageId: z.string().min(1),
+  blockIndex: z.number().int().nonnegative(),
+  language: z.string().min(1),
+  content: z.string().min(1),
 })
 
 const conversationsRoutes = new Hono<HonoEnv>()
@@ -47,5 +79,75 @@ const conversationsRoutes = new Hono<HonoEnv>()
 
     return c.json(result)
   })
+  .patch(
+    '/api/conversations/messages/metadata',
+    requireAuth,
+    sValidator('json', UpdateMessageMetadataBodySchema),
+    async (c) => {
+      const { DATABASE_URL = '' } = getServerEnv(c)
+      const email = c.get('email')
+      const body = c.req.valid('json')
+      const result = await chatConversationRepository.updateMessageMetadata(DATABASE_URL, email, {
+        conversationId: body.conversationId,
+        messageId: body.messageId,
+        metadataPatch: body.metadata,
+      })
+
+      if (!result.ok) {
+        if (result.reason === 'user-not-found' || result.reason === 'message-not-found') {
+          return c.json({ error: 'Not found' }, 404)
+        }
+        if (result.reason === 'forbidden') {
+          return c.json({ error: 'Forbidden' }, 403)
+        }
+        return c.json({ error: 'Only assistant messages can be updated' }, 400)
+      }
+
+      return c.json({ metadata: result.metadata })
+    }
+  )
+  .post(
+    '/api/conversations/messages/generated-files',
+    requireAuth,
+    sValidator('json', SaveGeneratedFileBodySchema),
+    async (c) => {
+      const env = getServerEnv(c)
+      const { DATABASE_URL = '' } = env
+      const email = c.get('email')
+      const body = c.req.valid('json')
+      const fileServerConfig = resolveFileServerConfig(env)
+
+      const result = await chatConversationRepository.saveGeneratedFile(
+        DATABASE_URL,
+        email,
+        {
+          conversationId: body.conversationId,
+          messageId: body.messageId,
+          blockIndex: body.blockIndex,
+          language: body.language,
+          content: body.content,
+        },
+        fileServerConfig
+      )
+
+      if (!result.ok) {
+        if (result.reason === 'user-not-found' || result.reason === 'message-not-found') {
+          return c.json({ error: 'Not found' }, 404)
+        }
+        if (result.reason === 'forbidden') {
+          return c.json({ error: 'Forbidden' }, 403)
+        }
+        if (result.reason === 'invalid-role') {
+          return c.json({ error: 'Unsupported language or message role' }, 400)
+        }
+        if (result.reason === 'file-server-unavailable') {
+          return c.json({ error: 'File server not configured' }, 503)
+        }
+        return c.json({ error: 'Failed to upload generated file' }, 502)
+      }
+
+      return c.json({ file: result.file, alreadyExisted: result.alreadyExisted })
+    }
+  )
 
 export { conversationsRoutes }

--- a/projects/portfolio/src/server/routes/shared.ts
+++ b/projects/portfolio/src/server/routes/shared.ts
@@ -12,6 +12,9 @@ export type Env = Partial<{
   COOKIE_EXPIRES: string
   LOG_LEVEL: string
   LOG_FILE: string
+  FILE_SERVER_URL: string
+  FILE_SERVER_ADMIN_USERNAME: string
+  FILE_SERVER_ADMIN_PASSWORD: string
 }>
 
 export type HonoEnv = {

--- a/projects/portfolio/src/types/chat.ts
+++ b/projects/portfolio/src/types/chat.ts
@@ -48,6 +48,18 @@ export const UserMessageSchema = z.object({
 
 export type UserMessage = z.infer<typeof UserMessageSchema>
 
+export const GeneratedCodeFileSchema = z.object({
+  blockIndex: z.number().int().nonnegative(),
+  language: z.string(),
+  fileName: z.string(),
+  publicPath: z.string(),
+  previewUrl: z.string(),
+  contentType: z.string(),
+  createdAt: z.string(),
+})
+
+export type GeneratedCodeFile = z.infer<typeof GeneratedCodeFileSchema>
+
 export const AssistantMetadataSchema = z
   .object({
     model: z.string().catch(''),
@@ -61,6 +73,7 @@ export const AssistantMetadataSchema = z
         reasoningTokens: z.number().optional(),
       })
       .catch({}),
+    generatedFiles: z.array(GeneratedCodeFileSchema).optional(),
   })
   .catch({ model: '', usage: {} })
 

--- a/projects/portfolio/src/types/index.ts
+++ b/projects/portfolio/src/types/index.ts
@@ -8,6 +8,7 @@ export {
   SystemMessageSchema,
   UserMetadataSchema,
   AssistantMetadataSchema,
+  GeneratedCodeFileSchema,
   ImageContentSchema,
   TextContentSchema,
   // /api/chat wire schemas
@@ -21,6 +22,7 @@ export {
   type SystemMessage,
   type UserMetadata,
   type AssistantMetadata,
+  type GeneratedCodeFile,
   type ImageContent,
   type TextContent,
   // /api/chat wire types

--- a/projects/portfolio/tests/client/components/message-renderer.test.tsx
+++ b/projects/portfolio/tests/client/components/message-renderer.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+
+import { MessageRenderer } from '#/client/components/chat/message-renderer'
+import type { AssistantMessage } from '#/types'
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('react-syntax-highlighter', () => ({
+  Prism: ({ children }: { children: string }) => <pre>{children}</pre>,
+}))
+
+vi.mock('react-syntax-highlighter/dist/cjs/styles/prism', () => ({
+  atomDark: {},
+}))
+
+afterEach(() => {
+  cleanup()
+})
+
+function createAssistantMessage(
+  content: string,
+  generatedFiles?: AssistantMessage['metadata']['generatedFiles']
+): AssistantMessage {
+  return {
+    id: 'message-1',
+    role: 'assistant',
+    content,
+    reasoningContent: '',
+    metadata: {
+      model: 'gpt-test',
+      usage: {},
+      generatedFiles,
+    },
+  }
+}
+
+describe('MessageRenderer', () => {
+  describe('生成コードアクション', () => {
+    it('未認証なら対応言語でも生成ボタンを表示しない', () => {
+      render(
+        <MessageRenderer
+          message={createAssistantMessage('```html\n<div>Hello</div>\n```')}
+          index={0}
+          conversationId='conversation-1'
+          canSaveGeneratedFile={false}
+          markdownPreview={true}
+          copied={false}
+          onCopyMessage={vi.fn()}
+          onSaveGeneratedFile={vi.fn().mockResolvedValue(null)}
+        />
+      )
+
+      expect(screen.queryByRole('button', { name: '生成' })).toBeNull()
+    })
+
+    it('認証済みなら対応言語の生成ボタンを表示する', () => {
+      render(
+        <MessageRenderer
+          message={createAssistantMessage('```html\n<div>Hello</div>\n```')}
+          index={0}
+          conversationId='conversation-1'
+          canSaveGeneratedFile={true}
+          markdownPreview={true}
+          copied={false}
+          onCopyMessage={vi.fn()}
+          onSaveGeneratedFile={vi.fn().mockResolvedValue(null)}
+        />
+      )
+
+      expect(screen.getByRole('button', { name: '生成' })).toBeTruthy()
+    })
+
+    it('非対応言語なら認証済みでも生成ボタンを表示しない', () => {
+      render(
+        <MessageRenderer
+          message={createAssistantMessage('```typescript\nconst value = 1\n```')}
+          index={0}
+          conversationId='conversation-1'
+          canSaveGeneratedFile={true}
+          markdownPreview={true}
+          copied={false}
+          onCopyMessage={vi.fn()}
+          onSaveGeneratedFile={vi.fn().mockResolvedValue(null)}
+        />
+      )
+
+      expect(screen.queryByRole('button', { name: '生成' })).toBeNull()
+    })
+  })
+
+  describe('既存生成ファイル', () => {
+    it('未認証でも既存プレビューは表示する', () => {
+      render(
+        <MessageRenderer
+          message={createAssistantMessage('```html\n<div>Hello</div>\n```', [
+            {
+              blockIndex: 0,
+              language: 'html',
+              fileName: 'message-1-block-0.html',
+              publicPath: '/public/portfolio/c1/message-1-block-0.html',
+              previewUrl: 'http://localhost/public/portfolio/c1/message-1-block-0.html',
+              contentType: 'text/html; charset=utf-8',
+              createdAt: '2026-04-19T00:00:00.000Z',
+            },
+          ])}
+          index={0}
+          conversationId='conversation-1'
+          canSaveGeneratedFile={false}
+          markdownPreview={true}
+          copied={false}
+          onCopyMessage={vi.fn()}
+          onSaveGeneratedFile={vi.fn().mockResolvedValue(null)}
+        />
+      )
+
+      expect(screen.getByRole('link', { name: 'プレビュー' })).toBeTruthy()
+      expect(screen.queryByRole('button', { name: '生成' })).toBeNull()
+    })
+  })
+})

--- a/projects/portfolio/tests/features/chat-conversations/save-generated-file.test.ts
+++ b/projects/portfolio/tests/features/chat-conversations/save-generated-file.test.ts
@@ -185,7 +185,7 @@ describe('saveGeneratedFile', () => {
       expect.objectContaining({
         fileName: 'm1-block-2.svg',
         contentType: 'image/svg+xml; charset=utf-8',
-        path: 'public/portfolio/c1',
+        path: 'public/portfolio/c1/m1-block-2.svg',
       })
     )
     expect(updateSets[0]).toMatchObject({

--- a/projects/portfolio/tests/features/chat-conversations/save-generated-file.test.ts
+++ b/projects/portfolio/tests/features/chat-conversations/save-generated-file.test.ts
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mockLogger } from '../../helpers/mock-logger'
+
+const importSubject = async (params: {
+  users: Array<{ id: string; email: string }>
+  ownedRow?: {
+    messageId: string
+    role: string
+    metadata: unknown
+    conversationUserId: string
+  }
+}) => {
+  mockLogger()
+  const updateSets: unknown[] = []
+  let selectCall = 0
+
+  const db = {
+    select: vi.fn(() => {
+      selectCall += 1
+      if (selectCall === 1) {
+        return {
+          from: vi.fn(() => ({
+            where: vi.fn().mockResolvedValue(params.users),
+          })),
+        }
+      }
+      return {
+        from: vi.fn(() => ({
+          innerJoin: vi.fn(() => ({
+            where: vi.fn().mockResolvedValue(params.ownedRow ? [params.ownedRow] : []),
+          })),
+        })),
+      }
+    }),
+    update: vi.fn(() => ({
+      set: vi.fn((values: unknown) => {
+        updateSets.push(values)
+        return { where: vi.fn().mockResolvedValue(undefined) }
+      }),
+    })),
+  }
+
+  vi.doMock('#/db', () => ({
+    getDatabase: vi.fn(() => db),
+  }))
+
+  const loginToFileServer = vi.fn().mockResolvedValue('session-value')
+  const uploadFileToFileServer = vi.fn().mockResolvedValue(undefined)
+  vi.doMock('#/server/features/chat-conversations/file-server-client', () => ({
+    loginToFileServer,
+    uploadFileToFileServer,
+  }))
+
+  const { saveGeneratedFile, resolveExtension } =
+    await import('#/server/features/chat-conversations/save-generated-file')
+  return { saveGeneratedFile, resolveExtension, updateSets, loginToFileServer, uploadFileToFileServer }
+}
+
+describe('saveGeneratedFile', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  it('file-server config が null なら file-server-unavailable を返す', async () => {
+    const { saveGeneratedFile, loginToFileServer } = await importSubject({
+      users: [{ id: 'u1', email: 'x@example.com' }],
+    })
+
+    const result = await saveGeneratedFile(
+      'postgres://db',
+      'x@example.com',
+      {
+        conversationId: 'c1',
+        messageId: 'm1',
+        blockIndex: 0,
+        language: 'html',
+        content: '<p>hello</p>',
+      },
+      null
+    )
+
+    expect(result).toEqual({ ok: false, reason: 'file-server-unavailable' })
+    expect(loginToFileServer).not.toHaveBeenCalled()
+  })
+
+  it('未対応の language は invalid-role を返す', async () => {
+    const { saveGeneratedFile } = await importSubject({
+      users: [{ id: 'u1', email: 'x@example.com' }],
+    })
+
+    const result = await saveGeneratedFile(
+      'postgres://db',
+      'x@example.com',
+      {
+        conversationId: 'c1',
+        messageId: 'm1',
+        blockIndex: 0,
+        language: 'python',
+        content: 'print(1)',
+      },
+      { baseUrl: 'http://fs', credentials: { username: 'admin', password: 'p' } }
+    )
+
+    expect(result.ok).toBe(false)
+  })
+
+  it('他ユーザーの conversation には forbidden を返す', async () => {
+    const { saveGeneratedFile } = await importSubject({
+      users: [{ id: 'u1', email: 'x@example.com' }],
+      ownedRow: { messageId: 'm1', role: 'assistant', metadata: {}, conversationUserId: 'other' },
+    })
+
+    const result = await saveGeneratedFile(
+      'postgres://db',
+      'x@example.com',
+      {
+        conversationId: 'c1',
+        messageId: 'm1',
+        blockIndex: 0,
+        language: 'html',
+        content: '<p/>',
+      },
+      { baseUrl: 'http://fs', credentials: { username: 'admin', password: 'p' } }
+    )
+
+    expect(result).toEqual({ ok: false, reason: 'forbidden' })
+  })
+
+  it('初回保存時のみ upload 実行し、再実行時は既存 file を返す', async () => {
+    const existing = {
+      blockIndex: 0,
+      language: 'html',
+      fileName: 'm1-block-0.html',
+      publicPath: '/public/portfolio/c1/m1-block-0.html',
+      previewUrl: 'http://fs/public/portfolio/c1/m1-block-0.html',
+      contentType: 'text/html; charset=utf-8',
+      createdAt: '2026-04-19T00:00:00.000Z',
+    }
+
+    // 再実行ケース
+    const { saveGeneratedFile, uploadFileToFileServer } = await importSubject({
+      users: [{ id: 'u1', email: 'x@example.com' }],
+      ownedRow: {
+        messageId: 'm1',
+        role: 'assistant',
+        metadata: { generatedFiles: [existing] },
+        conversationUserId: 'u1',
+      },
+    })
+
+    const result = await saveGeneratedFile(
+      'postgres://db',
+      'x@example.com',
+      { conversationId: 'c1', messageId: 'm1', blockIndex: 0, language: 'html', content: '<p/>' },
+      { baseUrl: 'http://fs', credentials: { username: 'admin', password: 'p' } }
+    )
+
+    expect(result).toEqual({ ok: true, file: existing, alreadyExisted: true })
+    expect(uploadFileToFileServer).not.toHaveBeenCalled()
+  })
+
+  it('新規保存時は login+upload して metadata.generatedFiles を更新する', async () => {
+    const { saveGeneratedFile, updateSets, loginToFileServer, uploadFileToFileServer } = await importSubject({
+      users: [{ id: 'u1', email: 'x@example.com' }],
+      ownedRow: {
+        messageId: 'm1',
+        role: 'assistant',
+        metadata: { model: 'gpt' },
+        conversationUserId: 'u1',
+      },
+    })
+
+    const result = await saveGeneratedFile(
+      'postgres://db',
+      'x@example.com',
+      { conversationId: 'c1', messageId: 'm1', blockIndex: 2, language: 'svg', content: '<svg/>' },
+      { baseUrl: 'http://fs', credentials: { username: 'admin', password: 'p' } }
+    )
+
+    expect(result.ok).toBe(true)
+    expect(loginToFileServer).toHaveBeenCalled()
+    expect(uploadFileToFileServer).toHaveBeenCalledWith(
+      expect.anything(),
+      'session-value',
+      expect.objectContaining({
+        fileName: 'm1-block-2.svg',
+        contentType: 'image/svg+xml; charset=utf-8',
+        path: 'public/portfolio/c1',
+      })
+    )
+    expect(updateSets[0]).toMatchObject({
+      metadata: {
+        model: 'gpt',
+        generatedFiles: [
+          expect.objectContaining({
+            blockIndex: 2,
+            publicPath: '/public/portfolio/c1/m1-block-2.svg',
+            previewUrl: 'http://fs/public/portfolio/c1/m1-block-2.svg',
+          }),
+        ],
+      },
+    })
+  })
+})

--- a/projects/portfolio/tests/features/chat-conversations/update-message-metadata.test.ts
+++ b/projects/portfolio/tests/features/chat-conversations/update-message-metadata.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mockLogger } from '../../helpers/mock-logger'
+
+const importSubject = async (params: {
+  users: Array<{ id: string; email: string }>
+  ownedRow?: {
+    messageId: string
+    role: string
+    metadata: unknown
+    conversationUserId: string
+  }
+}) => {
+  mockLogger()
+  const updateSets: unknown[] = []
+  let selectCall = 0
+
+  const db = {
+    select: vi.fn(() => {
+      selectCall += 1
+      if (selectCall === 1) {
+        return {
+          from: vi.fn(() => ({
+            where: vi.fn().mockResolvedValue(params.users),
+          })),
+        }
+      }
+      return {
+        from: vi.fn(() => ({
+          innerJoin: vi.fn(() => ({
+            where: vi.fn().mockResolvedValue(params.ownedRow ? [params.ownedRow] : []),
+          })),
+        })),
+      }
+    }),
+    update: vi.fn(() => ({
+      set: vi.fn((values: unknown) => {
+        updateSets.push(values)
+        return { where: vi.fn().mockResolvedValue(undefined) }
+      }),
+    })),
+  }
+
+  vi.doMock('#/db', () => ({
+    getDatabase: vi.fn(() => db),
+  }))
+
+  const { updateMessageMetadata } = await import('#/server/features/chat-conversations/update-message-metadata')
+  return { updateMessageMetadata, updateSets }
+}
+
+describe('updateMessageMetadata', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  it('ユーザーが居なければ user-not-found を返す', async () => {
+    const { updateMessageMetadata } = await importSubject({ users: [] })
+
+    const result = await updateMessageMetadata('postgres://db', 'x@example.com', {
+      conversationId: 'c1',
+      messageId: 'm1',
+      metadataPatch: { finishReason: 'stop' },
+    })
+
+    expect(result).toEqual({ ok: false, reason: 'user-not-found' })
+  })
+
+  it('message が無ければ message-not-found を返す', async () => {
+    const { updateMessageMetadata } = await importSubject({
+      users: [{ id: 'u1', email: 'x@example.com' }],
+      ownedRow: undefined,
+    })
+
+    const result = await updateMessageMetadata('postgres://db', 'x@example.com', {
+      conversationId: 'c1',
+      messageId: 'm1',
+      metadataPatch: {},
+    })
+
+    expect(result).toEqual({ ok: false, reason: 'message-not-found' })
+  })
+
+  it('他ユーザーの conversation には forbidden を返す', async () => {
+    const { updateMessageMetadata } = await importSubject({
+      users: [{ id: 'u1', email: 'x@example.com' }],
+      ownedRow: {
+        messageId: 'm1',
+        role: 'assistant',
+        metadata: {},
+        conversationUserId: 'other-user',
+      },
+    })
+
+    const result = await updateMessageMetadata('postgres://db', 'x@example.com', {
+      conversationId: 'c1',
+      messageId: 'm1',
+      metadataPatch: {},
+    })
+
+    expect(result).toEqual({ ok: false, reason: 'forbidden' })
+  })
+
+  it('assistant 以外は invalid-role を返す', async () => {
+    const { updateMessageMetadata } = await importSubject({
+      users: [{ id: 'u1', email: 'x@example.com' }],
+      ownedRow: {
+        messageId: 'm1',
+        role: 'user',
+        metadata: {},
+        conversationUserId: 'u1',
+      },
+    })
+
+    const result = await updateMessageMetadata('postgres://db', 'x@example.com', {
+      conversationId: 'c1',
+      messageId: 'm1',
+      metadataPatch: {},
+    })
+
+    expect(result).toEqual({ ok: false, reason: 'invalid-role' })
+  })
+
+  it('既存 metadata を壊さず merge して保存する', async () => {
+    const { updateMessageMetadata, updateSets } = await importSubject({
+      users: [{ id: 'u1', email: 'x@example.com' }],
+      ownedRow: {
+        messageId: 'm1',
+        role: 'assistant',
+        metadata: { model: 'gpt', usage: { totalTokens: 10 } },
+        conversationUserId: 'u1',
+      },
+    })
+
+    const result = await updateMessageMetadata('postgres://db', 'x@example.com', {
+      conversationId: 'c1',
+      messageId: 'm1',
+      metadataPatch: { finishReason: 'stop' },
+    })
+
+    expect(result.ok).toBe(true)
+    expect(updateSets[0]).toEqual({
+      metadata: {
+        model: 'gpt',
+        usage: { totalTokens: 10 },
+        finishReason: 'stop',
+      },
+    })
+  })
+})

--- a/projects/portfolio/tests/features/chat-conversations/update-message-metadata.test.ts
+++ b/projects/portfolio/tests/features/chat-conversations/update-message-metadata.test.ts
@@ -120,6 +120,31 @@ describe('updateMessageMetadata', () => {
     expect(result).toEqual({ ok: false, reason: 'invalid-role' })
   })
 
+  it('usage を patch するとき既存フィールドを deep merge する', async () => {
+    const { updateMessageMetadata, updateSets } = await importSubject({
+      users: [{ id: 'u1', email: 'x@example.com' }],
+      ownedRow: {
+        messageId: 'm1',
+        role: 'assistant',
+        metadata: { model: 'gpt', usage: { promptTokens: 100, completionTokens: 50, totalTokens: 150 } },
+        conversationUserId: 'u1',
+      },
+    })
+
+    await updateMessageMetadata('postgres://db', 'x@example.com', {
+      conversationId: 'c1',
+      messageId: 'm1',
+      metadataPatch: { usage: { completionTokens: 1 } },
+    })
+
+    expect(updateSets[0]).toEqual({
+      metadata: {
+        model: 'gpt',
+        usage: { promptTokens: 100, completionTokens: 1, totalTokens: 150 },
+      },
+    })
+  })
+
   it('既存 metadata を壊さず merge して保存する', async () => {
     const { updateMessageMetadata, updateSets } = await importSubject({
       users: [{ id: 'u1', email: 'x@example.com' }],

--- a/projects/portfolio/tests/features/chat-conversations/upsert-conversation.test.ts
+++ b/projects/portfolio/tests/features/chat-conversations/upsert-conversation.test.ts
@@ -125,6 +125,39 @@ describe('upsertConversation', () => {
     expect(uuidv7).toHaveBeenCalled()
   })
 
+  it('message.id が指定されていれば既存 id を保持する', async () => {
+    const { upsertConversation, insertValues, uuidv7 } = await importSubject({
+      users: [{ id: 'user-1', email: 'test@example.com' }],
+      existingConversations: [],
+    })
+
+    await upsertConversation('postgres://db', 'test@example.com', {
+      id: 'conversation-1',
+      title: 'title',
+      messages: [
+        {
+          id: 'keep-this-id',
+          role: 'assistant',
+          content: 'hi',
+          metadata: { model: 'gpt-test', usage: {} },
+        },
+        {
+          role: 'user',
+          content: 'no id',
+          reasoningContent: '',
+          metadata: { model: '' },
+        },
+      ],
+    })
+
+    expect(insertValues[1]).toEqual([
+      expect.objectContaining({ id: 'keep-this-id' }),
+      expect.objectContaining({ id: 'generated-message-id' }),
+    ])
+    // 既存 id を持つ message では uuidv7 を呼ばないこと
+    expect(uuidv7).toHaveBeenCalledTimes(1)
+  })
+
   it('既存会話は updatedAt を更新し、既存 message を削除して全件再挿入する', async () => {
     const { upsertConversation, updateSets, insertValues, deleteWheres } = await importSubject({
       users: [{ id: 'user-1', email: 'test@example.com' }],

--- a/projects/portfolio/tests/routes/conversations.test.ts
+++ b/projects/portfolio/tests/routes/conversations.test.ts
@@ -8,6 +8,8 @@ const { getSignedCookieMock, repositoryMock } = vi.hoisted(() => ({
     upsert: vi.fn(),
     delete: vi.fn(),
     deleteMessages: vi.fn(),
+    updateMessageMetadata: vi.fn(),
+    saveGeneratedFile: vi.fn(),
   },
 }))
 
@@ -123,6 +125,120 @@ describe('conversationsRoutes', () => {
 
     expect(res.status).toBe(200)
     expect(repositoryMock.delete).toHaveBeenCalledWith('postgres://db', 'test@example.com', ['conversation-1'])
+  })
+
+  it('PATCH /messages/metadata は認証必須', async () => {
+    vi.stubEnv('DATABASE_URL', 'postgres://db')
+    getSignedCookieMock.mockResolvedValue(null)
+
+    const res = await conversationsRoutes.request('/api/conversations/messages/metadata', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ conversationId: 'c1', messageId: 'm1', metadata: {} }),
+    })
+
+    expect(res.status).toBe(401)
+  })
+
+  it('PATCH /messages/metadata は assistant 以外なら 400 を返す', async () => {
+    vi.stubEnv('DATABASE_URL', 'postgres://db')
+    getSignedCookieMock.mockResolvedValue('test@example.com')
+    repositoryMock.updateMessageMetadata.mockResolvedValue({ ok: false, reason: 'invalid-role' })
+
+    const res = await conversationsRoutes.request('/api/conversations/messages/metadata', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ conversationId: 'c1', messageId: 'm1', metadata: { finishReason: 'stop' } }),
+    })
+
+    expect(res.status).toBe(400)
+  })
+
+  it('PATCH /messages/metadata は他ユーザーに forbidden で 403 を返す', async () => {
+    vi.stubEnv('DATABASE_URL', 'postgres://db')
+    getSignedCookieMock.mockResolvedValue('test@example.com')
+    repositoryMock.updateMessageMetadata.mockResolvedValue({ ok: false, reason: 'forbidden' })
+
+    const res = await conversationsRoutes.request('/api/conversations/messages/metadata', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ conversationId: 'c1', messageId: 'm1', metadata: {} }),
+    })
+
+    expect(res.status).toBe(403)
+  })
+
+  it('PATCH /messages/metadata は成功時に更新後の metadata を返す', async () => {
+    vi.stubEnv('DATABASE_URL', 'postgres://db')
+    getSignedCookieMock.mockResolvedValue('test@example.com')
+    repositoryMock.updateMessageMetadata.mockResolvedValue({
+      ok: true,
+      metadata: { model: 'gpt', usage: {}, finishReason: 'stop' },
+    })
+
+    const res = await conversationsRoutes.request('/api/conversations/messages/metadata', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ conversationId: 'c1', messageId: 'm1', metadata: { finishReason: 'stop' } }),
+    })
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({
+      metadata: { model: 'gpt', usage: {}, finishReason: 'stop' },
+    })
+  })
+
+  it('POST /messages/generated-files は file-server 未設定なら 503 を返す', async () => {
+    vi.stubEnv('DATABASE_URL', 'postgres://db')
+    vi.stubEnv('FILE_SERVER_URL', '')
+    vi.stubEnv('FILE_SERVER_ADMIN_USERNAME', '')
+    vi.stubEnv('FILE_SERVER_ADMIN_PASSWORD', '')
+    getSignedCookieMock.mockResolvedValue('test@example.com')
+    repositoryMock.saveGeneratedFile.mockResolvedValue({ ok: false, reason: 'file-server-unavailable' })
+
+    const res = await conversationsRoutes.request('/api/conversations/messages/generated-files', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        conversationId: 'c1',
+        messageId: 'm1',
+        blockIndex: 0,
+        language: 'html',
+        content: '<p/>',
+      }),
+    })
+
+    expect(res.status).toBe(503)
+  })
+
+  it('POST /messages/generated-files は成功時に file と alreadyExisted を返す', async () => {
+    vi.stubEnv('DATABASE_URL', 'postgres://db')
+    getSignedCookieMock.mockResolvedValue('test@example.com')
+    const file = {
+      blockIndex: 0,
+      language: 'html',
+      fileName: 'm1-block-0.html',
+      publicPath: '/public/portfolio/c1/m1-block-0.html',
+      previewUrl: 'http://fs/public/portfolio/c1/m1-block-0.html',
+      contentType: 'text/html; charset=utf-8',
+      createdAt: '2026-04-19T00:00:00.000Z',
+    }
+    repositoryMock.saveGeneratedFile.mockResolvedValue({ ok: true, file, alreadyExisted: false })
+
+    const res = await conversationsRoutes.request('/api/conversations/messages/generated-files', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        conversationId: 'c1',
+        messageId: 'm1',
+        blockIndex: 0,
+        language: 'html',
+        content: '<p/>',
+      }),
+    })
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({ file, alreadyExisted: false })
   })
 
   it('DELETE /messages は複数 query を repository.deleteMessages に渡す', async () => {

--- a/projects/portfolio/tests/types/chat.test.ts
+++ b/projects/portfolio/tests/types/chat.test.ts
@@ -1,4 +1,4 @@
-import { ConversationListResponseSchema } from '#/types'
+import { AssistantMetadataSchema, ConversationListResponseSchema, GeneratedCodeFileSchema } from '#/types'
 import { describe, expect, it } from 'vitest'
 
 describe('chat types', () => {
@@ -58,6 +58,64 @@ describe('chat types', () => {
           ],
         },
       ],
+    })
+  })
+
+  describe('AssistantMetadataSchema', () => {
+    it('generatedFiles を parse できる', () => {
+      const parsed = AssistantMetadataSchema.parse({
+        model: 'gpt',
+        usage: {},
+        generatedFiles: [
+          {
+            blockIndex: 0,
+            language: 'html',
+            fileName: 'msg-1-block-0.html',
+            publicPath: '/public/portfolio/conv-1/msg-1-block-0.html',
+            previewUrl: 'http://localhost:3001/public/portfolio/conv-1/msg-1-block-0.html',
+            contentType: 'text/html; charset=utf-8',
+            createdAt: '2026-04-19T00:00:00.000Z',
+          },
+        ],
+      })
+
+      expect(parsed.generatedFiles).toHaveLength(1)
+      expect(parsed.generatedFiles?.[0].blockIndex).toBe(0)
+    })
+
+    it('generatedFiles 未指定の metadata も parse できる', () => {
+      const parsed = AssistantMetadataSchema.parse({ model: 'gpt', usage: {} })
+      expect(parsed.generatedFiles).toBeUndefined()
+    })
+  })
+
+  describe('GeneratedCodeFileSchema', () => {
+    it('必須フィールドが揃っていれば parse できる', () => {
+      expect(() =>
+        GeneratedCodeFileSchema.parse({
+          blockIndex: 2,
+          language: 'svg',
+          fileName: 'msg-1-block-2.svg',
+          publicPath: '/public/portfolio/conv/msg-1-block-2.svg',
+          previewUrl: 'http://fs/public/portfolio/conv/msg-1-block-2.svg',
+          contentType: 'image/svg+xml; charset=utf-8',
+          createdAt: '2026-04-19T00:00:00.000Z',
+        })
+      ).not.toThrow()
+    })
+
+    it('blockIndex が負の値なら reject する', () => {
+      expect(() =>
+        GeneratedCodeFileSchema.parse({
+          blockIndex: -1,
+          language: 'svg',
+          fileName: 'f.svg',
+          publicPath: '/public/f.svg',
+          previewUrl: 'http://f/f.svg',
+          contentType: 'image/svg+xml',
+          createdAt: '2026-04-19T00:00:00.000Z',
+        })
+      ).toThrow()
     })
   })
 


### PR DESCRIPTION
## Issues

- Close #826

## Why

Portfolio の chat UI で assistant が生成した HTML / SVG の fenced code block を file-server 配下の公開パスに保存して、ブラウザで直接プレビューできる導線を整えるため。

## Summary

assistant メッセージの各 fenced code block に `blockIndex` を割り当て、HTML / SVG を `public/portfolio/<conversationId>/<messageId>-block-<blockIndex>.<ext>` として file-server にアップロードし、`metadata.generatedFiles` で再生成時の重複を抑止しつつプレビュー URL を提供する。

## Changes

- `AssistantMetadataSchema` に `generatedFiles` を追加し、共通の `GeneratedCodeFileSchema` を types から export
- `upsertConversation` で既存 `message.id` を保持するように修正
- `PATCH /api/conversations/messages/metadata` を追加し assistant metadata を部分更新できるようにする
- `POST /api/conversations/messages/generated-files` を追加し file-server への login / upload / metadata 更新を一括で処理
- `file-server-client` ヘルパーで admin credentials による session cookie 取得と `/api/upload` 呼び出しを集約
- chat UI に `AssistantCodeBlockContext` を追加し、render 順に安定した `blockIndex` で html/svg の「生成」「プレビュー」操作を提供（streaming 中 / inline code は対象外）
- `FILE_SERVER_URL` / `FILE_SERVER_ADMIN_USERNAME` / `FILE_SERVER_ADMIN_PASSWORD` を `.env.example` に追加
- types / features / routes に対応するテストを追加 / 更新

## Checklist

- [x] `bun run lint`
- [x] `bun run test`
- [x] `.env.example` を更新
- [ ] file-server 側は変更していないこと確認（AUTH_DIR ブート済みの admin を利用する前提）

## Details

- 保存パス: `public/portfolio/<conversationId>/<messageId>-block-<blockIndex>.<ext>`
- 対応拡張子: `html` / `htm` / `xhtml` / `svg`（それ以外は 400 `invalid-role` 相当を返す）
- 重複保存は `metadata.generatedFiles[].blockIndex` を見て `alreadyExisted: true` で既存 file を返す
- file-server の admin credentials は将来 user 単位の認可へ差し替えられるよう `resolveFileServerConfig` に閉じ込めている
