### PR TITLE
feat(file-server): add GUI move for files and folders (#836)

### DIFF
--- a/projects/file-server/AGENTS.md
+++ b/projects/file-server/AGENTS.md
@@ -3,6 +3,13 @@
 Web-based file server built with Bun + Hono + HTMX.
 Current features include empty file creation, per-directory Zip download via `/file/archive`, unauthenticated public file serving via `GET /public/*`, and GUI-based user management via `/admin/users`.
 
+## GUI Move
+
+- The browse list exposes a `Move` action alongside `Rename` and `Delete`. Clicking it opens a directory-picker modal served by `GET /api/move/picker`.
+- The picker is scope-bound: sources under `public/` can only choose destinations under `public/`, and sources under `private/<username>/` are limited to the same scope (admins see the entire `private/` tree; regular users see only their own `private/<username>/`).
+- Submitting selects the current picker directory as the destination and posts to `POST /api/move`, which moves the entry while preserving its basename. Renaming is handled by the existing `Rename` action.
+- `POST /api/move` errors: `PathError` (traversal/invalid path), `Forbidden` (no write permission on source or destination), `CrossScope` (public ⇄ private rejected even for admin), `DestNotFound`, `DestNotDirectory`, `InvalidDestination` (moving a directory into itself or a subdirectory), `AlreadyExists`.
+
 ## File Raw and Download Routes
 
 - `GET /file/raw` — preview-only route. Blocks `text/html`, `application/xhtml+xml`, `image/svg+xml`, and extensions `.html`, `.htm`, `.xhtml`, `.svg` with `403`. SVG is treated as source view (not embedded image) and is also blocked. Existing image/video/PDF preview behavior is preserved.
@@ -32,7 +39,7 @@ Current features include empty file creation, per-directory Zip download via `/f
 - `src/api/handlers.tsx` - API handlers
 - `src/components/` - JSX components
 - `src/utils/` - Utilities (incl. `virtualPath.ts` for scope resolution)
-- `tests/` - Tests (auth, read, upload, create-file, delete, mkdir, update, rename, public-route)
+- `tests/` - Tests (auth, read, upload, create-file, delete, mkdir, update, rename, move, public-route)
 - `tests/helpers/` - `createTestApp.ts` and `auth.ts` helpers
 
 ## Environment Variables

--- a/projects/file-server/src/api/handlers.tsx
+++ b/projects/file-server/src/api/handlers.tsx
@@ -9,6 +9,7 @@ import {
 } from "node:fs/promises"
 import * as path from "node:path"
 import type { Context } from "hono"
+import { MovePickerModal } from "../components/file-list/MovePickerModal"
 import type { AppBindings } from "../types"
 import {
   alreadyExistsResponse,
@@ -302,6 +303,234 @@ export async function renameHandler(c: Context<AppBindings>) {
   await rename(sourcePath, destinationPath)
 
   return renderFileListResponse(c, baseDir, normalizedParentPath)
+}
+
+function getTopScope(virtualPath: string): string | null {
+  const parts = virtualPath.split("/").filter(Boolean)
+  return parts[0] ?? null
+}
+
+function containsParentSegment(p: string): boolean {
+  return p
+    .replaceAll("\\", "/")
+    .split("/")
+    .some((seg) => seg === "..")
+}
+
+function resolveMovePickerRoot(
+  user:
+    | { type: "anonymous" }
+    | { type: "authenticated"; username: string; role: "admin" | "user" },
+  scope: "public" | "private",
+): string {
+  if (scope === "public") {
+    return "public"
+  }
+  if (user.type === "authenticated" && user.role === "user") {
+    return `private/${user.username}`
+  }
+  return "private"
+}
+
+export async function moveHandler(c: Context<AppBindings>) {
+  const validatedData = c.req.valid("form" as never) as {
+    path: string
+    destination: string
+  }
+  const { path: sourcePathParam, destination: destinationParam } = validatedData
+  const baseDir = getUploadDir(c)
+  const user = c.get("user") ?? { type: "anonymous" as const }
+
+  if (
+    isPathTraversal(sourcePathParam) ||
+    isPathTraversal(destinationParam) ||
+    containsParentSegment(sourcePathParam) ||
+    containsParentSegment(destinationParam)
+  ) {
+    return errorResponse(c, "PathError", "Invalid path", 400)
+  }
+
+  const normalizedSource = normalizeRelativePath(sourcePathParam)
+  const normalizedDestination = normalizeRelativePath(destinationParam)
+
+  if (!normalizedSource) {
+    return errorResponse(c, "PathError", "Invalid path", 400)
+  }
+
+  if (!requireWritePermission(user, normalizedSource)) {
+    return errorResponse(c, "Forbidden", "Access denied", 403)
+  }
+  if (!requireWritePermission(user, normalizedDestination)) {
+    return errorResponse(c, "Forbidden", "Access denied", 403)
+  }
+
+  const sourceScope = getTopScope(normalizedSource)
+  const destinationScope = getTopScope(normalizedDestination)
+  if (sourceScope !== destinationScope) {
+    return errorResponse(
+      c,
+      "CrossScope",
+      "Cannot move across public and private scopes",
+      400,
+    )
+  }
+
+  const sourcePath = path.join(baseDir, normalizedSource)
+  let sourceStat: Awaited<ReturnType<typeof fsStat>>
+  try {
+    sourceStat = await fsStat(sourcePath)
+  } catch (err: unknown) {
+    if (isNodeErrorCode(err, "ENOENT")) {
+      return errorResponse(
+        c,
+        "FileNotFound",
+        "File or directory does not exist",
+        400,
+      )
+    }
+    throw err
+  }
+
+  const destinationDirPath = path.join(baseDir, normalizedDestination)
+  try {
+    const destStat = await fsStat(destinationDirPath)
+    if (!destStat.isDirectory()) {
+      return errorResponse(
+        c,
+        "DestNotDirectory",
+        "Destination is not a directory",
+        400,
+      )
+    }
+  } catch (err: unknown) {
+    if (isNodeErrorCode(err, "ENOENT")) {
+      return errorResponse(
+        c,
+        "DestNotFound",
+        "Destination directory does not exist",
+        400,
+      )
+    }
+    throw err
+  }
+
+  if (sourceStat.isDirectory()) {
+    const resolvedSource = path.resolve(sourcePath)
+    const resolvedDest = path.resolve(destinationDirPath)
+    if (
+      resolvedDest === resolvedSource ||
+      resolvedDest.startsWith(`${resolvedSource}${path.sep}`)
+    ) {
+      return errorResponse(
+        c,
+        "InvalidDestination",
+        "Cannot move a directory into itself",
+        400,
+      )
+    }
+  }
+
+  const basename = path.basename(normalizedSource)
+  const finalDestinationRelative = normalizedDestination
+    ? `${normalizedDestination}/${basename}`
+    : basename
+  const finalDestinationPath = path.join(baseDir, finalDestinationRelative)
+
+  const sourceParent = normalizeRelativePath(path.dirname(normalizedSource))
+
+  if (path.resolve(sourcePath) === path.resolve(finalDestinationPath)) {
+    return renderFileListResponse(c, baseDir, sourceParent)
+  }
+
+  try {
+    await fsStat(finalDestinationPath)
+    return alreadyExistsResponse(c, basename)
+  } catch (err: unknown) {
+    if (!isNodeErrorCode(err, "ENOENT")) {
+      throw err
+    }
+  }
+
+  await rename(sourcePath, finalDestinationPath)
+
+  return renderFileListResponse(c, baseDir, sourceParent)
+}
+
+export async function movePickerHandler(c: Context<AppBindings>) {
+  const sourceParam = c.req.query("source") ?? ""
+  const destParam = c.req.query("dest")
+  const baseDir = getUploadDir(c)
+  const user = c.get("user") ?? { type: "anonymous" as const }
+
+  if (
+    !sourceParam ||
+    isPathTraversal(sourceParam) ||
+    containsParentSegment(sourceParam)
+  ) {
+    return errorResponse(c, "PathError", "Invalid source", 400)
+  }
+  if (destParam !== undefined && containsParentSegment(destParam)) {
+    return errorResponse(c, "PathError", "Invalid destination", 400)
+  }
+
+  const normalizedSource = normalizeRelativePath(sourceParam)
+  if (!normalizedSource) {
+    return errorResponse(c, "PathError", "Invalid source", 400)
+  }
+
+  if (!requireWritePermission(user, normalizedSource)) {
+    return errorResponse(c, "Forbidden", "Access denied", 403)
+  }
+
+  const scope = getTopScope(normalizedSource)
+  if (scope !== "public" && scope !== "private") {
+    return errorResponse(c, "PathError", "Invalid source scope", 400)
+  }
+
+  const pickerRoot = resolveMovePickerRoot(user, scope)
+
+  let currentDest: string
+  if (destParam === undefined) {
+    const sourceParent = normalizeRelativePath(path.dirname(normalizedSource))
+    currentDest = sourceParent || pickerRoot
+  } else {
+    const normalized = normalizeRelativePath(destParam)
+    currentDest = normalized || pickerRoot
+  }
+
+  if (isPathTraversal(currentDest)) {
+    return errorResponse(c, "PathError", "Invalid destination", 400)
+  }
+
+  if (currentDest !== pickerRoot && !currentDest.startsWith(`${pickerRoot}/`)) {
+    currentDest = pickerRoot
+  }
+
+  const resolved = resolveVirtualPath(baseDir, user, currentDest)
+  if (resolved.kind !== "resolved") {
+    return errorResponse(c, "PathError", "Cannot resolve destination", 400)
+  }
+
+  try {
+    const entries = await getFileList(resolved.resolvedPath)
+    const directories = entries
+      .filter((entry) => entry.type === "dir")
+      .map(({ mtime: _m, size: _s, ...rest }) => rest)
+    return c.html(
+      <MovePickerModal
+        source={normalizedSource}
+        sourceName={path.basename(normalizedSource)}
+        currentDest={currentDest}
+        pickerRoot={pickerRoot}
+        directories={directories}
+      />,
+    )
+  } catch (err: unknown) {
+    if (isNodeErrorCode(err, "ENOENT")) {
+      return errorResponse(c, "DestNotFound", "Destination does not exist", 400)
+    }
+    throw err
+  }
 }
 
 export async function updateFileHandler(c: Context<AppBindings>) {

--- a/projects/file-server/src/components/PageShell.tsx
+++ b/projects/file-server/src/components/PageShell.tsx
@@ -8,7 +8,7 @@ interface PageShellProps {
 
 const inlineFormErrorScript = `
   (() => {
-    const formEndpoints = new Set(["/api/file", "/api/mkdir", "/api/rename"]);
+    const formEndpoints = new Set(["/api/file", "/api/mkdir", "/api/rename", "/api/move"]);
 
     const getForm = (detail) => {
       const source = detail?.elt instanceof Element ? detail.elt : null;
@@ -56,6 +56,20 @@ const inlineFormErrorScript = `
       }
     });
 
+    document.addEventListener("htmx:afterRequest", (event) => {
+      const form = getForm(event.detail);
+      if (!form?.matches("[data-move-form]")) {
+        return;
+      }
+      if (!event.detail?.successful) {
+        return;
+      }
+      const picker = document.getElementById("move-picker-container");
+      if (picker) {
+        picker.innerHTML = "";
+      }
+    });
+
     document.addEventListener("htmx:responseError", (event) => {
       const form = getForm(event.detail);
       if (!form?.matches("[data-inline-error-form]")) {
@@ -75,10 +89,7 @@ const inlineFormErrorScript = `
 
       try {
         const payload = JSON.parse(xhr.responseText);
-        if (
-          payload?.error?.name !== "AlreadyExists" ||
-          typeof payload?.error?.message !== "string"
-        ) {
+        if (typeof payload?.error?.message !== "string") {
           return;
         }
         showFormError(form, payload.error.message);
@@ -166,6 +177,7 @@ export const PageShell: FC<PageShellProps> = ({ children, user }) => {
           </div>
         </div>
         <div id="file-viewer-container"></div>
+        <div id="move-picker-container"></div>
       </body>
     </html>
   )

--- a/projects/file-server/src/components/file-list/FileRow.tsx
+++ b/projects/file-server/src/components/file-list/FileRow.tsx
@@ -9,6 +9,7 @@ import { DeleteIcon } from "../icons/DeleteIcon"
 import { EditIcon } from "../icons/EditIcon"
 import { FileIcon } from "../icons/FileIcon"
 import { FolderIcon } from "../icons/FolderIcon"
+import { MoveIcon } from "../icons/MoveIcon"
 import {
   closeRenameFormScript,
   renameButtonScript,
@@ -30,7 +31,7 @@ export function FileRow({ file }: FileRowProps) {
   const renameFormId = `rename-form-${encodedPath}`
   const renameInputId = `rename-input-${encodedPath}`
   const browseHref = buildBrowseHref(file.path)
-  const showRowActions = file.canRename || file.canDelete
+  const showRowActions = file.canRename || file.canDelete || file.canMove
 
   return (
     <li
@@ -85,6 +86,25 @@ export function FileRow({ file }: FileRowProps) {
               className="flex shrink-0 justify-end gap-2"
               hx-on:click={stopPropagationScript}
             >
+              {file.canMove && (
+                <button
+                  type="button"
+                  title="Move"
+                  aria-label="Move"
+                  className={`${secondaryButtonClassName} h-8 w-8 px-0 md:w-auto md:px-3`}
+                  hx-get={`/api/move/picker?source=${encodedPath}`}
+                  hx-target="#move-picker-container"
+                  hx-swap="innerHTML"
+                >
+                  <span className="md:hidden">
+                    <MoveIcon />
+                  </span>
+                  <span className="hidden md:flex md:items-center md:gap-2">
+                    <MoveIcon />
+                    <span>Move</span>
+                  </span>
+                </button>
+              )}
               {file.canRename && (
                 <button
                   type="button"

--- a/projects/file-server/src/components/file-list/MovePickerModal.tsx
+++ b/projects/file-server/src/components/file-list/MovePickerModal.tsx
@@ -1,0 +1,177 @@
+import type { FC } from "hono/jsx"
+import {
+  dismissButtonClassName,
+  dismissIconButtonClassName,
+  primaryButtonClassName,
+} from "../buttonStyles"
+import { CloseIcon } from "../icons/CloseIcon"
+import { FolderIcon } from "../icons/FolderIcon"
+import { FormErrorMessage } from "./FormErrorMessage"
+import type { FileItem } from "./types"
+
+interface MovePickerModalProps {
+  source: string
+  sourceName: string
+  currentDest: string
+  pickerRoot: string
+  directories: FileItem[]
+}
+
+const closePickerScript =
+  "document.getElementById('move-picker-container').innerHTML = '';"
+
+interface PickerCrumb {
+  label: string
+  path: string
+}
+
+function buildPickerBreadcrumbs(
+  pickerRoot: string,
+  currentDest: string,
+): PickerCrumb[] {
+  const rootParts = pickerRoot.split("/").filter(Boolean)
+  const currentParts = currentDest.split("/").filter(Boolean)
+  const rootLabel = rootParts[rootParts.length - 1] ?? pickerRoot
+  const crumbs: PickerCrumb[] = [{ label: rootLabel, path: pickerRoot }]
+
+  let acc = pickerRoot
+  for (let i = rootParts.length; i < currentParts.length; i++) {
+    const part = currentParts[i]
+    acc = acc ? `${acc}/${part}` : part
+    crumbs.push({ label: part, path: acc })
+  }
+
+  return crumbs
+}
+
+function pickerHref(source: string, dest: string): string {
+  return `/api/move/picker?source=${encodeURIComponent(source)}&dest=${encodeURIComponent(dest)}`
+}
+
+export const MovePickerModal: FC<MovePickerModalProps> = ({
+  source,
+  sourceName,
+  currentDest,
+  pickerRoot,
+  directories,
+}) => {
+  const breadcrumbs = buildPickerBreadcrumbs(pickerRoot, currentDest)
+  const sourceParent = source.split("/").slice(0, -1).join("/")
+  const isSameAsSourceParent = currentDest === sourceParent
+
+  return (
+    <div
+      data-move-picker-modal
+      className="fixed inset-0 bg-black/30 backdrop-blur-sm flex items-center justify-center z-50 p-4"
+      hx-on:click={closePickerScript}
+    >
+      <div
+        className="bg-white p-6 rounded-2xl max-w-lg w-full max-h-[80vh] overflow-hidden flex flex-col border-4 border-indigo-300"
+        hx-on:click="event.stopPropagation();"
+      >
+        <div className="flex justify-between items-center mb-4 pb-4 border-b-2 border-indigo-200 flex-shrink-0 gap-3">
+          <h2 className="text-xl font-bold bg-gradient-to-r from-indigo-600 to-purple-600 bg-clip-text text-transparent truncate">
+            Move "{sourceName}"
+          </h2>
+          <button
+            type="button"
+            aria-label="Close"
+            hx-on:click={closePickerScript}
+            className={dismissIconButtonClassName}
+          >
+            <CloseIcon />
+          </button>
+        </div>
+
+        <nav
+          data-picker-breadcrumbs
+          className="mb-3 p-3 bg-gradient-to-r from-indigo-50 to-purple-50 rounded-xl border border-indigo-200 text-sm break-all"
+        >
+          {breadcrumbs.map((crumb, idx) => {
+            const isLast = idx === breadcrumbs.length - 1
+            return (
+              <span key={`${crumb.label}:${crumb.path}`}>
+                <button
+                  type="button"
+                  hx-get={pickerHref(source, crumb.path)}
+                  hx-target="#move-picker-container"
+                  hx-swap="innerHTML"
+                  className="text-indigo-600 font-semibold hover:text-purple-600 mx-1 cursor-pointer"
+                >
+                  {crumb.label}
+                </button>
+                {!isLast ? " / " : ""}
+              </span>
+            )
+          })}
+        </nav>
+
+        <div
+          data-picker-directories
+          className="flex-1 min-h-[8rem] overflow-y-auto mb-4 border border-indigo-100 rounded-xl"
+        >
+          {directories.length === 0 ? (
+            <p className="py-8 px-4 text-center text-gray-500">
+              No subdirectories here.
+            </p>
+          ) : (
+            <ul className="list-none p-2 m-0">
+              {directories.map((dir) => {
+                const dirPath = currentDest
+                  ? `${currentDest}/${dir.name}`
+                  : dir.name
+                return (
+                  <li
+                    key={dir.name}
+                    className="py-2 px-3 mb-1 rounded-lg border-2 border-transparent hover:border-indigo-300 hover:bg-indigo-50 cursor-pointer flex items-center gap-2 text-indigo-700 font-medium"
+                    hx-get={pickerHref(source, dirPath)}
+                    hx-target="#move-picker-container"
+                    hx-swap="innerHTML"
+                  >
+                    <FolderIcon />
+                    <span className="break-all">{dir.name}/</span>
+                  </li>
+                )
+              })}
+            </ul>
+          )}
+        </div>
+
+        <form
+          hx-post="/api/move"
+          hx-target="#file-list-container"
+          hx-swap="innerHTML"
+          data-inline-error-form
+          data-move-form
+          className="flex-shrink-0 pt-4 border-t-2 border-indigo-200"
+        >
+          <input type="hidden" name="path" value={source} />
+          <input type="hidden" name="destination" value={currentDest} />
+          <p className="mb-3 text-sm text-gray-600 break-all">
+            Destination:{" "}
+            <span data-picker-destination className="font-mono text-indigo-700">
+              {currentDest || "/"}
+            </span>
+          </p>
+          <div className="flex gap-2 justify-end">
+            <button
+              type="button"
+              className={dismissButtonClassName}
+              hx-on:click={closePickerScript}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className={primaryButtonClassName}
+              disabled={isSameAsSourceParent}
+            >
+              Move here
+            </button>
+          </div>
+          <FormErrorMessage />
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/projects/file-server/src/components/file-list/types.ts
+++ b/projects/file-server/src/components/file-list/types.ts
@@ -9,6 +9,7 @@ export interface BrowseEntry extends FileItem {
   path: string
   canRename: boolean
   canDelete: boolean
+  canMove: boolean
   badge?: string
 }
 

--- a/projects/file-server/src/components/icons/MoveIcon.tsx
+++ b/projects/file-server/src/components/icons/MoveIcon.tsx
@@ -1,0 +1,21 @@
+import type { FC } from "hono/jsx"
+
+export const MoveIcon: FC = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    aria-hidden="true"
+  >
+    <title>Move</title>
+    <path d="M5 9l-3 3 3 3" />
+    <path d="M19 9l3 3-3 3" />
+    <path d="M9 5l3-3 3 3" />
+    <path d="M9 19l3 3 3-3" />
+    <path d="M2 12h20" />
+    <path d="M12 2v20" />
+  </svg>
+)

--- a/projects/file-server/src/routes/api.ts
+++ b/projects/file-server/src/routes/api.ts
@@ -6,6 +6,8 @@ import {
   deleteFileHandler,
   listFilesHandler,
   mkdirHandler,
+  moveHandler,
+  movePickerHandler,
   renameHandler,
   updateFileHandler,
   uploadFileHandler,
@@ -13,6 +15,22 @@ import {
 import type { AppBindings } from "../types"
 
 const apiRoutes = new Hono<AppBindings>()
+
+// 移動先ディレクトリピッカー（HTMX）
+apiRoutes.get("/move/picker", movePickerHandler)
+
+// ファイル・ディレクトリ移動
+apiRoutes.post(
+  "/move",
+  zValidator(
+    "form",
+    z.object({
+      path: z.string(),
+      destination: z.string(),
+    }),
+  ),
+  moveHandler,
+)
 
 // ファイル・ディレクトリ一覧取得（JSON API）
 apiRoutes.get("/*", listFilesHandler)

--- a/projects/file-server/src/utils/browseContext.ts
+++ b/projects/file-server/src/utils/browseContext.ts
@@ -86,13 +86,19 @@ function toBrowseEntry(
   file: FileItem,
   entryPath: string,
   user: UserState,
-  options?: { canRename?: boolean; canDelete?: boolean; badge?: string },
+  options?: {
+    canRename?: boolean
+    canDelete?: boolean
+    canMove?: boolean
+    badge?: string
+  },
 ): BrowseEntry {
   return {
     ...file,
     path: entryPath,
     canRename: options?.canRename ?? requireWritePermission(user, entryPath),
     canDelete: options?.canDelete ?? requireWritePermission(user, entryPath),
+    canMove: options?.canMove ?? requireWritePermission(user, entryPath),
     badge: options?.badge,
   }
 }
@@ -107,6 +113,7 @@ async function buildUserHomeView(
     toBrowseEntry({ name: "public", type: "dir" }, "public", user, {
       canRename: false,
       canDelete: false,
+      canMove: false,
       badge: "Shared",
     }),
     ...homeEntries.map((entry) =>
@@ -135,6 +142,7 @@ function buildSyntheticView(
       toBrowseEntry(entry, joinVirtualPath(requestPath, entry.name), user, {
         canRename: false,
         canDelete: false,
+        canMove: false,
       }),
     ),
     canCreate: false,

--- a/projects/file-server/tests/move.test.ts
+++ b/projects/file-server/tests/move.test.ts
@@ -1,0 +1,481 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { mkdir, readFile, rm, stat, writeFile } from "node:fs/promises"
+import path from "node:path"
+import { getUsersFilePath } from "../src/utils/auth"
+import { resetUsersCacheForTests } from "../src/utils/userConfigCache"
+import { createTestSession } from "./helpers/auth"
+import { createTestApp } from "./helpers/createTestApp"
+
+const UPLOAD_DIR = "./tmp-test-move"
+const AUTH_DIR = path.join(UPLOAD_DIR, ".auth")
+const SESSION_SECRET = "0123456789abcdef0123456789abcdef"
+let app: Awaited<ReturnType<typeof createTestApp>>
+
+type PlainUser = { username: string; password: string; role?: "admin" | "user" }
+
+async function writeUsers(users: PlainUser[]) {
+  const usersFile = getUsersFilePath(AUTH_DIR)
+  const userConfigs = await Promise.all(
+    users.map(async (u) => ({
+      username: u.username,
+      passwordHash: await Bun.password.hash(u.password, {
+        algorithm: "bcrypt",
+        cost: 4,
+      }),
+      role: u.role ?? "user",
+      sessionVersion: 0,
+    })),
+  )
+  await mkdir(path.dirname(usersFile), { recursive: true })
+  await writeFile(usersFile, JSON.stringify(userConfigs), "utf-8")
+  resetUsersCacheForTests()
+}
+
+async function postMove(
+  body: URLSearchParams,
+  extraHeaders: Record<string, string> = {},
+) {
+  return app.request(
+    new Request("http://localhost/api/move", {
+      method: "POST",
+      body,
+      headers: {
+        "content-type": "application/x-www-form-urlencoded",
+        ...extraHeaders,
+      },
+    }),
+  )
+}
+
+beforeEach(async () => {
+  await rm(UPLOAD_DIR, { recursive: true, force: true })
+  app = await createTestApp({ uploadDir: UPLOAD_DIR })
+})
+
+afterEach(async () => {
+  await rm(UPLOAD_DIR, { recursive: true, force: true })
+})
+
+describe("POST /api/move", () => {
+  it("moves a file within public to another subdirectory", async () => {
+    await mkdir(path.join(UPLOAD_DIR, "public", "dst"), { recursive: true })
+    await writeFile(path.join(UPLOAD_DIR, "public", "src.txt"), "hello")
+
+    const body = new URLSearchParams({
+      path: "public/src.txt",
+      destination: "public/dst",
+    })
+    const res = await postMove(body)
+    expect(res.status).toBe(301)
+    expect(res.headers.get("location")).toBe("/?path=public")
+    expect(
+      await readFile(
+        path.join(UPLOAD_DIR, "public", "dst", "src.txt"),
+        "utf-8",
+      ),
+    ).toBe("hello")
+    expect(
+      Bun.file(path.join(UPLOAD_DIR, "public", "src.txt")).text(),
+    ).rejects.toThrow()
+  })
+
+  it("moves a folder with contents into another public directory", async () => {
+    await mkdir(path.join(UPLOAD_DIR, "public", "dst"), { recursive: true })
+    await mkdir(path.join(UPLOAD_DIR, "public", "src-dir"), { recursive: true })
+    await writeFile(
+      path.join(UPLOAD_DIR, "public", "src-dir", "inside.txt"),
+      "payload",
+    )
+
+    const body = new URLSearchParams({
+      path: "public/src-dir",
+      destination: "public/dst",
+    })
+    const res = await postMove(body)
+    expect(res.status).toBe(301)
+    expect(
+      await stat(path.join(UPLOAD_DIR, "public", "dst", "src-dir")),
+    ).toMatchObject({ isDirectory: expect.any(Function) })
+    expect(
+      await readFile(
+        path.join(UPLOAD_DIR, "public", "dst", "src-dir", "inside.txt"),
+        "utf-8",
+      ),
+    ).toBe("payload")
+    expect(
+      Bun.file(path.join(UPLOAD_DIR, "public", "src-dir", "inside.txt")).text(),
+    ).rejects.toThrow()
+  })
+
+  it("returns DestNotFound when destination directory does not exist", async () => {
+    await writeFile(path.join(UPLOAD_DIR, "public", "src.txt"), "hello")
+
+    const body = new URLSearchParams({
+      path: "public/src.txt",
+      destination: "public/missing-dir",
+    })
+    const res = await postMove(body)
+    expect(res.status).toBe(400)
+    const json = (await res.json()) as {
+      success: boolean
+      error: { name: string }
+    }
+    expect(json.success).toBe(false)
+    expect(json.error.name).toBe("DestNotFound")
+  })
+
+  it("returns DestNotDirectory when destination is a file", async () => {
+    await writeFile(path.join(UPLOAD_DIR, "public", "src.txt"), "hello")
+    await writeFile(path.join(UPLOAD_DIR, "public", "already.txt"), "other")
+
+    const body = new URLSearchParams({
+      path: "public/src.txt",
+      destination: "public/already.txt",
+    })
+    const res = await postMove(body)
+    expect(res.status).toBe(400)
+    const json = (await res.json()) as {
+      success: boolean
+      error: { name: string }
+    }
+    expect(json.success).toBe(false)
+    expect(json.error.name).toBe("DestNotDirectory")
+  })
+
+  it("returns AlreadyExists when a same-name entry is present at destination", async () => {
+    await mkdir(path.join(UPLOAD_DIR, "public", "dst"), { recursive: true })
+    await writeFile(path.join(UPLOAD_DIR, "public", "src.txt"), "hello")
+    await writeFile(
+      path.join(UPLOAD_DIR, "public", "dst", "src.txt"),
+      "blocking",
+    )
+
+    const body = new URLSearchParams({
+      path: "public/src.txt",
+      destination: "public/dst",
+    })
+    const res = await postMove(body)
+    expect(res.status).toBe(400)
+    const json = (await res.json()) as {
+      success: boolean
+      error: { name: string; message: string }
+    }
+    expect(json.success).toBe(false)
+    expect(json.error.name).toBe("AlreadyExists")
+    expect(json.error.message).toBe('"src.txt" already exists.')
+  })
+
+  it("rejects path traversal in source", async () => {
+    const body = new URLSearchParams({
+      path: "../bad",
+      destination: "public",
+    })
+    const res = await postMove(body)
+    expect(res.status).toBe(400)
+    const json = (await res.json()) as {
+      success: boolean
+      error: { name: string }
+    }
+    expect(json.error.name).toBe("PathError")
+  })
+
+  it("rejects path traversal in destination", async () => {
+    await writeFile(path.join(UPLOAD_DIR, "public", "src.txt"), "hello")
+    const body = new URLSearchParams({
+      path: "public/src.txt",
+      destination: "public/../private",
+    })
+    const res = await postMove(body)
+    expect(res.status).toBe(400)
+    const json = (await res.json()) as {
+      success: boolean
+      error: { name: string }
+    }
+    expect(json.error.name).toBe("PathError")
+  })
+
+  it("rejects moving across public and private scopes", async () => {
+    await writeFile(path.join(UPLOAD_DIR, "public", "src.txt"), "hello")
+
+    const body = new URLSearchParams({
+      path: "public/src.txt",
+      destination: "private",
+    })
+    const res = await postMove(body)
+    expect(res.status).toBe(400)
+    const json = (await res.json()) as {
+      success: boolean
+      error: { name: string }
+    }
+    expect(json.error.name).toBe("CrossScope")
+  })
+
+  it("rejects moving a directory into itself", async () => {
+    await mkdir(path.join(UPLOAD_DIR, "public", "foo"), { recursive: true })
+
+    const body = new URLSearchParams({
+      path: "public/foo",
+      destination: "public/foo",
+    })
+    const res = await postMove(body)
+    expect(res.status).toBe(400)
+    const json = (await res.json()) as {
+      success: boolean
+      error: { name: string }
+    }
+    expect(json.error.name).toBe("InvalidDestination")
+  })
+
+  it("rejects moving a directory into its own subdirectory", async () => {
+    await mkdir(path.join(UPLOAD_DIR, "public", "foo", "bar"), {
+      recursive: true,
+    })
+
+    const body = new URLSearchParams({
+      path: "public/foo",
+      destination: "public/foo/bar",
+    })
+    const res = await postMove(body)
+    expect(res.status).toBe(400)
+    const json = (await res.json()) as {
+      success: boolean
+      error: { name: string }
+    }
+    expect(json.error.name).toBe("InvalidDestination")
+  })
+
+  it("returns updated HTML via htmx", async () => {
+    await mkdir(path.join(UPLOAD_DIR, "public", "dst"), { recursive: true })
+    await writeFile(path.join(UPLOAD_DIR, "public", "src.txt"), "hello")
+
+    const body = new URLSearchParams({
+      path: "public/src.txt",
+      destination: "public/dst",
+    })
+    const res = await postMove(body, { "HX-Request": "true" })
+    expect(res.status).toBe(200)
+    const text = await res.text()
+    expect(text).toContain('id="file-list-container"')
+    expect(text).not.toContain("src.txt")
+    expect(text).not.toContain("<html")
+  })
+
+  it("pre-renders Move controls in the browse view", async () => {
+    await writeFile(path.join(UPLOAD_DIR, "public", "browse-test.txt"), "c")
+
+    const res = await app.request(new Request("http://localhost/?path=public"))
+    expect(res.status).toBe(200)
+    const text = await res.text()
+    expect(text).toContain('aria-label="Move"')
+    expect(text).toContain("/api/move/picker?source=")
+    expect(text).toContain('id="move-picker-container"')
+  })
+
+  it("allows a regular user to move within their own private scope", async () => {
+    app = await createTestApp({
+      uploadDir: UPLOAD_DIR,
+      authDir: AUTH_DIR,
+      sessionSecret: SESSION_SECRET,
+    })
+    await writeUsers([{ username: "alice", password: "password1" }])
+    await mkdir(path.join(UPLOAD_DIR, "private", "alice", "dst"), {
+      recursive: true,
+    })
+    await writeFile(
+      path.join(UPLOAD_DIR, "private", "alice", "src.txt"),
+      "mine",
+    )
+
+    const session = await createTestSession("alice", SESSION_SECRET)
+    const body = new URLSearchParams({
+      path: "private/alice/src.txt",
+      destination: "private/alice/dst",
+    })
+    const res = await postMove(body, { cookie: session.cookie })
+    expect(res.status).toBe(301)
+    expect(
+      await readFile(
+        path.join(UPLOAD_DIR, "private", "alice", "dst", "src.txt"),
+        "utf-8",
+      ),
+    ).toBe("mine")
+  })
+
+  it("rejects regular user moving into another user's private area", async () => {
+    app = await createTestApp({
+      uploadDir: UPLOAD_DIR,
+      authDir: AUTH_DIR,
+      sessionSecret: SESSION_SECRET,
+    })
+    await writeUsers([
+      { username: "alice", password: "password1" },
+      { username: "bob", password: "password2" },
+    ])
+    await mkdir(path.join(UPLOAD_DIR, "private", "alice"), { recursive: true })
+    await mkdir(path.join(UPLOAD_DIR, "private", "bob"), { recursive: true })
+    await writeFile(
+      path.join(UPLOAD_DIR, "private", "alice", "src.txt"),
+      "mine",
+    )
+
+    const session = await createTestSession("alice", SESSION_SECRET)
+    const body = new URLSearchParams({
+      path: "private/alice/src.txt",
+      destination: "private/bob",
+    })
+    const res = await postMove(body, { cookie: session.cookie })
+    expect(res.status).toBe(403)
+    const json = (await res.json()) as {
+      success: boolean
+      error: { name: string }
+    }
+    expect(json.error.name).toBe("Forbidden")
+  })
+
+  it("allows admin to move between users within private scope", async () => {
+    app = await createTestApp({
+      uploadDir: UPLOAD_DIR,
+      authDir: AUTH_DIR,
+      sessionSecret: SESSION_SECRET,
+    })
+    await writeUsers([
+      { username: "admin", password: "password1", role: "admin" },
+      { username: "alice", password: "password2" },
+      { username: "bob", password: "password3" },
+    ])
+    await mkdir(path.join(UPLOAD_DIR, "private", "bob"), { recursive: true })
+    await mkdir(path.join(UPLOAD_DIR, "private", "alice"), { recursive: true })
+    await writeFile(
+      path.join(UPLOAD_DIR, "private", "alice", "src.txt"),
+      "secret",
+    )
+
+    const session = await createTestSession("admin", SESSION_SECRET)
+    const body = new URLSearchParams({
+      path: "private/alice/src.txt",
+      destination: "private/bob",
+    })
+    const res = await postMove(body, { cookie: session.cookie })
+    expect(res.status).toBe(301)
+    expect(
+      await readFile(
+        path.join(UPLOAD_DIR, "private", "bob", "src.txt"),
+        "utf-8",
+      ),
+    ).toBe("secret")
+  })
+
+  it("rejects admin moving across public and private scopes", async () => {
+    app = await createTestApp({
+      uploadDir: UPLOAD_DIR,
+      authDir: AUTH_DIR,
+      sessionSecret: SESSION_SECRET,
+    })
+    await writeUsers([
+      { username: "admin", password: "password1", role: "admin" },
+      { username: "alice", password: "password2" },
+    ])
+    await mkdir(path.join(UPLOAD_DIR, "private", "alice"), { recursive: true })
+    await writeFile(path.join(UPLOAD_DIR, "public", "src.txt"), "hello")
+
+    const session = await createTestSession("admin", SESSION_SECRET)
+    const body = new URLSearchParams({
+      path: "public/src.txt",
+      destination: "private/alice",
+    })
+    const res = await postMove(body, { cookie: session.cookie })
+    expect(res.status).toBe(400)
+    const json = (await res.json()) as {
+      success: boolean
+      error: { name: string }
+    }
+    expect(json.error.name).toBe("CrossScope")
+  })
+})
+
+describe("GET /api/move/picker", () => {
+  it("returns the picker modal scoped to the source's directory tree", async () => {
+    await mkdir(path.join(UPLOAD_DIR, "public", "a"), { recursive: true })
+    await mkdir(path.join(UPLOAD_DIR, "public", "b"), { recursive: true })
+    await writeFile(path.join(UPLOAD_DIR, "public", "src.txt"), "hello")
+
+    const res = await app.request(
+      new Request("http://localhost/api/move/picker?source=public%2Fsrc.txt"),
+    )
+    expect(res.status).toBe(200)
+    const text = await res.text()
+    expect(text).toContain("data-move-picker-modal")
+    expect(text).toContain("a/")
+    expect(text).toContain("b/")
+    expect(text).toContain('hx-post="/api/move"')
+    expect(text).toContain('name="path"')
+    expect(text).toContain('value="public/src.txt"')
+  })
+
+  it("confines a regular user's picker to their own private scope", async () => {
+    app = await createTestApp({
+      uploadDir: UPLOAD_DIR,
+      authDir: AUTH_DIR,
+      sessionSecret: SESSION_SECRET,
+    })
+    await writeUsers([
+      { username: "alice", password: "password1" },
+      { username: "bob", password: "password2" },
+    ])
+    await mkdir(path.join(UPLOAD_DIR, "private", "alice", "inbox"), {
+      recursive: true,
+    })
+    await mkdir(path.join(UPLOAD_DIR, "private", "bob"), { recursive: true })
+    await writeFile(
+      path.join(UPLOAD_DIR, "private", "alice", "src.txt"),
+      "mine",
+    )
+
+    const session = await createTestSession("alice", SESSION_SECRET)
+    const res = await app.request(
+      new Request(
+        "http://localhost/api/move/picker?source=private%2Falice%2Fsrc.txt",
+        { headers: { cookie: session.cookie } },
+      ),
+    )
+    expect(res.status).toBe(200)
+    const text = await res.text()
+    expect(text).toContain("inbox/")
+    expect(text).not.toContain("bob/")
+  })
+
+  it("rejects picker access when the source is outside the user's scope", async () => {
+    app = await createTestApp({
+      uploadDir: UPLOAD_DIR,
+      authDir: AUTH_DIR,
+      sessionSecret: SESSION_SECRET,
+    })
+    await writeUsers([{ username: "alice", password: "password1" }])
+    await mkdir(path.join(UPLOAD_DIR, "private", "bob"), { recursive: true })
+    await writeFile(path.join(UPLOAD_DIR, "private", "bob", "x.txt"), "x")
+
+    const session = await createTestSession("alice", SESSION_SECRET)
+    const res = await app.request(
+      new Request(
+        "http://localhost/api/move/picker?source=private%2Fbob%2Fx.txt",
+        { headers: { cookie: session.cookie } },
+      ),
+    )
+    expect(res.status).toBe(403)
+  })
+
+  it("clamps a destination from the wrong scope back to the source's scope root", async () => {
+    await mkdir(path.join(UPLOAD_DIR, "public", "a"), { recursive: true })
+    await writeFile(path.join(UPLOAD_DIR, "public", "src.txt"), "hello")
+
+    const res = await app.request(
+      new Request(
+        "http://localhost/api/move/picker?source=public%2Fsrc.txt&dest=private",
+      ),
+    )
+    expect(res.status).toBe(200)
+    const text = await res.text()
+    expect(text).toContain('value="public"')
+    expect(text).toContain("a/")
+  })
+})


### PR DESCRIPTION
## Issues

- Close #836

## Why

ファイル管理実務では整理時に「別ディレクトリへ動かす」操作が頻繁に必要になるが、現状の GUI は Rename と Delete のみで、移動には一度ダウンロード→削除→再アップロードなどの迂回操作を強いる状態だった。通常のブラウザ操作だけで整理を完結できるようにする。

## Summary

HTMX ベースの一覧 UI から、ファイルとフォルダを別ディレクトリへ移動できるようにする。各行に `Move` ボタンを追加し、クリック時にスコープ束縛のディレクトリピッカーモーダルを開いて移動先を選ばせる。サーバ側は `POST /api/move` と `GET /api/move/picker` を新設し、パストラバーサル・権限・同一スコープ制約・自己ネスト移動・同名衝突を検証する。

## Changes

- `POST /api/move` を追加（`path` と `destination` を受け、basename を維持して移動）
- `GET /api/move/picker` を追加（ソースのスコープに閉じたディレクトリツリーをモーダル HTML で返す）
- `MovePickerModal` コンポーネントと `MoveIcon` を追加し、`FileViewerModal` と同じ視覚言語で実装
- `FileRow` に Move ボタンを `secondary` ロールで追加（Rename/Delete の並び内）
- `BrowseEntry.canMove` を追加し `browseContext` で `requireWritePermission` に合わせて付与
- `PageShell` に `#move-picker-container` を追加し、移動フォームの成功時にモーダルを自動クローズするグローバルハンドラを配線
- inline-form-error スクリプトを `/api/move` にも適用し、`AlreadyExists` 以外の API エラーも表示可能に拡張
- `tests/move.test.ts` を追加（API 20 ケース: public/private、admin 横断、cross-scope 拒否、picker のスコープ束縛、HTMX 応答、browse 事前描画 など）
- `AGENTS.md` に GUI Move セクションと API エラー一覧を追記

## Checklist

- [x] `POST /api/move` でファイルとフォルダを同一スコープ内の別ディレクトリへ移動できる
- [x] 通常ユーザーは自分の `private/<username>/` 配下だけを移動できる
- [x] admin は private 配下を横断できるが `public`/`private` の跨ぎ移動は拒否される
- [x] GUI の各行から Move フォーム（ピッカー）を開いて移動を実行できる
- [x] HTMX 実行時に一覧が正しく再描画される
- [x] `bun run lint` が成功する
- [x] `bun test` が成功する（178 pass）
- [ ] 実ブラウザでモーダル開閉・ディレクトリ遷移・成功時クローズ・エラー表示を確認する

## Details

- **UX 選定理由**: 自由入力フォームだとタイポ・存在しないパスを生みやすく、スコープ制約も視覚化しにくいため、HTMX モーダルのディレクトリピッカー方式を採用。`FileViewerModal` と同じシェルを流用して実装コストとデザイン分散を抑えた。
- **スコープ束縛の実装**: picker の root は source に応じて決定（public → `public`、private + 通常ユーザー → `private/<username>`、private + admin/anonymous → `private`）。dest クエリが root 外を指した場合は root にクランプする。
- **パス安全性**: `isPathTraversal` に加え、source/destination に `..` セグメントが含まれる入力は `path.join` の正規化による暗黙的スコープ越境を防ぐため明示的に `PathError` で拒否。
- **将来拡張**: 複数選択・一括移動は Issue の注記通り別 Issue で扱う。ピッカーの状態管理は現在サーバー側の URL パラメータで完結しており、Cut/Paste 方式などへ発展する場合でも干渉しない構造。
