### PR TITLE
feat(portfolio): move generate/preview actions into code block header

### DIFF
--- a/projects/portfolio/src/client/components/chat/assistant-code-block.tsx
+++ b/projects/portfolio/src/client/components/chat/assistant-code-block.tsx
@@ -83,18 +83,17 @@ function AssistantSavableCodeBlock({
 
   const existing = ctx.generatedFiles.find((f) => f.blockIndex === blockIndex)
   const supported = isSupportedLanguage(detectedLanguage)
-  const canShowActions = supported && (!!existing || ctx.canSaveGeneratedFile)
+  const previewHref = existing ? existing.previewUrl || existing.publicPath : undefined
+  const canShowSaveAction = supported && !existing && ctx.canSaveGeneratedFile
 
   return (
     <div>
-      <CodeBlockRenderer className={className} {...rest}>
+      <CodeBlockRenderer className={className} previewHref={previewHref} {...rest}>
         {children}
       </CodeBlockRenderer>
-      {canShowActions && (
+      {canShowSaveAction && (
         <GeneratedFileActions
-          existing={existing}
           disabled={ctx.disabled}
-          canSave={ctx.canSaveGeneratedFile}
           onSave={() =>
             ctx.onSave({
               blockIndex,
@@ -109,37 +108,13 @@ function AssistantSavableCodeBlock({
 }
 
 interface GeneratedFileActionsProps {
-  existing: GeneratedCodeFile | undefined
   disabled?: boolean
-  canSave?: boolean
   onSave: () => Promise<GeneratedCodeFile | null>
 }
 
-function GeneratedFileActions({ existing, disabled, canSave, onSave }: GeneratedFileActionsProps) {
+function GeneratedFileActions({ disabled, onSave }: GeneratedFileActionsProps) {
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
-
-  if (existing) {
-    const previewHref = existing.previewUrl || existing.publicPath
-
-    return (
-      <div className='mt-1 flex items-center gap-2 text-xs'>
-        <a
-          href={previewHref}
-          target='_blank'
-          rel='noopener noreferrer'
-          className='rounded-md border border-gray-200 bg-gray-50 px-2 py-1 text-gray-700 hover:bg-gray-100 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600'
-        >
-          プレビュー
-        </a>
-        <span className='text-gray-400 dark:text-gray-500'>{existing.fileName}</span>
-      </div>
-    )
-  }
-
-  if (!canSave) {
-    return null
-  }
 
   const handleClick = async () => {
     setSaving(true)

--- a/projects/portfolio/src/client/components/chat/assistant-code-block.tsx
+++ b/projects/portfolio/src/client/components/chat/assistant-code-block.tsx
@@ -86,41 +86,18 @@ function AssistantSavableCodeBlock({
   const previewHref = existing ? existing.previewUrl || existing.publicPath : undefined
   const canShowSaveAction = supported && !existing && ctx.canSaveGeneratedFile
 
-  return (
-    <div>
-      <CodeBlockRenderer className={className} previewHref={previewHref} {...rest}>
-        {children}
-      </CodeBlockRenderer>
-      {canShowSaveAction && (
-        <GeneratedFileActions
-          disabled={ctx.disabled}
-          onSave={() =>
-            ctx.onSave({
-              blockIndex,
-              language: detectedLanguage ?? '',
-              content: code,
-            })
-          }
-        />
-      )}
-    </div>
-  )
-}
-
-interface GeneratedFileActionsProps {
-  disabled?: boolean
-  onSave: () => Promise<GeneratedCodeFile | null>
-}
-
-function GeneratedFileActions({ disabled, onSave }: GeneratedFileActionsProps) {
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  const handleClick = async () => {
+  const handleSave = async () => {
     setSaving(true)
     setError(null)
     try {
-      await onSave()
+      await ctx.onSave({
+        blockIndex,
+        language: detectedLanguage ?? '',
+        content: code,
+      })
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to save')
     } finally {
@@ -129,16 +106,24 @@ function GeneratedFileActions({ disabled, onSave }: GeneratedFileActionsProps) {
   }
 
   return (
-    <div className='mt-1 flex items-center gap-2 text-xs'>
-      <button
-        type='button'
-        onClick={handleClick}
-        disabled={saving || disabled}
-        className='cursor-pointer rounded-md border border-gray-200 bg-gray-50 px-2 py-1 text-gray-700 hover:bg-gray-100 disabled:cursor-default disabled:opacity-60 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600'
+    <div>
+      <CodeBlockRenderer
+        className={className}
+        previewHref={previewHref}
+        generateAction={
+          canShowSaveAction
+            ? {
+                onClick: handleSave,
+                pending: saving,
+                disabled: ctx.disabled,
+              }
+            : undefined
+        }
+        {...rest}
       >
-        {saving ? '生成中…' : '生成'}
-      </button>
-      {error && <span className='text-red-500'>{error}</span>}
+        {children}
+      </CodeBlockRenderer>
+      {error && <div className='mt-1 text-red-500 text-xs'>{error}</div>}
     </div>
   )
 }

--- a/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
+++ b/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
@@ -1,6 +1,7 @@
 import { copyToClipboard } from '#/client/components/chat/copy-to-clipboard'
 import { CheckIcon } from '#/client/components/svg/check-icon'
 import { CopyIcon } from '#/client/components/svg/copy-icon'
+import { EyeIcon } from '#/client/components/svg/eye-icon'
 import type { AnchorHTMLAttributes, CSSProperties, HTMLAttributes, MouseEvent, ReactNode } from 'react'
 import { useState } from 'react'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
@@ -86,6 +87,25 @@ const SUPPORTED_LANGUAGES = [
 
 type CodeBlockRendererProps = HTMLAttributes<HTMLElement> & {
   children?: ReactNode | string
+  previewHref?: string
+}
+
+interface CodeBlockPreviewButtonProps {
+  href: string
+}
+
+function CodeBlockPreviewButton({ href }: CodeBlockPreviewButtonProps) {
+  return (
+    <a
+      href={href}
+      target='_blank'
+      rel='noopener noreferrer'
+      aria-label='Preview code block'
+      className='relative inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-md text-gray-600 transition-[background-color,color] duration-200 ease-out hover:bg-gray-200 hover:text-gray-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white dark:focus-visible:ring-gray-500'
+    >
+      <EyeIcon size={18} className='stroke-current' />
+    </a>
+  )
 }
 
 interface CodeBlockCopyButtonProps {
@@ -126,7 +146,7 @@ function CodeBlockCopyButton({ copied, onClick }: CodeBlockCopyButtonProps) {
   )
 }
 
-export function CodeBlockRenderer({ className, children }: CodeBlockRendererProps) {
+export function CodeBlockRenderer({ className, children, previewHref }: CodeBlockRendererProps) {
   const [copied, setCopied] = useState(false)
 
   const code = typeof children === 'string' ? children : Array.isArray(children) ? children.join('') : ''
@@ -189,7 +209,10 @@ export function CodeBlockRenderer({ className, children }: CodeBlockRendererProp
             <path d='M5 7.5L10 12.5L15 7.5' strokeWidth='1.8' strokeLinecap='round' strokeLinejoin='round' />
           </svg>
         </div>
-        <CodeBlockCopyButton copied={copied} onClick={handleClickCopy} />
+        <div className='flex items-center gap-1'>
+          {previewHref && <CodeBlockPreviewButton href={previewHref} />}
+          <CodeBlockCopyButton copied={copied} onClick={handleClickCopy} />
+        </div>
       </div>
       <div className='overflow-x-auto'>
         <SyntaxHighlighter

--- a/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
+++ b/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
@@ -2,6 +2,7 @@ import { copyToClipboard } from '#/client/components/chat/copy-to-clipboard'
 import { CheckIcon } from '#/client/components/svg/check-icon'
 import { CopyIcon } from '#/client/components/svg/copy-icon'
 import { EyeIcon } from '#/client/components/svg/eye-icon'
+import { SparkleIcon } from '#/client/components/svg/sparkle-icon'
 import type { AnchorHTMLAttributes, CSSProperties, HTMLAttributes, MouseEvent, ReactNode } from 'react'
 import { useState } from 'react'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
@@ -88,6 +89,13 @@ const SUPPORTED_LANGUAGES = [
 type CodeBlockRendererProps = HTMLAttributes<HTMLElement> & {
   children?: ReactNode | string
   previewHref?: string
+  generateAction?: CodeBlockGenerateAction
+}
+
+export interface CodeBlockGenerateAction {
+  onClick: () => void
+  pending?: boolean
+  disabled?: boolean
 }
 
 interface CodeBlockPreviewButtonProps {
@@ -105,6 +113,20 @@ function CodeBlockPreviewButton({ href }: CodeBlockPreviewButtonProps) {
     >
       <EyeIcon size={18} className='stroke-current' />
     </a>
+  )
+}
+
+function CodeBlockGenerateButton({ onClick, pending, disabled }: CodeBlockGenerateAction) {
+  return (
+    <button
+      type='button'
+      onClick={onClick}
+      disabled={pending || disabled}
+      aria-label={pending ? 'Generating preview' : 'Generate preview'}
+      className='relative inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-md text-gray-600 transition-[background-color,color] duration-200 ease-out hover:bg-gray-200 hover:text-gray-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 disabled:cursor-default disabled:opacity-60 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white dark:focus-visible:ring-gray-500'
+    >
+      <SparkleIcon size={18} className={`stroke-current ${pending ? 'animate-pulse' : ''}`} />
+    </button>
   )
 }
 
@@ -146,7 +168,7 @@ function CodeBlockCopyButton({ copied, onClick }: CodeBlockCopyButtonProps) {
   )
 }
 
-export function CodeBlockRenderer({ className, children, previewHref }: CodeBlockRendererProps) {
+export function CodeBlockRenderer({ className, children, previewHref, generateAction }: CodeBlockRendererProps) {
   const [copied, setCopied] = useState(false)
 
   const code = typeof children === 'string' ? children : Array.isArray(children) ? children.join('') : ''
@@ -211,6 +233,7 @@ export function CodeBlockRenderer({ className, children, previewHref }: CodeBloc
         </div>
         <div className='flex items-center gap-1'>
           {previewHref && <CodeBlockPreviewButton href={previewHref} />}
+          {!previewHref && generateAction && <CodeBlockGenerateButton {...generateAction} />}
           <CodeBlockCopyButton copied={copied} onClick={handleClickCopy} />
         </div>
       </div>

--- a/projects/portfolio/src/client/components/svg/eye-icon.tsx
+++ b/projects/portfolio/src/client/components/svg/eye-icon.tsx
@@ -1,0 +1,22 @@
+import { type IconProps, SvgIcon } from './icon-base'
+
+export function EyeIcon({ size = 24, className = 'stroke-black dark:stroke-white' }: IconProps) {
+  return (
+    <SvgIcon size={size} title='eye-icon'>
+      <path
+        d='M2.25 12C2.25 12 5.25 5.25 12 5.25C18.75 5.25 21.75 12 21.75 12C21.75 12 18.75 18.75 12 18.75C5.25 18.75 2.25 12 2.25 12Z'
+        className={className}
+        strokeWidth='1.5'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+      />
+      <path
+        d='M12 15C13.6569 15 15 13.6569 15 12C15 10.3431 13.6569 9 12 9C10.3431 9 9 10.3431 9 12C9 13.6569 10.3431 15 12 15Z'
+        className={className}
+        strokeWidth='1.5'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+      />
+    </SvgIcon>
+  )
+}

--- a/projects/portfolio/src/client/components/svg/sparkle-icon.tsx
+++ b/projects/portfolio/src/client/components/svg/sparkle-icon.tsx
@@ -1,0 +1,22 @@
+import { type IconProps, SvgIcon } from './icon-base'
+
+export function SparkleIcon({ size = 24, className = 'stroke-black dark:stroke-white' }: IconProps) {
+  return (
+    <SvgIcon size={size} title='sparkle-icon'>
+      <path
+        d='M12 3V7M12 17V21M5 12H3M21 12H19M6.34 6.34L4.93 4.93M19.07 19.07L17.66 17.66M6.34 17.66L4.93 19.07M19.07 4.93L17.66 6.34'
+        className={className}
+        strokeWidth='1.5'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+      />
+      <path
+        d='M12 8.5L13.2 10.8L15.5 12L13.2 13.2L12 15.5L10.8 13.2L8.5 12L10.8 10.8L12 8.5Z'
+        className={className}
+        strokeWidth='1.5'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+      />
+    </SvgIcon>
+  )
+}

--- a/projects/portfolio/tests/client/components/message-renderer.test.tsx
+++ b/projects/portfolio/tests/client/components/message-renderer.test.tsx
@@ -50,7 +50,7 @@ describe('MessageRenderer', () => {
         />
       )
 
-      expect(screen.queryByRole('button', { name: '生成' })).toBeNull()
+      expect(screen.queryByRole('button', { name: 'Generate preview' })).toBeNull()
     })
 
     it('認証済みなら対応言語の生成ボタンを表示する', () => {
@@ -67,7 +67,7 @@ describe('MessageRenderer', () => {
         />
       )
 
-      expect(screen.getByRole('button', { name: '生成' })).toBeTruthy()
+      expect(screen.getByRole('button', { name: 'Generate preview' })).toBeTruthy()
     })
 
     it('非対応言語なら認証済みでも生成ボタンを表示しない', () => {
@@ -84,7 +84,7 @@ describe('MessageRenderer', () => {
         />
       )
 
-      expect(screen.queryByRole('button', { name: '生成' })).toBeNull()
+      expect(screen.queryByRole('button', { name: 'Generate preview' })).toBeNull()
     })
   })
 
@@ -118,7 +118,7 @@ describe('MessageRenderer', () => {
       expect(previewLink.getAttribute('href')).toBe(
         'http://files.example.com/public/portfolio/c1/message-1-block-0.html'
       )
-      expect(screen.queryByRole('button', { name: '生成' })).toBeNull()
+      expect(screen.queryByRole('button', { name: 'Generate preview' })).toBeNull()
     })
   })
 })

--- a/projects/portfolio/tests/client/components/message-renderer.test.tsx
+++ b/projects/portfolio/tests/client/components/message-renderer.test.tsx
@@ -113,7 +113,7 @@ describe('MessageRenderer', () => {
         />
       )
 
-      const previewLink = screen.getByRole('link', { name: 'プレビュー' })
+      const previewLink = screen.getByRole('link', { name: 'Preview code block' })
       expect(previewLink).toBeTruthy()
       expect(previewLink.getAttribute('href')).toBe(
         'http://files.example.com/public/portfolio/c1/message-1-block-0.html'


### PR DESCRIPTION
## Why

チャットメッセージのHTML等のコードブロックで、プレビュー/生成アクションがコードブロック下部に独立したラベル付きボタンとして表示されており、視認性とレイアウトの密度が低かった。CodeBlockヘッダーの既存アクション（コピーボタン）と統一されたSVGアイコンボタンとして並べることで、UIを簡潔にする。

## Summary

生成コード向けの「プレビュー」「生成」アクションを CodeBlock ヘッダー（コピーボタンの左）に SVG アイコンボタンとして配置し、コードブロック下部のファイル名ラベルを廃止しました。

## Changes

- `EyeIcon`（プレビュー）と `SparkleIcon`（生成）を追加
- `CodeBlockRenderer` に `previewHref` と `generateAction` プロパティを追加し、ヘッダー右側に SVG ボタンを描画
- `AssistantSavableCodeBlock` で保存状態を管理し、既存ファイルの有無に応じてプレビュー/生成ボタンのどちらかを表示
- コードブロック下部の `GeneratedFileActions` を廃止（ファイル名ラベルとテキストボタンを削除、エラーメッセージのみ残す）
- `message-renderer.test.tsx` のアクセシブルネームを新しい aria-label に更新

## Checklist

- [x] `bun run test` 成功
- [x] `bun run lint` 成功
- [x] `bun run format` 適用済み
- [ ] ブラウザで実際に生成→プレビューの動線を確認
