### PR TITLE
fix(portfolio): preserve code block collapse state

### DIFF
--- a/projects/portfolio/src/client/components/chat/chat-main.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-main.tsx
@@ -42,6 +42,7 @@ export function ChatMain({
   const [conversationId, setConversationId] = useState<string | null>(null)
   const [messages, setMessages] = useState<Message[]>([])
   const [isSavingConversation, setIsSavingConversation] = useState(false)
+  const [streamMessageId, setStreamMessageId] = useState<string | null>(null)
   const {
     input,
     uploadImages,
@@ -69,6 +70,7 @@ export function ChatMain({
   useEffect(() => {
     setMessages([])
     setConversationId(null)
+    setStreamMessageId(null)
   }, [initTrigger])
 
   // 選択された会話のメッセージを設定
@@ -80,6 +82,7 @@ export function ChatMain({
     // 会話が選択された時、そのメッセージをドメイン型のまま設定（変換不要）
     setConversationId(currentConversation.id)
     setMessages(currentConversation.messages)
+    setStreamMessageId(null)
 
     // 会話IDが実際に変わったときだけスクロール（別タブから戻った際の誤動作防止）
     if (prevConversationIdRef.current !== currentConversation.id) {
@@ -118,7 +121,9 @@ export function ChatMain({
         messages.length === 0
           ? [...(params.systemMessage ? [params.systemMessage] : []), params.draftUserMessage]
           : [...messages, params.draftUserMessage]
+      const assistantMessageId = uuidv7()
       setMessages(nextMessages)
+      setStreamMessageId(assistantMessageId)
       resetAfterSubmit()
 
       submitChatCompletion({
@@ -133,55 +138,59 @@ export function ChatMain({
         temperature: form.temperature,
         maxTokens: form.maxTokens,
         reasoningEffort: settings.reasoningEffortEnabled ? settings.reasoningEffort : undefined,
-      }).then(async ({ result, responseTimeMs }) => {
-        const userContent = params.draftUserMessage.content
-
-        // assistant メッセージを state に追加（ドメイン型で保持）
-        const assistantMessage: Message | null = result
-          ? {
-              id: uuidv7(),
-              role: 'assistant' as const,
-              content: result.message.content,
-              reasoningContent: result.message.reasoningContent,
-              metadata: {
-                model: result.model,
-                apiMode: settings.apiMode,
-                finishReason: result.finishReason,
-                responseTimeMs: responseTimeMs,
-                usage: {
-                  promptTokens: result.usage?.promptTokens || 0,
-                  completionTokens: result.usage?.completionTokens || 0,
-                  totalTokens: result.usage?.totalTokens || 0,
-                  reasoningTokens: result.usage?.reasoningTokens,
-                },
-              },
-            }
-          : null
-
-        const finalMessages: Message[] = assistantMessage ? [...nextMessages, assistantMessage] : nextMessages
-        setMessages(finalMessages)
-
-        // 会話IDが指定されていない場合は会話IDを新規作成
-        const currentConversationId =
-          conversationId ||
-          (() => {
-            const newConversationId = uuidv7()
-            setConversationId(newConversationId)
-            return newConversationId
-          })()
-
-        // 親コンポーネントに更新されたメッセージを通知（ドメイン型をそのまま渡す）
-        setIsSavingConversation(true)
-        try {
-          await onConversationChange?.({
-            id: currentConversationId,
-            title: typeof userContent === 'string' ? userContent.slice(0, CONVERSATION_TITLE_MAX_LENGTH) : '',
-            messages: finalMessages,
-          })
-        } finally {
-          setIsSavingConversation(false)
-        }
       })
+        .then(async ({ result, responseTimeMs }) => {
+          const userContent = params.draftUserMessage.content
+
+          // assistant メッセージを state に追加（ドメイン型で保持）
+          const assistantMessage: Message | null = result
+            ? {
+                id: assistantMessageId,
+                role: 'assistant' as const,
+                content: result.message.content,
+                reasoningContent: result.message.reasoningContent,
+                metadata: {
+                  model: result.model,
+                  apiMode: settings.apiMode,
+                  finishReason: result.finishReason,
+                  responseTimeMs: responseTimeMs,
+                  usage: {
+                    promptTokens: result.usage?.promptTokens || 0,
+                    completionTokens: result.usage?.completionTokens || 0,
+                    totalTokens: result.usage?.totalTokens || 0,
+                    reasoningTokens: result.usage?.reasoningTokens,
+                  },
+                },
+              }
+            : null
+
+          const finalMessages: Message[] = assistantMessage ? [...nextMessages, assistantMessage] : nextMessages
+          setMessages(finalMessages)
+
+          // 会話IDが指定されていない場合は会話IDを新規作成
+          const currentConversationId =
+            conversationId ||
+            (() => {
+              const newConversationId = uuidv7()
+              setConversationId(newConversationId)
+              return newConversationId
+            })()
+
+          // 親コンポーネントに更新されたメッセージを通知（ドメイン型をそのまま渡す）
+          setIsSavingConversation(true)
+          try {
+            await onConversationChange?.({
+              id: currentConversationId,
+              title: typeof userContent === 'string' ? userContent.slice(0, CONVERSATION_TITLE_MAX_LENGTH) : '',
+              messages: finalMessages,
+            })
+          } finally {
+            setIsSavingConversation(false)
+          }
+        })
+        .finally(() => {
+          setStreamMessageId(null)
+        })
     },
     [
       buildChatMessages,
@@ -361,6 +370,7 @@ export function ChatMain({
             markdownPreview={settings.markdownPreview}
             loading={loading}
             stream={stream}
+            streamMessageId={streamMessageId}
             copiedId={copiedId}
             savingConversation={isSavingConversation}
             messageEndRef={messageEndRef}

--- a/projects/portfolio/src/client/components/chat/chat-message-list.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-message-list.tsx
@@ -1,8 +1,10 @@
 import type { SaveGeneratedFileRequest } from '#/client/components/chat/assistant-code-block'
 import {
+  CodeBlockOpenStateContext,
   CodeBlockRenderer,
   MarkdownLink,
   StreamingCodeBlockContext,
+  type CodeBlockOpenChangeHandler,
 } from '#/client/components/chat/code-block-renderer'
 import type { ChatStreamState } from '#/client/components/chat/hooks/chat-response'
 import { MessageRenderer } from '#/client/components/chat/message-renderer'
@@ -10,7 +12,7 @@ import { ReasoningSection } from '#/client/components/chat/reasoning-section'
 import { ChatbotIcon } from '#/client/components/svg/chatbot-icon'
 import { SpinnerIcon } from '#/client/components/svg/spinner-icon'
 import type { GeneratedCodeFile, Message } from '#/types'
-import { memo, type ReactNode, type RefObject } from 'react'
+import { memo, type ReactNode, type RefObject, useCallback, useRef, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 
@@ -28,6 +30,7 @@ interface ChatMessageListProps {
   markdownPreview: boolean
   loading: boolean
   stream: ChatStreamState | null
+  streamMessageId?: string | null
   copiedId: string
   savingConversation?: boolean
   messageEndRef: RefObject<HTMLDivElement | null>
@@ -43,6 +46,7 @@ export function ChatMessageList({
   markdownPreview,
   loading,
   stream,
+  streamMessageId,
   copiedId,
   savingConversation,
   messageEndRef,
@@ -50,6 +54,25 @@ export function ChatMessageList({
   onDeleteMessage,
   onSaveGeneratedFile,
 }: ChatMessageListProps) {
+  const streamCodeBlockCursorRef = useRef({ current: 0 })
+  streamCodeBlockCursorRef.current.current = 0
+  const [codeBlockOpenBlocks, setCodeBlockOpenBlocks] = useState<ReadonlyMap<string, boolean>>(() => new Map())
+  const handleCodeBlockOpenChange = useCallback<CodeBlockOpenChangeHandler>((key, isOpen) => {
+    setCodeBlockOpenBlocks((prev) => {
+      if (prev.get(key) === isOpen || (!isOpen && !prev.has(key))) {
+        return prev
+      }
+
+      const next = new Map(prev)
+      if (isOpen) {
+        next.set(key, true)
+      } else {
+        next.delete(key)
+      }
+      return next
+    })
+  }, [])
+
   return (
     <div className='container mx-auto mt-4 max-w-(--breakpoint-lg) px-4'>
       <div className='message-list'>
@@ -64,6 +87,8 @@ export function ChatMessageList({
           onCopyMessage={onCopyMessage}
           onDeleteMessage={onDeleteMessage}
           onSaveGeneratedFile={onSaveGeneratedFile}
+          codeBlockOpenBlocks={codeBlockOpenBlocks}
+          onCodeBlockOpenChange={handleCodeBlockOpenChange}
         />
         {loading && (
           <div className='flex align-item'>
@@ -77,11 +102,24 @@ export function ChatMessageList({
                 )}
                 {markdownPreview ? (
                   <div className='prose mt-1 max-w-(--breakpoint-md) break-all dark:text-white'>
-                    <StreamingCodeBlockContext.Provider value={true}>
-                      <ReactMarkdown remarkPlugins={markdownRemarkPlugins} components={markdownComponents}>
-                        {stream.content}
-                      </ReactMarkdown>
-                    </StreamingCodeBlockContext.Provider>
+                    <CodeBlockOpenStateContext.Provider
+                      value={
+                        streamMessageId
+                          ? {
+                              messageId: streamMessageId,
+                              cursor: streamCodeBlockCursorRef.current,
+                              openBlocks: codeBlockOpenBlocks,
+                              onOpenChange: handleCodeBlockOpenChange,
+                            }
+                          : null
+                      }
+                    >
+                      <StreamingCodeBlockContext.Provider value={true}>
+                        <ReactMarkdown remarkPlugins={markdownRemarkPlugins} components={markdownComponents}>
+                          {stream.content}
+                        </ReactMarkdown>
+                      </StreamingCodeBlockContext.Provider>
+                    </CodeBlockOpenStateContext.Provider>
                   </div>
                 ) : (
                   <div className='message text-left'>
@@ -112,6 +150,8 @@ interface MessageHistoryProps {
   copiedId: string
   disabled: boolean
   savingConversation?: boolean
+  codeBlockOpenBlocks: ReadonlyMap<string, boolean>
+  onCodeBlockOpenChange: CodeBlockOpenChangeHandler
   onCopyMessage: (message: string, index: number) => void
   onDeleteMessage: (index: number) => void
   onSaveGeneratedFile?: (messageIndex: number, params: SaveGeneratedFileRequest) => Promise<GeneratedCodeFile | null>
@@ -125,6 +165,8 @@ const MessageHistory = memo(function MessageHistory({
   copiedId,
   disabled,
   savingConversation,
+  codeBlockOpenBlocks,
+  onCodeBlockOpenChange,
   onCopyMessage,
   onDeleteMessage,
   onSaveGeneratedFile,
@@ -141,6 +183,8 @@ const MessageHistory = memo(function MessageHistory({
       copied={copiedId === `chat_${index}`}
       disabled={disabled}
       savingConversation={savingConversation}
+      codeBlockOpenBlocks={codeBlockOpenBlocks}
+      onCodeBlockOpenChange={onCodeBlockOpenChange}
       onCopyMessage={onCopyMessage}
       onDeleteMessage={onDeleteMessage}
       onSaveGeneratedFile={onSaveGeneratedFile}

--- a/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
+++ b/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
@@ -207,9 +207,12 @@ export function CodeBlockRenderer({ className, children, actions }: CodeBlockRen
   // (react-markdown adds a trailing \n to fenced code blocks)
   const isBlock = detectedLanguage !== undefined || (typeof children === 'string' && code.includes('\n'))
   const isRenderableBlock = isBlock && typeof children === 'string'
-  const stateKey = isRenderableBlock && openState ? `${openState.messageId}:${openState.cursor.current++}` : undefined
+  const lineCount = code.replace(/\n$/, '').split('\n').length
+  const canCollapse = lineCount >= 4
+  const stateKey =
+    isRenderableBlock && canCollapse && openState ? `${openState.messageId}:${openState.cursor.current++}` : undefined
   const controlledOpen = stateKey ? (openState?.openBlocks.get(stateKey) ?? false) : undefined
-  const isOpen = controlledOpen ?? uncontrolledOpen
+  const isOpen = !canCollapse || (controlledOpen ?? uncontrolledOpen)
   const setIsOpen = (value: boolean | ((current: boolean) => boolean)) => {
     const nextOpen = typeof value === 'function' ? value(isOpen) : value
     if (stateKey && openState) {
@@ -234,8 +237,7 @@ export function CodeBlockRenderer({ className, children, actions }: CodeBlockRen
     ? SUPPORTED_LANGUAGES
     : [initialLanguage, ...SUPPORTED_LANGUAGES]
 
-  const lineCount = code.replace(/\n$/, '').split('\n').length
-  const peekMode = !isOpen
+  const peekMode = canCollapse && !isOpen
   const toggle = () => setIsOpen((v) => !v)
 
   const handleClickCopy = async () => {
@@ -250,17 +252,19 @@ export function CodeBlockRenderer({ className, children, actions }: CodeBlockRen
   }
 
   const highlighter = (
-    <div className='max-w-full overflow-x-auto'>
-      <SyntaxHighlighter
-        style={atomDark}
-        language={selectedLanguage}
-        customStyle={CUSTOM_STYLE}
-        codeTagProps={{ style: CUSTOM_STYLE }}
-        showLineNumbers={selectedLanguage !== 'plain'}
-        lineNumberStyle={{ color: '#6b7280', minWidth: '2.5em' }}
-      >
-        {code}
-      </SyntaxHighlighter>
+    <div className='bg-[#282c34]'>
+      <div className='code-block-scrollbar max-w-full overflow-x-auto rounded-b-md'>
+        <SyntaxHighlighter
+          style={atomDark}
+          language={selectedLanguage}
+          customStyle={CUSTOM_STYLE}
+          codeTagProps={{ style: CUSTOM_STYLE }}
+          showLineNumbers={selectedLanguage !== 'plain'}
+          lineNumberStyle={{ color: '#6b7280', minWidth: '2.5em' }}
+        >
+          {code}
+        </SyntaxHighlighter>
+      </div>
     </div>
   )
 
@@ -268,21 +272,23 @@ export function CodeBlockRenderer({ className, children, actions }: CodeBlockRen
     <div className='my-2 w-full max-w-full min-w-0 overflow-hidden rounded-lg border border-gray-200 dark:border-gray-600'>
       <div className='flex items-center justify-between border-b border-gray-200 bg-gray-50 px-3 py-1.5 dark:border-gray-600 dark:bg-[#282c34]'>
         <div className='flex items-center gap-1'>
-          <button
-            type='button'
-            onClick={toggle}
-            aria-expanded={isOpen}
-            aria-label={isOpen ? 'Collapse code block' : 'Expand code block'}
-            className='inline-flex h-6 w-6 cursor-pointer items-center justify-center rounded text-gray-600 transition-colors duration-200 ease-out hover:bg-gray-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 dark:text-gray-300 dark:hover:bg-gray-700 dark:focus-visible:ring-gray-500'
-          >
-            <span
-              className={`inline-flex transition-transform duration-200 ease-out motion-reduce:transition-none ${
-                isOpen ? 'rotate-90' : ''
-              }`}
+          {canCollapse && (
+            <button
+              type='button'
+              onClick={toggle}
+              aria-expanded={isOpen}
+              aria-label={isOpen ? 'Collapse code block' : 'Expand code block'}
+              className='inline-flex h-6 w-6 cursor-pointer items-center justify-center rounded text-gray-600 transition-colors duration-200 ease-out hover:bg-gray-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 dark:text-gray-300 dark:hover:bg-gray-700 dark:focus-visible:ring-gray-500'
             >
-              <ChevronRightIcon size={10} />
-            </span>
-          </button>
+              <span
+                className={`inline-flex transition-transform duration-200 ease-out motion-reduce:transition-none ${
+                  isOpen ? 'rotate-90' : ''
+                }`}
+              >
+                <ChevronRightIcon size={10} />
+              </span>
+            </button>
+          )}
           <div className='relative'>
             <select
               value={selectedLanguage}
@@ -310,7 +316,7 @@ export function CodeBlockRenderer({ className, children, actions }: CodeBlockRen
           <CodeBlockCopyButton copied={copied} onClick={handleClickCopy} disabled={streaming} />
         </div>
       </div>
-      {!isOpen && (
+      {canCollapse && !isOpen && (
         <button
           type='button'
           onClick={toggle}
@@ -320,7 +326,7 @@ export function CodeBlockRenderer({ className, children, actions }: CodeBlockRen
         </button>
       )}
       {peekMode ? (
-        <div className='relative h-24 select-none overflow-hidden'>
+        <div className='relative h-24 select-none overflow-hidden bg-[#282c34]'>
           <div className='pointer-events-none absolute inset-x-0 bottom-0 overflow-hidden'>
             <SyntaxHighlighter
               style={atomDark}

--- a/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
+++ b/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
@@ -235,7 +235,7 @@ export function CodeBlockRenderer({ className, children, actions }: CodeBlockRen
     : [initialLanguage, ...SUPPORTED_LANGUAGES]
 
   const lineCount = code.replace(/\n$/, '').split('\n').length
-  const peekMode = streaming && !isOpen
+  const peekMode = !isOpen
   const toggle = () => setIsOpen((v) => !v)
 
   const handleClickCopy = async () => {

--- a/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
+++ b/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
@@ -11,6 +11,19 @@ import { atomDark } from 'react-syntax-highlighter/dist/cjs/styles/prism'
 
 export const StreamingCodeBlockContext = createContext<boolean>(false)
 
+export type CodeBlockOpenBlocks = ReadonlyMap<string, boolean>
+
+export type CodeBlockOpenChangeHandler = (key: string, isOpen: boolean) => void
+
+export interface CodeBlockOpenStateContextValue {
+  messageId: string
+  cursor: { current: number }
+  openBlocks: CodeBlockOpenBlocks
+  onOpenChange: CodeBlockOpenChangeHandler
+}
+
+export const CodeBlockOpenStateContext = createContext<CodeBlockOpenStateContextValue | null>(null)
+
 const CUSTOM_STYLE: CSSProperties = {
   fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
   fontWeight: 400,
@@ -181,19 +194,32 @@ function CodeBlockCopyButton({ copied, onClick, disabled }: CodeBlockCopyButtonP
 export function CodeBlockRenderer({ className, children, actions }: CodeBlockRendererProps) {
   const [copied, setCopied] = useState(false)
   const streaming = useContext(StreamingCodeBlockContext)
+  const openState = useContext(CodeBlockOpenStateContext)
 
   const code = typeof children === 'string' ? children : Array.isArray(children) ? children.join('') : ''
   const detectedLanguage = className?.split('-')[1]
   const initialLanguage = detectedLanguage ?? 'plain'
 
   const [selectedLanguage, setSelectedLanguage] = useState(initialLanguage)
-  const [isOpen, setIsOpen] = useState(!streaming)
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false)
 
   // Block code: has a language identifier OR children contains newlines
   // (react-markdown adds a trailing \n to fenced code blocks)
   const isBlock = detectedLanguage !== undefined || (typeof children === 'string' && code.includes('\n'))
+  const isRenderableBlock = isBlock && typeof children === 'string'
+  const stateKey = isRenderableBlock && openState ? `${openState.messageId}:${openState.cursor.current++}` : undefined
+  const controlledOpen = stateKey ? (openState?.openBlocks.get(stateKey) ?? false) : undefined
+  const isOpen = controlledOpen ?? uncontrolledOpen
+  const setIsOpen = (value: boolean | ((current: boolean) => boolean)) => {
+    const nextOpen = typeof value === 'function' ? value(isOpen) : value
+    if (stateKey && openState) {
+      openState.onOpenChange(stateKey, nextOpen)
+    } else {
+      setUncontrolledOpen(nextOpen)
+    }
+  }
 
-  if (!isBlock || typeof children !== 'string') {
+  if (!isRenderableBlock) {
     return (
       <code
         className={`${className ?? ''} before:content-none after:content-none rounded bg-gray-100 px-1 py-0.5 font-mono text-sm dark:bg-gray-700`}

--- a/projects/portfolio/src/client/components/chat/message-renderer.tsx
+++ b/projects/portfolio/src/client/components/chat/message-renderer.tsx
@@ -4,7 +4,12 @@ import {
   type SaveGeneratedFileRequest,
 } from '#/client/components/chat/assistant-code-block'
 import { ChatResults } from '#/client/components/chat/chat-results'
-import { MarkdownLink } from '#/client/components/chat/code-block-renderer'
+import {
+  CodeBlockOpenStateContext,
+  MarkdownLink,
+  type CodeBlockOpenBlocks,
+  type CodeBlockOpenChangeHandler,
+} from '#/client/components/chat/code-block-renderer'
 import { ReasoningSection } from '#/client/components/chat/reasoning-section'
 import { ChatbotIcon } from '#/client/components/svg/chatbot-icon'
 import { CheckIcon } from '#/client/components/svg/check-icon'
@@ -35,6 +40,8 @@ interface MessageRendererProps {
   copied: boolean
   disabled?: boolean
   savingConversation?: boolean
+  codeBlockOpenBlocks?: CodeBlockOpenBlocks
+  onCodeBlockOpenChange?: CodeBlockOpenChangeHandler
   onCopyMessage: (message: string, index: number) => void
   onDeleteMessage?: (index: number) => void
   onSaveGeneratedFile?: (messageIndex: number, params: SaveGeneratedFileRequest) => Promise<GeneratedCodeFile | null>
@@ -107,6 +114,8 @@ function MessageRendererComponent({
   copied,
   disabled,
   savingConversation,
+  codeBlockOpenBlocks,
+  onCodeBlockOpenChange,
   onCopyMessage,
   onDeleteMessage,
   onSaveGeneratedFile,
@@ -115,6 +124,8 @@ function MessageRendererComponent({
   // 子の AssistantAwareCodeBlock が順序どおり blockIndex を取得できるようにする。
   const cursorRef = useRef({ current: 0 })
   cursorRef.current.current = 0
+  const codeBlockCursorRef = useRef({ current: 0 })
+  codeBlockCursorRef.current.current = 0
 
   if (message.role === 'system') {
     return null
@@ -173,9 +184,22 @@ function MessageRendererComponent({
       : null
 
   const markdownBody = (
-    <ReactMarkdown remarkPlugins={markdownRemarkPlugins} components={markdownComponents}>
-      {message.content}
-    </ReactMarkdown>
+    <CodeBlockOpenStateContext.Provider
+      value={
+        message.id && codeBlockOpenBlocks && onCodeBlockOpenChange
+          ? {
+              messageId: message.id,
+              cursor: codeBlockCursorRef.current,
+              openBlocks: codeBlockOpenBlocks,
+              onOpenChange: onCodeBlockOpenChange,
+            }
+          : null
+      }
+    >
+      <ReactMarkdown remarkPlugins={markdownRemarkPlugins} components={markdownComponents}>
+        {message.content}
+      </ReactMarkdown>
+    </CodeBlockOpenStateContext.Provider>
   )
   const dumpMessages = messages.slice(0, index + 1)
 
@@ -219,6 +243,8 @@ export const MessageRenderer = memo(
     prevProps.copied === nextProps.copied &&
     prevProps.disabled === nextProps.disabled &&
     prevProps.savingConversation === nextProps.savingConversation &&
+    prevProps.codeBlockOpenBlocks === nextProps.codeBlockOpenBlocks &&
+    prevProps.onCodeBlockOpenChange === nextProps.onCodeBlockOpenChange &&
     prevProps.onCopyMessage === nextProps.onCopyMessage &&
     prevProps.onDeleteMessage === nextProps.onDeleteMessage &&
     prevProps.onSaveGeneratedFile === nextProps.onSaveGeneratedFile

--- a/projects/portfolio/src/client/main.css
+++ b/projects/portfolio/src/client/main.css
@@ -134,6 +134,22 @@ body {
   border: none;
 }
 
+.code-block-scrollbar {
+  scrollbar-width: auto;
+}
+
+.code-block-scrollbar::-webkit-scrollbar {
+  height: 12px;
+}
+
+.code-block-scrollbar::-webkit-scrollbar-track {
+  margin-inline: 8px;
+}
+
+.code-block-scrollbar::-webkit-scrollbar-thumb {
+  border-radius: 6px;
+}
+
 .messages-dump-scroll::-webkit-scrollbar-corner {
   background-color: inherit;
 }

--- a/projects/portfolio/tests/client/components/chat-message-list.test.tsx
+++ b/projects/portfolio/tests/client/components/chat-message-list.test.tsx
@@ -41,7 +41,7 @@ describe('ChatMessageList', () => {
         markdownPreview: true,
         loading: true,
         stream: {
-          content: '```typescript\nconst value = 1\n```',
+          content: '```typescript\nconst a = 1\nconst b = 2\nconst c = 3\nconst d = 4\n```',
           reasoningContent: '',
         },
         streamMessageId: 'assistant-1',
@@ -57,7 +57,12 @@ describe('ChatMessageList', () => {
       rerender(
         <ChatMessageList
           {...props}
-          messages={[createAssistantMessage('assistant-1', '```typescript\nconst value = 1\n```')]}
+          messages={[
+            createAssistantMessage(
+              'assistant-1',
+              '```typescript\nconst a = 1\nconst b = 2\nconst c = 3\nconst d = 4\n```'
+            ),
+          ]}
           loading={false}
           stream={null}
         />

--- a/projects/portfolio/tests/client/components/chat-message-list.test.tsx
+++ b/projects/portfolio/tests/client/components/chat-message-list.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+
+import { ChatMessageList } from '#/client/components/chat/chat-message-list'
+import type { AssistantMessage } from '#/types'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { createRef } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('react-syntax-highlighter', () => ({
+  Prism: ({ children }: { children: string }) => <pre>{children}</pre>,
+}))
+
+vi.mock('react-syntax-highlighter/dist/cjs/styles/prism', () => ({
+  atomDark: {},
+}))
+
+afterEach(() => {
+  cleanup()
+})
+
+function createAssistantMessage(id: string, content: string): AssistantMessage {
+  return {
+    id,
+    role: 'assistant',
+    content,
+    reasoningContent: '',
+    metadata: {
+      model: 'gpt-test',
+      usage: {},
+    },
+  }
+}
+
+describe('ChatMessageList', () => {
+  describe('ストリーム中のコードブロック', () => {
+    it('完了後も開閉状態を維持する', () => {
+      const messageEndRef = createRef<HTMLDivElement>()
+      const props = {
+        messages: [],
+        conversationId: 'conversation-1',
+        markdownPreview: true,
+        loading: true,
+        stream: {
+          content: '```typescript\nconst value = 1\n```',
+          reasoningContent: '',
+        },
+        streamMessageId: 'assistant-1',
+        copiedId: '',
+        messageEndRef,
+        onCopyMessage: vi.fn(),
+        onDeleteMessage: vi.fn(),
+      }
+
+      const { rerender } = render(<ChatMessageList {...props} />)
+      fireEvent.click(screen.getByRole('button', { name: 'Expand code block' }))
+
+      rerender(
+        <ChatMessageList
+          {...props}
+          messages={[createAssistantMessage('assistant-1', '```typescript\nconst value = 1\n```')]}
+          loading={false}
+          stream={null}
+        />
+      )
+
+      expect(screen.getByRole('button', { name: 'Collapse code block' })).toBeTruthy()
+    })
+  })
+})

--- a/projects/portfolio/tests/client/components/message-renderer.test.tsx
+++ b/projects/portfolio/tests/client/components/message-renderer.test.tsx
@@ -35,6 +35,25 @@ function createAssistantMessage(
 }
 
 describe('MessageRenderer', () => {
+  describe('コードブロックの開閉', () => {
+    it('初期表示では閉じている', () => {
+      render(
+        <MessageRenderer
+          message={createAssistantMessage('```typescript\nconst value = 1\n```')}
+          index={0}
+          messages={[]}
+          conversationId='conversation-1'
+          markdownPreview={true}
+          copied={false}
+          onCopyMessage={vi.fn()}
+        />
+      )
+
+      expect(screen.getByRole('button', { name: 'Expand code block' })).toBeTruthy()
+      expect(screen.getByText('折りたたみ中（1 行・クリックで展開）')).toBeTruthy()
+    })
+  })
+
   describe('生成コードアクション', () => {
     it('未認証なら対応言語でも生成ボタンを表示しない', () => {
       render(

--- a/projects/portfolio/tests/client/components/message-renderer.test.tsx
+++ b/projects/portfolio/tests/client/components/message-renderer.test.tsx
@@ -36,10 +36,10 @@ function createAssistantMessage(
 
 describe('MessageRenderer', () => {
   describe('コードブロックの開閉', () => {
-    it('初期表示では閉じている', () => {
+    it('4行以上なら初期表示では閉じている', () => {
       render(
         <MessageRenderer
-          message={createAssistantMessage('```typescript\nconst value = 1\n```')}
+          message={createAssistantMessage('```typescript\nconst a = 1\nconst b = 2\nconst c = 3\nconst d = 4\n```')}
           index={0}
           messages={[]}
           conversationId='conversation-1'
@@ -50,8 +50,26 @@ describe('MessageRenderer', () => {
       )
 
       expect(screen.getByRole('button', { name: 'Expand code block' })).toBeTruthy()
-      expect(screen.getByText('折りたたみ中（1 行・クリックで展開）')).toBeTruthy()
-      expect(screen.getByText('const value = 1')).toBeTruthy()
+      expect(screen.getByText('折りたたみ中（4 行・クリックで展開）')).toBeTruthy()
+      expect(screen.getByText((text) => text.includes('const a = 1'))).toBeTruthy()
+    })
+
+    it('3行以下なら折りたたみ操作を表示せず全文表示する', () => {
+      render(
+        <MessageRenderer
+          message={createAssistantMessage('```typescript\nconst a = 1\nconst b = 2\nconst c = 3\n```')}
+          index={0}
+          messages={[]}
+          conversationId='conversation-1'
+          markdownPreview={true}
+          copied={false}
+          onCopyMessage={vi.fn()}
+        />
+      )
+
+      expect(screen.queryByRole('button', { name: 'Expand code block' })).toBeNull()
+      expect(screen.queryByText('折りたたみ中（3 行・クリックで展開）')).toBeNull()
+      expect(screen.getByText((text) => text.includes('const c = 3'))).toBeTruthy()
     })
   })
 

--- a/projects/portfolio/tests/client/components/message-renderer.test.tsx
+++ b/projects/portfolio/tests/client/components/message-renderer.test.tsx
@@ -51,6 +51,7 @@ describe('MessageRenderer', () => {
 
       expect(screen.getByRole('button', { name: 'Expand code block' })).toBeTruthy()
       expect(screen.getByText('折りたたみ中（1 行・クリックで展開）')).toBeTruthy()
+      expect(screen.getByText('const value = 1')).toBeTruthy()
     })
   })
 


### PR DESCRIPTION
## Why

チャットのコードブロックがストリーム完了後に意図せず開き直るほか、短いコードや横スクロールバーの表示が UI として不自然だったため改善します。

## Summary

コードブロックの開閉状態をメッセージ単位で保持し、ストリーム中から完了後の表示へ引き継ぎます。短いコードブロックは折りたたまず全文表示し、コードブロック専用の横スクロールバー表示も調整します。

## Changes

- コードブロックをデフォルト閉状態にし、ストリーム完了後も開閉状態を維持
- 非ストリーム時の閉状態でもコードの preview を表示
- 3行以下のコードブロックは折りたたみ操作を非表示にして全文表示
- コードブロック専用の横スクロールバーを太めに調整
- 開閉状態と短いコードブロック挙動のテストを追加

## Checklist

- [x] bun run format:check
- [x] bun run lint
- [x] bun run test
