### PR TITLE
feat(portfolio): code block spinner + auto preview and chat UI polish

### DIFF
--- a/projects/portfolio/src/client/components/chat/assistant-code-block.tsx
+++ b/projects/portfolio/src/client/components/chat/assistant-code-block.tsx
@@ -1,6 +1,10 @@
-import { CodeBlockRenderer } from '#/client/components/chat/code-block-renderer'
+import {
+  CodeBlockGenerateButton,
+  CodeBlockPreviewButton,
+  CodeBlockRenderer,
+} from '#/client/components/chat/code-block-renderer'
 import type { GeneratedCodeFile } from '#/types'
-import { createContext, type HTMLAttributes, type ReactNode, useContext, useState } from 'react'
+import { createContext, type HTMLAttributes, type ReactNode, useContext, useEffect, useRef, useState } from 'react'
 
 export type SaveGeneratedFileRequest = {
   blockIndex: number
@@ -88,10 +92,12 @@ function AssistantSavableCodeBlock({
 
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const awaitingPreviewRef = useRef(false)
 
   const handleSave = async () => {
     setSaving(true)
     setError(null)
+    awaitingPreviewRef.current = true
     try {
       await ctx.onSave({
         blockIndex,
@@ -99,28 +105,29 @@ function AssistantSavableCodeBlock({
         content: code,
       })
     } catch (err) {
+      awaitingPreviewRef.current = false
       setError(err instanceof Error ? err.message : 'Failed to save')
     } finally {
       setSaving(false)
     }
   }
 
+  useEffect(() => {
+    if (previewHref && awaitingPreviewRef.current) {
+      window.open(previewHref, '_blank', 'noopener,noreferrer')
+      awaitingPreviewRef.current = false
+    }
+  }, [previewHref])
+
+  const actions = previewHref ? (
+    <CodeBlockPreviewButton href={previewHref} />
+  ) : canShowSaveAction ? (
+    <CodeBlockGenerateButton onClick={handleSave} pending={saving} disabled={ctx.disabled} />
+  ) : undefined
+
   return (
     <div>
-      <CodeBlockRenderer
-        className={className}
-        previewHref={previewHref}
-        generateAction={
-          canShowSaveAction
-            ? {
-                onClick: handleSave,
-                pending: saving,
-                disabled: ctx.disabled,
-              }
-            : undefined
-        }
-        {...rest}
-      >
+      <CodeBlockRenderer className={className} actions={actions} {...rest}>
         {children}
       </CodeBlockRenderer>
       {error && <div className='mt-1 text-red-500 text-xs'>{error}</div>}

--- a/projects/portfolio/src/client/components/chat/chat-main.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-main.tsx
@@ -364,8 +364,7 @@ export function ChatMain({
               name='userInput'
               value={input}
               textAreaRows={textAreaRows}
-              placeholder={loading ? 'しばらくお待ちください' : '質問してみよう！'}
-              disabled={loading}
+              placeholder='質問してみよう！'
               rightBottom={
                 <SendButton
                   color={settings.interactiveMode ? 'primary' : 'green'}

--- a/projects/portfolio/src/client/components/chat/chat-main.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-main.tsx
@@ -381,10 +381,10 @@ export function ChatMain({
                         type='button'
                         onClick={onClick}
                         disabled={loading || !!stream}
-                        className='group flex cursor-pointer items-center gap-0.5 rounded-3xl border border-gray-200 bg-white px-2 py-1 transition-colors hover:bg-gray-100 focus:border-primary-700 focus:outline-none focus:ring-0.5 disabled:opacity-50 disabled:hover:cursor-default disabled:hover:bg-white'
+                        className='group flex cursor-pointer items-center gap-0.5 rounded-3xl border border-gray-200 bg-white px-2 py-1 transition-colors hover:bg-gray-100 focus:border-primary-700 focus:outline-none focus:ring-0.5 disabled:opacity-50 disabled:hover:cursor-default disabled:hover:bg-white dark:border-gray-600 dark:bg-gray-700 dark:hover:bg-gray-600 dark:disabled:hover:bg-gray-700'
                       >
                         <UploadIcon size={20} className='fill-gray-500 group-disabled:fill-gray-300' />
-                        <div className='hidden sm:block mr-0.5 text-gray-500 text-xs group-disabled:text-gray-300'>
+                        <div className='hidden sm:block mr-0.5 text-gray-500 text-xs group-disabled:text-gray-300 dark:text-gray-400 dark:group-disabled:text-gray-500'>
                           画像アップロード
                         </div>
                       </button>

--- a/projects/portfolio/src/client/components/chat/chat-message-list.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-message-list.tsx
@@ -1,5 +1,9 @@
 import type { SaveGeneratedFileRequest } from '#/client/components/chat/assistant-code-block'
-import { CodeBlockRenderer, MarkdownLink } from '#/client/components/chat/code-block-renderer'
+import {
+  CodeBlockRenderer,
+  MarkdownLink,
+  StreamingCodeBlockContext,
+} from '#/client/components/chat/code-block-renderer'
 import type { ChatStreamState } from '#/client/components/chat/hooks/chat-response'
 import { MessageRenderer } from '#/client/components/chat/message-renderer'
 import { ReasoningSection } from '#/client/components/chat/reasoning-section'
@@ -73,9 +77,11 @@ export function ChatMessageList({
                 )}
                 {markdownPreview ? (
                   <div className='prose mt-1 max-w-(--breakpoint-md) break-all dark:text-white'>
-                    <ReactMarkdown remarkPlugins={markdownRemarkPlugins} components={markdownComponents}>
-                      {stream.content}
-                    </ReactMarkdown>
+                    <StreamingCodeBlockContext.Provider value={true}>
+                      <ReactMarkdown remarkPlugins={markdownRemarkPlugins} components={markdownComponents}>
+                        {stream.content}
+                      </ReactMarkdown>
+                    </StreamingCodeBlockContext.Provider>
                   </div>
                 ) : (
                   <div className='message text-left'>

--- a/projects/portfolio/src/client/components/chat/chat-message-list.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-message-list.tsx
@@ -67,7 +67,7 @@ export function ChatMessageList({
               <ChatbotIcon size={32} className='stroke-gray-600 dark:stroke-white' />
             </div>
             {stream ? (
-              <div className='message ml-2 text-left'>
+              <div className='message ml-2 min-w-0 flex-1 text-left'>
                 {stream.reasoningContent && (
                   <ReasoningSection content={stream.reasoningContent} isStreaming={!stream.content} />
                 )}

--- a/projects/portfolio/src/client/components/chat/chat-settings/model-selector.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-settings/model-selector.tsx
@@ -20,7 +20,7 @@ export function ModelSelector() {
             name='model'
             className={`w-full appearance-none rounded-md border px-3 py-2 pr-9 text-sm outline-none transition-all duration-200 ${
               fakeMode
-                ? 'cursor-not-allowed border-gray-200 bg-gray-50 text-gray-400'
+                ? 'cursor-not-allowed border-gray-200 bg-gray-50 text-gray-400 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-500'
                 : 'border-gray-300 bg-white text-gray-900 hover:border-gray-400 focus:border-blue-500 focus:ring-2 focus:ring-blue-200 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:focus:ring-blue-800'
             }`}
             onChange={handleChangeAutoModel}
@@ -70,7 +70,7 @@ export function ModelSelector() {
       placeholder='Enter model name'
       className={`w-full rounded-md border px-3 py-2 text-sm outline-none transition-all ${
         fakeMode
-          ? 'cursor-not-allowed border-gray-200 bg-gray-50 text-gray-400'
+          ? 'cursor-not-allowed border-gray-200 bg-gray-50 text-gray-400 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-500'
           : 'border-gray-300 bg-white text-gray-900 focus:border-blue-500 focus:ring-2 focus:ring-blue-200 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:focus:ring-blue-800'
       }`}
     />

--- a/projects/portfolio/src/client/components/chat/chat-settings/model-selector.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-settings/model-selector.tsx
@@ -15,31 +15,43 @@ export function ModelSelector() {
   if (autoModel) {
     return (
       <div className='space-y-1'>
-        <select
-          name='model'
-          className={`w-full rounded-md border px-3 py-2 text-sm outline-none transition-all duration-200 ${
-            fakeMode
-              ? 'cursor-not-allowed border-gray-200 bg-gray-50 text-gray-400'
-              : 'border-gray-300 bg-white text-gray-900 hover:border-gray-400 focus:border-blue-500 focus:ring-2 focus:ring-blue-200 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:focus:ring-blue-800'
-          }`}
-          onChange={handleChangeAutoModel}
-          disabled={fakeMode || isLoadingModels || fetchedModels.length === 0}
-          value={settings.model}
-        >
-          {isLoadingModels ? (
-            <option>Loading...</option>
-          ) : fetchError ? (
-            <option>Error: {fetchError}</option>
-          ) : fetchedModels.length === 0 ? (
-            <option>No models available</option>
-          ) : (
-            fetchedModels.map((modelName) => (
-              <option key={modelName} value={modelName}>
-                {modelName}
-              </option>
-            ))
-          )}
-        </select>
+        <div className='relative'>
+          <select
+            name='model'
+            className={`w-full appearance-none rounded-md border px-3 py-2 pr-9 text-sm outline-none transition-all duration-200 ${
+              fakeMode
+                ? 'cursor-not-allowed border-gray-200 bg-gray-50 text-gray-400'
+                : 'border-gray-300 bg-white text-gray-900 hover:border-gray-400 focus:border-blue-500 focus:ring-2 focus:ring-blue-200 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:focus:ring-blue-800'
+            }`}
+            onChange={handleChangeAutoModel}
+            disabled={fakeMode || isLoadingModels || fetchedModels.length === 0}
+            value={settings.model}
+          >
+            {isLoadingModels ? (
+              <option>Loading...</option>
+            ) : fetchError ? (
+              <option>Error: {fetchError}</option>
+            ) : fetchedModels.length === 0 ? (
+              <option>No models available</option>
+            ) : (
+              fetchedModels.map((modelName) => (
+                <option key={modelName} value={modelName}>
+                  {modelName}
+                </option>
+              ))
+            )}
+          </select>
+          <svg
+            viewBox='0 0 20 20'
+            aria-hidden='true'
+            className={`pointer-events-none absolute top-1/2 right-3 h-4 w-4 -translate-y-1/2 ${
+              fakeMode ? 'stroke-gray-400' : 'stroke-gray-600 dark:stroke-gray-300'
+            }`}
+            fill='none'
+          >
+            <path d='M5 7.5L10 12.5L15 7.5' strokeWidth='1.8' strokeLinecap='round' strokeLinejoin='round' />
+          </svg>
+        </div>
         {fetchError && (
           <p className='text-xs text-red-600 dark:text-red-400'>
             {fetchError}. Please check your Base URL and API key.

--- a/projects/portfolio/src/client/components/chat/chat-settings/settings/reasoning-effort.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-settings/settings/reasoning-effort.tsx
@@ -23,7 +23,7 @@ export function ReasoningEffort() {
           className={`flex-1 rounded-md border px-3 py-2 text-sm outline-none ${
             reasoningEffortEnabled
               ? 'border-gray-300 bg-white text-gray-900 focus:border-blue-500 focus:ring-2 focus:ring-blue-200 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:focus:ring-blue-800'
-              : 'cursor-not-allowed border-gray-200 bg-gray-50 text-gray-400'
+              : 'cursor-not-allowed border-gray-200 bg-gray-50 text-gray-400 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-500'
           }`}
         >
           <option value='none'>none</option>

--- a/projects/portfolio/src/client/components/chat/chat-settings/settings/text-input.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-settings/settings/text-input.tsx
@@ -41,7 +41,7 @@ export function TextInput({
         max={max}
         className={`w-full rounded-md border px-3 py-2 text-sm outline-none transition-all ${
           disabled
-            ? 'cursor-not-allowed border-gray-200 bg-gray-50 text-gray-400'
+            ? 'cursor-not-allowed border-gray-200 bg-gray-50 text-gray-400 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-500'
             : 'border-gray-300 bg-white text-gray-900 focus:border-blue-500 focus:ring-2 focus:ring-blue-200 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:focus:ring-blue-800'
         }`}
       />

--- a/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
+++ b/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
@@ -4,7 +4,7 @@ import { CopyIcon } from '#/client/components/svg/copy-icon'
 import { EyeIcon } from '#/client/components/svg/eye-icon'
 import { SparkleIcon } from '#/client/components/svg/sparkle-icon'
 import type { AnchorHTMLAttributes, CSSProperties, HTMLAttributes, MouseEvent, ReactNode } from 'react'
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 import { atomDark } from 'react-syntax-highlighter/dist/cjs/styles/prism'
 
@@ -125,7 +125,24 @@ function CodeBlockGenerateButton({ onClick, pending, disabled }: CodeBlockGenera
       aria-label={pending ? 'Generating preview' : 'Generate preview'}
       className='relative inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-md text-gray-600 transition-[background-color,color] duration-200 ease-out hover:bg-gray-200 hover:text-gray-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 disabled:cursor-default disabled:opacity-60 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white dark:focus-visible:ring-gray-500'
     >
-      <SparkleIcon size={18} className={`stroke-current ${pending ? 'animate-pulse' : ''}`} />
+      {pending ? (
+        <svg
+          viewBox='0 0 24 24'
+          aria-hidden='true'
+          fill='none'
+          className='h-[18px] w-[18px] animate-spin'
+        >
+          <circle cx='12' cy='12' r='9' strokeWidth='2.5' className='stroke-current opacity-25' />
+          <path
+            d='M21 12a9 9 0 0 0-9-9'
+            strokeWidth='2.5'
+            strokeLinecap='round'
+            className='stroke-current'
+          />
+        </svg>
+      ) : (
+        <SparkleIcon size={18} className='stroke-current' />
+      )}
     </button>
   )
 }
@@ -170,12 +187,26 @@ function CodeBlockCopyButton({ copied, onClick }: CodeBlockCopyButtonProps) {
 
 export function CodeBlockRenderer({ className, children, previewHref, generateAction }: CodeBlockRendererProps) {
   const [copied, setCopied] = useState(false)
+  const awaitingPreviewRef = useRef(false)
 
   const code = typeof children === 'string' ? children : Array.isArray(children) ? children.join('') : ''
   const detectedLanguage = className?.split('-')[1]
   const initialLanguage = detectedLanguage ?? 'plain'
 
   const [selectedLanguage, setSelectedLanguage] = useState(initialLanguage)
+
+  useEffect(() => {
+    if (generateAction?.pending) {
+      awaitingPreviewRef.current = true
+    }
+  }, [generateAction?.pending])
+
+  useEffect(() => {
+    if (previewHref && awaitingPreviewRef.current) {
+      window.open(previewHref, '_blank', 'noopener,noreferrer')
+      awaitingPreviewRef.current = false
+    }
+  }, [previewHref])
 
   // Block code: has a language identifier OR children contains newlines
   // (react-markdown adds a trailing \n to fenced code blocks)

--- a/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
+++ b/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
@@ -1,12 +1,15 @@
 import { copyToClipboard } from '#/client/components/chat/copy-to-clipboard'
 import { CheckIcon } from '#/client/components/svg/check-icon'
+import { ChevronRightIcon } from '#/client/components/svg/chevron-right-icon'
 import { CopyIcon } from '#/client/components/svg/copy-icon'
 import { EyeIcon } from '#/client/components/svg/eye-icon'
 import { SparkleIcon } from '#/client/components/svg/sparkle-icon'
 import type { AnchorHTMLAttributes, CSSProperties, HTMLAttributes, MouseEvent, ReactNode } from 'react'
-import { useState } from 'react'
+import { createContext, useContext, useState } from 'react'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 import { atomDark } from 'react-syntax-highlighter/dist/cjs/styles/prism'
+
+export const StreamingCodeBlockContext = createContext<boolean>(false)
 
 const CUSTOM_STYLE: CSSProperties = {
   fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
@@ -125,19 +128,9 @@ export function CodeBlockGenerateButton({ onClick, pending, disabled }: CodeBloc
       className='relative inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-md text-gray-600 transition-[background-color,color] duration-200 ease-out hover:bg-gray-200 hover:text-gray-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 disabled:cursor-default disabled:opacity-60 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white dark:focus-visible:ring-gray-500'
     >
       {pending ? (
-        <svg
-          viewBox='0 0 24 24'
-          aria-hidden='true'
-          fill='none'
-          className='h-[18px] w-[18px] animate-spin'
-        >
+        <svg viewBox='0 0 24 24' aria-hidden='true' fill='none' className='h-[18px] w-[18px] animate-spin'>
           <circle cx='12' cy='12' r='9' strokeWidth='2.5' className='stroke-current opacity-25' />
-          <path
-            d='M21 12a9 9 0 0 0-9-9'
-            strokeWidth='2.5'
-            strokeLinecap='round'
-            className='stroke-current'
-          />
+          <path d='M21 12a9 9 0 0 0-9-9' strokeWidth='2.5' strokeLinecap='round' className='stroke-current' />
         </svg>
       ) : (
         <SparkleIcon size={18} className='stroke-current' />
@@ -186,12 +179,14 @@ function CodeBlockCopyButton({ copied, onClick }: CodeBlockCopyButtonProps) {
 
 export function CodeBlockRenderer({ className, children, actions }: CodeBlockRendererProps) {
   const [copied, setCopied] = useState(false)
+  const streaming = useContext(StreamingCodeBlockContext)
 
   const code = typeof children === 'string' ? children : Array.isArray(children) ? children.join('') : ''
   const detectedLanguage = className?.split('-')[1]
   const initialLanguage = detectedLanguage ?? 'plain'
 
   const [selectedLanguage, setSelectedLanguage] = useState(initialLanguage)
+  const [isOpen, setIsOpen] = useState(!streaming)
 
   // Block code: has a language identifier OR children contains newlines
   // (react-markdown adds a trailing \n to fenced code blocks)
@@ -212,6 +207,10 @@ export function CodeBlockRenderer({ className, children, actions }: CodeBlockRen
     ? SUPPORTED_LANGUAGES
     : [initialLanguage, ...SUPPORTED_LANGUAGES]
 
+  const lineCount = code.replace(/\n$/, '').split('\n').length
+  const peekMode = streaming && !isOpen
+  const toggle = () => setIsOpen((v) => !v)
+
   const handleClickCopy = async () => {
     setCopied(true)
     try {
@@ -223,47 +222,88 @@ export function CodeBlockRenderer({ className, children, actions }: CodeBlockRen
     setCopied(false)
   }
 
+  const highlighter = (
+    <div className='max-w-full overflow-x-auto'>
+      <SyntaxHighlighter
+        style={atomDark}
+        language={selectedLanguage}
+        customStyle={CUSTOM_STYLE}
+        codeTagProps={{ style: CUSTOM_STYLE }}
+        showLineNumbers={selectedLanguage !== 'plain'}
+        lineNumberStyle={{ color: '#6b7280', minWidth: '2.5em' }}
+      >
+        {code}
+      </SyntaxHighlighter>
+    </div>
+  )
+
   return (
     <div className='my-2 w-full max-w-full min-w-0 overflow-hidden rounded-lg border border-gray-200 dark:border-gray-600'>
       <div className='flex items-center justify-between border-b border-gray-200 bg-gray-50 px-3 py-1.5 dark:border-gray-600 dark:bg-[#282c34]'>
-        <div className='relative'>
-          <select
-            value={selectedLanguage}
-            onChange={(e) => setSelectedLanguage(e.target.value)}
-            className='cursor-pointer appearance-none rounded border-none bg-gray-50 pr-6 text-xs text-gray-600 dark:bg-[#282c34] dark:text-gray-300'
+        <div className='flex items-center gap-1'>
+          <button
+            type='button'
+            onClick={toggle}
+            aria-expanded={isOpen}
+            aria-label={isOpen ? 'Collapse code block' : 'Expand code block'}
+            className='inline-flex h-6 w-6 cursor-pointer items-center justify-center rounded text-gray-600 transition-colors duration-200 ease-out hover:bg-gray-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 dark:text-gray-300 dark:hover:bg-gray-700 dark:focus-visible:ring-gray-500'
           >
-            {languageOptions.map((lang) => (
-              <option key={lang} value={lang} className='bg-white text-gray-900 dark:bg-[#282c34] dark:text-gray-100'>
-                {lang}
-              </option>
-            ))}
-          </select>
-          <svg
-            viewBox='0 0 20 20'
-            aria-hidden='true'
-            className='pointer-events-none absolute top-1/2 right-1 h-3.5 w-3.5 -translate-y-1/2 stroke-gray-600 dark:stroke-gray-300'
-            fill='none'
-          >
-            <path d='M5 7.5L10 12.5L15 7.5' strokeWidth='1.8' strokeLinecap='round' strokeLinejoin='round' />
-          </svg>
+            <span
+              className={`inline-flex transition-transform duration-200 ease-out motion-reduce:transition-none ${
+                isOpen ? 'rotate-90' : ''
+              }`}
+            >
+              <ChevronRightIcon size={10} />
+            </span>
+          </button>
+          <div className='relative'>
+            <select
+              value={selectedLanguage}
+              onChange={(e) => setSelectedLanguage(e.target.value)}
+              className='cursor-pointer appearance-none rounded border-none bg-gray-50 pr-6 text-xs text-gray-600 dark:bg-[#282c34] dark:text-gray-300'
+            >
+              {languageOptions.map((lang) => (
+                <option key={lang} value={lang} className='bg-white text-gray-900 dark:bg-[#282c34] dark:text-gray-100'>
+                  {lang}
+                </option>
+              ))}
+            </select>
+            <svg
+              viewBox='0 0 20 20'
+              aria-hidden='true'
+              className='pointer-events-none absolute top-1/2 right-1 h-3.5 w-3.5 -translate-y-1/2 stroke-gray-600 dark:stroke-gray-300'
+              fill='none'
+            >
+              <path d='M5 7.5L10 12.5L15 7.5' strokeWidth='1.8' strokeLinecap='round' strokeLinejoin='round' />
+            </svg>
+          </div>
         </div>
         <div className='flex items-center gap-1'>
           {actions}
           <CodeBlockCopyButton copied={copied} onClick={handleClickCopy} />
         </div>
       </div>
-      <div className='max-w-full overflow-x-auto'>
-        <SyntaxHighlighter
-          style={atomDark}
-          language={selectedLanguage}
-          customStyle={CUSTOM_STYLE}
-          codeTagProps={{ style: CUSTOM_STYLE }}
-          showLineNumbers={selectedLanguage !== 'plain'}
-          lineNumberStyle={{ color: '#6b7280', minWidth: '2.5em' }}
+      {!isOpen && (
+        <button
+          type='button'
+          onClick={toggle}
+          className='flex w-full cursor-pointer items-center bg-gray-50 px-3 py-1.5 text-left text-gray-500 text-xs transition-colors duration-200 ease-out hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-inset dark:bg-[#282c34] dark:text-gray-400 dark:hover:bg-gray-700 dark:focus-visible:ring-gray-500'
         >
-          {code}
-        </SyntaxHighlighter>
-      </div>
+          {streaming ? `生成中（${lineCount} 行・クリックで展開）` : `折りたたみ中（${lineCount} 行・クリックで展開）`}
+        </button>
+      )}
+      {peekMode ? (
+        <div className='flex max-h-24 flex-col justify-end overflow-hidden'>{highlighter}</div>
+      ) : (
+        <div
+          aria-hidden={!isOpen}
+          className={`grid overflow-hidden transition-[grid-template-rows] duration-200 ease-out motion-reduce:transition-none ${
+            isOpen ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
+          }`}
+        >
+          <div className='min-h-0'>{highlighter}</div>
+        </div>
+      )}
     </div>
   )
 }

--- a/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
+++ b/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
@@ -224,7 +224,7 @@ export function CodeBlockRenderer({ className, children, actions }: CodeBlockRen
   }
 
   return (
-    <div className='my-2 overflow-hidden rounded-lg border border-gray-200 dark:border-gray-600'>
+    <div className='my-2 w-full max-w-full min-w-0 overflow-hidden rounded-lg border border-gray-200 dark:border-gray-600'>
       <div className='flex items-center justify-between border-b border-gray-200 bg-gray-50 px-3 py-1.5 dark:border-gray-600 dark:bg-[#282c34]'>
         <div className='relative'>
           <select
@@ -252,7 +252,7 @@ export function CodeBlockRenderer({ className, children, actions }: CodeBlockRen
           <CodeBlockCopyButton copied={copied} onClick={handleClickCopy} />
         </div>
       </div>
-      <div className='overflow-x-auto'>
+      <div className='max-w-full overflow-x-auto'>
         <SyntaxHighlighter
           style={atomDark}
           language={selectedLanguage}

--- a/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
+++ b/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
@@ -293,7 +293,28 @@ export function CodeBlockRenderer({ className, children, actions }: CodeBlockRen
         </button>
       )}
       {peekMode ? (
-        <div className='flex max-h-24 flex-col justify-end overflow-hidden'>{highlighter}</div>
+        <div className='relative h-24 select-none overflow-hidden'>
+          <div className='pointer-events-none absolute inset-x-0 bottom-0 overflow-hidden'>
+            <SyntaxHighlighter
+              style={atomDark}
+              language={selectedLanguage}
+              customStyle={{ ...CUSTOM_STYLE, overflow: 'hidden' }}
+              codeTagProps={{ style: CUSTOM_STYLE }}
+              showLineNumbers={selectedLanguage !== 'plain'}
+              lineNumberStyle={{ color: '#6b7280', minWidth: '2.5em' }}
+            >
+              {code}
+            </SyntaxHighlighter>
+          </div>
+          <div
+            aria-hidden='true'
+            className='pointer-events-none absolute inset-x-0 top-0 h-12 backdrop-blur-[3px]'
+            style={{
+              maskImage: 'linear-gradient(to bottom, black 30%, transparent)',
+              WebkitMaskImage: 'linear-gradient(to bottom, black 30%, transparent)',
+            }}
+          />
+        </div>
       ) : (
         <div
           aria-hidden={!isOpen}

--- a/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
+++ b/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
@@ -142,19 +142,20 @@ export function CodeBlockGenerateButton({ onClick, pending, disabled }: CodeBloc
 interface CodeBlockCopyButtonProps {
   copied: boolean
   onClick: () => void
+  disabled?: boolean
 }
 
-function CodeBlockCopyButton({ copied, onClick }: CodeBlockCopyButtonProps) {
+function CodeBlockCopyButton({ copied, onClick, disabled }: CodeBlockCopyButtonProps) {
   return (
     <button
       type='button'
       onClick={onClick}
-      disabled={copied}
+      disabled={copied || disabled}
       aria-label={copied ? 'Copied code block' : 'Copy code block'}
-      className={`relative inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-md text-gray-600 transition-[background-color,color] duration-200 ease-out focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 dark:text-gray-300 dark:focus-visible:ring-gray-500 disabled:cursor-default ${
+      className={`relative inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-md text-gray-600 transition-[background-color,color] duration-200 ease-out focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 dark:text-gray-300 dark:focus-visible:ring-gray-500 ${
         copied
-          ? 'text-emerald-600 dark:text-emerald-400'
-          : 'hover:bg-gray-200 hover:text-gray-800 dark:hover:bg-gray-700 dark:hover:text-white'
+          ? 'text-emerald-600 disabled:cursor-default dark:text-emerald-400'
+          : 'hover:bg-gray-200 hover:text-gray-800 disabled:cursor-not-allowed disabled:opacity-30 disabled:hover:bg-transparent disabled:hover:text-gray-600 dark:hover:bg-gray-700 dark:hover:text-white dark:disabled:hover:bg-transparent dark:disabled:hover:text-gray-300'
       }`}
     >
       <span className='relative h-[18px] w-[18px]' aria-hidden='true'>
@@ -280,7 +281,7 @@ export function CodeBlockRenderer({ className, children, actions }: CodeBlockRen
         </div>
         <div className='flex items-center gap-1'>
           {actions}
-          <CodeBlockCopyButton copied={copied} onClick={handleClickCopy} />
+          <CodeBlockCopyButton copied={copied} onClick={handleClickCopy} disabled={streaming} />
         </div>
       </div>
       {!isOpen && (

--- a/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
+++ b/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
@@ -4,7 +4,7 @@ import { CopyIcon } from '#/client/components/svg/copy-icon'
 import { EyeIcon } from '#/client/components/svg/eye-icon'
 import { SparkleIcon } from '#/client/components/svg/sparkle-icon'
 import type { AnchorHTMLAttributes, CSSProperties, HTMLAttributes, MouseEvent, ReactNode } from 'react'
-import { useEffect, useRef, useState } from 'react'
+import { useState } from 'react'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 import { atomDark } from 'react-syntax-highlighter/dist/cjs/styles/prism'
 
@@ -88,21 +88,14 @@ const SUPPORTED_LANGUAGES = [
 
 type CodeBlockRendererProps = HTMLAttributes<HTMLElement> & {
   children?: ReactNode | string
-  previewHref?: string
-  generateAction?: CodeBlockGenerateAction
+  actions?: ReactNode
 }
 
-export interface CodeBlockGenerateAction {
-  onClick: () => void
-  pending?: boolean
-  disabled?: boolean
-}
-
-interface CodeBlockPreviewButtonProps {
+export interface CodeBlockPreviewButtonProps {
   href: string
 }
 
-function CodeBlockPreviewButton({ href }: CodeBlockPreviewButtonProps) {
+export function CodeBlockPreviewButton({ href }: CodeBlockPreviewButtonProps) {
   return (
     <a
       href={href}
@@ -116,7 +109,13 @@ function CodeBlockPreviewButton({ href }: CodeBlockPreviewButtonProps) {
   )
 }
 
-function CodeBlockGenerateButton({ onClick, pending, disabled }: CodeBlockGenerateAction) {
+export interface CodeBlockGenerateButtonProps {
+  onClick: () => void
+  pending?: boolean
+  disabled?: boolean
+}
+
+export function CodeBlockGenerateButton({ onClick, pending, disabled }: CodeBlockGenerateButtonProps) {
   return (
     <button
       type='button'
@@ -185,28 +184,14 @@ function CodeBlockCopyButton({ copied, onClick }: CodeBlockCopyButtonProps) {
   )
 }
 
-export function CodeBlockRenderer({ className, children, previewHref, generateAction }: CodeBlockRendererProps) {
+export function CodeBlockRenderer({ className, children, actions }: CodeBlockRendererProps) {
   const [copied, setCopied] = useState(false)
-  const awaitingPreviewRef = useRef(false)
 
   const code = typeof children === 'string' ? children : Array.isArray(children) ? children.join('') : ''
   const detectedLanguage = className?.split('-')[1]
   const initialLanguage = detectedLanguage ?? 'plain'
 
   const [selectedLanguage, setSelectedLanguage] = useState(initialLanguage)
-
-  useEffect(() => {
-    if (generateAction?.pending) {
-      awaitingPreviewRef.current = true
-    }
-  }, [generateAction?.pending])
-
-  useEffect(() => {
-    if (previewHref && awaitingPreviewRef.current) {
-      window.open(previewHref, '_blank', 'noopener,noreferrer')
-      awaitingPreviewRef.current = false
-    }
-  }, [previewHref])
 
   // Block code: has a language identifier OR children contains newlines
   // (react-markdown adds a trailing \n to fenced code blocks)
@@ -263,8 +248,7 @@ export function CodeBlockRenderer({ className, children, previewHref, generateAc
           </svg>
         </div>
         <div className='flex items-center gap-1'>
-          {previewHref && <CodeBlockPreviewButton href={previewHref} />}
-          {!previewHref && generateAction && <CodeBlockGenerateButton {...generateAction} />}
+          {actions}
           <CodeBlockCopyButton copied={copied} onClick={handleClickCopy} />
         </div>
       </div>

--- a/projects/portfolio/src/client/components/chat/conversation-history.tsx
+++ b/projects/portfolio/src/client/components/chat/conversation-history.tsx
@@ -51,7 +51,7 @@ export function ConversationHistory({
           type='button'
           onClick={onNewConversation}
           disabled={disabled}
-          className='flex w-full items-center gap-2 rounded-md border border-gray-300 bg-white px-3 py-1.5 font-medium text-gray-700 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 enabled:cursor-pointer hover:enabled:bg-gray-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:hover:enabled:bg-gray-600'
+          className='flex w-full items-center gap-2 rounded-md border border-gray-300 bg-white px-3 py-1.5 font-medium text-gray-700 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 enabled:cursor-pointer disabled:cursor-not-allowed disabled:opacity-50 hover:enabled:bg-gray-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:hover:enabled:bg-gray-600'
         >
           <NewChatIcon className='fill-gray-600 dark:fill-gray-400' size={16} />
           新しい会話

--- a/projects/portfolio/src/client/components/svg/icon-base.tsx
+++ b/projects/portfolio/src/client/components/svg/icon-base.tsx
@@ -14,8 +14,15 @@ interface SvgIconProps {
 
 export function SvgIcon({ size = 24, viewBox = '0 0 24 24', title, children }: SvgIconProps) {
   return (
-    <svg width={size} height={size} viewBox={viewBox} fill='none' xmlns='http://www.w3.org/2000/svg'>
-      <title>{title}</title>
+    <svg
+      width={size}
+      height={size}
+      viewBox={viewBox}
+      fill='none'
+      xmlns='http://www.w3.org/2000/svg'
+      role='img'
+      aria-label={title}
+    >
       {children}
     </svg>
   )

--- a/projects/portfolio/src/client/components/svg/spinner-icon.tsx
+++ b/projects/portfolio/src/client/components/svg/spinner-icon.tsx
@@ -4,8 +4,14 @@ interface Props {
 
 export function SpinnerIcon({ className = 'fill-blue-500 dark:fill-blue-400' }: Props) {
   return (
-    <svg viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg' className='h-8 w-8 animate-spin'>
-      <title>spinner-icon</title>
+    <svg
+      viewBox='0 0 24 24'
+      fill='none'
+      xmlns='http://www.w3.org/2000/svg'
+      className='h-8 w-8 animate-spin'
+      role='img'
+      aria-label='Loading'
+    >
       {/* グラデーションの定義 */}
       <defs>
         <linearGradient id='gradient' x1='0%' y1='0%' x2='100%' y2='100%'>

--- a/projects/portfolio/tests/client/components/conversation-history.test.tsx
+++ b/projects/portfolio/tests/client/components/conversation-history.test.tsx
@@ -40,7 +40,7 @@ describe('ConversationHistory', () => {
 
     expect(screen.getByText('2026/04/14')).toBeTruthy()
     expect(screen.getByText('2')).toBeTruthy()
-    expect(within(container).getByTitle('message-icon')).toBeTruthy()
+    expect(within(container).getByLabelText('message-icon')).toBeTruthy()
   })
 
   it('updatedAt がない会話はメッセージ数アイコンのみ表示する', () => {
@@ -69,6 +69,6 @@ describe('ConversationHistory', () => {
     )
 
     expect(screen.getByText('1')).toBeTruthy()
-    expect(within(container).getByTitle('message-icon')).toBeTruthy()
+    expect(within(container).getByLabelText('message-icon')).toBeTruthy()
   })
 })


### PR DESCRIPTION
## Why

コード生成中のブロック UI が静止していて進捗が分かりにくく、ストリーミング中の挙動や各種ダークモード対応にも粗があったため、チャット UI の生成体験と仕上げを整える。

## Summary

コードブロックに生成中スピナーと自動プレビュー展開を追加し、ストリーミング中のレイアウト安定化・操作可否の整理を行う。あわせてダークモード・アイコンのツールチップなど周辺 UI のリグレッションをまとめて修正した。

## Changes

- コードブロックの生成ボタンにスピナーを追加し、生成中は自動でプレビューを開くように変更
- ストリーミング中のコードブロック幅を安定化し、ピークビューで最新行を下端にピン留め
- コードブロックのアクションボタンを slot として切り出し、折りたたみ + ストリーミング時ピーク表示に対応
- ストリーミング中もチャット入力を編集可能にしつつ、コピーボタンは無効化
- 新規会話ボタン / チャット設定の無効化状態のダークモード対応と視認性強化
- 画像アップロードボタン・モデルセレクタ矢印のダークモード対応
- SVG アイコンの `<title>` を `role='img'` + `aria-label` に置き換え、ホバー時のデフォルトツールチップを抑制

## Checklist

- [x] `bun run lint` が通ることを確認
- [ ] チャット UI をブラウザで操作し、ストリーミング中の挙動とダーク/ライト両モードの見た目を確認
