### PR TITLE
fix(file-server): add utf-8 charset to HTML responses

### DIFF
--- a/projects/file-server/src/routes/file.tsx
+++ b/projects/file-server/src/routes/file.tsx
@@ -95,7 +95,7 @@ fileRoutes.get("/", async (c) => {
 
   const contentBuffer = await readFile(resolved.resolvedPath)
   const headers: Record<string, string> = {
-    "Content-Type": resolved.mimeType,
+    "Content-Type": resolved.responseMimeType,
     "Content-Disposition": `attachment; filename*=UTF-8''${encodeURIComponent(path.basename(resolved.resolvedPath))}`,
   }
   return new Response(toArrayBuffer(contentBuffer), { headers })
@@ -120,7 +120,10 @@ fileRoutes.get("/raw", async (c) => {
     )
   }
 
-  return readBinaryFileResponse(resolved.resolvedPath, resolved.mimeType)
+  return readBinaryFileResponse(
+    resolved.resolvedPath,
+    resolved.responseMimeType,
+  )
 })
 
 fileRoutes.get("/download", async (c) => {
@@ -136,7 +139,7 @@ fileRoutes.get("/download", async (c) => {
   const contentBuffer = await readFile(resolved.resolvedPath)
   return new Response(toArrayBuffer(contentBuffer), {
     headers: {
-      "Content-Type": resolved.mimeType,
+      "Content-Type": resolved.responseMimeType,
       "Content-Disposition": `attachment; filename*=UTF-8''${encodeURIComponent(path.basename(resolved.resolvedPath))}`,
     },
   })

--- a/projects/file-server/src/routes/public.tsx
+++ b/projects/file-server/src/routes/public.tsx
@@ -1,7 +1,7 @@
 import * as path from "node:path"
 import { Hono } from "hono"
-import * as mime from "mime-types"
 import type { AppBindings } from "../types"
+import { resolveResponseMimeType } from "../utils/mimeType"
 import { isPathTraversal } from "../utils/pathTraversal"
 import { errorResponse, getUploadDir } from "../utils/requestUtils"
 
@@ -21,7 +21,7 @@ publicRoutes.get("/*", async (c) => {
   }
 
   const resolvedPath = path.join(baseDir, "public", rawPath)
-  const mimeType = mime.lookup(resolvedPath) || "application/octet-stream"
+  const responseMimeType = resolveResponseMimeType(resolvedPath)
 
   try {
     const { stat, readFile } = await import("node:fs/promises")
@@ -32,7 +32,7 @@ publicRoutes.get("/*", async (c) => {
 
     const content = await readFile(resolvedPath)
     return new Response(content, {
-      headers: { "Content-Type": mimeType },
+      headers: { "Content-Type": responseMimeType },
     })
   } catch (err: unknown) {
     const isEnoent =

--- a/projects/file-server/src/utils/fileRouteUtils.tsx
+++ b/projects/file-server/src/utils/fileRouteUtils.tsx
@@ -1,25 +1,25 @@
 import { readdir, readFile } from "node:fs/promises"
 import * as path from "node:path"
 import type { Context } from "hono"
-import * as mime from "mime-types"
 import type { AppBindings } from "../types"
+import { lookupMimeType, normalizeResponseMimeType } from "./mimeType"
 import { errorResponse, getRequestPath, getUploadDir } from "./requestUtils"
 import { resolveVirtualPath } from "./virtualPath"
 
 const ACTIVE_MIME_TYPES = new Set([
-	"text/html",
-	"application/xhtml+xml",
-	"image/svg+xml",
+  "text/html",
+  "application/xhtml+xml",
+  "image/svg+xml",
 ])
 
 const ACTIVE_EXTENSIONS = new Set([".html", ".htm", ".xhtml", ".svg"])
 
 export function isActiveContent(filePath: string, mimeType: string): boolean {
-	if (ACTIVE_MIME_TYPES.has(mimeType)) {
-		return true
-	}
-	const ext = path.extname(filePath).toLowerCase()
-	return ACTIVE_EXTENSIONS.has(ext)
+  if (ACTIVE_MIME_TYPES.has(mimeType)) {
+    return true
+  }
+  const ext = path.extname(filePath).toLowerCase()
+  return ACTIVE_EXTENSIONS.has(ext)
 }
 
 const EMPTY_ZIP_ARCHIVE = new Uint8Array([
@@ -128,11 +128,12 @@ export async function resolveRequestedFile(
   try {
     const { stat: fsStat } = await import("node:fs/promises")
     const statResult = await fsStat(resolvedPath)
-    const mimeType = mime.lookup(resolvedPath) || "application/octet-stream"
+    const mimeType = lookupMimeType(resolvedPath)
     return {
       baseDir,
       requestPath,
       resolvedPath,
+      responseMimeType: normalizeResponseMimeType(mimeType),
       stat: statResult,
       mimeType,
     }
@@ -151,11 +152,11 @@ export async function resolveRequestedFile(
 
 export async function readBinaryFileResponse(
   resolvedPath: string,
-  mimeType: string,
+  responseMimeType: string,
 ) {
   const contentBuffer = await readFile(resolvedPath)
   return new Response(toArrayBuffer(contentBuffer), {
-    headers: { "Content-Type": mimeType },
+    headers: { "Content-Type": responseMimeType },
   })
 }
 

--- a/projects/file-server/src/utils/mimeType.ts
+++ b/projects/file-server/src/utils/mimeType.ts
@@ -1,0 +1,32 @@
+import * as mime from "mime-types"
+
+const DEFAULT_MIME_TYPE = "application/octet-stream"
+
+export const lookupMimeType = (filePath: string) => {
+  const mimeType = mime.lookup(filePath)
+  return typeof mimeType === "string" ? mimeType : DEFAULT_MIME_TYPE
+}
+
+const isUtf8TextMime = (mimeType: string) =>
+  /^text\//.test(mimeType) ||
+  mimeType === "application/javascript" ||
+  mimeType === "application/json" ||
+  mimeType === "application/xml" ||
+  mimeType === "image/svg+xml" ||
+  mimeType.endsWith("+json") ||
+  mimeType.endsWith("+xml")
+
+export const normalizeResponseMimeType = (mimeType: string) => {
+  const [baseMimeType] = mimeType.split(";")
+  const normalizedMimeType =
+    baseMimeType?.trim().toLowerCase() || DEFAULT_MIME_TYPE
+
+  if (!isUtf8TextMime(normalizedMimeType) || /;\s*charset=/i.test(mimeType)) {
+    return normalizedMimeType
+  }
+
+  return `${normalizedMimeType}; charset=utf-8`
+}
+
+export const resolveResponseMimeType = (filePath: string) =>
+  normalizeResponseMimeType(lookupMimeType(filePath))

--- a/projects/file-server/src/utils/mimeType.ts
+++ b/projects/file-server/src/utils/mimeType.ts
@@ -21,8 +21,12 @@ export const normalizeResponseMimeType = (mimeType: string) => {
   const normalizedMimeType =
     baseMimeType?.trim().toLowerCase() || DEFAULT_MIME_TYPE
 
-  if (!isUtf8TextMime(normalizedMimeType) || /;\s*charset=/i.test(mimeType)) {
+  if (!isUtf8TextMime(normalizedMimeType)) {
     return normalizedMimeType
+  }
+
+  if (/;\s*charset=/i.test(mimeType)) {
+    return mimeType
   }
 
   return `${normalizedMimeType}; charset=utf-8`

--- a/projects/file-server/tests/file-raw-download.test.ts
+++ b/projects/file-server/tests/file-raw-download.test.ts
@@ -1,394 +1,397 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test"
 import { mkdir, rm } from "node:fs/promises"
 import * as path from "node:path"
-import { createTestApp } from "./helpers/createTestApp"
 import { createTestSession } from "./helpers/auth"
+import { createTestApp } from "./helpers/createTestApp"
 
 const SESSION_SECRET = "test-secret-for-raw-download"
 
 describe("GET /file/raw - active content blocking", () => {
-	const UPLOAD_DIR = "./tmp-test-raw-block"
-	let app: Awaited<ReturnType<typeof createTestApp>>
+  const UPLOAD_DIR = "./tmp-test-raw-block"
+  let app: Awaited<ReturnType<typeof createTestApp>>
 
-	beforeEach(async () => {
-		await rm(UPLOAD_DIR, { recursive: true, force: true })
-		app = await createTestApp({ uploadDir: UPLOAD_DIR })
-	})
+  beforeEach(async () => {
+    await rm(UPLOAD_DIR, { recursive: true, force: true })
+    app = await createTestApp({ uploadDir: UPLOAD_DIR })
+  })
 
-	afterEach(async () => {
-		await rm(UPLOAD_DIR, { recursive: true, force: true })
-	})
+  afterEach(async () => {
+    await rm(UPLOAD_DIR, { recursive: true, force: true })
+  })
 
-	it("should return 403 for HTML file in public", async () => {
-		await Bun.write(
-			path.join(UPLOAD_DIR, "public", "page.html"),
-			"<html><body>hello</body></html>",
-		)
-		const res = await app.request(
-			new Request("http://localhost/file/raw?path=public%2Fpage.html"),
-		)
-		expect(res.status).toBe(403)
-		const data = (await res.json()) as { error: { name: string } }
-		expect(data.error.name).toBe("ActiveContentNotAllowed")
-	})
+  it("should return 403 for HTML file in public", async () => {
+    await Bun.write(
+      path.join(UPLOAD_DIR, "public", "page.html"),
+      "<html><body>hello</body></html>",
+    )
+    const res = await app.request(
+      new Request("http://localhost/file/raw?path=public%2Fpage.html"),
+    )
+    expect(res.status).toBe(403)
+    const data = (await res.json()) as { error: { name: string } }
+    expect(data.error.name).toBe("ActiveContentNotAllowed")
+  })
 
-	it("should return 403 for .htm file", async () => {
-		await Bun.write(
-			path.join(UPLOAD_DIR, "public", "page.htm"),
-			"<html>hello</html>",
-		)
-		const res = await app.request(
-			new Request("http://localhost/file/raw?path=public%2Fpage.htm"),
-		)
-		expect(res.status).toBe(403)
-		const data = (await res.json()) as { error: { name: string } }
-		expect(data.error.name).toBe("ActiveContentNotAllowed")
-	})
+  it("should return 403 for .htm file", async () => {
+    await Bun.write(
+      path.join(UPLOAD_DIR, "public", "page.htm"),
+      "<html>hello</html>",
+    )
+    const res = await app.request(
+      new Request("http://localhost/file/raw?path=public%2Fpage.htm"),
+    )
+    expect(res.status).toBe(403)
+    const data = (await res.json()) as { error: { name: string } }
+    expect(data.error.name).toBe("ActiveContentNotAllowed")
+  })
 
-	it("should return 403 for .xhtml file", async () => {
-		await Bun.write(
-			path.join(UPLOAD_DIR, "public", "page.xhtml"),
-			'<?xml version="1.0"?><html xmlns="http://www.w3.org/1999/xhtml"></html>',
-		)
-		const res = await app.request(
-			new Request("http://localhost/file/raw?path=public%2Fpage.xhtml"),
-		)
-		expect(res.status).toBe(403)
-		const data = (await res.json()) as { error: { name: string } }
-		expect(data.error.name).toBe("ActiveContentNotAllowed")
-	})
+  it("should return 403 for .xhtml file", async () => {
+    await Bun.write(
+      path.join(UPLOAD_DIR, "public", "page.xhtml"),
+      '<?xml version="1.0"?><html xmlns="http://www.w3.org/1999/xhtml"></html>',
+    )
+    const res = await app.request(
+      new Request("http://localhost/file/raw?path=public%2Fpage.xhtml"),
+    )
+    expect(res.status).toBe(403)
+    const data = (await res.json()) as { error: { name: string } }
+    expect(data.error.name).toBe("ActiveContentNotAllowed")
+  })
 
-	it("should return 403 for SVG file", async () => {
-		await Bun.write(
-			path.join(UPLOAD_DIR, "public", "image.svg"),
-			'<svg xmlns="http://www.w3.org/2000/svg"><circle r="10"/></svg>',
-		)
-		const res = await app.request(
-			new Request("http://localhost/file/raw?path=public%2Fimage.svg"),
-		)
-		expect(res.status).toBe(403)
-		const data = (await res.json()) as { error: { name: string } }
-		expect(data.error.name).toBe("ActiveContentNotAllowed")
-	})
+  it("should return 403 for SVG file", async () => {
+    await Bun.write(
+      path.join(UPLOAD_DIR, "public", "image.svg"),
+      '<svg xmlns="http://www.w3.org/2000/svg"><circle r="10"/></svg>',
+    )
+    const res = await app.request(
+      new Request("http://localhost/file/raw?path=public%2Fimage.svg"),
+    )
+    expect(res.status).toBe(403)
+    const data = (await res.json()) as { error: { name: string } }
+    expect(data.error.name).toBe("ActiveContentNotAllowed")
+  })
 
-	it("should serve PNG image without block", async () => {
-		const pngBytes = new Uint8Array([
-			0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
-		])
-		await Bun.write(path.join(UPLOAD_DIR, "public", "image.png"), pngBytes)
-		const res = await app.request(
-			new Request("http://localhost/file/raw?path=public%2Fimage.png"),
-		)
-		expect(res.status).toBe(200)
-		expect(res.headers.get("Content-Type")).toContain("image/png")
-	})
+  it("should serve PNG image without block", async () => {
+    const pngBytes = new Uint8Array([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+    ])
+    await Bun.write(path.join(UPLOAD_DIR, "public", "image.png"), pngBytes)
+    const res = await app.request(
+      new Request("http://localhost/file/raw?path=public%2Fimage.png"),
+    )
+    expect(res.status).toBe(200)
+    expect(res.headers.get("Content-Type")).toContain("image/png")
+  })
 
-	it("should serve text file without block", async () => {
-		await Bun.write(path.join(UPLOAD_DIR, "public", "note.txt"), "hello world")
-		const res = await app.request(
-			new Request("http://localhost/file/raw?path=public%2Fnote.txt"),
-		)
-		expect(res.status).toBe(200)
-	})
+  it("should serve text file without block", async () => {
+    await Bun.write(path.join(UPLOAD_DIR, "public", "note.txt"), "hello world")
+    const res = await app.request(
+      new Request("http://localhost/file/raw?path=public%2Fnote.txt"),
+    )
+    expect(res.status).toBe(200)
+  })
 
-	it("should return 403 for HTML in private dir (auth disabled)", async () => {
-		await mkdir(path.join(UPLOAD_DIR, "private"), { recursive: true })
-		await Bun.write(
-			path.join(UPLOAD_DIR, "private", "secret.html"),
-			"<html>secret</html>",
-		)
-		const res = await app.request(
-			new Request("http://localhost/file/raw?path=private%2Fsecret.html"),
-		)
-		expect(res.status).toBe(403)
-		const data = (await res.json()) as { error: { name: string } }
-		expect(data.error.name).toBe("ActiveContentNotAllowed")
-	})
+  it("should return 403 for HTML in private dir (auth disabled)", async () => {
+    await mkdir(path.join(UPLOAD_DIR, "private"), { recursive: true })
+    await Bun.write(
+      path.join(UPLOAD_DIR, "private", "secret.html"),
+      "<html>secret</html>",
+    )
+    const res = await app.request(
+      new Request("http://localhost/file/raw?path=private%2Fsecret.html"),
+    )
+    expect(res.status).toBe(403)
+    const data = (await res.json()) as { error: { name: string } }
+    expect(data.error.name).toBe("ActiveContentNotAllowed")
+  })
 })
 
 describe("GET /file/raw - active content blocking with auth", () => {
-	const UPLOAD_DIR = "./tmp-test-raw-block-auth"
-	let app: Awaited<ReturnType<typeof createTestApp>>
+  const UPLOAD_DIR = "./tmp-test-raw-block-auth"
+  let app: Awaited<ReturnType<typeof createTestApp>>
 
-	beforeEach(async () => {
-		await rm(UPLOAD_DIR, { recursive: true, force: true })
-		app = await createTestApp({
-			uploadDir: UPLOAD_DIR,
-			sessionSecret: SESSION_SECRET,
-			seedUsers: [
-				{ username: "admin", password: "pass", role: "admin" },
-				{ username: "alice", password: "pass", role: "user" },
-			],
-		})
-	})
+  beforeEach(async () => {
+    await rm(UPLOAD_DIR, { recursive: true, force: true })
+    app = await createTestApp({
+      uploadDir: UPLOAD_DIR,
+      sessionSecret: SESSION_SECRET,
+      seedUsers: [
+        { username: "admin", password: "pass", role: "admin" },
+        { username: "alice", password: "pass", role: "user" },
+      ],
+    })
+  })
 
-	afterEach(async () => {
-		await rm(UPLOAD_DIR, { recursive: true, force: true })
-	})
+  afterEach(async () => {
+    await rm(UPLOAD_DIR, { recursive: true, force: true })
+  })
 
-	it("should return 403 for SVG in private dir even with valid session", async () => {
-		const session = await createTestSession("alice", SESSION_SECRET)
-		await mkdir(path.join(UPLOAD_DIR, "private", "alice"), { recursive: true })
-		await Bun.write(
-			path.join(UPLOAD_DIR, "private", "alice", "chart.svg"),
-			'<svg xmlns="http://www.w3.org/2000/svg"></svg>',
-		)
-		const res = await app.request(
-			new Request(
-				"http://localhost/file/raw?path=private%2Falice%2Fchart.svg",
-				{ headers: { Cookie: session.cookie } },
-			),
-		)
-		expect(res.status).toBe(403)
-		const data = (await res.json()) as { error: { name: string } }
-		expect(data.error.name).toBe("ActiveContentNotAllowed")
-	})
+  it("should return 403 for SVG in private dir even with valid session", async () => {
+    const session = await createTestSession("alice", SESSION_SECRET)
+    await mkdir(path.join(UPLOAD_DIR, "private", "alice"), { recursive: true })
+    await Bun.write(
+      path.join(UPLOAD_DIR, "private", "alice", "chart.svg"),
+      '<svg xmlns="http://www.w3.org/2000/svg"></svg>',
+    )
+    const res = await app.request(
+      new Request(
+        "http://localhost/file/raw?path=private%2Falice%2Fchart.svg",
+        { headers: { Cookie: session.cookie } },
+      ),
+    )
+    expect(res.status).toBe(403)
+    const data = (await res.json()) as { error: { name: string } }
+    expect(data.error.name).toBe("ActiveContentNotAllowed")
+  })
 
-	it("should deny access to other user private file (403 Forbidden)", async () => {
-		const session = await createTestSession("alice", SESSION_SECRET)
-		await mkdir(path.join(UPLOAD_DIR, "private", "admin"), { recursive: true })
-		await Bun.write(
-			path.join(UPLOAD_DIR, "private", "admin", "secret.png"),
-			new Uint8Array([0x89, 0x50, 0x4e, 0x47]),
-		)
-		const res = await app.request(
-			new Request(
-				"http://localhost/file/raw?path=private%2Fadmin%2Fsecret.png",
-				{ headers: { Cookie: session.cookie } },
-			),
-		)
-		expect(res.status).toBe(403)
-	})
+  it("should deny access to other user private file (403 Forbidden)", async () => {
+    const session = await createTestSession("alice", SESSION_SECRET)
+    await mkdir(path.join(UPLOAD_DIR, "private", "admin"), { recursive: true })
+    await Bun.write(
+      path.join(UPLOAD_DIR, "private", "admin", "secret.png"),
+      new Uint8Array([0x89, 0x50, 0x4e, 0x47]),
+    )
+    const res = await app.request(
+      new Request(
+        "http://localhost/file/raw?path=private%2Fadmin%2Fsecret.png",
+        { headers: { Cookie: session.cookie } },
+      ),
+    )
+    expect(res.status).toBe(403)
+  })
 })
 
 describe("GET /file/download", () => {
-	const UPLOAD_DIR = "./tmp-test-download"
-	let app: Awaited<ReturnType<typeof createTestApp>>
+  const UPLOAD_DIR = "./tmp-test-download"
+  let app: Awaited<ReturnType<typeof createTestApp>>
 
-	beforeEach(async () => {
-		await rm(UPLOAD_DIR, { recursive: true, force: true })
-		app = await createTestApp({ uploadDir: UPLOAD_DIR })
-	})
+  beforeEach(async () => {
+    await rm(UPLOAD_DIR, { recursive: true, force: true })
+    app = await createTestApp({ uploadDir: UPLOAD_DIR })
+  })
 
-	afterEach(async () => {
-		await rm(UPLOAD_DIR, { recursive: true, force: true })
-	})
+  afterEach(async () => {
+    await rm(UPLOAD_DIR, { recursive: true, force: true })
+  })
 
-	it("should download HTML file with attachment disposition", async () => {
-		await Bun.write(
-			path.join(UPLOAD_DIR, "public", "page.html"),
-			"<html><body>hello</body></html>",
-		)
-		const res = await app.request(
-			new Request("http://localhost/file/download?path=public%2Fpage.html"),
-		)
-		expect(res.status).toBe(200)
-		const disposition = res.headers.get("Content-Disposition")
-		expect(disposition).toContain("attachment")
-		expect(disposition).toContain("page.html")
-	})
+  it("should download HTML file with attachment disposition", async () => {
+    await Bun.write(
+      path.join(UPLOAD_DIR, "public", "page.html"),
+      "<html><body>こんにちは</body></html>",
+    )
+    const res = await app.request(
+      new Request("http://localhost/file/download?path=public%2Fpage.html"),
+    )
+    expect(res.status).toBe(200)
+    expect(res.headers.get("Content-Type")).toBe("text/html; charset=utf-8")
+    const disposition = res.headers.get("Content-Disposition")
+    expect(disposition).toContain("attachment")
+    expect(disposition).toContain("page.html")
+  })
 
-	it("should download SVG file with attachment disposition", async () => {
-		await Bun.write(
-			path.join(UPLOAD_DIR, "public", "image.svg"),
-			'<svg xmlns="http://www.w3.org/2000/svg"></svg>',
-		)
-		const res = await app.request(
-			new Request("http://localhost/file/download?path=public%2Fimage.svg"),
-		)
-		expect(res.status).toBe(200)
-		const disposition = res.headers.get("Content-Disposition")
-		expect(disposition).toContain("attachment")
-		expect(disposition).toContain("image.svg")
-	})
+  it("should download SVG file with attachment disposition", async () => {
+    await Bun.write(
+      path.join(UPLOAD_DIR, "public", "image.svg"),
+      '<svg xmlns="http://www.w3.org/2000/svg"></svg>',
+    )
+    const res = await app.request(
+      new Request("http://localhost/file/download?path=public%2Fimage.svg"),
+    )
+    expect(res.status).toBe(200)
+    expect(res.headers.get("Content-Type")).toBe("image/svg+xml; charset=utf-8")
+    const disposition = res.headers.get("Content-Disposition")
+    expect(disposition).toContain("attachment")
+    expect(disposition).toContain("image.svg")
+  })
 
-	it("should download PNG file with attachment disposition", async () => {
-		const pngBytes = new Uint8Array([
-			0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
-		])
-		await Bun.write(path.join(UPLOAD_DIR, "public", "photo.png"), pngBytes)
-		const res = await app.request(
-			new Request("http://localhost/file/download?path=public%2Fphoto.png"),
-		)
-		expect(res.status).toBe(200)
-		const disposition = res.headers.get("Content-Disposition")
-		expect(disposition).toContain("attachment")
-		expect(disposition).toContain("photo.png")
-	})
+  it("should download PNG file with attachment disposition", async () => {
+    const pngBytes = new Uint8Array([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+    ])
+    await Bun.write(path.join(UPLOAD_DIR, "public", "photo.png"), pngBytes)
+    const res = await app.request(
+      new Request("http://localhost/file/download?path=public%2Fphoto.png"),
+    )
+    expect(res.status).toBe(200)
+    expect(res.headers.get("Content-Type")).toBe("image/png")
+    const disposition = res.headers.get("Content-Disposition")
+    expect(disposition).toContain("attachment")
+    expect(disposition).toContain("photo.png")
+  })
 
-	it("should download text file with attachment disposition", async () => {
-		await Bun.write(
-			path.join(UPLOAD_DIR, "public", "note.txt"),
-			"some text content",
-		)
-		const res = await app.request(
-			new Request("http://localhost/file/download?path=public%2Fnote.txt"),
-		)
-		expect(res.status).toBe(200)
-		const disposition = res.headers.get("Content-Disposition")
-		expect(disposition).toContain("attachment")
-		expect(disposition).toContain("note.txt")
-	})
+  it("should download text file with attachment disposition", async () => {
+    await Bun.write(
+      path.join(UPLOAD_DIR, "public", "note.txt"),
+      "some text content",
+    )
+    const res = await app.request(
+      new Request("http://localhost/file/download?path=public%2Fnote.txt"),
+    )
+    expect(res.status).toBe(200)
+    const disposition = res.headers.get("Content-Disposition")
+    expect(disposition).toContain("attachment")
+    expect(disposition).toContain("note.txt")
+  })
 
-	it("should return 400 for non-existent file", async () => {
-		const res = await app.request(
-			new Request("http://localhost/file/download?path=public%2Fnotfound.bin"),
-		)
-		expect(res.status).toBe(400)
-		const data = (await res.json()) as { error: { name: string } }
-		expect(data.error.name).toBe("NotFound")
-	})
+  it("should return 400 for non-existent file", async () => {
+    const res = await app.request(
+      new Request("http://localhost/file/download?path=public%2Fnotfound.bin"),
+    )
+    expect(res.status).toBe(400)
+    const data = (await res.json()) as { error: { name: string } }
+    expect(data.error.name).toBe("NotFound")
+  })
 
-	it("should return 400 for directory path", async () => {
-		await mkdir(path.join(UPLOAD_DIR, "public", "subdir"), { recursive: true })
-		const res = await app.request(
-			new Request("http://localhost/file/download?path=public%2Fsubdir"),
-		)
-		expect(res.status).toBe(400)
-		const data = (await res.json()) as { error: { name: string } }
-		expect(data.error.name).toBe("NotAFile")
-	})
+  it("should return 400 for directory path", async () => {
+    await mkdir(path.join(UPLOAD_DIR, "public", "subdir"), { recursive: true })
+    const res = await app.request(
+      new Request("http://localhost/file/download?path=public%2Fsubdir"),
+    )
+    expect(res.status).toBe(400)
+    const data = (await res.json()) as { error: { name: string } }
+    expect(data.error.name).toBe("NotAFile")
+  })
 
-	it("should reject path traversal", async () => {
-		const res = await app.request(
-			new Request("http://localhost/file/download?path=../secret"),
-		)
-		expect(res.status).toBe(403)
-		const data = (await res.json()) as { error: { name: string } }
-		expect(data.error.name).toBe("Forbidden")
-	})
+  it("should reject path traversal", async () => {
+    const res = await app.request(
+      new Request("http://localhost/file/download?path=../secret"),
+    )
+    expect(res.status).toBe(403)
+    const data = (await res.json()) as { error: { name: string } }
+    expect(data.error.name).toBe("Forbidden")
+  })
 })
 
 describe("GET /file/download - with auth", () => {
-	const UPLOAD_DIR = "./tmp-test-download-auth"
-	let app: Awaited<ReturnType<typeof createTestApp>>
+  const UPLOAD_DIR = "./tmp-test-download-auth"
+  let app: Awaited<ReturnType<typeof createTestApp>>
 
-	beforeEach(async () => {
-		await rm(UPLOAD_DIR, { recursive: true, force: true })
-		app = await createTestApp({
-			uploadDir: UPLOAD_DIR,
-			sessionSecret: SESSION_SECRET,
-			seedUsers: [
-				{ username: "admin", password: "pass", role: "admin" },
-				{ username: "alice", password: "pass", role: "user" },
-			],
-		})
-	})
+  beforeEach(async () => {
+    await rm(UPLOAD_DIR, { recursive: true, force: true })
+    app = await createTestApp({
+      uploadDir: UPLOAD_DIR,
+      sessionSecret: SESSION_SECRET,
+      seedUsers: [
+        { username: "admin", password: "pass", role: "admin" },
+        { username: "alice", password: "pass", role: "user" },
+      ],
+    })
+  })
 
-	afterEach(async () => {
-		await rm(UPLOAD_DIR, { recursive: true, force: true })
-	})
+  afterEach(async () => {
+    await rm(UPLOAD_DIR, { recursive: true, force: true })
+  })
 
-	it("should allow user to download own private file", async () => {
-		const session = await createTestSession("alice", SESSION_SECRET)
-		await mkdir(path.join(UPLOAD_DIR, "private", "alice"), { recursive: true })
-		await Bun.write(
-			path.join(UPLOAD_DIR, "private", "alice", "report.html"),
-			"<html>report</html>",
-		)
-		const res = await app.request(
-			new Request(
-				"http://localhost/file/download?path=private%2Falice%2Freport.html",
-				{ headers: { Cookie: session.cookie } },
-			),
-		)
-		expect(res.status).toBe(200)
-		const disposition = res.headers.get("Content-Disposition")
-		expect(disposition).toContain("attachment")
-		expect(disposition).toContain("report.html")
-	})
+  it("should allow user to download own private file", async () => {
+    const session = await createTestSession("alice", SESSION_SECRET)
+    await mkdir(path.join(UPLOAD_DIR, "private", "alice"), { recursive: true })
+    await Bun.write(
+      path.join(UPLOAD_DIR, "private", "alice", "report.html"),
+      "<html>report</html>",
+    )
+    const res = await app.request(
+      new Request(
+        "http://localhost/file/download?path=private%2Falice%2Freport.html",
+        { headers: { Cookie: session.cookie } },
+      ),
+    )
+    expect(res.status).toBe(200)
+    const disposition = res.headers.get("Content-Disposition")
+    expect(disposition).toContain("attachment")
+    expect(disposition).toContain("report.html")
+  })
 
-	it("should deny download of other user private file", async () => {
-		const session = await createTestSession("alice", SESSION_SECRET)
-		await mkdir(path.join(UPLOAD_DIR, "private", "admin"), { recursive: true })
-		await Bun.write(
-			path.join(UPLOAD_DIR, "private", "admin", "secret.txt"),
-			"top secret",
-		)
-		const res = await app.request(
-			new Request(
-				"http://localhost/file/download?path=private%2Fadmin%2Fsecret.txt",
-				{ headers: { Cookie: session.cookie } },
-			),
-		)
-		expect(res.status).toBe(403)
-	})
+  it("should deny download of other user private file", async () => {
+    const session = await createTestSession("alice", SESSION_SECRET)
+    await mkdir(path.join(UPLOAD_DIR, "private", "admin"), { recursive: true })
+    await Bun.write(
+      path.join(UPLOAD_DIR, "private", "admin", "secret.txt"),
+      "top secret",
+    )
+    const res = await app.request(
+      new Request(
+        "http://localhost/file/download?path=private%2Fadmin%2Fsecret.txt",
+        { headers: { Cookie: session.cookie } },
+      ),
+    )
+    expect(res.status).toBe(403)
+  })
 })
 
 describe("GET /file - viewer routing regression", () => {
-	const UPLOAD_DIR = "./tmp-test-file-viewer-regression"
-	let app: Awaited<ReturnType<typeof createTestApp>>
+  const UPLOAD_DIR = "./tmp-test-file-viewer-regression"
+  let app: Awaited<ReturnType<typeof createTestApp>>
 
-	beforeEach(async () => {
-		await rm(UPLOAD_DIR, { recursive: true, force: true })
-		app = await createTestApp({ uploadDir: UPLOAD_DIR })
-	})
+  beforeEach(async () => {
+    await rm(UPLOAD_DIR, { recursive: true, force: true })
+    app = await createTestApp({ uploadDir: UPLOAD_DIR })
+  })
 
-	afterEach(async () => {
-		await rm(UPLOAD_DIR, { recursive: true, force: true })
-	})
+  afterEach(async () => {
+    await rm(UPLOAD_DIR, { recursive: true, force: true })
+  })
 
-	it("should render SVG as source view (text viewer), not image viewer", async () => {
-		await Bun.write(
-			path.join(UPLOAD_DIR, "public", "chart.svg"),
-			'<svg xmlns="http://www.w3.org/2000/svg"><circle r="10"/></svg>',
-		)
-		const res = await app.request(
-			new Request("http://localhost/file?path=public%2Fchart.svg", {
-				headers: { "HX-Request": "true" },
-			}),
-		)
-		expect(res.status).toBe(200)
-		const text = await res.text()
-		expect(text).toMatch(/<pre[^>]*>/)
-		expect(text).not.toContain("<img")
-	})
+  it("should render SVG as source view (text viewer), not image viewer", async () => {
+    await Bun.write(
+      path.join(UPLOAD_DIR, "public", "chart.svg"),
+      '<svg xmlns="http://www.w3.org/2000/svg"><circle r="10"/></svg>',
+    )
+    const res = await app.request(
+      new Request("http://localhost/file?path=public%2Fchart.svg", {
+        headers: { "HX-Request": "true" },
+      }),
+    )
+    expect(res.status).toBe(200)
+    const text = await res.text()
+    expect(text).toMatch(/<pre[^>]*>/)
+    expect(text).not.toContain("<img")
+  })
 
-	it("should render HTML as source view (text viewer), not image viewer", async () => {
-		await Bun.write(
-			path.join(UPLOAD_DIR, "public", "page.html"),
-			"<html><body>hello</body></html>",
-		)
-		const res = await app.request(
-			new Request("http://localhost/file?path=public%2Fpage.html", {
-				headers: { "HX-Request": "true" },
-			}),
-		)
-		expect(res.status).toBe(200)
-		const text = await res.text()
-		expect(text).toMatch(/<pre[^>]*>/)
-		expect(text).not.toContain("<img")
-	})
+  it("should render HTML as source view (text viewer), not image viewer", async () => {
+    await Bun.write(
+      path.join(UPLOAD_DIR, "public", "page.html"),
+      "<html><body>hello</body></html>",
+    )
+    const res = await app.request(
+      new Request("http://localhost/file?path=public%2Fpage.html", {
+        headers: { "HX-Request": "true" },
+      }),
+    )
+    expect(res.status).toBe(200)
+    const text = await res.text()
+    expect(text).toMatch(/<pre[^>]*>/)
+    expect(text).not.toContain("<img")
+  })
 
-	it("should render PNG as image viewer, not source view", async () => {
-		const pngBytes = new Uint8Array([
-			0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
-		])
-		await Bun.write(path.join(UPLOAD_DIR, "public", "photo.png"), pngBytes)
-		const res = await app.request(
-			new Request("http://localhost/file?path=public%2Fphoto.png", {
-				headers: { "HX-Request": "true" },
-			}),
-		)
-		expect(res.status).toBe(200)
-		const text = await res.text()
-		expect(text).toContain("<img")
-		expect(text).not.toMatch(/<pre[^>]*>/)
-	})
+  it("should render PNG as image viewer, not source view", async () => {
+    const pngBytes = new Uint8Array([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+    ])
+    await Bun.write(path.join(UPLOAD_DIR, "public", "photo.png"), pngBytes)
+    const res = await app.request(
+      new Request("http://localhost/file?path=public%2Fphoto.png", {
+        headers: { "HX-Request": "true" },
+      }),
+    )
+    expect(res.status).toBe(200)
+    const text = await res.text()
+    expect(text).toContain("<img")
+    expect(text).not.toMatch(/<pre[^>]*>/)
+  })
 
-	it("should render PDF as PDF viewer (iframe), not source view", async () => {
-		await Bun.write(
-			path.join(UPLOAD_DIR, "public", "doc.pdf"),
-			"%PDF-1.4 fake pdf content",
-		)
-		const res = await app.request(
-			new Request("http://localhost/file?path=public%2Fdoc.pdf", {
-				headers: { "HX-Request": "true" },
-			}),
-		)
-		expect(res.status).toBe(200)
-		const text = await res.text()
-		expect(text).toContain("<iframe")
-		expect(text).not.toMatch(/<pre[^>]*>/)
-	})
+  it("should render PDF as PDF viewer (iframe), not source view", async () => {
+    await Bun.write(
+      path.join(UPLOAD_DIR, "public", "doc.pdf"),
+      "%PDF-1.4 fake pdf content",
+    )
+    const res = await app.request(
+      new Request("http://localhost/file?path=public%2Fdoc.pdf", {
+        headers: { "HX-Request": "true" },
+      }),
+    )
+    expect(res.status).toBe(200)
+    const text = await res.text()
+    expect(text).toContain("<iframe")
+    expect(text).not.toMatch(/<pre[^>]*>/)
+  })
 })

--- a/projects/file-server/tests/file-raw-download.test.ts
+++ b/projects/file-server/tests/file-raw-download.test.ts
@@ -1,397 +1,397 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test"
 import { mkdir, rm } from "node:fs/promises"
 import * as path from "node:path"
-import { createTestSession } from "./helpers/auth"
 import { createTestApp } from "./helpers/createTestApp"
+import { createTestSession } from "./helpers/auth"
 
 const SESSION_SECRET = "test-secret-for-raw-download"
 
 describe("GET /file/raw - active content blocking", () => {
-  const UPLOAD_DIR = "./tmp-test-raw-block"
-  let app: Awaited<ReturnType<typeof createTestApp>>
+	const UPLOAD_DIR = "./tmp-test-raw-block"
+	let app: Awaited<ReturnType<typeof createTestApp>>
 
-  beforeEach(async () => {
-    await rm(UPLOAD_DIR, { recursive: true, force: true })
-    app = await createTestApp({ uploadDir: UPLOAD_DIR })
-  })
+	beforeEach(async () => {
+		await rm(UPLOAD_DIR, { recursive: true, force: true })
+		app = await createTestApp({ uploadDir: UPLOAD_DIR })
+	})
 
-  afterEach(async () => {
-    await rm(UPLOAD_DIR, { recursive: true, force: true })
-  })
+	afterEach(async () => {
+		await rm(UPLOAD_DIR, { recursive: true, force: true })
+	})
 
-  it("should return 403 for HTML file in public", async () => {
-    await Bun.write(
-      path.join(UPLOAD_DIR, "public", "page.html"),
-      "<html><body>hello</body></html>",
-    )
-    const res = await app.request(
-      new Request("http://localhost/file/raw?path=public%2Fpage.html"),
-    )
-    expect(res.status).toBe(403)
-    const data = (await res.json()) as { error: { name: string } }
-    expect(data.error.name).toBe("ActiveContentNotAllowed")
-  })
+	it("should return 403 for HTML file in public", async () => {
+		await Bun.write(
+			path.join(UPLOAD_DIR, "public", "page.html"),
+			"<html><body>hello</body></html>",
+		)
+		const res = await app.request(
+			new Request("http://localhost/file/raw?path=public%2Fpage.html"),
+		)
+		expect(res.status).toBe(403)
+		const data = (await res.json()) as { error: { name: string } }
+		expect(data.error.name).toBe("ActiveContentNotAllowed")
+	})
 
-  it("should return 403 for .htm file", async () => {
-    await Bun.write(
-      path.join(UPLOAD_DIR, "public", "page.htm"),
-      "<html>hello</html>",
-    )
-    const res = await app.request(
-      new Request("http://localhost/file/raw?path=public%2Fpage.htm"),
-    )
-    expect(res.status).toBe(403)
-    const data = (await res.json()) as { error: { name: string } }
-    expect(data.error.name).toBe("ActiveContentNotAllowed")
-  })
+	it("should return 403 for .htm file", async () => {
+		await Bun.write(
+			path.join(UPLOAD_DIR, "public", "page.htm"),
+			"<html>hello</html>",
+		)
+		const res = await app.request(
+			new Request("http://localhost/file/raw?path=public%2Fpage.htm"),
+		)
+		expect(res.status).toBe(403)
+		const data = (await res.json()) as { error: { name: string } }
+		expect(data.error.name).toBe("ActiveContentNotAllowed")
+	})
 
-  it("should return 403 for .xhtml file", async () => {
-    await Bun.write(
-      path.join(UPLOAD_DIR, "public", "page.xhtml"),
-      '<?xml version="1.0"?><html xmlns="http://www.w3.org/1999/xhtml"></html>',
-    )
-    const res = await app.request(
-      new Request("http://localhost/file/raw?path=public%2Fpage.xhtml"),
-    )
-    expect(res.status).toBe(403)
-    const data = (await res.json()) as { error: { name: string } }
-    expect(data.error.name).toBe("ActiveContentNotAllowed")
-  })
+	it("should return 403 for .xhtml file", async () => {
+		await Bun.write(
+			path.join(UPLOAD_DIR, "public", "page.xhtml"),
+			'<?xml version="1.0"?><html xmlns="http://www.w3.org/1999/xhtml"></html>',
+		)
+		const res = await app.request(
+			new Request("http://localhost/file/raw?path=public%2Fpage.xhtml"),
+		)
+		expect(res.status).toBe(403)
+		const data = (await res.json()) as { error: { name: string } }
+		expect(data.error.name).toBe("ActiveContentNotAllowed")
+	})
 
-  it("should return 403 for SVG file", async () => {
-    await Bun.write(
-      path.join(UPLOAD_DIR, "public", "image.svg"),
-      '<svg xmlns="http://www.w3.org/2000/svg"><circle r="10"/></svg>',
-    )
-    const res = await app.request(
-      new Request("http://localhost/file/raw?path=public%2Fimage.svg"),
-    )
-    expect(res.status).toBe(403)
-    const data = (await res.json()) as { error: { name: string } }
-    expect(data.error.name).toBe("ActiveContentNotAllowed")
-  })
+	it("should return 403 for SVG file", async () => {
+		await Bun.write(
+			path.join(UPLOAD_DIR, "public", "image.svg"),
+			'<svg xmlns="http://www.w3.org/2000/svg"><circle r="10"/></svg>',
+		)
+		const res = await app.request(
+			new Request("http://localhost/file/raw?path=public%2Fimage.svg"),
+		)
+		expect(res.status).toBe(403)
+		const data = (await res.json()) as { error: { name: string } }
+		expect(data.error.name).toBe("ActiveContentNotAllowed")
+	})
 
-  it("should serve PNG image without block", async () => {
-    const pngBytes = new Uint8Array([
-      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
-    ])
-    await Bun.write(path.join(UPLOAD_DIR, "public", "image.png"), pngBytes)
-    const res = await app.request(
-      new Request("http://localhost/file/raw?path=public%2Fimage.png"),
-    )
-    expect(res.status).toBe(200)
-    expect(res.headers.get("Content-Type")).toContain("image/png")
-  })
+	it("should serve PNG image without block", async () => {
+		const pngBytes = new Uint8Array([
+			0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+		])
+		await Bun.write(path.join(UPLOAD_DIR, "public", "image.png"), pngBytes)
+		const res = await app.request(
+			new Request("http://localhost/file/raw?path=public%2Fimage.png"),
+		)
+		expect(res.status).toBe(200)
+		expect(res.headers.get("Content-Type")).toContain("image/png")
+	})
 
-  it("should serve text file without block", async () => {
-    await Bun.write(path.join(UPLOAD_DIR, "public", "note.txt"), "hello world")
-    const res = await app.request(
-      new Request("http://localhost/file/raw?path=public%2Fnote.txt"),
-    )
-    expect(res.status).toBe(200)
-  })
+	it("should serve text file without block", async () => {
+		await Bun.write(path.join(UPLOAD_DIR, "public", "note.txt"), "hello world")
+		const res = await app.request(
+			new Request("http://localhost/file/raw?path=public%2Fnote.txt"),
+		)
+		expect(res.status).toBe(200)
+	})
 
-  it("should return 403 for HTML in private dir (auth disabled)", async () => {
-    await mkdir(path.join(UPLOAD_DIR, "private"), { recursive: true })
-    await Bun.write(
-      path.join(UPLOAD_DIR, "private", "secret.html"),
-      "<html>secret</html>",
-    )
-    const res = await app.request(
-      new Request("http://localhost/file/raw?path=private%2Fsecret.html"),
-    )
-    expect(res.status).toBe(403)
-    const data = (await res.json()) as { error: { name: string } }
-    expect(data.error.name).toBe("ActiveContentNotAllowed")
-  })
+	it("should return 403 for HTML in private dir (auth disabled)", async () => {
+		await mkdir(path.join(UPLOAD_DIR, "private"), { recursive: true })
+		await Bun.write(
+			path.join(UPLOAD_DIR, "private", "secret.html"),
+			"<html>secret</html>",
+		)
+		const res = await app.request(
+			new Request("http://localhost/file/raw?path=private%2Fsecret.html"),
+		)
+		expect(res.status).toBe(403)
+		const data = (await res.json()) as { error: { name: string } }
+		expect(data.error.name).toBe("ActiveContentNotAllowed")
+	})
 })
 
 describe("GET /file/raw - active content blocking with auth", () => {
-  const UPLOAD_DIR = "./tmp-test-raw-block-auth"
-  let app: Awaited<ReturnType<typeof createTestApp>>
+	const UPLOAD_DIR = "./tmp-test-raw-block-auth"
+	let app: Awaited<ReturnType<typeof createTestApp>>
 
-  beforeEach(async () => {
-    await rm(UPLOAD_DIR, { recursive: true, force: true })
-    app = await createTestApp({
-      uploadDir: UPLOAD_DIR,
-      sessionSecret: SESSION_SECRET,
-      seedUsers: [
-        { username: "admin", password: "pass", role: "admin" },
-        { username: "alice", password: "pass", role: "user" },
-      ],
-    })
-  })
+	beforeEach(async () => {
+		await rm(UPLOAD_DIR, { recursive: true, force: true })
+		app = await createTestApp({
+			uploadDir: UPLOAD_DIR,
+			sessionSecret: SESSION_SECRET,
+			seedUsers: [
+				{ username: "admin", password: "pass", role: "admin" },
+				{ username: "alice", password: "pass", role: "user" },
+			],
+		})
+	})
 
-  afterEach(async () => {
-    await rm(UPLOAD_DIR, { recursive: true, force: true })
-  })
+	afterEach(async () => {
+		await rm(UPLOAD_DIR, { recursive: true, force: true })
+	})
 
-  it("should return 403 for SVG in private dir even with valid session", async () => {
-    const session = await createTestSession("alice", SESSION_SECRET)
-    await mkdir(path.join(UPLOAD_DIR, "private", "alice"), { recursive: true })
-    await Bun.write(
-      path.join(UPLOAD_DIR, "private", "alice", "chart.svg"),
-      '<svg xmlns="http://www.w3.org/2000/svg"></svg>',
-    )
-    const res = await app.request(
-      new Request(
-        "http://localhost/file/raw?path=private%2Falice%2Fchart.svg",
-        { headers: { Cookie: session.cookie } },
-      ),
-    )
-    expect(res.status).toBe(403)
-    const data = (await res.json()) as { error: { name: string } }
-    expect(data.error.name).toBe("ActiveContentNotAllowed")
-  })
+	it("should return 403 for SVG in private dir even with valid session", async () => {
+		const session = await createTestSession("alice", SESSION_SECRET)
+		await mkdir(path.join(UPLOAD_DIR, "private", "alice"), { recursive: true })
+		await Bun.write(
+			path.join(UPLOAD_DIR, "private", "alice", "chart.svg"),
+			'<svg xmlns="http://www.w3.org/2000/svg"></svg>',
+		)
+		const res = await app.request(
+			new Request(
+				"http://localhost/file/raw?path=private%2Falice%2Fchart.svg",
+				{ headers: { Cookie: session.cookie } },
+			),
+		)
+		expect(res.status).toBe(403)
+		const data = (await res.json()) as { error: { name: string } }
+		expect(data.error.name).toBe("ActiveContentNotAllowed")
+	})
 
-  it("should deny access to other user private file (403 Forbidden)", async () => {
-    const session = await createTestSession("alice", SESSION_SECRET)
-    await mkdir(path.join(UPLOAD_DIR, "private", "admin"), { recursive: true })
-    await Bun.write(
-      path.join(UPLOAD_DIR, "private", "admin", "secret.png"),
-      new Uint8Array([0x89, 0x50, 0x4e, 0x47]),
-    )
-    const res = await app.request(
-      new Request(
-        "http://localhost/file/raw?path=private%2Fadmin%2Fsecret.png",
-        { headers: { Cookie: session.cookie } },
-      ),
-    )
-    expect(res.status).toBe(403)
-  })
+	it("should deny access to other user private file (403 Forbidden)", async () => {
+		const session = await createTestSession("alice", SESSION_SECRET)
+		await mkdir(path.join(UPLOAD_DIR, "private", "admin"), { recursive: true })
+		await Bun.write(
+			path.join(UPLOAD_DIR, "private", "admin", "secret.png"),
+			new Uint8Array([0x89, 0x50, 0x4e, 0x47]),
+		)
+		const res = await app.request(
+			new Request(
+				"http://localhost/file/raw?path=private%2Fadmin%2Fsecret.png",
+				{ headers: { Cookie: session.cookie } },
+			),
+		)
+		expect(res.status).toBe(403)
+	})
 })
 
 describe("GET /file/download", () => {
-  const UPLOAD_DIR = "./tmp-test-download"
-  let app: Awaited<ReturnType<typeof createTestApp>>
+	const UPLOAD_DIR = "./tmp-test-download"
+	let app: Awaited<ReturnType<typeof createTestApp>>
 
-  beforeEach(async () => {
-    await rm(UPLOAD_DIR, { recursive: true, force: true })
-    app = await createTestApp({ uploadDir: UPLOAD_DIR })
-  })
+	beforeEach(async () => {
+		await rm(UPLOAD_DIR, { recursive: true, force: true })
+		app = await createTestApp({ uploadDir: UPLOAD_DIR })
+	})
 
-  afterEach(async () => {
-    await rm(UPLOAD_DIR, { recursive: true, force: true })
-  })
+	afterEach(async () => {
+		await rm(UPLOAD_DIR, { recursive: true, force: true })
+	})
 
-  it("should download HTML file with attachment disposition", async () => {
-    await Bun.write(
-      path.join(UPLOAD_DIR, "public", "page.html"),
-      "<html><body>こんにちは</body></html>",
-    )
-    const res = await app.request(
-      new Request("http://localhost/file/download?path=public%2Fpage.html"),
-    )
-    expect(res.status).toBe(200)
-    expect(res.headers.get("Content-Type")).toBe("text/html; charset=utf-8")
-    const disposition = res.headers.get("Content-Disposition")
-    expect(disposition).toContain("attachment")
-    expect(disposition).toContain("page.html")
-  })
+	it("should download HTML file with attachment disposition", async () => {
+		await Bun.write(
+			path.join(UPLOAD_DIR, "public", "page.html"),
+			"<html><body>こんにちは</body></html>",
+		)
+		const res = await app.request(
+			new Request("http://localhost/file/download?path=public%2Fpage.html"),
+		)
+		expect(res.status).toBe(200)
+		expect(res.headers.get("Content-Type")).toBe("text/html; charset=utf-8")
+		const disposition = res.headers.get("Content-Disposition")
+		expect(disposition).toContain("attachment")
+		expect(disposition).toContain("page.html")
+	})
 
-  it("should download SVG file with attachment disposition", async () => {
-    await Bun.write(
-      path.join(UPLOAD_DIR, "public", "image.svg"),
-      '<svg xmlns="http://www.w3.org/2000/svg"></svg>',
-    )
-    const res = await app.request(
-      new Request("http://localhost/file/download?path=public%2Fimage.svg"),
-    )
-    expect(res.status).toBe(200)
-    expect(res.headers.get("Content-Type")).toBe("image/svg+xml; charset=utf-8")
-    const disposition = res.headers.get("Content-Disposition")
-    expect(disposition).toContain("attachment")
-    expect(disposition).toContain("image.svg")
-  })
+	it("should download SVG file with attachment disposition", async () => {
+		await Bun.write(
+			path.join(UPLOAD_DIR, "public", "image.svg"),
+			'<svg xmlns="http://www.w3.org/2000/svg"></svg>',
+		)
+		const res = await app.request(
+			new Request("http://localhost/file/download?path=public%2Fimage.svg"),
+		)
+		expect(res.status).toBe(200)
+		expect(res.headers.get("Content-Type")).toBe("image/svg+xml; charset=utf-8")
+		const disposition = res.headers.get("Content-Disposition")
+		expect(disposition).toContain("attachment")
+		expect(disposition).toContain("image.svg")
+	})
 
-  it("should download PNG file with attachment disposition", async () => {
-    const pngBytes = new Uint8Array([
-      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
-    ])
-    await Bun.write(path.join(UPLOAD_DIR, "public", "photo.png"), pngBytes)
-    const res = await app.request(
-      new Request("http://localhost/file/download?path=public%2Fphoto.png"),
-    )
-    expect(res.status).toBe(200)
-    expect(res.headers.get("Content-Type")).toBe("image/png")
-    const disposition = res.headers.get("Content-Disposition")
-    expect(disposition).toContain("attachment")
-    expect(disposition).toContain("photo.png")
-  })
+	it("should download PNG file with attachment disposition", async () => {
+		const pngBytes = new Uint8Array([
+			0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+		])
+		await Bun.write(path.join(UPLOAD_DIR, "public", "photo.png"), pngBytes)
+		const res = await app.request(
+			new Request("http://localhost/file/download?path=public%2Fphoto.png"),
+		)
+		expect(res.status).toBe(200)
+		expect(res.headers.get("Content-Type")).toBe("image/png")
+		const disposition = res.headers.get("Content-Disposition")
+		expect(disposition).toContain("attachment")
+		expect(disposition).toContain("photo.png")
+	})
 
-  it("should download text file with attachment disposition", async () => {
-    await Bun.write(
-      path.join(UPLOAD_DIR, "public", "note.txt"),
-      "some text content",
-    )
-    const res = await app.request(
-      new Request("http://localhost/file/download?path=public%2Fnote.txt"),
-    )
-    expect(res.status).toBe(200)
-    const disposition = res.headers.get("Content-Disposition")
-    expect(disposition).toContain("attachment")
-    expect(disposition).toContain("note.txt")
-  })
+	it("should download text file with attachment disposition", async () => {
+		await Bun.write(
+			path.join(UPLOAD_DIR, "public", "note.txt"),
+			"some text content",
+		)
+		const res = await app.request(
+			new Request("http://localhost/file/download?path=public%2Fnote.txt"),
+		)
+		expect(res.status).toBe(200)
+		const disposition = res.headers.get("Content-Disposition")
+		expect(disposition).toContain("attachment")
+		expect(disposition).toContain("note.txt")
+	})
 
-  it("should return 400 for non-existent file", async () => {
-    const res = await app.request(
-      new Request("http://localhost/file/download?path=public%2Fnotfound.bin"),
-    )
-    expect(res.status).toBe(400)
-    const data = (await res.json()) as { error: { name: string } }
-    expect(data.error.name).toBe("NotFound")
-  })
+	it("should return 400 for non-existent file", async () => {
+		const res = await app.request(
+			new Request("http://localhost/file/download?path=public%2Fnotfound.bin"),
+		)
+		expect(res.status).toBe(400)
+		const data = (await res.json()) as { error: { name: string } }
+		expect(data.error.name).toBe("NotFound")
+	})
 
-  it("should return 400 for directory path", async () => {
-    await mkdir(path.join(UPLOAD_DIR, "public", "subdir"), { recursive: true })
-    const res = await app.request(
-      new Request("http://localhost/file/download?path=public%2Fsubdir"),
-    )
-    expect(res.status).toBe(400)
-    const data = (await res.json()) as { error: { name: string } }
-    expect(data.error.name).toBe("NotAFile")
-  })
+	it("should return 400 for directory path", async () => {
+		await mkdir(path.join(UPLOAD_DIR, "public", "subdir"), { recursive: true })
+		const res = await app.request(
+			new Request("http://localhost/file/download?path=public%2Fsubdir"),
+		)
+		expect(res.status).toBe(400)
+		const data = (await res.json()) as { error: { name: string } }
+		expect(data.error.name).toBe("NotAFile")
+	})
 
-  it("should reject path traversal", async () => {
-    const res = await app.request(
-      new Request("http://localhost/file/download?path=../secret"),
-    )
-    expect(res.status).toBe(403)
-    const data = (await res.json()) as { error: { name: string } }
-    expect(data.error.name).toBe("Forbidden")
-  })
+	it("should reject path traversal", async () => {
+		const res = await app.request(
+			new Request("http://localhost/file/download?path=../secret"),
+		)
+		expect(res.status).toBe(403)
+		const data = (await res.json()) as { error: { name: string } }
+		expect(data.error.name).toBe("Forbidden")
+	})
 })
 
 describe("GET /file/download - with auth", () => {
-  const UPLOAD_DIR = "./tmp-test-download-auth"
-  let app: Awaited<ReturnType<typeof createTestApp>>
+	const UPLOAD_DIR = "./tmp-test-download-auth"
+	let app: Awaited<ReturnType<typeof createTestApp>>
 
-  beforeEach(async () => {
-    await rm(UPLOAD_DIR, { recursive: true, force: true })
-    app = await createTestApp({
-      uploadDir: UPLOAD_DIR,
-      sessionSecret: SESSION_SECRET,
-      seedUsers: [
-        { username: "admin", password: "pass", role: "admin" },
-        { username: "alice", password: "pass", role: "user" },
-      ],
-    })
-  })
+	beforeEach(async () => {
+		await rm(UPLOAD_DIR, { recursive: true, force: true })
+		app = await createTestApp({
+			uploadDir: UPLOAD_DIR,
+			sessionSecret: SESSION_SECRET,
+			seedUsers: [
+				{ username: "admin", password: "pass", role: "admin" },
+				{ username: "alice", password: "pass", role: "user" },
+			],
+		})
+	})
 
-  afterEach(async () => {
-    await rm(UPLOAD_DIR, { recursive: true, force: true })
-  })
+	afterEach(async () => {
+		await rm(UPLOAD_DIR, { recursive: true, force: true })
+	})
 
-  it("should allow user to download own private file", async () => {
-    const session = await createTestSession("alice", SESSION_SECRET)
-    await mkdir(path.join(UPLOAD_DIR, "private", "alice"), { recursive: true })
-    await Bun.write(
-      path.join(UPLOAD_DIR, "private", "alice", "report.html"),
-      "<html>report</html>",
-    )
-    const res = await app.request(
-      new Request(
-        "http://localhost/file/download?path=private%2Falice%2Freport.html",
-        { headers: { Cookie: session.cookie } },
-      ),
-    )
-    expect(res.status).toBe(200)
-    const disposition = res.headers.get("Content-Disposition")
-    expect(disposition).toContain("attachment")
-    expect(disposition).toContain("report.html")
-  })
+	it("should allow user to download own private file", async () => {
+		const session = await createTestSession("alice", SESSION_SECRET)
+		await mkdir(path.join(UPLOAD_DIR, "private", "alice"), { recursive: true })
+		await Bun.write(
+			path.join(UPLOAD_DIR, "private", "alice", "report.html"),
+			"<html>report</html>",
+		)
+		const res = await app.request(
+			new Request(
+				"http://localhost/file/download?path=private%2Falice%2Freport.html",
+				{ headers: { Cookie: session.cookie } },
+			),
+		)
+		expect(res.status).toBe(200)
+		const disposition = res.headers.get("Content-Disposition")
+		expect(disposition).toContain("attachment")
+		expect(disposition).toContain("report.html")
+	})
 
-  it("should deny download of other user private file", async () => {
-    const session = await createTestSession("alice", SESSION_SECRET)
-    await mkdir(path.join(UPLOAD_DIR, "private", "admin"), { recursive: true })
-    await Bun.write(
-      path.join(UPLOAD_DIR, "private", "admin", "secret.txt"),
-      "top secret",
-    )
-    const res = await app.request(
-      new Request(
-        "http://localhost/file/download?path=private%2Fadmin%2Fsecret.txt",
-        { headers: { Cookie: session.cookie } },
-      ),
-    )
-    expect(res.status).toBe(403)
-  })
+	it("should deny download of other user private file", async () => {
+		const session = await createTestSession("alice", SESSION_SECRET)
+		await mkdir(path.join(UPLOAD_DIR, "private", "admin"), { recursive: true })
+		await Bun.write(
+			path.join(UPLOAD_DIR, "private", "admin", "secret.txt"),
+			"top secret",
+		)
+		const res = await app.request(
+			new Request(
+				"http://localhost/file/download?path=private%2Fadmin%2Fsecret.txt",
+				{ headers: { Cookie: session.cookie } },
+			),
+		)
+		expect(res.status).toBe(403)
+	})
 })
 
 describe("GET /file - viewer routing regression", () => {
-  const UPLOAD_DIR = "./tmp-test-file-viewer-regression"
-  let app: Awaited<ReturnType<typeof createTestApp>>
+	const UPLOAD_DIR = "./tmp-test-file-viewer-regression"
+	let app: Awaited<ReturnType<typeof createTestApp>>
 
-  beforeEach(async () => {
-    await rm(UPLOAD_DIR, { recursive: true, force: true })
-    app = await createTestApp({ uploadDir: UPLOAD_DIR })
-  })
+	beforeEach(async () => {
+		await rm(UPLOAD_DIR, { recursive: true, force: true })
+		app = await createTestApp({ uploadDir: UPLOAD_DIR })
+	})
 
-  afterEach(async () => {
-    await rm(UPLOAD_DIR, { recursive: true, force: true })
-  })
+	afterEach(async () => {
+		await rm(UPLOAD_DIR, { recursive: true, force: true })
+	})
 
-  it("should render SVG as source view (text viewer), not image viewer", async () => {
-    await Bun.write(
-      path.join(UPLOAD_DIR, "public", "chart.svg"),
-      '<svg xmlns="http://www.w3.org/2000/svg"><circle r="10"/></svg>',
-    )
-    const res = await app.request(
-      new Request("http://localhost/file?path=public%2Fchart.svg", {
-        headers: { "HX-Request": "true" },
-      }),
-    )
-    expect(res.status).toBe(200)
-    const text = await res.text()
-    expect(text).toMatch(/<pre[^>]*>/)
-    expect(text).not.toContain("<img")
-  })
+	it("should render SVG as source view (text viewer), not image viewer", async () => {
+		await Bun.write(
+			path.join(UPLOAD_DIR, "public", "chart.svg"),
+			'<svg xmlns="http://www.w3.org/2000/svg"><circle r="10"/></svg>',
+		)
+		const res = await app.request(
+			new Request("http://localhost/file?path=public%2Fchart.svg", {
+				headers: { "HX-Request": "true" },
+			}),
+		)
+		expect(res.status).toBe(200)
+		const text = await res.text()
+		expect(text).toMatch(/<pre[^>]*>/)
+		expect(text).not.toContain("<img")
+	})
 
-  it("should render HTML as source view (text viewer), not image viewer", async () => {
-    await Bun.write(
-      path.join(UPLOAD_DIR, "public", "page.html"),
-      "<html><body>hello</body></html>",
-    )
-    const res = await app.request(
-      new Request("http://localhost/file?path=public%2Fpage.html", {
-        headers: { "HX-Request": "true" },
-      }),
-    )
-    expect(res.status).toBe(200)
-    const text = await res.text()
-    expect(text).toMatch(/<pre[^>]*>/)
-    expect(text).not.toContain("<img")
-  })
+	it("should render HTML as source view (text viewer), not image viewer", async () => {
+		await Bun.write(
+			path.join(UPLOAD_DIR, "public", "page.html"),
+			"<html><body>hello</body></html>",
+		)
+		const res = await app.request(
+			new Request("http://localhost/file?path=public%2Fpage.html", {
+				headers: { "HX-Request": "true" },
+			}),
+		)
+		expect(res.status).toBe(200)
+		const text = await res.text()
+		expect(text).toMatch(/<pre[^>]*>/)
+		expect(text).not.toContain("<img")
+	})
 
-  it("should render PNG as image viewer, not source view", async () => {
-    const pngBytes = new Uint8Array([
-      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
-    ])
-    await Bun.write(path.join(UPLOAD_DIR, "public", "photo.png"), pngBytes)
-    const res = await app.request(
-      new Request("http://localhost/file?path=public%2Fphoto.png", {
-        headers: { "HX-Request": "true" },
-      }),
-    )
-    expect(res.status).toBe(200)
-    const text = await res.text()
-    expect(text).toContain("<img")
-    expect(text).not.toMatch(/<pre[^>]*>/)
-  })
+	it("should render PNG as image viewer, not source view", async () => {
+		const pngBytes = new Uint8Array([
+			0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+		])
+		await Bun.write(path.join(UPLOAD_DIR, "public", "photo.png"), pngBytes)
+		const res = await app.request(
+			new Request("http://localhost/file?path=public%2Fphoto.png", {
+				headers: { "HX-Request": "true" },
+			}),
+		)
+		expect(res.status).toBe(200)
+		const text = await res.text()
+		expect(text).toContain("<img")
+		expect(text).not.toMatch(/<pre[^>]*>/)
+	})
 
-  it("should render PDF as PDF viewer (iframe), not source view", async () => {
-    await Bun.write(
-      path.join(UPLOAD_DIR, "public", "doc.pdf"),
-      "%PDF-1.4 fake pdf content",
-    )
-    const res = await app.request(
-      new Request("http://localhost/file?path=public%2Fdoc.pdf", {
-        headers: { "HX-Request": "true" },
-      }),
-    )
-    expect(res.status).toBe(200)
-    const text = await res.text()
-    expect(text).toContain("<iframe")
-    expect(text).not.toMatch(/<pre[^>]*>/)
-  })
+	it("should render PDF as PDF viewer (iframe), not source view", async () => {
+		await Bun.write(
+			path.join(UPLOAD_DIR, "public", "doc.pdf"),
+			"%PDF-1.4 fake pdf content",
+		)
+		const res = await app.request(
+			new Request("http://localhost/file?path=public%2Fdoc.pdf", {
+				headers: { "HX-Request": "true" },
+			}),
+		)
+		expect(res.status).toBe(200)
+		const text = await res.text()
+		expect(text).toContain("<iframe")
+		expect(text).not.toMatch(/<pre[^>]*>/)
+	})
 })

--- a/projects/file-server/tests/mimeType.test.ts
+++ b/projects/file-server/tests/mimeType.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "bun:test"
+import {
+  lookupMimeType,
+  normalizeResponseMimeType,
+  resolveResponseMimeType,
+} from "../src/utils/mimeType"
+
+describe("lookupMimeType", () => {
+  it("returns detected mime type for known extensions", () => {
+    expect(lookupMimeType("index.html")).toBe("text/html")
+  })
+
+  it("falls back to application/octet-stream for unknown extensions", () => {
+    expect(lookupMimeType("file.unknownext")).toBe("application/octet-stream")
+  })
+})
+
+describe("normalizeResponseMimeType", () => {
+  it("adds utf-8 charset to text/html", () => {
+    expect(normalizeResponseMimeType("text/html")).toBe("text/html; charset=utf-8")
+  })
+
+  it("keeps an existing charset parameter", () => {
+    expect(normalizeResponseMimeType("text/html; charset=iso-8859-1")).toBe(
+      "text/html; charset=iso-8859-1",
+    )
+  })
+
+  it("adds utf-8 charset to +json mime types", () => {
+    expect(normalizeResponseMimeType("application/ld+json")).toBe(
+      "application/ld+json; charset=utf-8",
+    )
+  })
+
+  it("adds utf-8 charset to +xml mime types", () => {
+    expect(normalizeResponseMimeType("application/atom+xml")).toBe(
+      "application/atom+xml; charset=utf-8",
+    )
+  })
+
+  it("does not add charset to binary mime types", () => {
+    expect(normalizeResponseMimeType("image/png")).toBe("image/png")
+  })
+})
+
+describe("resolveResponseMimeType", () => {
+  it("resolves text/html with utf-8 charset from a file path", () => {
+    expect(resolveResponseMimeType("page.html")).toBe("text/html; charset=utf-8")
+  })
+
+  it("resolves binary mime types without adding charset", () => {
+    expect(resolveResponseMimeType("image.png")).toBe("image/png")
+  })
+})

--- a/projects/file-server/tests/public-route.test.ts
+++ b/projects/file-server/tests/public-route.test.ts
@@ -103,7 +103,7 @@ describe("GET /public/*", () => {
   it("serves an HTML file", async () => {
     await writeFile(
       path.join(UPLOAD_DIR, "public", "page.html"),
-      "<html></html>",
+      "<html><body>こんにちは</body></html>",
     )
 
     const res = await app.request(
@@ -111,7 +111,8 @@ describe("GET /public/*", () => {
     )
 
     expect(res.status).toBe(200)
-    expect(res.headers.get("content-type")).toContain("text/html")
+    expect(res.headers.get("content-type")).toBe("text/html; charset=utf-8")
+    expect(await res.text()).toContain("こんにちは")
   })
 
   it("serves an HTM file", async () => {
@@ -125,7 +126,7 @@ describe("GET /public/*", () => {
     )
 
     expect(res.status).toBe(200)
-    expect(res.headers.get("content-type")).toContain("text/html")
+    expect(res.headers.get("content-type")).toBe("text/html; charset=utf-8")
   })
 
   it("serves an SVG file", async () => {
@@ -139,7 +140,7 @@ describe("GET /public/*", () => {
     )
 
     expect(res.status).toBe(200)
-    expect(res.headers.get("content-type")).toContain("image/svg+xml")
+    expect(res.headers.get("content-type")).toBe("image/svg+xml; charset=utf-8")
   })
 
   it("serves an XHTML file", async () => {
@@ -153,6 +154,9 @@ describe("GET /public/*", () => {
     )
 
     expect(res.status).toBe(200)
+    expect(res.headers.get("content-type")).toBe(
+      "application/xhtml+xml; charset=utf-8",
+    )
   })
 
   it("serves HTML in a subdirectory with encoded path", async () => {
@@ -167,7 +171,19 @@ describe("GET /public/*", () => {
     )
 
     expect(res.status).toBe(200)
-    expect(res.headers.get("content-type")).toContain("text/html")
+    expect(res.headers.get("content-type")).toBe("text/html; charset=utf-8")
+  })
+
+  it("does not add charset to binary content types", async () => {
+    const pngHeader = Buffer.from([0x89, 0x50, 0x4e, 0x47])
+    await writeFile(path.join(UPLOAD_DIR, "public", "binary.png"), pngHeader)
+
+    const res = await app.request(
+      new Request("http://localhost/public/binary.png"),
+    )
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get("content-type")).toBe("image/png")
   })
 
   it("returns 404 when path is a directory", async () => {


### PR DESCRIPTION
## Issues

- Close #828

## Why

`/public/*` の HTML 系レスポンスに `charset=utf-8` が付いておらず、`<meta charset>` がない生成 HTML で日本語が文字化けするためです。

## Summary

public 配信と file 系レスポンスで使う MIME を共通化し、UTF-8 前提のテキスト系 MIME に `charset=utf-8` を付与するようにしました。あわせて HTML 系とバイナリ系の Content-Type を確認する回帰テストを追加しました。

## Changes

- `src/utils/mimeType.ts` を追加し、レスポンス用 MIME 正規化 helper を実装
- `/public/*` と `/file` 系レスポンスで helper を利用するよう変更
- HTML/HTM/XHTML/SVG に `charset=utf-8` が付くことと、PNG に不要な charset が付かないことをテストで確認

## Checklist

- [x] `bun run lint`
- [x] `bun test`
