### PR TITLE
feat(portfolio): add messages JSON dump viewer to ChatResults (#850)

### DIFF
--- a/projects/portfolio/src/client/components/chat/chat-message-list.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-message-list.tsx
@@ -134,6 +134,7 @@ const MessageHistory = memo(function MessageHistory({
       key={message.id ?? `chat_${index}`}
       message={message}
       index={index}
+      messages={messages}
       conversationId={conversationId}
       canSaveGeneratedFile={canSaveGeneratedFile}
       markdownPreview={markdownPreview}

--- a/projects/portfolio/src/client/components/chat/chat-results.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-results.tsx
@@ -1,5 +1,5 @@
-import { ChevronRightIcon } from '#/client/components/svg/chevron-right-icon'
 import { MessagesDumpViewer } from '#/client/components/chat/messages-dump-viewer'
+import { ChevronRightIcon } from '#/client/components/svg/chevron-right-icon'
 import { EyeIcon } from '#/client/components/svg/eye-icon'
 import type { AssistantMetadata, Message } from '#/types'
 import { memo, useState } from 'react'

--- a/projects/portfolio/src/client/components/chat/chat-results.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-results.tsx
@@ -1,9 +1,12 @@
 import { ChevronRightIcon } from '#/client/components/svg/chevron-right-icon'
-import type { AssistantMetadata } from '#/types'
-import { memo, useState } from 'react'
+import { CloseIcon } from '#/client/components/svg/close-icon'
+import { EyeIcon } from '#/client/components/svg/eye-icon'
+import type { AssistantMetadata, Message } from '#/types'
+import { memo, useEffect, useState } from 'react'
 
 interface ChatResultsProps {
   metadata: AssistantMetadata
+  messages: Message[]
 }
 
 function formatResponseTime(ms: number): string {
@@ -15,8 +18,57 @@ function formatResponseTime(ms: number): string {
 
 const badgeClass = 'flex items-center rounded-md bg-gray-100 px-2 py-1 text-xs dark:bg-gray-700 dark:text-gray-300'
 
-function ChatResultsComponent({ metadata }: ChatResultsProps) {
+function MessagesDumpViewer({ messages, open, onClose }: { messages: Message[]; open: boolean; onClose: () => void }) {
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose()
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [open, onClose])
+
+  if (!open) {
+    return null
+  }
+
+  return (
+    <div className='fixed inset-0 z-50 flex items-center justify-center p-4'>
+      <div className='fixed inset-0 bg-black/50' onClick={onClose} aria-hidden='true' />
+      <div
+        className='relative z-10 flex max-h-[80vh] w-full max-w-2xl flex-col rounded-lg border border-gray-200 bg-white shadow-lg dark:border-gray-700 dark:bg-gray-800'
+        role='dialog'
+        aria-modal='true'
+        aria-label='Messages dump viewer'
+      >
+        <div className='flex items-center justify-between border-b border-gray-200 px-4 py-2 dark:border-gray-700'>
+          <span className='text-sm font-medium text-gray-900 dark:text-gray-100'>Messages Dump</span>
+          <button
+            type='button'
+            className='flex h-8 w-8 cursor-pointer items-center justify-center rounded-full text-gray-500 transition-[background-color,color] duration-200 ease-out hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white dark:focus-visible:ring-gray-500'
+            onClick={onClose}
+            aria-label='Close viewer'
+          >
+            <CloseIcon size={20} />
+          </button>
+        </div>
+        <div className='overflow-auto p-4'>
+          <pre className='text-xs text-gray-800 dark:text-gray-200'>
+            <code>{JSON.stringify(messages, null, 2)}</code>
+          </pre>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function ChatResultsComponent({ metadata, messages }: ChatResultsProps) {
   const [open, setOpen] = useState(false)
+  const [dumpOpen, setDumpOpen] = useState(false)
 
   if (!metadata.model) {
     return null
@@ -26,23 +78,34 @@ function ChatResultsComponent({ metadata }: ChatResultsProps) {
 
   return (
     <div className='mt-2'>
-      <button
-        type='button'
-        className='flex cursor-pointer flex-wrap items-center gap-1 text-xs text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300'
-        onClick={() => setOpen((prev) => !prev)}
-        aria-expanded={open}
-      >
-        <span>{model}</span>
-        {responseTimeMs !== undefined && (
-          <>
-            <span>/</span>
-            <span>{formatResponseTime(responseTimeMs)}</span>
-          </>
-        )}
-        <span className={`ml-0.5 inline-flex transition-transform duration-200 ${open ? '-rotate-90' : 'rotate-90'}`}>
-          <ChevronRightIcon />
-        </span>
-      </button>
+      <div className='flex flex-wrap items-center gap-2'>
+        <button
+          type='button'
+          className='flex cursor-pointer flex-wrap items-center gap-1 text-xs text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300'
+          onClick={() => setOpen((prev) => !prev)}
+          aria-expanded={open}
+        >
+          <span>{model}</span>
+          {responseTimeMs !== undefined && (
+            <>
+              <span>/</span>
+              <span>{formatResponseTime(responseTimeMs)}</span>
+            </>
+          )}
+          <span className={`ml-0.5 inline-flex transition-transform duration-200 ${open ? '-rotate-90' : 'rotate-90'}`}>
+            <ChevronRightIcon />
+          </span>
+        </button>
+        <button
+          type='button'
+          className='flex cursor-pointer items-center gap-1 text-xs text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300'
+          onClick={() => setDumpOpen(true)}
+          aria-label='Open messages dump viewer'
+        >
+          <span>messages: ({messages.length})</span>
+          <EyeIcon size={14} className='stroke-current' />
+        </button>
+      </div>
       <div
         aria-hidden={!open}
         className={`grid overflow-hidden transition-[grid-template-rows,opacity,margin] duration-200 ease-out motion-reduce:transition-none ${
@@ -80,6 +143,7 @@ function ChatResultsComponent({ metadata }: ChatResultsProps) {
           </div>
         </div>
       </div>
+      <MessagesDumpViewer messages={messages} open={dumpOpen} onClose={() => setDumpOpen(false)} />
     </div>
   )
 }

--- a/projects/portfolio/src/client/components/chat/chat-results.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-results.tsx
@@ -1,10 +1,8 @@
-import { CheckIcon } from '#/client/components/svg/check-icon'
 import { ChevronRightIcon } from '#/client/components/svg/chevron-right-icon'
-import { CloseIcon } from '#/client/components/svg/close-icon'
-import { CopyIcon } from '#/client/components/svg/copy-icon'
+import { MessagesDumpViewer } from '#/client/components/chat/messages-dump-viewer'
 import { EyeIcon } from '#/client/components/svg/eye-icon'
 import type { AssistantMetadata, Message } from '#/types'
-import { memo, useEffect, useState } from 'react'
+import { memo, useState } from 'react'
 
 interface ChatResultsProps {
   metadata: AssistantMetadata
@@ -19,95 +17,6 @@ function formatResponseTime(ms: number): string {
 }
 
 const badgeClass = 'flex items-center rounded-md bg-gray-100 px-2 py-1 text-xs dark:bg-gray-700 dark:text-gray-300'
-
-function MessagesDumpViewer({ messages, open, onClose }: { messages: Message[]; open: boolean; onClose: () => void }) {
-  const [copied, setCopied] = useState(false)
-
-  useEffect(() => {
-    if (!open) {
-      return
-    }
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        onClose()
-      }
-    }
-    document.addEventListener('keydown', handleKeyDown)
-    return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [open, onClose])
-
-  useEffect(() => {
-    if (!copied) {
-      return
-    }
-    const timer = setTimeout(() => setCopied(false), 2000)
-    return () => clearTimeout(timer)
-  }, [copied])
-
-  if (!open) {
-    return null
-  }
-
-  const json = JSON.stringify(messages, null, 2)
-
-  const handleCopy = async () => {
-    await navigator.clipboard.writeText(json)
-    setCopied(true)
-  }
-
-  const iconButtonClass =
-    'flex h-8 w-8 cursor-pointer items-center justify-center rounded-full text-gray-500 transition-[background-color,color] duration-200 ease-out hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white dark:focus-visible:ring-gray-500'
-
-  return (
-    <div className='fixed inset-0 z-50 flex items-center justify-center p-4'>
-      <div className='fixed inset-0 bg-black/50' onClick={onClose} aria-hidden='true' />
-      <div
-        className='relative z-10 flex max-h-[80vh] w-full max-w-2xl flex-col rounded-lg border border-gray-200 bg-white shadow-lg dark:border-gray-700 dark:bg-gray-800'
-        role='dialog'
-        aria-modal='true'
-        aria-label='Messages dump viewer'
-      >
-        <div className='flex items-center justify-between border-b border-gray-200 px-4 py-2 dark:border-gray-700'>
-          <span className='text-sm font-medium text-gray-900 dark:text-gray-100'>Messages Dump</span>
-          <div className='flex items-center gap-1'>
-            <button
-              type='button'
-              className={`${iconButtonClass} ${copied ? 'text-emerald-600 dark:text-emerald-400' : ''}`}
-              onClick={handleCopy}
-              disabled={copied}
-              aria-label={copied ? 'Copied' : 'Copy JSON'}
-            >
-              <span
-                aria-hidden='true'
-                className={`absolute transition-[opacity,transform] duration-200 ease-out motion-reduce:transition-none ${
-                  copied ? '-translate-y-0.5 scale-90 opacity-0' : 'translate-y-0 scale-100 opacity-100'
-                }`}
-              >
-                <CopyIcon size={18} className='stroke-current' />
-              </span>
-              <span
-                aria-hidden='true'
-                className={`absolute transition-[opacity,transform] duration-200 ease-out motion-reduce:transition-none ${
-                  copied ? 'translate-y-0 scale-100 opacity-100' : 'translate-y-0.5 scale-90 opacity-0'
-                }`}
-              >
-                <CheckIcon size={18} className='stroke-current' />
-              </span>
-            </button>
-            <button type='button' className={iconButtonClass} onClick={onClose} aria-label='Close viewer'>
-              <CloseIcon size={20} />
-            </button>
-          </div>
-        </div>
-        <div className='overflow-auto p-4'>
-          <pre className='text-xs text-gray-800 dark:text-gray-200'>
-            <code>{json}</code>
-          </pre>
-        </div>
-      </div>
-    </div>
-  )
-}
 
 function ChatResultsComponent({ metadata, messages }: ChatResultsProps) {
   const [open, setOpen] = useState(false)

--- a/projects/portfolio/src/client/components/chat/chat-results.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-results.tsx
@@ -17,6 +17,8 @@ function formatResponseTime(ms: number): string {
 }
 
 const badgeClass = 'flex items-center rounded-md bg-gray-100 px-2 py-1 text-xs dark:bg-gray-700 dark:text-gray-300'
+const usageBadgeClass = `${badgeClass} max-w-full flex-wrap gap-x-1 gap-y-0.5`
+const usageItemClass = 'inline-flex items-center gap-0.5'
 
 function ChatResultsComponent({ metadata, messages }: ChatResultsProps) {
   const [open, setOpen] = useState(false)
@@ -76,24 +78,31 @@ function ChatResultsComponent({ metadata, messages }: ChatResultsProps) {
                 <span>{finishReason}</span>
               </div>
             )}
-            <div className={badgeClass}>
+            <div className={usageBadgeClass}>
               <span className='mr-1'>usage:</span>
-              <span className='mr-0.5'>(input:</span>
-              <span>{usage.promptTokens ?? '--'}</span>
-              <span className='mr-0.5'>/</span>
-              <span className='mr-0.5'>output:</span>
-              <span>{usage.completionTokens ?? '--'}</span>
-              <span className='mr-0.5'>/</span>
-              <span className='mr-0.5'>total:</span>
-              <span>{usage.totalTokens ?? '--'}</span>
+              <span className={usageItemClass}>
+                <span>input:</span>
+                <span>{usage.promptTokens ?? '--'}</span>
+              </span>
+              <span className='text-gray-400 dark:text-gray-500'>/</span>
+              <span className={usageItemClass}>
+                <span>output:</span>
+                <span>{usage.completionTokens ?? '--'}</span>
+              </span>
+              <span className='text-gray-400 dark:text-gray-500'>/</span>
+              <span className={usageItemClass}>
+                <span>total:</span>
+                <span>{usage.totalTokens ?? '--'}</span>
+              </span>
               {usage.reasoningTokens !== undefined && (
                 <>
-                  <span className='mr-0.5'>/</span>
-                  <span className='mr-0.5'>reasoning:</span>
-                  <span>{usage.reasoningTokens}</span>
+                  <span className='text-gray-400 dark:text-gray-500'>/</span>
+                  <span className={usageItemClass}>
+                    <span>reasoning:</span>
+                    <span>{usage.reasoningTokens}</span>
+                  </span>
                 </>
               )}
-              <span>)</span>
             </div>
           </div>
         </div>

--- a/projects/portfolio/src/client/components/chat/chat-results.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-results.tsx
@@ -1,5 +1,7 @@
+import { CheckIcon } from '#/client/components/svg/check-icon'
 import { ChevronRightIcon } from '#/client/components/svg/chevron-right-icon'
 import { CloseIcon } from '#/client/components/svg/close-icon'
+import { CopyIcon } from '#/client/components/svg/copy-icon'
 import { EyeIcon } from '#/client/components/svg/eye-icon'
 import type { AssistantMetadata, Message } from '#/types'
 import { memo, useEffect, useState } from 'react'
@@ -19,6 +21,8 @@ function formatResponseTime(ms: number): string {
 const badgeClass = 'flex items-center rounded-md bg-gray-100 px-2 py-1 text-xs dark:bg-gray-700 dark:text-gray-300'
 
 function MessagesDumpViewer({ messages, open, onClose }: { messages: Message[]; open: boolean; onClose: () => void }) {
+  const [copied, setCopied] = useState(false)
+
   useEffect(() => {
     if (!open) {
       return
@@ -32,9 +36,27 @@ function MessagesDumpViewer({ messages, open, onClose }: { messages: Message[]; 
     return () => document.removeEventListener('keydown', handleKeyDown)
   }, [open, onClose])
 
+  useEffect(() => {
+    if (!copied) {
+      return
+    }
+    const timer = setTimeout(() => setCopied(false), 2000)
+    return () => clearTimeout(timer)
+  }, [copied])
+
   if (!open) {
     return null
   }
+
+  const json = JSON.stringify(messages, null, 2)
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(json)
+    setCopied(true)
+  }
+
+  const iconButtonClass =
+    'flex h-8 w-8 cursor-pointer items-center justify-center rounded-full text-gray-500 transition-[background-color,color] duration-200 ease-out hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white dark:focus-visible:ring-gray-500'
 
   return (
     <div className='fixed inset-0 z-50 flex items-center justify-center p-4'>
@@ -47,18 +69,39 @@ function MessagesDumpViewer({ messages, open, onClose }: { messages: Message[]; 
       >
         <div className='flex items-center justify-between border-b border-gray-200 px-4 py-2 dark:border-gray-700'>
           <span className='text-sm font-medium text-gray-900 dark:text-gray-100'>Messages Dump</span>
-          <button
-            type='button'
-            className='flex h-8 w-8 cursor-pointer items-center justify-center rounded-full text-gray-500 transition-[background-color,color] duration-200 ease-out hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white dark:focus-visible:ring-gray-500'
-            onClick={onClose}
-            aria-label='Close viewer'
-          >
-            <CloseIcon size={20} />
-          </button>
+          <div className='flex items-center gap-1'>
+            <button
+              type='button'
+              className={`${iconButtonClass} ${copied ? 'text-emerald-600 dark:text-emerald-400' : ''}`}
+              onClick={handleCopy}
+              disabled={copied}
+              aria-label={copied ? 'Copied' : 'Copy JSON'}
+            >
+              <span
+                aria-hidden='true'
+                className={`absolute transition-[opacity,transform] duration-200 ease-out motion-reduce:transition-none ${
+                  copied ? '-translate-y-0.5 scale-90 opacity-0' : 'translate-y-0 scale-100 opacity-100'
+                }`}
+              >
+                <CopyIcon size={18} className='stroke-current' />
+              </span>
+              <span
+                aria-hidden='true'
+                className={`absolute transition-[opacity,transform] duration-200 ease-out motion-reduce:transition-none ${
+                  copied ? 'translate-y-0 scale-100 opacity-100' : 'translate-y-0.5 scale-90 opacity-0'
+                }`}
+              >
+                <CheckIcon size={18} className='stroke-current' />
+              </span>
+            </button>
+            <button type='button' className={iconButtonClass} onClick={onClose} aria-label='Close viewer'>
+              <CloseIcon size={20} />
+            </button>
+          </div>
         </div>
         <div className='overflow-auto p-4'>
           <pre className='text-xs text-gray-800 dark:text-gray-200'>
-            <code>{JSON.stringify(messages, null, 2)}</code>
+            <code>{json}</code>
           </pre>
         </div>
       </div>

--- a/projects/portfolio/src/client/components/chat/chat-results.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-results.tsx
@@ -83,6 +83,9 @@ function ChatResultsComponent({ metadata, messages }: ChatResultsProps) {
               <span className='mr-0.5'>/</span>
               <span className='mr-0.5'>output:</span>
               <span>{usage.completionTokens ?? '--'}</span>
+              <span className='mr-0.5'>/</span>
+              <span className='mr-0.5'>total:</span>
+              <span>{usage.totalTokens ?? '--'}</span>
               {usage.reasoningTokens !== undefined && (
                 <>
                   <span className='mr-0.5'>/</span>

--- a/projects/portfolio/src/client/components/chat/hooks/use-chat-form.ts
+++ b/projects/portfolio/src/client/components/chat/hooks/use-chat-form.ts
@@ -153,7 +153,6 @@ const createMessage = (
             })),
           ]
         : inputText,
-    reasoningContent: '',
     metadata: { model, apiMode },
   }
 
@@ -176,14 +175,12 @@ const createTemplateMessage = (
     id: uuidv7(),
     role: 'user',
     content: templateInput.content,
-    reasoningContent: '',
     metadata: { model: templateInput.model || model, apiMode },
   }
   const systemMessage: Message = {
     id: uuidv7(),
     role: 'system',
     content: templateInput.prompt,
-    reasoningContent: '',
   }
 
   const allMessages: Message[] =

--- a/projects/portfolio/src/client/components/chat/message-renderer.tsx
+++ b/projects/portfolio/src/client/components/chat/message-renderer.tsx
@@ -177,6 +177,7 @@ function MessageRendererComponent({
       {message.content}
     </ReactMarkdown>
   )
+  const dumpMessages = messages.slice(0, index + 1)
 
   return (
     <div className='flex'>
@@ -201,7 +202,7 @@ function MessageRendererComponent({
         <MessageActionBar copied={copied}>
           <CopyMessageButton copied={copied} onClick={() => onCopyMessage(message.content, index)} />
         </MessageActionBar>
-        <ChatResults metadata={message.metadata} messages={messages} />
+        <ChatResults metadata={message.metadata} messages={dumpMessages} />
       </div>
     </div>
   )

--- a/projects/portfolio/src/client/components/chat/message-renderer.tsx
+++ b/projects/portfolio/src/client/components/chat/message-renderer.tsx
@@ -28,6 +28,7 @@ const markdownComponents = {
 interface MessageRendererProps {
   message: Message
   index: number
+  messages: Message[]
   conversationId: string | null
   canSaveGeneratedFile?: boolean
   markdownPreview: boolean
@@ -99,6 +100,7 @@ function CopyMessageButton({ copied, onClick }: CopyMessageButtonProps) {
 function MessageRendererComponent({
   message,
   index,
+  messages,
   conversationId,
   canSaveGeneratedFile,
   markdownPreview,
@@ -199,7 +201,7 @@ function MessageRendererComponent({
         <MessageActionBar copied={copied}>
           <CopyMessageButton copied={copied} onClick={() => onCopyMessage(message.content, index)} />
         </MessageActionBar>
-        <ChatResults metadata={message.metadata} />
+        <ChatResults metadata={message.metadata} messages={messages} />
       </div>
     </div>
   )

--- a/projects/portfolio/src/client/components/chat/messages-dump-viewer.tsx
+++ b/projects/portfolio/src/client/components/chat/messages-dump-viewer.tsx
@@ -1,0 +1,106 @@
+import { CheckIcon } from '#/client/components/svg/check-icon'
+import { CloseIcon } from '#/client/components/svg/close-icon'
+import { CopyIcon } from '#/client/components/svg/copy-icon'
+import { useLockBodyScroll } from '#/client/hooks/use-lock-body-scroll'
+import type { Message } from '#/types'
+import { useEffect, useState } from 'react'
+
+interface MessagesDumpViewerProps {
+  messages: Message[]
+  open: boolean
+  onClose: () => void
+}
+
+export function MessagesDumpViewer({ messages, open, onClose }: MessagesDumpViewerProps) {
+  const [copied, setCopied] = useState(false)
+
+  useLockBodyScroll(open)
+
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose()
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [open, onClose])
+
+  useEffect(() => {
+    if (!copied) {
+      return
+    }
+
+    const timer = setTimeout(() => setCopied(false), 2000)
+    return () => clearTimeout(timer)
+  }, [copied])
+
+  if (!open) {
+    return null
+  }
+
+  const json = JSON.stringify(messages, null, 2)
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(json)
+    setCopied(true)
+  }
+
+  const iconButtonClass =
+    'flex h-8 w-8 cursor-pointer items-center justify-center rounded-full text-gray-500 transition-[background-color,color] duration-200 ease-out hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white dark:focus-visible:ring-gray-500'
+
+  return (
+    <div className='fixed inset-0 z-50 flex items-center justify-center p-4'>
+      <div className='fixed inset-0 bg-black/50' onClick={onClose} aria-hidden='true' />
+      <div
+        className='relative z-10 flex max-h-[80vh] w-full max-w-2xl flex-col rounded-lg border border-gray-200 bg-white shadow-lg dark:border-gray-700 dark:bg-gray-800'
+        role='dialog'
+        aria-modal='true'
+        aria-label='Messages dump viewer'
+      >
+        <div className='flex items-center justify-between border-b border-gray-200 px-4 py-2 dark:border-gray-700'>
+          <span className='text-sm font-medium text-gray-900 dark:text-gray-100'>Messages Dump</span>
+          <div className='flex items-center gap-1'>
+            <button
+              type='button'
+              className={`${iconButtonClass} ${copied ? 'text-emerald-600 dark:text-emerald-400' : ''}`}
+              onClick={handleCopy}
+              disabled={copied}
+              aria-label={copied ? 'Copied' : 'Copy JSON'}
+            >
+              <span
+                aria-hidden='true'
+                className={`absolute transition-[opacity,transform] duration-200 ease-out motion-reduce:transition-none ${
+                  copied ? '-translate-y-0.5 scale-90 opacity-0' : 'translate-y-0 scale-100 opacity-100'
+                }`}
+              >
+                <CopyIcon size={18} className='stroke-current' />
+              </span>
+              <span
+                aria-hidden='true'
+                className={`absolute transition-[opacity,transform] duration-200 ease-out motion-reduce:transition-none ${
+                  copied ? 'translate-y-0 scale-100 opacity-100' : 'translate-y-0.5 scale-90 opacity-0'
+                }`}
+              >
+                <CheckIcon size={18} className='stroke-current' />
+              </span>
+            </button>
+            <button type='button' className={iconButtonClass} onClick={onClose} aria-label='Close viewer'>
+              <CloseIcon size={20} />
+            </button>
+          </div>
+        </div>
+        <div className='overflow-auto p-4'>
+          <pre className='text-xs text-gray-800 dark:text-gray-200'>
+            <code>{json}</code>
+          </pre>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/projects/portfolio/src/client/components/chat/messages-dump-viewer.tsx
+++ b/projects/portfolio/src/client/components/chat/messages-dump-viewer.tsx
@@ -58,7 +58,7 @@ export function MessagesDumpViewer({ messages, open, onClose }: MessagesDumpView
     <div className='fixed inset-0 z-50 flex items-center justify-center p-4'>
       <div className='fixed inset-0 bg-black/50' onClick={onClose} aria-hidden='true' />
       <div
-        className='relative z-10 flex max-h-[80vh] w-full max-w-2xl flex-col rounded-lg border border-gray-200 bg-white shadow-lg dark:border-gray-700 dark:bg-gray-800'
+        className='relative z-10 flex max-h-[80vh] w-full max-w-2xl flex-col overflow-hidden rounded-lg border border-gray-200 bg-white shadow-lg dark:border-gray-700 dark:bg-gray-800'
         role='dialog'
         aria-modal='true'
         aria-label='Messages dump viewer'
@@ -95,8 +95,8 @@ export function MessagesDumpViewer({ messages, open, onClose }: MessagesDumpView
             </button>
           </div>
         </div>
-        <div className='overflow-auto p-4'>
-          <pre className='text-xs text-gray-800 dark:text-gray-200'>
+        <div className='messages-dump-scroll overflow-auto bg-gray-50 p-4 dark:bg-gray-800'>
+          <pre className='w-max min-w-full pr-4 text-xs text-gray-800 dark:text-gray-200'>
             <code>{json}</code>
           </pre>
         </div>

--- a/projects/portfolio/src/client/main.css
+++ b/projects/portfolio/src/client/main.css
@@ -133,3 +133,7 @@ body {
   border-radius: 4px;
   border: none;
 }
+
+.messages-dump-scroll::-webkit-scrollbar-corner {
+  background-color: inherit;
+}

--- a/projects/portfolio/src/server/features/chat-conversations/read-conversations.ts
+++ b/projects/portfolio/src/server/features/chat-conversations/read-conversations.ts
@@ -178,7 +178,7 @@ function buildMessage(
       id: row.id,
       role: 'user',
       content,
-      reasoningContent: row.reasoningContent,
+      reasoningContent: row.reasoningContent || undefined,
       metadata: (row.metadata ?? {}) as UserMetadata,
     }
   }
@@ -198,7 +198,7 @@ function buildMessage(
       id: row.id,
       role: 'system',
       content: typeof content === 'string' ? content : '',
-      reasoningContent: row.reasoningContent,
+      reasoningContent: row.reasoningContent || undefined,
       metadata: (row.metadata as Record<string, never> | undefined) ?? undefined,
     }
   }

--- a/projects/portfolio/src/types/chat.ts
+++ b/projects/portfolio/src/types/chat.ts
@@ -47,7 +47,7 @@ export const UserMessageSchema = z.object({
   role: z.literal('user'),
   // 修正: string | Array<TextContent | ImageContent> に対応
   content: z.union([z.string(), z.array(z.union([TextContentSchema, ImageContentSchema]))]),
-  reasoningContent: z.string().default(''),
+  reasoningContent: z.string().optional(),
   metadata: UserMetadataSchema,
 })
 
@@ -99,7 +99,7 @@ export const SystemMessageSchema = z.object({
   id: z.string().optional(),
   role: z.literal('system'),
   content: z.string(),
-  reasoningContent: z.string().default(''),
+  reasoningContent: z.string().optional(),
   metadata: z.object({}).optional(),
 })
 

--- a/projects/portfolio/tests/client/components/chat-results.test.tsx
+++ b/projects/portfolio/tests/client/components/chat-results.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+
+import { ChatResults } from '#/client/components/chat/chat-results'
+import type { AssistantMetadata, Message } from '#/types'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+afterEach(() => {
+  cleanup()
+})
+
+function createMetadata(overrides?: Partial<AssistantMetadata>): AssistantMetadata {
+  return {
+    model: 'gpt-test',
+    usage: {},
+    ...overrides,
+  }
+}
+
+function createMessages(count: number): Message[] {
+  return Array.from({ length: count }, (_, i) => ({
+    role: 'user',
+    content: `message-${i}`,
+    reasoningContent: '',
+    metadata: { model: 'gpt-test' },
+  }))
+}
+
+describe('ChatResults', () => {
+  describe('metadata display', () => {
+    it('renders model name and toggles usage badges', () => {
+      render(<ChatResults metadata={createMetadata({ finishReason: 'stop', responseTimeMs: 500 })} messages={[]} />)
+
+      const toggleButton = screen.getByText('gpt-test')
+      expect(toggleButton).toBeTruthy()
+
+      fireEvent.click(toggleButton)
+      expect(screen.getByText('finish_reason:')).toBeTruthy()
+      expect(screen.getByText('stop')).toBeTruthy()
+    })
+
+    it('returns null when model is empty', () => {
+      const { container } = render(<ChatResults metadata={createMetadata({ model: '' })} messages={[]} />)
+      expect(container.firstChild).toBeNull()
+    })
+  })
+
+  describe('messages dump trigger', () => {
+    it('displays current messages count', () => {
+      render(<ChatResults metadata={createMetadata()} messages={createMessages(3)} />)
+
+      expect(screen.getByText('messages: (3)')).toBeTruthy()
+    })
+
+    it('opens popover on click and shows formatted JSON', () => {
+      const messages = createMessages(2)
+      render(<ChatResults metadata={createMetadata()} messages={messages} />)
+
+      const dumpButton = screen.getByLabelText('Open messages dump viewer')
+      fireEvent.click(dumpButton)
+
+      expect(screen.getByRole('dialog', { name: 'Messages dump viewer' })).toBeTruthy()
+      expect(screen.getByText(/"role": "user"/)).toBeTruthy()
+    })
+
+    it('closes popover on backdrop click', () => {
+      const { container } = render(<ChatResults metadata={createMetadata()} messages={createMessages(1)} />)
+
+      fireEvent.click(screen.getByLabelText('Open messages dump viewer'))
+      expect(screen.getByRole('dialog')).toBeTruthy()
+
+      const backdrop = container.querySelector('.bg-black\\/50')
+      expect(backdrop).toBeTruthy()
+      fireEvent.click(backdrop!)
+      expect(screen.queryByRole('dialog')).toBeNull()
+    })
+
+    it('closes popover on close button click', () => {
+      render(<ChatResults metadata={createMetadata()} messages={createMessages(1)} />)
+
+      fireEvent.click(screen.getByLabelText('Open messages dump viewer'))
+      expect(screen.getByRole('dialog')).toBeTruthy()
+
+      fireEvent.click(screen.getByLabelText('Close viewer'))
+      expect(screen.queryByRole('dialog')).toBeNull()
+    })
+
+    it('closes popover on Escape key', () => {
+      render(<ChatResults metadata={createMetadata()} messages={createMessages(1)} />)
+
+      fireEvent.click(screen.getByLabelText('Open messages dump viewer'))
+      expect(screen.getByRole('dialog')).toBeTruthy()
+
+      fireEvent.keyDown(document, { key: 'Escape' })
+      expect(screen.queryByRole('dialog')).toBeNull()
+    })
+  })
+})

--- a/projects/portfolio/tests/client/components/chat-results.test.tsx
+++ b/projects/portfolio/tests/client/components/chat-results.test.tsx
@@ -3,7 +3,7 @@
 import { ChatResults } from '#/client/components/chat/chat-results'
 import type { AssistantMetadata, Message } from '#/types'
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 afterEach(() => {
   cleanup()
@@ -93,6 +93,19 @@ describe('ChatResults', () => {
 
       fireEvent.keyDown(document, { key: 'Escape' })
       expect(screen.queryByRole('dialog')).toBeNull()
+    })
+
+    it('copies JSON to clipboard on copy button click', async () => {
+      const writeText = vi.fn().mockResolvedValue(undefined)
+      Object.assign(navigator, { clipboard: { writeText } })
+
+      const messages = createMessages(2)
+      render(<ChatResults metadata={createMetadata()} messages={messages} />)
+
+      fireEvent.click(screen.getByLabelText('Open messages dump viewer'))
+      fireEvent.click(screen.getByLabelText('Copy JSON'))
+
+      expect(writeText).toHaveBeenCalledWith(JSON.stringify(messages, null, 2))
     })
   })
 })

--- a/projects/portfolio/tests/client/components/message-renderer.test.tsx
+++ b/projects/portfolio/tests/client/components/message-renderer.test.tsx
@@ -41,6 +41,7 @@ describe('MessageRenderer', () => {
         <MessageRenderer
           message={createAssistantMessage('```html\n<div>Hello</div>\n```')}
           index={0}
+          messages={[]}
           conversationId='conversation-1'
           canSaveGeneratedFile={false}
           markdownPreview={true}
@@ -58,6 +59,7 @@ describe('MessageRenderer', () => {
         <MessageRenderer
           message={createAssistantMessage('```html\n<div>Hello</div>\n```')}
           index={0}
+          messages={[]}
           conversationId='conversation-1'
           canSaveGeneratedFile={true}
           markdownPreview={true}
@@ -75,6 +77,7 @@ describe('MessageRenderer', () => {
         <MessageRenderer
           message={createAssistantMessage('```typescript\nconst value = 1\n```')}
           index={0}
+          messages={[]}
           conversationId='conversation-1'
           canSaveGeneratedFile={true}
           markdownPreview={true}
@@ -104,6 +107,7 @@ describe('MessageRenderer', () => {
             },
           ])}
           index={0}
+          messages={[]}
           conversationId='conversation-1'
           canSaveGeneratedFile={false}
           markdownPreview={true}

--- a/projects/portfolio/tests/features/chat-conversations/read-conversations.test.ts
+++ b/projects/portfolio/tests/features/chat-conversations/read-conversations.test.ts
@@ -103,7 +103,8 @@ describe('readConversations', () => {
             id: 'message-1',
             role: 'system',
             content: 'system',
-            reasoningContent: '',
+            // reasoningContent が空文字列の場合は undefined
+            reasoningContent: undefined,
             // metadata が null の場合は undefined（SystemMessage.metadata は optional）
             metadata: undefined,
           },


### PR DESCRIPTION
## Issues

- Close #850

## Summary

ChatResults に現在の `Message[]` を確認できる JSON dump viewer を追加しました。各アシスタントメッセージに `messages: (count)` トリガーを設置し、クリックで整形済み JSON を表示するモーダルダイアログを開きます。

## Changes

- `ChatResults` に `messages: Message[]` プロパティを追加
- `MessagesDumpViewer` コンポーネントを新規実装
  - モーダルダイアログで `JSON.stringify(messages, null, 2)` を表示
  - Escape キー、バックドロップクリック、閉じるボタンで閉じられる
  - ヘッダーに Copy ボタンを配置（クリップボードに JSON をコピー）
- `MessageRenderer` / `ChatMessageList` を更新して `messages` を伝播
- `ChatResults` のテストを新規作成

## Checklist

- [x] `bun run lint` passes
- [x] `bun run test` passes
- [x] `bun run format` applied
- [x] Each assistant message exposes "messages: (count)" trigger
- [x] Popover open/close works with keyboard and pointer
- [x] Long JSON content scrolls vertically and horizontally
- [x] Existing ChatResults metadata display still works
