### PR TITLE
[portfolio] Chat会話履歴をURL同期しリロード復元できるようにする

### DIFF
--- a/projects/portfolio/src/client/pages/chat/index.tsx
+++ b/projects/portfolio/src/client/pages/chat/index.tsx
@@ -5,14 +5,18 @@ import { ConversationHistory } from '#/client/components/chat/conversation-histo
 import { SpinnerIcon } from '#/client/components/svg/spinner-icon'
 import { useChatPageState } from '#/client/pages/chat/use-chat-page-state'
 import { useMetaProps } from '#/client/pages/home'
+import { Route } from '#/client/routes/chat'
 import type { AppType } from '#/server/app.d'
 import { ConversationListResponseSchema, type Conversation } from '#/types'
 import { useQuery } from '@tanstack/react-query'
 import { hc } from 'hono/client'
+import { useCallback, useEffect } from 'react'
 
 const client = hc<AppType>('/')
 
 export function Chat() {
+  const { conversationId } = Route.useSearch()
+  const navigate = Route.useNavigate()
   const {
     selectedConversationId,
     isSettingsPopupOpen,
@@ -25,10 +29,9 @@ export function Chat() {
     toggleSidebar,
     toggleSettingsPopup,
     closeSettingsPopup,
-    selectConversation,
     setSubmitting,
     updateSettings,
-  } = useChatPageState()
+  } = useChatPageState(conversationId ?? null)
 
   const { email } = useMetaProps()
   const isAuthenticated = !!email
@@ -45,6 +48,53 @@ export function Chat() {
 
   const conversations = query.data ?? []
   const currentConversation = conversations.find(({ id }) => id === selectedConversationId) || null
+  const navigateToNewConversation = useCallback(() => {
+    startNewConversation()
+    void navigate({
+      to: '/chat',
+      search: { conversationId: undefined },
+    })
+  }, [navigate, startNewConversation])
+
+  const navigateToConversation = useCallback(
+    (nextConversationId: string, replace = false) => {
+      void navigate({
+        to: '/chat',
+        search: { conversationId: nextConversationId },
+        replace,
+      })
+    },
+    [navigate]
+  )
+
+  useEffect(() => {
+    if (!selectedConversationId) {
+      return
+    }
+
+    if (!isAuthenticated) {
+      void navigate({
+        to: '/chat',
+        search: { conversationId: undefined },
+        replace: true,
+      })
+      return
+    }
+
+    if (query.isLoading) {
+      return
+    }
+
+    if (conversations.some(({ id }) => id === selectedConversationId)) {
+      return
+    }
+
+    void navigate({
+      to: '/chat',
+      search: { conversationId: undefined },
+      replace: true,
+    })
+  }, [conversations, isAuthenticated, navigate, query.isLoading, selectedConversationId])
 
   const handleDeleteConversation = (conversationId: string) => {
     if (!email) {
@@ -62,7 +112,7 @@ export function Chat() {
 
           // カレントの会話が削除された場合、新しい会話を開始
           if (conversationId === selectedConversationId) {
-            startNewConversation()
+            navigateToNewConversation()
           }
         }
       })
@@ -87,7 +137,7 @@ export function Chat() {
 
           // カレントの会話が削除された場合、新しい会話を開始
           if (isConversationEmpty) {
-            startNewConversation()
+            navigateToNewConversation()
           }
         }
       })
@@ -97,8 +147,10 @@ export function Chat() {
   }
 
   const handleConversationChange = async (conversation: Conversation): Promise<void> => {
-    // カレントの会話IDを更新
-    selectConversation(conversation.id)
+    const shouldReplace = !selectedConversationId
+    if (conversation.id !== selectedConversationId) {
+      navigateToConversation(conversation.id, shouldReplace)
+    }
 
     if (!email) return
 
@@ -129,9 +181,11 @@ export function Chat() {
               conversations={conversations}
               currentConversationId={selectedConversationId}
               disabled={!showSettingsActions}
-              onSelectConversation={selectConversation}
+              onSelectConversation={(nextConversationId) => {
+                navigateToConversation(nextConversationId)
+              }}
               onDeleteConversation={handleDeleteConversation}
-              onNewConversation={startNewConversation}
+              onNewConversation={navigateToNewConversation}
             />
           )
         )
@@ -143,7 +197,7 @@ export function Chat() {
         showPopup={isSettingsPopupOpen}
         showSidebarToggle={!!email}
         isSidebarToggleDisabled={isSubmitting}
-        onNewChat={startNewConversation}
+        onNewChat={navigateToNewConversation}
         onShowMenu={toggleSettingsPopup}
         onToggleSidebar={toggleSidebar}
         onChange={updateSettings}

--- a/projects/portfolio/src/client/pages/chat/index.tsx
+++ b/projects/portfolio/src/client/pages/chat/index.tsx
@@ -48,6 +48,7 @@ export function Chat() {
 
   const conversations = query.data ?? []
   const currentConversation = conversations.find(({ id }) => id === selectedConversationId) || null
+  const isResolvingConversation = selectedConversationId !== null && currentConversation === null
   const navigateToNewConversation = useCallback(() => {
     startNewConversation()
     void navigate({
@@ -148,17 +149,20 @@ export function Chat() {
 
   const handleConversationChange = async (conversation: Conversation): Promise<void> => {
     const shouldReplace = !selectedConversationId
-    if (conversation.id !== selectedConversationId) {
-      navigateToConversation(conversation.id, shouldReplace)
-    }
-
     if (!email) return
 
     try {
       const res = await client.api.conversations.$post({ json: conversation })
       if (res.status === 200) {
         // 成功した場合は、会話履歴を再取得
-        query.refetch()
+        const refetched = await query.refetch()
+
+        if (
+          conversation.id !== selectedConversationId &&
+          (refetched.data ?? []).some(({ id }) => id === conversation.id)
+        ) {
+          navigateToConversation(conversation.id, shouldReplace)
+        }
       }
     } catch (error) {
       console.error('Error updating conversation:', error)
@@ -203,15 +207,22 @@ export function Chat() {
         onChange={updateSettings}
         onHidePopup={closeSettingsPopup}
       />
-      <ChatMain
-        initTrigger={newChatTrigger}
-        settings={settings}
-        canSaveGeneratedFile={isAuthenticated}
-        onSubmitting={setSubmitting}
-        currentConversation={currentConversation}
-        onConversationChange={handleConversationChange}
-        onDeleteMessages={handleDeleteConversationMessage}
-      />
+      {isResolvingConversation ? (
+        <div className='flex min-h-0 flex-1 items-center justify-center gap-2'>
+          <SpinnerIcon />
+          <span className='text-sm text-gray-500 dark:text-gray-400'>会話を読み込み中...</span>
+        </div>
+      ) : (
+        <ChatMain
+          initTrigger={newChatTrigger}
+          settings={settings}
+          canSaveGeneratedFile={isAuthenticated}
+          onSubmitting={setSubmitting}
+          currentConversation={currentConversation}
+          onConversationChange={handleConversationChange}
+          onDeleteMessages={handleDeleteConversationMessage}
+        />
+      )}
     </ChatLayout>
   )
 }

--- a/projects/portfolio/src/client/pages/chat/use-chat-page-state.ts
+++ b/projects/portfolio/src/client/pages/chat/use-chat-page-state.ts
@@ -1,16 +1,24 @@
 import { readFromLocalStorage, saveToLocalStorage, type Settings } from '#/client/storage/remote-storage-settings'
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
-export function useChatPageState() {
-  const [selectedConversationId, setSelectedConversationId] = useState<string | null>(null)
+export function useChatPageState(selectedConversationId: string | null) {
   const [isSettingsPopupOpen, setIsSettingsPopupOpen] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [newChatTrigger, setNewChatTrigger] = useState(Date.now())
   const [settings, setSettings] = useState<Settings>(() => readFromLocalStorage())
   const [isSidebarOpen, setIsSidebarOpen] = useState(() => readFromLocalStorage().sidebarOpen)
+  const previousConversationIdRef = useRef<string | null>(selectedConversationId)
+
+  useEffect(() => {
+    if (previousConversationIdRef.current !== null && selectedConversationId === null) {
+      setIsSettingsPopupOpen(false)
+      setNewChatTrigger(Date.now())
+    }
+
+    previousConversationIdRef.current = selectedConversationId
+  }, [selectedConversationId])
 
   const startNewConversation = useCallback(() => {
-    setSelectedConversationId(null)
     setIsSettingsPopupOpen(false)
     setNewChatTrigger(Date.now())
   }, [])
@@ -29,10 +37,6 @@ export function useChatPageState() {
 
   const closeSettingsPopup = useCallback(() => {
     setIsSettingsPopupOpen(false)
-  }, [])
-
-  const selectConversation = useCallback((conversationId: string) => {
-    setSelectedConversationId(conversationId)
   }, [])
 
   const setSubmitting = useCallback((submitting: boolean) => {
@@ -55,7 +59,6 @@ export function useChatPageState() {
     toggleSidebar,
     toggleSettingsPopup,
     closeSettingsPopup,
-    selectConversation,
     setSubmitting,
     updateSettings,
   }

--- a/projects/portfolio/src/client/routes/chat.tsx
+++ b/projects/portfolio/src/client/routes/chat.tsx
@@ -1,9 +1,19 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { lazy } from 'react'
+import { z } from 'zod'
 
 const Chat = lazy(() => import('#/client/pages/chat').then((module) => ({ default: module.Chat })))
 
 export const Route = createFileRoute('/chat')({
+  validateSearch: z.object({
+    conversationId: z.preprocess((value) => {
+      if (typeof value !== 'string') {
+        return undefined
+      }
+
+      return value.length > 0 ? value : undefined
+    }, z.string().optional()),
+  }),
   component: RouteComponent,
 })
 

--- a/projects/portfolio/tests/client/hooks/use-chat-page-state.test.ts
+++ b/projects/portfolio/tests/client/hooks/use-chat-page-state.test.ts
@@ -40,6 +40,10 @@ const createLocalStorageMock = (initialEntries: Record<string, string> = {}) => 
   }
 }
 
+type HookProps = {
+  selectedConversationId: string | null
+}
+
 describe('useChatPageState', () => {
   beforeEach(() => {
     vi.stubGlobal(
@@ -56,14 +60,15 @@ describe('useChatPageState', () => {
     return mod.useChatPageState
   }
 
-  it('startNewConversation で選択中会話を解除し popup を閉じて trigger を更新する', async () => {
+  it('startNewConversation で popup を閉じて trigger を更新する', async () => {
     const useChatPageState = await importHook()
     const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(100)
 
-    const { result } = renderHook(() => useChatPageState())
+    const { result } = renderHook(({ selectedConversationId }: HookProps) => useChatPageState(selectedConversationId), {
+      initialProps: { selectedConversationId: 'conversation-1' as string | null },
+    })
 
     act(() => {
-      result.current.selectConversation('conversation-1')
       result.current.toggleSettingsPopup()
     })
 
@@ -76,14 +81,14 @@ describe('useChatPageState', () => {
       result.current.startNewConversation()
     })
 
-    expect(result.current.selectedConversationId).toBeNull()
+    expect(result.current.selectedConversationId).toBe('conversation-1')
     expect(result.current.isSettingsPopupOpen).toBe(false)
     expect(result.current.newChatTrigger).toBe(200)
   })
 
   it('setSubmitting が showSettingsActions を反転する', async () => {
     const useChatPageState = await importHook()
-    const { result } = renderHook(() => useChatPageState())
+    const { result } = renderHook(() => useChatPageState(null))
 
     expect(result.current.showSettingsActions).toBe(true)
 
@@ -104,10 +109,14 @@ describe('useChatPageState', () => {
 
   it('会話選択と settings 更新を独立して保持する', async () => {
     const useChatPageState = await importHook()
-    const { result } = renderHook(() => useChatPageState())
+    const { result, rerender } = renderHook(
+      ({ selectedConversationId }: HookProps) => useChatPageState(selectedConversationId),
+      {
+        initialProps: { selectedConversationId: 'conversation-2' as string | null },
+      }
+    )
 
     act(() => {
-      result.current.selectConversation('conversation-2')
       result.current.updateSettings({
         ...result.current.settings,
         model: 'gpt-5',
@@ -118,5 +127,33 @@ describe('useChatPageState', () => {
     expect(result.current.selectedConversationId).toBe('conversation-2')
     expect(result.current.settings.model).toBe('gpt-5')
     expect(result.current.settings.streamMode).toBe(false)
+
+    rerender({ selectedConversationId: 'conversation-3' })
+
+    expect(result.current.selectedConversationId).toBe('conversation-3')
+    expect(result.current.settings.model).toBe('gpt-5')
+  })
+
+  it('選択中会話が null になると新規会話 trigger を更新する', async () => {
+    const useChatPageState = await importHook()
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(100)
+
+    const { result, rerender } = renderHook(
+      ({ selectedConversationId }: HookProps) => useChatPageState(selectedConversationId),
+      {
+        initialProps: { selectedConversationId: 'conversation-1' as string | null },
+      }
+    )
+
+    act(() => {
+      result.current.toggleSettingsPopup()
+    })
+
+    nowSpy.mockReturnValue(300)
+    rerender({ selectedConversationId: null })
+
+    expect(result.current.selectedConversationId).toBeNull()
+    expect(result.current.isSettingsPopupOpen).toBe(false)
+    expect(result.current.newChatTrigger).toBe(300)
   })
 })

--- a/projects/portfolio/tests/client/pages/chat.test.tsx
+++ b/projects/portfolio/tests/client/pages/chat.test.tsx
@@ -4,6 +4,43 @@ import { render, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+const STORAGE_KEY = 'portfolio.chat-settings'
+
+const defaultSettings = {
+  schemaVersion: '1.1.0',
+  model: 'gpt-4.1-mini',
+  baseURL: '',
+  apiKey: '',
+  temperature: 0.7,
+  temperatureEnabled: false,
+  maxTokens: undefined,
+  reasoningEffort: 'medium',
+  reasoningEffortEnabled: false,
+  fakeMode: false,
+  autoModel: false,
+  markdownPreview: true,
+  streamMode: true,
+  interactiveMode: true,
+  templateModels: {},
+}
+
+const createLocalStorageMock = (initialEntries: Record<string, string> = {}) => {
+  const store = new Map(Object.entries(initialEntries))
+
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value)
+    },
+    removeItem: (key: string) => {
+      store.delete(key)
+    },
+    clear: () => {
+      store.clear()
+    },
+  }
+}
+
 const navigateMock = vi.fn()
 const useSearchMock = vi.fn()
 const useQueryMock = vi.fn()
@@ -92,6 +129,12 @@ const conversations = [
 
 describe('Chat page', () => {
   beforeEach(() => {
+    vi.stubGlobal(
+      'localStorage',
+      createLocalStorageMock({
+        [STORAGE_KEY]: JSON.stringify(defaultSettings),
+      })
+    )
     vi.resetModules()
     vi.clearAllMocks()
     chatMainProps = null

--- a/projects/portfolio/tests/client/pages/chat.test.tsx
+++ b/projects/portfolio/tests/client/pages/chat.test.tsx
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+
+import { render, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const navigateMock = vi.fn()
+const useSearchMock = vi.fn()
+const useQueryMock = vi.fn()
+const useMetaPropsMock = vi.fn()
+const conversationsGetMock = vi.fn()
+const conversationsPostMock = vi.fn()
+const conversationsDeleteMock = vi.fn()
+const messagesDeleteMock = vi.fn()
+
+let chatMainProps: Record<string, unknown> | null = null
+let conversationHistoryProps: Record<string, unknown> | null = null
+
+vi.mock('#/client/routes/chat', () => ({
+  Route: {
+    useSearch: () => useSearchMock(),
+    useNavigate: () => navigateMock,
+  },
+}))
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: (...args: unknown[]) => useQueryMock(...args),
+}))
+
+vi.mock('#/client/pages/home', () => ({
+  useMetaProps: () => useMetaPropsMock(),
+}))
+
+vi.mock('hono/client', () => ({
+  hc: () => ({
+    api: {
+      conversations: {
+        $get: (...args: unknown[]) => conversationsGetMock(...args),
+        $post: (...args: unknown[]) => conversationsPostMock(...args),
+        $delete: (...args: unknown[]) => conversationsDeleteMock(...args),
+        messages: {
+          $delete: (...args: unknown[]) => messagesDeleteMock(...args),
+        },
+      },
+    },
+  }),
+}))
+
+vi.mock('#/client/components/chat/chat-layout', () => ({
+  ChatLayout: ({ children, conversations }: { children: ReactNode; conversations?: ReactNode }) => (
+    <div>
+      {conversations}
+      {children}
+    </div>
+  ),
+}))
+
+vi.mock('#/client/components/chat/chat-settings', () => ({
+  ChatSettings: () => null,
+}))
+
+vi.mock('#/client/components/chat/chat-main', () => ({
+  ChatMain: (props: Record<string, unknown>) => {
+    chatMainProps = props
+    return null
+  },
+}))
+
+vi.mock('#/client/components/chat/conversation-history', () => ({
+  ConversationHistory: (props: Record<string, unknown>) => {
+    conversationHistoryProps = props
+    return null
+  },
+}))
+
+const conversations = [
+  {
+    id: 'conversation-1',
+    title: '会話1',
+    updatedAt: new Date('2026-04-21T00:00:00.000Z'),
+    messages: [
+      {
+        id: 'message-1',
+        role: 'user' as const,
+        content: 'hello',
+        reasoningContent: '',
+        metadata: { model: 'gpt-test' },
+      },
+    ],
+  },
+]
+
+describe('Chat page', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    chatMainProps = null
+    conversationHistoryProps = null
+    useMetaPropsMock.mockReturnValue({ email: 'test@example.com' })
+    useSearchMock.mockReturnValue({})
+    useQueryMock.mockReturnValue({
+      data: conversations,
+      isLoading: false,
+      refetch: vi.fn(),
+    })
+    conversationsGetMock.mockResolvedValue({
+      json: async () => ({ data: conversations }),
+    })
+    conversationsPostMock.mockResolvedValue({ status: 200 })
+    conversationsDeleteMock.mockResolvedValue({ status: 200 })
+    messagesDeleteMock.mockResolvedValue({ status: 200 })
+  })
+
+  it('URL の conversationId に対応する会話を ChatMain に渡す', async () => {
+    useSearchMock.mockReturnValue({ conversationId: 'conversation-1' })
+
+    const { Chat } = await import('#/client/pages/chat')
+    render(<Chat />)
+
+    expect(chatMainProps?.currentConversation).toEqual(conversations[0])
+  })
+
+  it('無効な conversationId は /chat に replace で正規化する', async () => {
+    useSearchMock.mockReturnValue({ conversationId: 'missing-conversation' })
+
+    const { Chat } = await import('#/client/pages/chat')
+    render(<Chat />)
+
+    await waitFor(() => {
+      expect(navigateMock).toHaveBeenCalledWith({
+        to: '/chat',
+        search: { conversationId: undefined },
+        replace: true,
+      })
+    })
+  })
+
+  it('新規会話の初回保存成功時は conversationId 付き URL へ replace する', async () => {
+    const { Chat } = await import('#/client/pages/chat')
+    render(<Chat />)
+
+    const onConversationChange = chatMainProps?.onConversationChange as
+      | ((conversation: (typeof conversations)[number]) => Promise<void>)
+      | undefined
+
+    expect(onConversationChange).toBeTypeOf('function')
+
+    await onConversationChange?.(conversations[0])
+
+    expect(navigateMock).toHaveBeenCalledWith({
+      to: '/chat',
+      search: { conversationId: 'conversation-1' },
+      replace: true,
+    })
+  })
+
+  it('会話履歴選択時は conversationId 付き URL へ遷移する', async () => {
+    const { Chat } = await import('#/client/pages/chat')
+    render(<Chat />)
+
+    const onSelectConversation = conversationHistoryProps?.onSelectConversation as
+      | ((conversationId: string) => void)
+      | undefined
+
+    expect(onSelectConversation).toBeTypeOf('function')
+
+    onSelectConversation?.('conversation-1')
+
+    expect(navigateMock).toHaveBeenCalledWith({
+      to: '/chat',
+      search: { conversationId: 'conversation-1' },
+      replace: false,
+    })
+  })
+})

--- a/projects/portfolio/tests/client/pages/chat.test.tsx
+++ b/projects/portfolio/tests/client/pages/chat.test.tsx
@@ -53,6 +53,15 @@ const messagesDeleteMock = vi.fn()
 let chatMainProps: Record<string, unknown> | null = null
 let conversationHistoryProps: Record<string, unknown> | null = null
 
+const createDeferred = <T,>() => {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((nextResolve) => {
+    resolve = nextResolve
+  })
+
+  return { promise, resolve }
+}
+
 vi.mock('#/client/routes/chat', () => ({
   Route: {
     useSearch: () => useSearchMock(),
@@ -144,6 +153,7 @@ describe('Chat page', () => {
     useQueryMock.mockReturnValue({
       data: conversations,
       isLoading: false,
+      isFetching: false,
       refetch: vi.fn(),
     })
     conversationsGetMock.mockResolvedValue({
@@ -179,6 +189,14 @@ describe('Chat page', () => {
   })
 
   it('新規会話の初回保存成功時は conversationId 付き URL へ replace する', async () => {
+    const refetchMock = vi.fn().mockResolvedValue({ data: conversations })
+    useQueryMock.mockReturnValue({
+      data: conversations,
+      isLoading: false,
+      isFetching: false,
+      refetch: refetchMock,
+    })
+
     const { Chat } = await import('#/client/pages/chat')
     render(<Chat />)
 
@@ -189,6 +207,40 @@ describe('Chat page', () => {
     expect(onConversationChange).toBeTypeOf('function')
 
     await onConversationChange?.(conversations[0])
+
+    expect(refetchMock).toHaveBeenCalledTimes(1)
+    expect(navigateMock).toHaveBeenCalledWith({
+      to: '/chat',
+      search: { conversationId: 'conversation-1' },
+      replace: true,
+    })
+  })
+
+  it('初回保存では refetch 完了まで conversationId 付き URL へ遷移しない', async () => {
+    const deferred = createDeferred<{ data: typeof conversations }>()
+    const refetchMock = vi.fn().mockReturnValue(deferred.promise)
+    useQueryMock.mockReturnValue({
+      data: conversations,
+      isLoading: false,
+      isFetching: false,
+      refetch: refetchMock,
+    })
+
+    const { Chat } = await import('#/client/pages/chat')
+    render(<Chat />)
+
+    const onConversationChange = chatMainProps?.onConversationChange as
+      | ((conversation: (typeof conversations)[number]) => Promise<void>)
+      | undefined
+
+    expect(onConversationChange).toBeTypeOf('function')
+
+    const savePromise = onConversationChange?.(conversations[0])
+
+    expect(navigateMock).not.toHaveBeenCalled()
+
+    deferred.resolve({ data: conversations })
+    await savePromise
 
     expect(navigateMock).toHaveBeenCalledWith({
       to: '/chat',
@@ -214,5 +266,21 @@ describe('Chat page', () => {
       search: { conversationId: 'conversation-1' },
       replace: false,
     })
+  })
+
+  it('conversationId 解決中は ChatMain の代わりに loading を表示する', async () => {
+    useSearchMock.mockReturnValue({ conversationId: 'conversation-1' })
+    useQueryMock.mockReturnValue({
+      data: [],
+      isLoading: true,
+      isFetching: true,
+      refetch: vi.fn(),
+    })
+
+    const { Chat } = await import('#/client/pages/chat')
+    const view = render(<Chat />)
+
+    expect(chatMainProps).toBeNull()
+    expect(view.getAllByText('会話を読み込み中...').length).toBeGreaterThan(0)
   })
 })


### PR DESCRIPTION
## Issues

- Close #843

## Why

Chat の会話選択が URL に反映されず、保存済み会話を開いたまま /chat を再読込すると新規会話ビューに戻っていました。会話状態を URL で表現し、再訪・リロード・直接アクセスでも同じ会話を復元できるようにします。

## Summary

Chat ページの会話選択状態を URL 検索パラメータ基準に変更しました。保存済み会話の選択、新規会話開始、初回保存成功、無効な conversationId 指定時の正規化を URL と同期します。

## Changes

- /chat ルートで conversationId 検索パラメータを受け取るように変更
- Chat ページで URL から選択会話を解決し、選択・新規開始・削除・初回保存時の navigate を実装
- useChatPageState を URL 駆動の状態管理に合わせて更新
- Chat URL 同期と正規化を確認する hook / page テストを追加

## Checklist

- [x] bun run format
- [x] bun run lint
- [x] bun run test
