### PR TITLE
fix(portfolio): improve chat text and code block display

### DIFF
--- a/projects/portfolio/src/client/components/chat/chat-message-list.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-message-list.tsx
@@ -85,7 +85,9 @@ export function ChatMessageList({
                   </div>
                 ) : (
                   <div className='message text-left'>
-                    <p className='wrap-break-word mt-1 inline-block whitespace-pre-wrap break-all'>{stream.content}</p>
+                    <p className='wrap-break-word mt-1 inline-block whitespace-pre-wrap break-all text-gray-900 dark:text-gray-100'>
+                      {stream.content}
+                    </p>
                   </div>
                 )}
               </div>

--- a/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
+++ b/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
@@ -321,9 +321,7 @@ export function CodeBlockRenderer({ className, children, actions }: CodeBlockRen
           aria-hidden={!isOpen}
           className={`grid transition-[grid-template-rows] duration-200 ease-out motion-reduce:transition-none ${
             isOpen ? 'overflow-y-hidden' : 'overflow-hidden'
-          } ${
-            isOpen ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
-          }`}
+          } ${isOpen ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'}`}
         >
           <div className='min-h-0'>{highlighter}</div>
         </div>

--- a/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
+++ b/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
@@ -319,7 +319,9 @@ export function CodeBlockRenderer({ className, children, actions }: CodeBlockRen
       ) : (
         <div
           aria-hidden={!isOpen}
-          className={`grid overflow-y-hidden transition-[grid-template-rows] duration-200 ease-out motion-reduce:transition-none ${
+          className={`grid transition-[grid-template-rows] duration-200 ease-out motion-reduce:transition-none ${
+            isOpen ? 'overflow-y-hidden' : 'overflow-hidden'
+          } ${
             isOpen ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
           }`}
         >

--- a/projects/portfolio/src/client/components/chat/message-renderer.tsx
+++ b/projects/portfolio/src/client/components/chat/message-renderer.tsx
@@ -191,7 +191,9 @@ function MessageRendererComponent({
           </div>
         ) : (
           <div className='message text-left'>
-            <p className='wrap-break-word mt-1 inline-block whitespace-pre-wrap break-all'>{message.content}</p>
+            <p className='wrap-break-word mt-1 inline-block whitespace-pre-wrap break-all text-gray-900 dark:text-gray-100'>
+              {message.content}
+            </p>
           </div>
         )}
         <MessageActionBar copied={copied}>


### PR DESCRIPTION
## Issues

- None

## Why

チャット UI で 2 つの表示上の違和感が残っていました。マークダウンプレビューを無効にしたときの生テキストがダークモードでも黒いままで読みにくく、折りたたんだコードブロックでは未展開でも横スクロールバーが見えていました。

## Summary

チャットの生テキスト表示をライト/ダークモード対応にし、コードブロックの折りたたみ時のスクロール表示を調整しました。展開時の横スクロールは維持したまま、折りたたみ時だけ不要なスクロールバーを隠しています。

## Changes

- マークダウンプレビュー OFF 時のアシスタント生テキストとストリーミングテキストにテーマ対応の文字色を追加
- コードブロックの折りたたみコンテナの overflow 制御を見直し、折りたたみ時だけ横スクロールバーを非表示化
- 展開時は従来どおりコードブロック本体で横スクロールできるよう維持

## Checklist

- [x] `bun run format`
- [x] `bun run lint`
- [x] `bun run test`
