### PR TITLE
fix(portfolio): prevent auto-scroll when returning from other tabs in chat

### DIFF
--- a/projects/portfolio/src/client/components/chat/chat-main.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-main.tsx
@@ -37,6 +37,7 @@ export function ChatMain({
   onDeleteMessages,
 }: Props) {
   const formRef = useRef<HTMLFormElement>(null)
+  const prevConversationIdRef = useRef<string | null>(null)
 
   const [conversationId, setConversationId] = useState<string | null>(null)
   const [messages, setMessages] = useState<Message[]>([])
@@ -79,9 +80,14 @@ export function ChatMain({
     // 会話が選択された時、そのメッセージをドメイン型のまま設定（変換不要）
     setConversationId(currentConversation.id)
     setMessages(currentConversation.messages)
-    setTimeout(() => {
-      scrollToMessageEnd()
-    }, 0)
+
+    // 会話IDが実際に変わったときだけスクロール（別タブから戻った際の誤動作防止）
+    if (prevConversationIdRef.current !== currentConversation.id) {
+      prevConversationIdRef.current = currentConversation.id
+      setTimeout(() => {
+        scrollToMessageEnd()
+      }, 0)
+    }
   }, [currentConversation, scrollToMessageEnd])
 
   const handleSubmit = useCallback(


### PR DESCRIPTION
## Why

別タブに移動して戻るとコンポーネントが再レンダリングされ、`currentConversation`オブジェクトの参照が変わります。会話ID自体は変わっていないのに`useEffect`が再発火してスクロール位置が一番下に移動してしまう誤動作がありました。

## Summary

会話IDが実際に変わったときだけスクロール処理を実行するよう修正しました。`useRef`を使って前回の会話IDを追跡し、会話の切り替え時のみスクロールするようになった。

## Changes

- `prevConversationIdRef`を追加して前回の会話IDを追跡
- 会話IDが変わった場合のみ`scrollToMessageEnd()`を呼び出すように条件分岐を追加
- サイドバーでの会話履歴操作時のスクロールは従来通り動作

## Checklist

- [x] 変更内容を確認した
