### PR TITLE
fix(portfolio): Chat のコードブロック内で横スクロールが機能しない (#845)

### DIFF
--- a/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
+++ b/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
@@ -319,7 +319,7 @@ export function CodeBlockRenderer({ className, children, actions }: CodeBlockRen
       ) : (
         <div
           aria-hidden={!isOpen}
-          className={`grid overflow-hidden transition-[grid-template-rows] duration-200 ease-out motion-reduce:transition-none ${
+          className={`grid overflow-y-hidden transition-[grid-template-rows] duration-200 ease-out motion-reduce:transition-none ${
             isOpen ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
           }`}
         >


### PR DESCRIPTION
## Issues

- Close #845

## Why

PR #838 でコードブロックの折りたたみアニメーションを実装した際、アニメーションラッパーに `overflow-hidden` を追加したことで、横スクロール（`overflow-x: auto`）が機能しなくなっていた。

## Summary

アニメーションラッパーの `overflow-hidden` を `overflow-y-hidden` に変更し、縦方向のクリッピングを維持しつつ横スクロールを復活させる。

## Changes

- `code-block-renderer.tsx`: 折りたたみアニメーション用ラッパーのクラスを `overflow-hidden` から `overflow-y-hidden` に変更

## Checklist

- [x] lint パス (`bun run lint`)
- [x] テストパス (`bun run test`)
- [x] 横スクロールが機能するようになった
- [x] 折りたたみ/展開アニメーションが正常に動作する
