### PR TITLE
feat(portfolio): add collapsible chat sidebar with animation

### DIFF
--- a/projects/portfolio/src/client/components/chat/chat-layout.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-layout.tsx
@@ -9,19 +9,30 @@ interface Props {
 export function ChatLayout({ conversations, isSidebarOpen, onToggleSidebar, children }: PropsWithChildren<Props>) {
   return conversations ? (
     <div className='flex h-[calc(100dvh-3.5rem)] overflow-hidden bg-white md:h-dvh dark:bg-gray-900'>
-      {/* サイドバー - モバイルではドロワー、デスクトップでは常時表示 */}
+      {/* モバイル用ドロワー */}
       <div
-        className={`fixed top-14 bottom-0 left-0 z-50 w-64 border-gray-200 border-r bg-white dark:border-gray-700 dark:bg-gray-800 transform transition-transform duration-300 ease-in-out md:relative md:top-0 md:translate-x-0 md:w-56 md:z-auto ${
+        className={`fixed top-14 bottom-0 left-0 z-50 w-64 bg-white dark:bg-gray-800 transform transition-transform duration-300 ease-in-out md:hidden ${
           isSidebarOpen ? 'translate-x-0' : '-translate-x-full'
         }`}
       >
-        {conversations}
+        <div className='h-full border-gray-200 border-r dark:border-gray-700'>{conversations}</div>
       </div>
 
       {/* オーバーレイ背景 - モバイルのみ */}
       {isSidebarOpen && (
         <div className='fixed top-14 bottom-0 left-0 right-0 bg-black/50 z-40 md:hidden' onClick={onToggleSidebar} />
       )}
+
+      {/* デスクトップ用サイドバー（幅アニメーション） */}
+      <div
+        className={`hidden md:block shrink-0 overflow-hidden transition-[width] duration-300 ease-in-out ${
+          isSidebarOpen ? 'w-56' : 'w-0'
+        }`}
+      >
+        <div className='h-full w-56 border-gray-200 border-r bg-gray-50 dark:border-gray-700 dark:bg-gray-800'>
+          {conversations}
+        </div>
+      </div>
 
       <div className='min-w-0 flex h-full min-h-0 flex-1 flex-col bg-white dark:bg-gray-900'>{children}</div>
     </div>

--- a/projects/portfolio/src/client/components/chat/chat-settings/chat-settings.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-settings/chat-settings.tsx
@@ -12,6 +12,7 @@ interface Props {
   showNewChat?: boolean
   showPopup?: boolean
   showSidebarToggle?: boolean
+  isSidebarToggleDisabled?: boolean
   onNewChat?: () => void
   onShowMenu?: () => void
   onToggleSidebar?: () => void
@@ -24,6 +25,7 @@ export function ChatSettings({
   showNewChat = true,
   showPopup,
   showSidebarToggle = true,
+  isSidebarToggleDisabled = false,
   onNewChat,
   onShowMenu,
   onToggleSidebar,
@@ -44,7 +46,8 @@ export function ChatSettings({
                 <button
                   type='button'
                   onClick={onToggleSidebar}
-                  className='flex cursor-pointer items-center justify-center rounded-md p-2 text-gray-600 transition hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-400 md:hidden dark:text-gray-300 dark:hover:bg-gray-700 dark:focus:ring-gray-500'
+                  disabled={isSidebarToggleDisabled}
+                  className='flex items-center justify-center rounded-md p-2 text-gray-600 transition hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-400 enabled:cursor-pointer disabled:cursor-not-allowed disabled:opacity-40 dark:text-gray-300 dark:hover:bg-gray-700 dark:focus:ring-gray-500'
                 >
                   <SidebarIcon className='fill-[#5D5D5D] dark:fill-gray-300' />
                 </button>

--- a/projects/portfolio/src/client/pages/chat/index.tsx
+++ b/projects/portfolio/src/client/pages/chat/index.tsx
@@ -139,7 +139,7 @@ export function Chat() {
     >
       <ChatSettings
         showActions={showSettingsActions}
-        showNewChat={conversations.length <= 0 || !isSidebarOpen}
+        showNewChat={(!query.isLoading && conversations.length <= 0) || !isSidebarOpen}
         showPopup={isSettingsPopupOpen}
         showSidebarToggle={!!email}
         isSidebarToggleDisabled={isSubmitting}

--- a/projects/portfolio/src/client/pages/chat/index.tsx
+++ b/projects/portfolio/src/client/pages/chat/index.tsx
@@ -139,7 +139,7 @@ export function Chat() {
     >
       <ChatSettings
         showActions={showSettingsActions}
-        showNewChat={conversations.length <= 0}
+        showNewChat={conversations.length <= 0 || !isSidebarOpen}
         showPopup={isSettingsPopupOpen}
         showSidebarToggle={!!email}
         isSidebarToggleDisabled={isSubmitting}

--- a/projects/portfolio/src/client/pages/chat/index.tsx
+++ b/projects/portfolio/src/client/pages/chat/index.tsx
@@ -9,20 +9,20 @@ import type { AppType } from '#/server/app.d'
 import { ConversationListResponseSchema, type Conversation } from '#/types'
 import { useQuery } from '@tanstack/react-query'
 import { hc } from 'hono/client'
-import { useState } from 'react'
 
 const client = hc<AppType>('/')
 
 export function Chat() {
-  const [isSidebarOpen, setIsSidebarOpen] = useState(true)
   const {
     selectedConversationId,
     isSettingsPopupOpen,
     isSubmitting,
+    isSidebarOpen,
     newChatTrigger,
     settings,
     showSettingsActions,
     startNewConversation,
+    toggleSidebar,
     toggleSettingsPopup,
     closeSettingsPopup,
     selectConversation,
@@ -116,7 +116,7 @@ export function Chat() {
   return (
     <ChatLayout
       isSidebarOpen={isSidebarOpen}
-      onToggleSidebar={() => setIsSidebarOpen(!isSidebarOpen)}
+      onToggleSidebar={toggleSidebar}
       conversations={
         query.isLoading ? (
           <div className='flex h-full flex-col items-center justify-center gap-2'>
@@ -145,7 +145,7 @@ export function Chat() {
         isSidebarToggleDisabled={isSubmitting}
         onNewChat={startNewConversation}
         onShowMenu={toggleSettingsPopup}
-        onToggleSidebar={() => setIsSidebarOpen(!isSidebarOpen)}
+        onToggleSidebar={toggleSidebar}
         onChange={updateSettings}
         onHidePopup={closeSettingsPopup}
       />

--- a/projects/portfolio/src/client/pages/chat/index.tsx
+++ b/projects/portfolio/src/client/pages/chat/index.tsx
@@ -14,10 +14,11 @@ import { useState } from 'react'
 const client = hc<AppType>('/')
 
 export function Chat() {
-  const [isSidebarOpen, setIsSidebarOpen] = useState(false)
+  const [isSidebarOpen, setIsSidebarOpen] = useState(true)
   const {
     selectedConversationId,
     isSettingsPopupOpen,
+    isSubmitting,
     newChatTrigger,
     settings,
     showSettingsActions,
@@ -141,6 +142,7 @@ export function Chat() {
         showNewChat={conversations.length <= 0}
         showPopup={isSettingsPopupOpen}
         showSidebarToggle={!!email}
+        isSidebarToggleDisabled={isSubmitting}
         onNewChat={startNewConversation}
         onShowMenu={toggleSettingsPopup}
         onToggleSidebar={() => setIsSidebarOpen(!isSidebarOpen)}

--- a/projects/portfolio/src/client/pages/chat/use-chat-page-state.ts
+++ b/projects/portfolio/src/client/pages/chat/use-chat-page-state.ts
@@ -1,4 +1,4 @@
-import { readFromLocalStorage, type Settings } from '#/client/storage/remote-storage-settings'
+import { readFromLocalStorage, saveToLocalStorage, type Settings } from '#/client/storage/remote-storage-settings'
 import { useCallback, useState } from 'react'
 
 export function useChatPageState() {
@@ -7,11 +7,20 @@ export function useChatPageState() {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [newChatTrigger, setNewChatTrigger] = useState(Date.now())
   const [settings, setSettings] = useState<Settings>(() => readFromLocalStorage())
+  const [isSidebarOpen, setIsSidebarOpen] = useState(() => readFromLocalStorage().sidebarOpen)
 
   const startNewConversation = useCallback(() => {
     setSelectedConversationId(null)
     setIsSettingsPopupOpen(false)
     setNewChatTrigger(Date.now())
+  }, [])
+
+  const toggleSidebar = useCallback(() => {
+    setIsSidebarOpen((current) => {
+      const next = !current
+      saveToLocalStorage({ sidebarOpen: next })
+      return next
+    })
   }, [])
 
   const toggleSettingsPopup = useCallback(() => {
@@ -38,10 +47,12 @@ export function useChatPageState() {
     selectedConversationId,
     isSettingsPopupOpen,
     isSubmitting,
+    isSidebarOpen,
     newChatTrigger,
     settings,
     showSettingsActions: !isSubmitting,
     startNewConversation,
+    toggleSidebar,
     toggleSettingsPopup,
     closeSettingsPopup,
     selectConversation,

--- a/projects/portfolio/src/client/storage/remote-storage-settings.ts
+++ b/projects/portfolio/src/client/storage/remote-storage-settings.ts
@@ -18,6 +18,7 @@ export interface Settings {
   markdownPreview: boolean
   streamMode: boolean
   interactiveMode: boolean
+  sidebarOpen: boolean
   templateModels: {
     [key: string]: {
       model: string
@@ -44,6 +45,7 @@ const defaultSettings: Settings = {
   markdownPreview: true,
   streamMode: true,
   interactiveMode: true,
+  sidebarOpen: true,
   templateModels: {},
 }
 


### PR DESCRIPTION
## Why

ログイン済みの場合、チャット画面の左サイドバー（会話履歴）が常時表示されており、収納できなかった。よくある管理画面のように開閉できるようにしたい。

## Summary

チャット画面の会話履歴サイドバーにアニメーション付きの開閉機能を追加した。開閉状態はローカルストレージに永続化され、リロード後も維持される。ストリーム中はトグルボタンを非活性化してUXの安全性を確保した。

## Changes

- `chat-layout.tsx`: モバイル用ドロワーとデスクトップ用サイドバーを分離。デスクトップは `transition-[width] duration-300` で幅アニメーション（`w-56` ↔ `w-0`）
- `chat-settings.tsx`: サイドバートグルボタンをデスクトップでも表示。ストリーム中は `disabled` にする `isSidebarToggleDisabled` prop を追加
- `remote-storage-settings.ts`: `Settings` に `sidebarOpen: boolean`（デフォルト `true`）を追加
- `use-chat-page-state.ts`: `isSidebarOpen` / `toggleSidebar` を追加。toggle 時に `saveToLocalStorage` で永続化
- `chat/index.tsx`: サイドバーが閉じているときは新規会話ボタンを表示。フェッチ中のちらつきも修正

## Checklist

- [ ] デスクトップでサイドバーをアニメーション付きで開閉できる
- [ ] モバイルでもドロワー動作が維持されている
- [ ] 開閉状態がリロード後も保持される
- [ ] ストリーム中はトグルボタンが非活性になっている
- [ ] サイドバーを閉じた状態で新規会話ボタンが表示される
- [ ] リロード時に新規会話ボタンのちらつきが発生しない
