### PR TITLE
fix(portfolio): improve code block language select tap area and chat icon color

### DIFF
--- a/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
+++ b/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
@@ -261,7 +261,7 @@ export function CodeBlockRenderer({ className, children, actions }: CodeBlockRen
             <select
               value={selectedLanguage}
               onChange={(e) => setSelectedLanguage(e.target.value)}
-              className='cursor-pointer appearance-none rounded border-none bg-gray-50 pr-6 text-xs text-gray-600 dark:bg-[#282c34] dark:text-gray-300'
+              className='cursor-pointer appearance-none rounded border-none bg-gray-50 py-1 pr-6 text-xs text-gray-600 dark:bg-[#282c34] dark:text-gray-300'
             >
               {languageOptions.map((lang) => (
                 <option key={lang} value={lang} className='bg-white text-gray-900 dark:bg-[#282c34] dark:text-gray-100'>

--- a/projects/portfolio/src/client/components/chat/conversation-history.tsx
+++ b/projects/portfolio/src/client/components/chat/conversation-history.tsx
@@ -53,7 +53,7 @@ export function ConversationHistory({
           disabled={disabled}
           className='flex w-full items-center gap-2 rounded-md border border-gray-300 bg-white px-3 py-1.5 font-medium text-gray-700 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 enabled:cursor-pointer disabled:cursor-not-allowed disabled:opacity-50 hover:enabled:bg-gray-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:hover:enabled:bg-gray-600'
         >
-          <NewChatIcon className='fill-gray-600 dark:fill-gray-400' size={16} />
+          <NewChatIcon className='fill-[#5D5D5D] dark:fill-gray-300' size={16} />
           新しい会話
         </button>
       </div>


### PR DESCRIPTION
## Why

コードブロックの言語選択ドロップダウンのクリック・タップ領域が狭く操作しにくかったため、上下パディングを追加して押しやすくする。

## Summary

コードブロックレンダラーの言語セレクトに `py-1` を追加してタップ領域を拡大した。あわせてチャットサイドバーの「新しい会話」ボタンアイコンのカラーを微調整した。

## Changes

- `code-block-renderer.tsx`: 言語選択 `<select>` に `py-1` を追加してクリック領域を拡大
- `conversation-history.tsx`: `NewChatIcon` のカラーを `fill-gray-600 dark:fill-gray-400` → `fill-[#5D5D5D] dark:fill-gray-300` に調整

## Checklist

- [x] 言語選択ドロップダウンの上下パディングを追加
- [x] アイコンカラーの微調整
