### PR TITLE
feat(portfolio): improve chat settings UI/UX

### DIFF
--- a/projects/portfolio/src/client/components/chat/chat-main.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-main.tsx
@@ -382,9 +382,9 @@ export function ChatMain({
               tabIndex={isPinnedToBottom ? -1 : 0}
               disabled={isPinnedToBottom}
               onClick={() => scrollToMessageEnd('smooth')}
-              className='pointer-events-auto inline-flex h-9 w-9 items-center justify-center rounded-full border border-gray-200 bg-white/95 text-gray-700 transition-colors hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 dark:border-gray-600 dark:bg-gray-800/95 dark:text-gray-100 dark:hover:bg-gray-700 dark:focus-visible:ring-gray-500'
+              className='pointer-events-auto inline-flex h-8 w-8 items-center justify-center rounded-full border border-gray-200 bg-white/95 text-gray-700 transition-colors hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 dark:border-gray-600 dark:bg-gray-800/95 dark:text-gray-100 dark:hover:bg-gray-700 dark:focus-visible:ring-gray-500'
             >
-              <ArrowDownIcon size={16} className='stroke-current' />
+              <ArrowDownIcon size={14} className='stroke-current' />
             </button>
           </div>
         )}

--- a/projects/portfolio/src/client/components/chat/chat-main.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-main.tsx
@@ -113,6 +113,7 @@ export function ChatMain({
         streamMode: settings.streamMode,
         temperature: form.temperature,
         maxTokens: form.maxTokens,
+        reasoningEffort: settings.reasoningEffortEnabled ? settings.reasoningEffort : undefined,
       })
       if (!params) {
         return

--- a/projects/portfolio/src/client/components/chat/chat-main.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-main.tsx
@@ -7,6 +7,7 @@ import { useMessageScroll } from '#/client/components/chat/hooks/use-message-scr
 import { useStreamProcessor } from '#/client/components/chat/hooks/use-stream-processor'
 import { PromptTemplate, type TemplateInput } from '#/client/components/chat/prompt-template'
 import { FileImageInput, FileImagePreview } from '#/client/components/input/file-image-input'
+import { ArrowDownIcon } from '#/client/components/svg/arrow-down-icon'
 import { ArrowUpIcon } from '#/client/components/svg/arrow-up-icon'
 import { StopIcon } from '#/client/components/svg/stop-icon'
 import { UploadIcon } from '#/client/components/svg/upload-icon'
@@ -59,13 +60,19 @@ export function ChatMain({
   const { loading, stream, cancelStream, submitChatCompletion } = useStreamProcessor({
     onSubmitting,
   })
-  const { scrollContainerRef, bottomChatInputContainerRef, messageEndRef, handleScroll, scrollToMessageEnd } =
-    useMessageScroll({
-      loading,
-      streamMode: settings.streamMode,
-      stream,
-      messages,
-    })
+  const {
+    scrollContainerRef,
+    bottomChatInputContainerRef,
+    messageEndRef,
+    isPinnedToBottom,
+    handleScroll,
+    scrollToMessageEnd,
+  } = useMessageScroll({
+    loading,
+    streamMode: settings.streamMode,
+    stream,
+    messages,
+  })
 
   useEffect(() => {
     setMessages([])
@@ -361,28 +368,38 @@ export function ChatMain({
           </div>
         </div>
       )}
-      <div
-        ref={scrollContainerRef}
-        onScroll={handleScroll}
-        className={emptyMessage ? 'hidden' : 'min-h-0 flex-1 overflow-y-auto'}
-      >
-        {!emptyMessage && (
-          <ChatMessageList
-            messages={messages}
-            conversationId={conversationId}
-            canSaveGeneratedFile={canSaveGeneratedFile}
-            markdownPreview={settings.markdownPreview}
-            loading={loading}
-            stream={stream}
-            streamMessageId={streamMessageId}
-            copiedId={copiedId}
-            savingConversation={isSavingConversation}
-            messageEndRef={messageEndRef}
-            onCopyMessage={copyMessage}
-            onDeleteMessage={handleClickDeleteMessage}
-            onSaveGeneratedFile={handleSaveGeneratedFile}
-          />
+      <div className={emptyMessage ? 'hidden' : 'relative min-h-0 flex-1'}>
+        {!emptyMessage && !isPinnedToBottom && (
+          <div className='pointer-events-none absolute inset-x-0 bottom-4 z-10 flex justify-center px-4'>
+            <button
+              type='button'
+              aria-label='最下部へ移動'
+              onClick={() => scrollToMessageEnd('smooth')}
+              className='pointer-events-auto inline-flex h-9 w-9 items-center justify-center rounded-full border border-gray-200 bg-white/95 text-gray-700 transition-colors hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 dark:border-gray-600 dark:bg-gray-800/95 dark:text-gray-100 dark:hover:bg-gray-700 dark:focus-visible:ring-gray-500'
+            >
+              <ArrowDownIcon size={16} className='stroke-current' />
+            </button>
+          </div>
         )}
+        <div ref={scrollContainerRef} onScroll={handleScroll} className='min-h-0 h-full overflow-y-auto'>
+          {!emptyMessage && (
+            <ChatMessageList
+              messages={messages}
+              conversationId={conversationId}
+              canSaveGeneratedFile={canSaveGeneratedFile}
+              markdownPreview={settings.markdownPreview}
+              loading={loading}
+              stream={stream}
+              streamMessageId={streamMessageId}
+              copiedId={copiedId}
+              savingConversation={isSavingConversation}
+              messageEndRef={messageEndRef}
+              onCopyMessage={copyMessage}
+              onDeleteMessage={handleClickDeleteMessage}
+              onSaveGeneratedFile={handleSaveGeneratedFile}
+            />
+          )}
+        </div>
       </div>
 
       <div ref={bottomChatInputContainerRef} className='container mx-auto max-w-(--breakpoint-lg)'>

--- a/projects/portfolio/src/client/components/chat/chat-main.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-main.tsx
@@ -110,6 +110,9 @@ export function ChatMain({
         interactiveMode: settings.interactiveMode,
         messages,
         model: form.model,
+        streamMode: settings.streamMode,
+        temperature: form.temperature,
+        maxTokens: form.maxTokens,
       })
       if (!params) {
         return

--- a/projects/portfolio/src/client/components/chat/chat-main.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-main.tsx
@@ -369,11 +369,18 @@ export function ChatMain({
         </div>
       )}
       <div className={emptyMessage ? 'hidden' : 'relative min-h-0 flex-1'}>
-        {!emptyMessage && !isPinnedToBottom && (
-          <div className='pointer-events-none absolute inset-x-0 bottom-4 z-10 flex justify-center px-4'>
+        {!emptyMessage && (
+          <div
+            className={`absolute inset-x-0 bottom-4 z-10 flex justify-center px-4 transition-opacity duration-200 ease-out motion-reduce:transition-none ${
+              isPinnedToBottom ? 'pointer-events-none opacity-0' : 'pointer-events-none opacity-100'
+            }`}
+          >
             <button
               type='button'
               aria-label='最下部へ移動'
+              aria-hidden={isPinnedToBottom}
+              tabIndex={isPinnedToBottom ? -1 : 0}
+              disabled={isPinnedToBottom}
               onClick={() => scrollToMessageEnd('smooth')}
               className='pointer-events-auto inline-flex h-9 w-9 items-center justify-center rounded-full border border-gray-200 bg-white/95 text-gray-700 transition-colors hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 dark:border-gray-600 dark:bg-gray-800/95 dark:text-gray-100 dark:hover:bg-gray-700 dark:focus-visible:ring-gray-500'
             >

--- a/projects/portfolio/src/client/components/chat/chat-message-list.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-message-list.tsx
@@ -10,6 +10,7 @@ import type { ChatStreamState } from '#/client/components/chat/hooks/chat-respon
 import { MessageRenderer } from '#/client/components/chat/message-renderer'
 import { ReasoningSection } from '#/client/components/chat/reasoning-section'
 import { ChatbotIcon } from '#/client/components/svg/chatbot-icon'
+import { ChatbotTypingIcon } from '#/client/components/svg/chatbot-typing-icon'
 import { SpinnerIcon } from '#/client/components/svg/spinner-icon'
 import type { GeneratedCodeFile, Message } from '#/types'
 import { memo, type ReactNode, type RefObject, useCallback, useRef, useState } from 'react'
@@ -93,7 +94,11 @@ export function ChatMessageList({
         {loading && (
           <div className='flex align-item'>
             <div className='flex h-8 w-8 justify-center rounded-full border border-gray-300 bg-white align-center dark:border-gray-600 dark:bg-gray-800'>
-              <ChatbotIcon size={32} className='stroke-gray-600 dark:stroke-white' />
+              {stream ? (
+                <ChatbotTypingIcon size={32} className='stroke-gray-600 dark:stroke-white' />
+              ) : (
+                <ChatbotIcon size={32} className='stroke-gray-600 dark:stroke-white' />
+              )}
             </div>
             {stream ? (
               <div className='message ml-2 min-w-0 flex-1 text-left'>

--- a/projects/portfolio/src/client/components/chat/chat-settings/chat-settings-form.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-settings/chat-settings-form.tsx
@@ -6,6 +6,15 @@ import { ReasoningEffort } from './settings/reasoning-effort'
 import { TemperatureSlider } from './settings/temperature-slider'
 import { TextInput } from './settings/text-input'
 
+function SectionHeading({ children }: { children: string }) {
+  return (
+    <h3 className='flex items-center gap-3 text-sm font-medium text-gray-500 uppercase dark:text-gray-400'>
+      <span>{children}</span>
+      <span aria-hidden='true' className='min-w-0 flex-1 border-gray-300 border-t dark:border-gray-600' />
+    </h3>
+  )
+}
+
 export function ChatSettingsForm() {
   const {
     settings,
@@ -28,7 +37,7 @@ export function ChatSettingsForm() {
     <div className='flex flex-col gap-5'>
       {/* Model Section */}
       <section className='space-y-3'>
-        <h3 className='text-sm font-medium text-gray-500 uppercase dark:text-gray-400'>Model</h3>
+        <SectionHeading>Model</SectionHeading>
         <div className='space-y-3'>
           {/* Model Selection */}
           <div className='space-y-2'>
@@ -47,7 +56,7 @@ export function ChatSettingsForm() {
 
       {/* API Configuration */}
       <section className='space-y-3'>
-        <h3 className='text-sm font-medium text-gray-500 uppercase dark:text-gray-400'>API Configuration</h3>
+        <SectionHeading>API Configuration</SectionHeading>
         <div className='space-y-3'>
           <div className='space-y-2'>
             <label className='block text-sm font-medium text-gray-700 dark:text-gray-300'>API Mode</label>
@@ -105,7 +114,7 @@ export function ChatSettingsForm() {
 
       {/* Parameters */}
       <section className='space-y-3'>
-        <h3 className='text-sm font-medium text-gray-500 uppercase dark:text-gray-400'>Parameters</h3>
+        <SectionHeading>Parameters</SectionHeading>
         <div className='space-y-4'>
           <TemperatureSlider />
 
@@ -126,7 +135,7 @@ export function ChatSettingsForm() {
 
       {/* Display Options */}
       <section className='space-y-3'>
-        <h3 className='text-sm font-medium text-gray-500 uppercase dark:text-gray-400'>Display Options</h3>
+        <SectionHeading>Display Options</SectionHeading>
         <div className='space-y-3'>
           <ToggleInput
             label='Markdown Preview'
@@ -151,7 +160,7 @@ export function ChatSettingsForm() {
 
       {/* Debug Options */}
       <section className='space-y-3'>
-        <h3 className='text-sm font-medium text-gray-500 uppercase dark:text-gray-400'>Debug Options</h3>
+        <SectionHeading>Debug Options</SectionHeading>
         <div className='space-y-2'>
           <ToggleInput
             label='Fake Mode'

--- a/projects/portfolio/src/client/components/chat/chat-settings/chat-settings-form.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-settings/chat-settings-form.tsx
@@ -95,7 +95,9 @@ export function ChatSettingsForm() {
               onChange={handleChangeApiKey}
             />
             <p className='text-xs text-gray-500 dark:text-gray-400'>
-              API Key はブラウザの localStorage に保存されます。秘匿ストアではありません。
+              API Key はブラウザの localStorage に保存されます。
+              <br />
+              秘匿ストアではありません。
             </p>
           </div>
         </div>

--- a/projects/portfolio/src/client/components/chat/chat-settings/chat-settings-panel.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-settings/chat-settings-panel.tsx
@@ -1,3 +1,4 @@
+import { CloseIcon } from '#/client/components/svg/close-icon'
 import type { ReactNode } from 'react'
 
 interface Props {
@@ -32,16 +33,13 @@ export function ChatSettingsPanel({ show, children, onClose }: Props) {
           <h2 id='chat-settings-title' className='text-lg font-semibold text-gray-900 dark:text-gray-100'>
             Chat Settings
           </h2>
-          {/* Close button - visible on mobile */}
           <button
             type='button'
             onClick={onClose}
-            className='rounded-md p-1 text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 sm:hidden dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200'
+            className='flex cursor-pointer items-center justify-center rounded-md p-1 text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-400 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200 dark:focus:ring-gray-500'
             aria-label='Close settings'
           >
-            <svg className='h-6 w-6' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
-              <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M6 18L18 6M6 6l12 12' />
-            </svg>
+            <CloseIcon className='fill-current' />
           </button>
         </div>
 

--- a/projects/portfolio/src/client/components/chat/chat-settings/chat-settings.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-settings/chat-settings.tsx
@@ -12,6 +12,7 @@ interface Props {
   showNewChat?: boolean
   showPopup?: boolean
   showSidebarToggle?: boolean
+  isSidebarOpen?: boolean
   isSidebarToggleDisabled?: boolean
   onNewChat?: () => void
   onShowMenu?: () => void
@@ -25,6 +26,7 @@ export function ChatSettings({
   showNewChat = true,
   showPopup,
   showSidebarToggle = true,
+  isSidebarOpen = true,
   isSidebarToggleDisabled = false,
   onNewChat,
   onShowMenu,
@@ -49,7 +51,10 @@ export function ChatSettings({
                   disabled={isSidebarToggleDisabled}
                   className='flex items-center justify-center rounded-md p-2 text-gray-600 transition hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-400 enabled:cursor-pointer disabled:cursor-not-allowed disabled:opacity-40 dark:text-gray-300 dark:hover:bg-gray-700 dark:focus:ring-gray-500'
                 >
-                  <SidebarIcon className='fill-[#5D5D5D] dark:fill-gray-300' />
+                  <SidebarIcon
+                    variant={isSidebarOpen ? 'collapse' : 'expand'}
+                    className='fill-[#5D5D5D] dark:fill-gray-300'
+                  />
                 </button>
               )}
               {showNewChat && (

--- a/projects/portfolio/src/client/components/chat/chat-settings/settings/temperature-slider.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-settings/settings/temperature-slider.tsx
@@ -15,7 +15,7 @@ export function TemperatureSlider() {
           Temperature
         </label>
         <span className={`text-sm ${temperatureEnabled ? 'text-gray-700 dark:text-gray-300' : 'text-gray-400'}`}>
-          {temperature.toFixed(2)}
+          {temperatureEnabled ? temperature.toFixed(2) : '--'}
         </span>
       </div>
       <div className='flex items-center gap-3'>

--- a/projects/portfolio/src/client/components/chat/hooks/use-chat-form.ts
+++ b/projects/portfolio/src/client/components/chat/hooks/use-chat-form.ts
@@ -1,5 +1,5 @@
 import type { TemplateInput } from '#/client/components/chat/prompt-template'
-import type { ApiChatMessage, ApiMode, Message } from '#/types'
+import type { ApiChatMessage, ApiMode, Message, ReasoningEffort } from '#/types'
 import { toApiChatMessage } from '#/types'
 import { type ChangeEvent, type KeyboardEvent, type RefObject, useEffect, useState } from 'react'
 import { uuidv7 } from 'uuidv7'
@@ -20,6 +20,7 @@ interface BuildChatMessagesParams {
   streamMode: boolean
   temperature?: number
   maxTokens?: number
+  reasoningEffort?: ReasoningEffort
 }
 
 interface BuiltChatMessages {
@@ -92,6 +93,7 @@ export function useChatForm({ initTrigger, formRef }: UseChatFormParams) {
     streamMode,
     temperature,
     maxTokens,
+    reasoningEffort,
   }: BuildChatMessagesParams): BuiltChatMessages | null => {
     if (templateInput) {
       return createTemplateMessage(templateInput, model, {
@@ -101,6 +103,7 @@ export function useChatForm({ initTrigger, formRef }: UseChatFormParams) {
         streamMode,
         temperature,
         maxTokens,
+        reasoningEffort,
       })
     }
 
@@ -112,6 +115,7 @@ export function useChatForm({ initTrigger, formRef }: UseChatFormParams) {
       streamMode,
       temperature,
       maxTokens,
+      reasoningEffort,
     })
   }
 
@@ -148,6 +152,7 @@ const createMessage = (
     streamMode,
     temperature,
     maxTokens,
+    reasoningEffort,
   }: {
     apiMode: ApiMode
     interactiveMode: boolean
@@ -156,6 +161,7 @@ const createMessage = (
     streamMode: boolean
     temperature?: number
     maxTokens?: number
+    reasoningEffort?: ReasoningEffort
   }
 ): BuiltChatMessages | null => {
   if (!inputText) {
@@ -180,7 +186,7 @@ const createMessage = (
             })),
           ]
         : inputText,
-    metadata: { model, apiMode, stream: streamMode, temperature, maxTokens },
+    metadata: { model, apiMode, stream: streamMode, temperature, maxTokens, reasoningEffort },
   }
 
   const allMessages: Message[] = [...messages, draftUserMessage]
@@ -203,6 +209,7 @@ const createTemplateMessage = (
     streamMode,
     temperature,
     maxTokens,
+    reasoningEffort,
   }: {
     apiMode: ApiMode
     interactiveMode: boolean
@@ -210,13 +217,21 @@ const createTemplateMessage = (
     streamMode: boolean
     temperature?: number
     maxTokens?: number
+    reasoningEffort?: ReasoningEffort
   }
 ): BuiltChatMessages => {
   const draftUserMessage: Message = {
     id: uuidv7(),
     role: 'user',
     content: templateInput.content,
-    metadata: { model: templateInput.model || model, apiMode, stream: streamMode, temperature, maxTokens },
+    metadata: {
+      model: templateInput.model || model,
+      apiMode,
+      stream: streamMode,
+      temperature,
+      maxTokens,
+      reasoningEffort,
+    },
   }
   const systemMessage: Message = {
     id: uuidv7(),

--- a/projects/portfolio/src/client/components/chat/hooks/use-chat-form.ts
+++ b/projects/portfolio/src/client/components/chat/hooks/use-chat-form.ts
@@ -17,6 +17,9 @@ interface BuildChatMessagesParams {
   interactiveMode: boolean
   messages: Message[]
   model: string
+  streamMode: boolean
+  temperature?: number
+  maxTokens?: number
 }
 
 interface BuiltChatMessages {
@@ -86,12 +89,30 @@ export function useChatForm({ initTrigger, formRef }: UseChatFormParams) {
     interactiveMode,
     messages,
     model,
+    streamMode,
+    temperature,
+    maxTokens,
   }: BuildChatMessagesParams): BuiltChatMessages | null => {
     if (templateInput) {
-      return createTemplateMessage(templateInput, model, { apiMode, interactiveMode, messages })
+      return createTemplateMessage(templateInput, model, {
+        apiMode,
+        interactiveMode,
+        messages,
+        streamMode,
+        temperature,
+        maxTokens,
+      })
     }
 
-    return createMessage(input.trim(), model, { apiMode, interactiveMode, messages, uploadImages })
+    return createMessage(input.trim(), model, {
+      apiMode,
+      interactiveMode,
+      messages,
+      uploadImages,
+      streamMode,
+      temperature,
+      maxTokens,
+    })
   }
 
   const resetAfterSubmit = () => {
@@ -124,11 +145,17 @@ const createMessage = (
     interactiveMode,
     messages,
     uploadImages,
+    streamMode,
+    temperature,
+    maxTokens,
   }: {
     apiMode: ApiMode
     interactiveMode: boolean
     messages: Message[]
     uploadImages: string[]
+    streamMode: boolean
+    temperature?: number
+    maxTokens?: number
   }
 ): BuiltChatMessages | null => {
   if (!inputText) {
@@ -153,7 +180,7 @@ const createMessage = (
             })),
           ]
         : inputText,
-    metadata: { model, apiMode },
+    metadata: { model, apiMode, stream: streamMode, temperature, maxTokens },
   }
 
   const allMessages: Message[] = [...messages, draftUserMessage]
@@ -169,13 +196,27 @@ const createMessage = (
 const createTemplateMessage = (
   templateInput: TemplateInput,
   model: string,
-  { apiMode, interactiveMode, messages }: { apiMode: ApiMode; interactiveMode: boolean; messages: Message[] }
+  {
+    apiMode,
+    interactiveMode,
+    messages,
+    streamMode,
+    temperature,
+    maxTokens,
+  }: {
+    apiMode: ApiMode
+    interactiveMode: boolean
+    messages: Message[]
+    streamMode: boolean
+    temperature?: number
+    maxTokens?: number
+  }
 ): BuiltChatMessages => {
   const draftUserMessage: Message = {
     id: uuidv7(),
     role: 'user',
     content: templateInput.content,
-    metadata: { model: templateInput.model || model, apiMode },
+    metadata: { model: templateInput.model || model, apiMode, stream: streamMode, temperature, maxTokens },
   }
   const systemMessage: Message = {
     id: uuidv7(),

--- a/projects/portfolio/src/client/components/chat/hooks/use-message-scroll.ts
+++ b/projects/portfolio/src/client/components/chat/hooks/use-message-scroll.ts
@@ -13,8 +13,15 @@ export function useMessageScroll({ loading, streamMode, stream, messages }: UseM
   const scrollContainerRef = useRef<HTMLDivElement>(null)
   const bottomChatInputContainerRef = useRef<HTMLDivElement>(null)
   const messageEndRef = useRef<HTMLDivElement>(null)
+  const scrollAnimationFrameRef = useRef<number | null>(null)
   const [bottomChatInputContainerHeight, setBottomChatInputContainerHeight] = useState(0)
   const [isPinnedToBottom, setIsPinnedToBottom] = useState(true)
+
+  const cancelScrollAnimation = useCallback(() => {
+    if (scrollAnimationFrameRef.current === null) return
+    cancelAnimationFrame(scrollAnimationFrameRef.current)
+    scrollAnimationFrameRef.current = null
+  }, [])
 
   useEffect(() => {
     const bottomChatInputContainerObserver = new ResizeObserver(([element]) => {
@@ -31,6 +38,8 @@ export function useMessageScroll({ loading, streamMode, stream, messages }: UseM
       }
     }
   }, [])
+
+  useEffect(() => cancelScrollAnimation, [cancelScrollAnimation])
 
   useEffect(() => {
     if (!loading) return
@@ -53,13 +62,50 @@ export function useMessageScroll({ loading, streamMode, stream, messages }: UseM
     }
   }, [])
 
-  const scrollToMessageEnd = useCallback((behavior: ScrollBehavior = 'instant') => {
-    setIsPinnedToBottom(true)
-    messageEndRef.current?.scrollIntoView({
-      behavior,
-      block: 'end',
-    })
-  }, [])
+  const scrollToMessageEnd = useCallback(
+    (behavior: ScrollBehavior = 'instant') => {
+      setIsPinnedToBottom(true)
+      const scrollContainer = scrollContainerRef.current
+      if (behavior === 'smooth' && scrollContainer) {
+        cancelScrollAnimation()
+
+        const targetScrollTop = Math.max(0, scrollContainer.scrollHeight - scrollContainer.clientHeight)
+        const startScrollTop = scrollContainer.scrollTop
+        const distance = targetScrollTop - startScrollTop
+        const prefersReducedMotion =
+          typeof window !== 'undefined' && window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
+
+        if (prefersReducedMotion || Math.abs(distance) < 4) {
+          scrollContainer.scrollTop = targetScrollTop
+          return
+        }
+
+        const duration = Math.min(520, Math.max(280, Math.abs(distance) * 0.35))
+        const startTime = performance.now()
+        const easeOutQuart = (progress: number) => 1 - (1 - progress) ** 4
+        const animate = (currentTime: number) => {
+          const elapsed = currentTime - startTime
+          const progress = Math.min(elapsed / duration, 1)
+          scrollContainer.scrollTop = startScrollTop + distance * easeOutQuart(progress)
+
+          if (progress < 1) {
+            scrollAnimationFrameRef.current = requestAnimationFrame(animate)
+          } else {
+            scrollAnimationFrameRef.current = null
+          }
+        }
+
+        scrollAnimationFrameRef.current = requestAnimationFrame(animate)
+        return
+      }
+
+      messageEndRef.current?.scrollIntoView({
+        behavior,
+        block: 'end',
+      })
+    },
+    [cancelScrollAnimation]
+  )
 
   return {
     scrollContainerRef,

--- a/projects/portfolio/src/client/components/chat/hooks/use-message-scroll.ts
+++ b/projects/portfolio/src/client/components/chat/hooks/use-message-scroll.ts
@@ -14,7 +14,7 @@ export function useMessageScroll({ loading, streamMode, stream, messages }: UseM
   const bottomChatInputContainerRef = useRef<HTMLDivElement>(null)
   const messageEndRef = useRef<HTMLDivElement>(null)
   const [bottomChatInputContainerHeight, setBottomChatInputContainerHeight] = useState(0)
-  const [autoScroll, setAutoScroll] = useState(true)
+  const [isPinnedToBottom, setIsPinnedToBottom] = useState(true)
 
   useEffect(() => {
     const bottomChatInputContainerObserver = new ResizeObserver(([element]) => {
@@ -38,22 +38,23 @@ export function useMessageScroll({ loading, streamMode, stream, messages }: UseM
   }, [loading])
 
   useEffect(() => {
-    if (!autoScroll) return
+    if (!isPinnedToBottom) return
     messageEndRef.current?.scrollIntoView(!streamMode && { behavior: 'smooth' })
-  }, [stream, messages.length, streamMode, autoScroll, bottomChatInputContainerHeight])
+  }, [stream, messages.length, streamMode, isPinnedToBottom, bottomChatInputContainerHeight])
 
   const handleScroll = useCallback(() => {
     if (!scrollContainerRef.current) return
     const { scrollTop, scrollHeight, clientHeight } = scrollContainerRef.current
     const threshold = 36
     if (scrollTop + clientHeight >= scrollHeight - threshold) {
-      setAutoScroll(true)
+      setIsPinnedToBottom(true)
     } else {
-      setAutoScroll(false)
+      setIsPinnedToBottom(false)
     }
   }, [])
 
   const scrollToMessageEnd = useCallback((behavior: ScrollBehavior = 'instant') => {
+    setIsPinnedToBottom(true)
     messageEndRef.current?.scrollIntoView({
       behavior,
       block: 'end',
@@ -65,6 +66,7 @@ export function useMessageScroll({ loading, streamMode, stream, messages }: UseM
     bottomChatInputContainerRef,
     bottomChatInputContainerHeight,
     messageEndRef,
+    isPinnedToBottom,
     handleScroll,
     scrollToMessageEnd,
   }

--- a/projects/portfolio/src/client/components/svg/arrow-down-icon.tsx
+++ b/projects/portfolio/src/client/components/svg/arrow-down-icon.tsx
@@ -1,0 +1,15 @@
+import { type IconProps, SvgIcon } from './icon-base'
+
+export function ArrowDownIcon({ size = 24, className = 'stroke-current' }: IconProps) {
+  return (
+    <SvgIcon size={size} title='arrow-down-icon'>
+      <path
+        d='M12 4V20M12 20L5 13M12 20L19 13'
+        strokeWidth='2'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+        className={className}
+      />
+    </SvgIcon>
+  )
+}

--- a/projects/portfolio/src/client/components/svg/chatbot-typing-icon.tsx
+++ b/projects/portfolio/src/client/components/svg/chatbot-typing-icon.tsx
@@ -1,0 +1,97 @@
+import { type IconProps, SvgIcon } from './icon-base'
+
+export function ChatbotTypingIcon({ size = 24, className = 'stroke-black dark:stroke-white' }: IconProps) {
+  return (
+    <SvgIcon size={size} viewBox='0 0 400 400' title='chatbot-typing-icon'>
+      <style>{`
+        .bot-root { transform-origin: center; animation: botBob 0.8s ease-in-out infinite; }
+        .bot-head { transform-origin: 190px 150px; animation: botHeadSwing 0.52s ease-in-out infinite; }
+        .bot-arm-left { transform-origin: 100px 191px; animation: botTapLeft 0.18s ease-in-out infinite 0.06s; }
+        .bot-arm-1 { transform-origin: 219px 236px; animation: botTap1 0.14s ease-in-out infinite; }
+        .bot-arm-2 { transform-origin: 219px 190px; animation: botTap2 0.14s ease-in-out infinite; }
+        .bot-eye { transform-origin: center; animation: botBlink 2.1s ease-in-out infinite; }
+        .spark-1 { animation: spark1 0.35s ease-in-out infinite; }
+        .spark-2 { animation: spark2 0.28s ease-in-out infinite; }
+        .spark-3 { animation: spark3 0.31s ease-in-out infinite; }
+
+        @keyframes botBob {
+          0%, 100% { transform: translateY(0px); }
+          50% { transform: translate(-2px, -5px) rotate(-1deg); }
+        }
+
+        @keyframes botTap1 {
+          0%, 100% { transform: rotate(0deg) translateY(0px); }
+          50% { transform: rotate(6deg) translate(2px, 10px); }
+        }
+
+        @keyframes botTap2 {
+          0%, 100% { transform: rotate(0deg) translateY(0px); }
+          50% { transform: rotate(8deg) translate(5px, 12px); }
+        }
+
+        @keyframes botTapLeft {
+          0%, 100% { transform: rotate(0deg) translate(0px, 0px); }
+          50% { transform: rotate(-7deg) translate(-4px, 10px); }
+        }
+
+        @keyframes botHeadSwing {
+          0%, 100% { transform: rotate(0deg) translate(0px, 0px); }
+          50% { transform: rotate(2.2deg) translate(1px, -1px); }
+        }
+
+        @keyframes botBlink {
+          0%, 45%, 100% { transform: scaleY(1); }
+          48%, 52% { transform: scaleY(0.2); }
+        }
+
+        @keyframes spark1 {
+          0%, 100% { transform: translateY(0); opacity: 0; }
+          50% { transform: translateY(-10px); opacity: 1; }
+        }
+
+        @keyframes spark2 {
+          0%, 100% { transform: translateY(0); opacity: 0; }
+          50% { transform: translateY(-10px); opacity: 1; }
+        }
+
+        @keyframes spark3 {
+          0%, 100% { transform: translateY(0); opacity: 0; }
+          50% { transform: translateY(-12px); opacity: 1; }
+        }
+      `}</style>
+
+      <g
+        fill='none'
+        stroke='currentColor'
+        strokeWidth='16'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+        className={`bot-root ${className}`}
+      >
+        <g className='bot-head'>
+          <path d='M97.8357 54.6682C177.199 59.5311 213.038 52.9891 238.043 52.9891C261.298 52.9891 272.24 129.465 262.683 152.048C253.672 173.341 100.331 174.196 93.1919 165.763C84.9363 156.008 89.7095 115.275 89.7095 101.301' />
+          <path d='M80.1174 119.041C75.5996 120.222 71.0489 119.99 66.4414 120.41' />
+          <path d='M59.5935 109.469C59.6539 117.756 59.5918 125.915 58.9102 134.086' />
+          <path d='M277.741 115.622C281.155 115.268 284.589 114.823 287.997 114.255' />
+          <path d='M291.412 104.682C292.382 110.109 292.095 115.612 292.095 121.093' />
+          <path d='M225.768 116.466C203.362 113.993 181.657 115.175 160.124 118.568' />
+        </g>
+
+        <path className='bot-arm-left' d='M98.3318 190.694C-10.6597 291.485 121.25 273.498 148.233 295.083' />
+        <path className='bot-arm-left' d='M98.3301 190.694C99.7917 213.702 101.164 265.697 100.263 272.898' />
+        <path d='M203.398 241.72C352.097 239.921 374.881 226.73 312.524 341.851' />
+        <path d='M285.55 345.448C196.81 341.85 136.851 374.229 178.223 264.504' />
+        <path d='M180.018 345.448C160.77 331.385 139.302 320.213 120.658 304.675' />
+        <path className='bot-arm-1' d='M218.395 190.156C219.024 205.562 219.594 220.898 219.594 236.324' />
+        <path className='bot-arm-2' d='M218.395 190.156C225.896 202.037 232.97 209.77 241.777 230.327' />
+      </g>
+
+      <ellipse className='bot-eye' cx='177' cy='130' rx='7' ry='5' fill='currentColor' />
+      <ellipse className='bot-eye' cx='208' cy='130' rx='7' ry='5' fill='currentColor' />
+
+      <circle className='spark-1' cx='246' cy='262' r='2.8' fill='currentColor' />
+      <circle className='spark-2' cx='286' cy='258' r='2.4' fill='currentColor' />
+      <circle className='spark-3' cx='310' cy='264' r='2.6' fill='currentColor' />
+    </SvgIcon>
+  )
+}

--- a/projects/portfolio/src/client/components/svg/sidebar-icon.tsx
+++ b/projects/portfolio/src/client/components/svg/sidebar-icon.tsx
@@ -1,15 +1,30 @@
 import { type IconProps, SvgIcon } from './icon-base'
 
-export function SidebarIcon({ size = 24, className = 'fill-black dark:fill-white' }: IconProps) {
+interface SidebarIconProps extends IconProps {
+  variant?: 'collapse' | 'expand'
+}
+
+export function SidebarIcon({
+  size = 24,
+  className = 'fill-black dark:fill-white',
+  variant = 'collapse',
+}: SidebarIconProps) {
+  const arrowPath =
+    variant === 'collapse'
+      ? 'M15.707 8.293a1 1 0 0 1 0 1.414L13.414 12l2.293 2.293a1 1 0 0 1-1.414 1.414l-3-3a1 1 0 0 1 0-1.414l3-3a1 1 0 0 1 1.414 0Z'
+      : 'M12.293 8.293a1 1 0 0 1 1.414 0l3 3a1 1 0 0 1 0 1.414l-3 3a1 1 0 0 1-1.414-1.414L14.586 12l-2.293-2.293a1 1 0 0 1 0-1.414Z'
+
   return (
     <SvgIcon size={size} title='sidebar-icon'>
       <rect width='24' height='24' fill='none' />
-      {/* 左側のパネル */}
-      <rect x='3' y='5' width='6' height='14' rx='1.5' className={className} />
-      {/* 右側のコンテンツエリアを表す2本の線 */}
-      <rect x='12' y='5' width='9' height='2' rx='1' className={className} />
-      <rect x='12' y='10' width='7' height='2' rx='1' className={className} />
-      <rect x='12' y='15' width='9' height='2' rx='1' className={className} />
+      {/* サイドバー領域を持つウィンドウ枠 */}
+      <path
+        fillRule='evenodd'
+        clipRule='evenodd'
+        d='M5.5 4C4.119 4 3 5.119 3 6.5v11C3 18.881 4.119 20 5.5 20h13c1.381 0 2.5-1.119 2.5-2.5v-11C21 5.119 19.881 4 18.5 4h-13ZM5 6.5C5 6.224 5.224 6 5.5 6H8v12H5.5c-.276 0-.5-.224-.5-.5v-11ZM10 18h8.5c.276 0 .5-.224.5-.5v-11c0-.276-.224-.5-.5-.5H10v12Z'
+        className={className}
+      />
+      <path d={arrowPath} className={className} />
     </SvgIcon>
   )
 }

--- a/projects/portfolio/src/client/pages/chat/index.tsx
+++ b/projects/portfolio/src/client/pages/chat/index.tsx
@@ -200,6 +200,7 @@ export function Chat() {
         showNewChat={(!query.isLoading && conversations.length <= 0) || !isSidebarOpen}
         showPopup={isSettingsPopupOpen}
         showSidebarToggle={!!email}
+        isSidebarOpen={isSidebarOpen}
         isSidebarToggleDisabled={isSubmitting}
         onNewChat={navigateToNewConversation}
         onShowMenu={toggleSettingsPopup}

--- a/projects/portfolio/src/server/routes/chat.ts
+++ b/projects/portfolio/src/server/routes/chat.ts
@@ -6,7 +6,7 @@ import { convertCompletion, convertStreamChunks } from '#/server/features/chat/c
 import type { CompletionChunk, ResponsesStreamChunk, StreamChunk } from '#/server/features/chat/transport'
 import { logger } from '#/server/lib/logger'
 import { ApiChatMessageSchema, type ApiMode } from '#/types'
-import { ChatApiRequestSchema } from '#/types/chat-api'
+import { ChatApiRequestSchema, type ChatApiRequest } from '#/types/chat-api'
 import { sValidator } from '@hono/standard-validator'
 import { Hono } from 'hono'
 import { streamSSE } from 'hono/streaming'
@@ -96,6 +96,51 @@ function normalizeApiMode(apiMode: ApiMode | undefined): ApiMode {
   return apiMode ?? 'chat_completions'
 }
 
+function buildChatRequestLog({
+  header,
+  req,
+  apiMode,
+  stream,
+  includeUsage,
+}: {
+  header: z.infer<typeof ChatHeaderSchema>
+  req: ChatApiRequest
+  apiMode: ApiMode
+  stream: boolean
+  includeUsage?: boolean
+}) {
+  const providerRequest =
+    apiMode === 'responses'
+      ? {
+          model: req.model,
+          input: req.messages,
+          temperature: req.temperature,
+          max_output_tokens: req.maxTokens,
+          reasoning: req.reasoningEffort ? { effort: req.reasoningEffort } : undefined,
+          stream,
+        }
+      : {
+          model: req.model,
+          messages: req.messages,
+          temperature: req.temperature,
+          max_tokens: req.maxTokens,
+          reasoning_effort: req.reasoningEffort,
+          stream,
+          stream_options: includeUsage ? { include_usage: true } : undefined,
+        }
+
+  return {
+    baseURL: header['base-url'],
+    apiMode,
+    appRequest: {
+      ...req,
+      apiMode,
+      stream,
+    },
+    providerRequest,
+  }
+}
+
 const streamStubCompletion = (
   c: Parameters<typeof streamSSE>[0],
   req: z.infer<typeof StubChatRequestSchema>,
@@ -138,6 +183,18 @@ const chatRoutes = new Hono<HonoEnv>()
     const requestLogger = c.var.logger ?? logger
 
     try {
+      requestLogger.debug(
+        {
+          request: buildChatRequestLog({
+            header,
+            req,
+            apiMode,
+            stream: false,
+          }),
+        },
+        'Chat request received'
+      )
+
       const completion = await chat.completions(
         {
           apiKey: header['api-key'],
@@ -174,6 +231,19 @@ const chatRoutes = new Hono<HonoEnv>()
 
     let completion
     try {
+      requestLogger.debug(
+        {
+          request: buildChatRequestLog({
+            header,
+            req,
+            apiMode,
+            stream: true,
+            includeUsage: true,
+          }),
+        },
+        'Stream chat request received'
+      )
+
       completion = await chat.completions(
         {
           apiKey: header['api-key'],

--- a/projects/portfolio/src/types/chat-api.ts
+++ b/projects/portfolio/src/types/chat-api.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { ApiChatMessageSchema, ApiModeSchema } from './chat'
+import { ApiChatMessageSchema, ApiModeSchema, ReasoningEffortSchema } from './chat'
 
 // ============================================
 // /api/chat, /api/chat/stream 公開コントラクト
@@ -12,7 +12,7 @@ export const ChatApiRequestSchema = z.object({
   apiMode: ApiModeSchema.optional(),
   temperature: z.number().min(0).max(1).optional(),
   maxTokens: z.number().min(1).optional(),
-  reasoningEffort: z.enum(['none', 'minimal', 'low', 'medium', 'high', 'xhigh']).optional(),
+  reasoningEffort: ReasoningEffortSchema.optional(),
 })
 
 export type ChatApiRequest = z.infer<typeof ChatApiRequestSchema>

--- a/projects/portfolio/src/types/chat.ts
+++ b/projects/portfolio/src/types/chat.ts
@@ -8,6 +8,10 @@ export const ApiModeSchema = z.enum(['chat_completions', 'responses'])
 
 export type ApiMode = z.infer<typeof ApiModeSchema>
 
+export const ReasoningEffortSchema = z.enum(['none', 'minimal', 'low', 'medium', 'high', 'xhigh'])
+
+export type ReasoningEffort = z.infer<typeof ReasoningEffortSchema>
+
 /** 画像コンテンツ */
 export const ImageContentSchema = z.object({
   type: z.literal('image_url'),
@@ -37,6 +41,7 @@ export const UserMetadataSchema = z
     stream: z.boolean().optional(),
     temperature: z.number().optional(),
     maxTokens: z.number().optional(),
+    reasoningEffort: ReasoningEffortSchema.optional(),
   })
   .catch({ model: '' })
 

--- a/projects/portfolio/src/types/index.ts
+++ b/projects/portfolio/src/types/index.ts
@@ -10,6 +10,7 @@ export {
   AssistantMetadataSchema,
   GeneratedCodeFileSchema,
   ApiModeSchema,
+  ReasoningEffortSchema,
   ImageContentSchema,
   TextContentSchema,
   // /api/chat wire schemas
@@ -25,6 +26,7 @@ export {
   type AssistantMetadata,
   type GeneratedCodeFile,
   type ApiMode,
+  type ReasoningEffort,
   type ImageContent,
   type TextContent,
   // /api/chat wire types

--- a/projects/portfolio/tests/client/components/chat-main.test.tsx
+++ b/projects/portfolio/tests/client/components/chat-main.test.tsx
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+
+import type { Settings } from '#/client/storage/remote-storage-settings'
+import type { AssistantMessage, Conversation, UserMessage } from '#/types'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const useMessageScrollMock = vi.fn()
+const scrollToMessageEndMock = vi.fn()
+
+vi.mock('#/client/components/chat/chat-input', () => ({
+  ChatInput: () => <div data-testid='chat-input' />,
+}))
+
+vi.mock('#/client/components/chat/chat-message-list', () => ({
+  ChatMessageList: () => <div data-testid='chat-message-list' />,
+}))
+
+vi.mock('#/client/components/chat/hooks/use-chat-form', () => ({
+  useChatForm: () => ({
+    input: '',
+    uploadImages: [],
+    textAreaRows: 2,
+    setTemplateInput: vi.fn(),
+    handleUploadImageChange: vi.fn(),
+    handleChangeInput: vi.fn(),
+    handleKeyDown: vi.fn(),
+    handleChangeComposition: vi.fn(),
+    buildChatMessages: vi.fn(),
+    resetAfterSubmit: vi.fn(),
+  }),
+}))
+
+vi.mock('#/client/components/chat/hooks/use-message-copy', () => ({
+  useMessageCopy: () => ({
+    copiedId: '',
+    copyMessage: vi.fn(),
+  }),
+}))
+
+vi.mock('#/client/components/chat/hooks/use-message-scroll', () => ({
+  useMessageScroll: (...args: unknown[]) => useMessageScrollMock(...args),
+}))
+
+vi.mock('#/client/components/chat/hooks/use-stream-processor', () => ({
+  useStreamProcessor: () => ({
+    loading: false,
+    stream: null,
+    cancelStream: vi.fn(),
+    submitChatCompletion: vi.fn(),
+  }),
+}))
+
+vi.mock('#/client/components/chat/prompt-template', () => ({
+  PromptTemplate: () => <div data-testid='prompt-template' />,
+}))
+
+vi.mock('#/client/components/input/file-image-input', () => ({
+  FileImageInput: ({ fileInputButton }: { fileInputButton: (onClick: () => void) => React.ReactNode }) => (
+    <div>{fileInputButton(vi.fn())}</div>
+  ),
+  FileImagePreview: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+const createUserMessage = (id: string, content: string): UserMessage => ({
+  id,
+  role: 'user',
+  content,
+  reasoningContent: '',
+  metadata: {
+    model: 'gpt-test',
+  },
+})
+
+const createAssistantMessage = (id: string, content: string): AssistantMessage => ({
+  id,
+  role: 'assistant',
+  content,
+  reasoningContent: '',
+  metadata: {
+    model: 'gpt-test',
+    usage: {},
+  },
+})
+
+const currentConversation: Conversation = {
+  id: 'conversation-1',
+  title: '会話',
+  messages: [createUserMessage('message-1', 'こんにちは'), createAssistantMessage('message-2', 'こんばんは')],
+}
+
+const settings: Settings = {
+  schemaVersion: '1.2.0',
+  model: 'gpt-4.1-mini',
+  baseURL: '',
+  apiKey: '',
+  apiMode: 'chat_completions',
+  temperature: 0.7,
+  temperatureEnabled: false,
+  maxTokens: undefined,
+  reasoningEffort: 'medium',
+  reasoningEffortEnabled: false,
+  fakeMode: false,
+  autoModel: false,
+  markdownPreview: true,
+  streamMode: true,
+  interactiveMode: true,
+  sidebarOpen: true,
+  templateModels: {},
+}
+
+describe('ChatMain', () => {
+  beforeEach(() => {
+    useMessageScrollMock.mockReturnValue({
+      scrollContainerRef: { current: null },
+      bottomChatInputContainerRef: { current: null },
+      messageEndRef: { current: null },
+      isPinnedToBottom: true,
+      handleScroll: vi.fn(),
+      scrollToMessageEnd: scrollToMessageEndMock,
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('最下端に吸着している間は最新へ移動ボタンを表示しない', async () => {
+    const { ChatMain } = await import('#/client/components/chat/chat-main')
+
+    render(<ChatMain settings={settings} currentConversation={currentConversation} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('chat-message-list')).toBeTruthy()
+    })
+    expect(screen.queryByRole('button', { name: '最下部へ移動' })).toBeNull()
+  })
+
+  it('最下端から離れると最新へ移動ボタンを表示し、押下でスクロールする', async () => {
+    useMessageScrollMock.mockReturnValue({
+      scrollContainerRef: { current: null },
+      bottomChatInputContainerRef: { current: null },
+      messageEndRef: { current: null },
+      isPinnedToBottom: false,
+      handleScroll: vi.fn(),
+      scrollToMessageEnd: scrollToMessageEndMock,
+    })
+
+    const { ChatMain } = await import('#/client/components/chat/chat-main')
+
+    render(<ChatMain settings={settings} currentConversation={currentConversation} />)
+
+    const button = await screen.findByRole('button', { name: '最下部へ移動' })
+    fireEvent.click(button)
+
+    expect(scrollToMessageEndMock).toHaveBeenCalledWith('smooth')
+  })
+})

--- a/projects/portfolio/tests/client/components/chat-message-list.test.tsx
+++ b/projects/portfolio/tests/client/components/chat-message-list.test.tsx
@@ -70,5 +70,28 @@ describe('ChatMessageList', () => {
 
       expect(screen.getByRole('button', { name: 'Collapse code block' })).toBeTruthy()
     })
+
+    it('ストリーム中はタイピングアイコンを表示する', () => {
+      render(
+        <ChatMessageList
+          messages={[]}
+          conversationId='conversation-1'
+          markdownPreview={true}
+          loading={true}
+          stream={{
+            content: 'typing...',
+            reasoningContent: '',
+          }}
+          streamMessageId='assistant-1'
+          copiedId=''
+          messageEndRef={createRef<HTMLDivElement>()}
+          onCopyMessage={vi.fn()}
+          onDeleteMessage={vi.fn()}
+        />
+      )
+
+      expect(screen.getByRole('img', { name: 'chatbot-typing-icon' })).toBeTruthy()
+      expect(screen.queryByRole('img', { name: 'chatbot-icon' })).toBeNull()
+    })
   })
 })

--- a/projects/portfolio/tests/client/hooks/use-chat-form.test.tsx
+++ b/projects/portfolio/tests/client/hooks/use-chat-form.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+describe('useChatForm', () => {
+  const importSubject = async () => {
+    const { useChatForm } = await import('#/client/components/chat/hooks/use-chat-form')
+    return { useChatForm }
+  }
+
+  const createChangeEvent = (value: string) =>
+    ({ target: { value } }) as unknown as React.ChangeEvent<HTMLTextAreaElement>
+
+  it('送信設定を user message metadata に残す', async () => {
+    const { useChatForm } = await importSubject()
+    const formRef = { current: null }
+    const { result } = renderHook(() => useChatForm({ formRef }))
+
+    act(() => {
+      result.current.handleChangeInput(createChangeEvent('hello'))
+    })
+
+    const built = result.current.buildChatMessages({
+      apiMode: 'chat_completions',
+      interactiveMode: true,
+      messages: [],
+      model: 'gpt-test',
+      streamMode: true,
+      temperature: 0.4,
+      maxTokens: 256,
+    })
+
+    expect(built?.draftUserMessage.metadata).toEqual({
+      model: 'gpt-test',
+      apiMode: 'chat_completions',
+      stream: true,
+      temperature: 0.4,
+      maxTokens: 256,
+    })
+  })
+})

--- a/projects/portfolio/tests/client/hooks/use-chat-form.test.tsx
+++ b/projects/portfolio/tests/client/hooks/use-chat-form.test.tsx
@@ -29,6 +29,7 @@ describe('useChatForm', () => {
       streamMode: true,
       temperature: 0.4,
       maxTokens: 256,
+      reasoningEffort: 'high',
     })
 
     expect(built?.draftUserMessage.metadata).toEqual({
@@ -37,6 +38,7 @@ describe('useChatForm', () => {
       stream: true,
       temperature: 0.4,
       maxTokens: 256,
+      reasoningEffort: 'high',
     })
   })
 })

--- a/projects/portfolio/tests/client/hooks/use-message-scroll.test.tsx
+++ b/projects/portfolio/tests/client/hooks/use-message-scroll.test.tsx
@@ -8,6 +8,7 @@ describe('useMessageScroll', () => {
   const messages: Message[] = []
 
   beforeEach(() => {
+    vi.spyOn(performance, 'now').mockReturnValue(0)
     vi.stubGlobal(
       'ResizeObserver',
       class ResizeObserver {
@@ -16,6 +17,15 @@ describe('useMessageScroll', () => {
         disconnect() {}
       }
     )
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({ matches: false }))
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((callback: FrameRequestCallback) => {
+        callback(1000)
+        return 1
+      })
+    )
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
   })
 
   afterEach(() => {
@@ -102,11 +112,8 @@ describe('useMessageScroll', () => {
       scrollHeight: { value: 600, writable: true },
       clientHeight: { value: 200, writable: true },
     })
-    const scrollIntoView = vi.fn()
-
     act(() => {
       result.current.scrollContainerRef.current = scrollContainer
-      result.current.messageEndRef.current = { scrollIntoView } as unknown as HTMLDivElement
       result.current.handleScroll()
     })
 
@@ -115,9 +122,7 @@ describe('useMessageScroll', () => {
     })
 
     expect(result.current.isPinnedToBottom).toBe(true)
-    expect(scrollIntoView).toHaveBeenCalledWith({
-      behavior: 'smooth',
-      block: 'end',
-    })
+    expect(scrollContainer.scrollTop).toBe(400)
+    expect(requestAnimationFrame).toHaveBeenCalled()
   })
 })

--- a/projects/portfolio/tests/client/hooks/use-message-scroll.test.tsx
+++ b/projects/portfolio/tests/client/hooks/use-message-scroll.test.tsx
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+
+import type { Message } from '#/types'
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('useMessageScroll', () => {
+  const messages: Message[] = []
+
+  beforeEach(() => {
+    vi.stubGlobal(
+      'ResizeObserver',
+      class ResizeObserver {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      }
+    )
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  const importSubject = async () => {
+    const { useMessageScroll } = await import('#/client/components/chat/hooks/use-message-scroll')
+    return { useMessageScroll }
+  }
+
+  it('最下端から離れると isPinnedToBottom が false になる', async () => {
+    const { useMessageScroll } = await importSubject()
+    const { result } = renderHook(() =>
+      useMessageScroll({
+        loading: false,
+        streamMode: true,
+        stream: null,
+        messages,
+      })
+    )
+
+    const scrollContainer = document.createElement('div')
+    Object.defineProperties(scrollContainer, {
+      scrollTop: { value: 100, writable: true },
+      scrollHeight: { value: 600, writable: true },
+      clientHeight: { value: 200, writable: true },
+    })
+
+    act(() => {
+      result.current.scrollContainerRef.current = scrollContainer
+      result.current.handleScroll()
+    })
+
+    expect(result.current.isPinnedToBottom).toBe(false)
+  })
+
+  it('閾値内へ戻ると isPinnedToBottom が true になる', async () => {
+    const { useMessageScroll } = await importSubject()
+    const { result } = renderHook(() =>
+      useMessageScroll({
+        loading: false,
+        streamMode: true,
+        stream: null,
+        messages,
+      })
+    )
+
+    const scrollContainer = document.createElement('div')
+    Object.defineProperties(scrollContainer, {
+      scrollTop: { value: 100, writable: true },
+      scrollHeight: { value: 600, writable: true },
+      clientHeight: { value: 200, writable: true },
+    })
+
+    act(() => {
+      result.current.scrollContainerRef.current = scrollContainer
+      result.current.handleScroll()
+    })
+
+    act(() => {
+      scrollContainer.scrollTop = 370
+      result.current.handleScroll()
+    })
+
+    expect(result.current.isPinnedToBottom).toBe(true)
+  })
+
+  it('scrollToMessageEnd でスクロールしつつ isPinnedToBottom を true に戻す', async () => {
+    const { useMessageScroll } = await importSubject()
+    const { result } = renderHook(() =>
+      useMessageScroll({
+        loading: false,
+        streamMode: true,
+        stream: null,
+        messages,
+      })
+    )
+
+    const scrollContainer = document.createElement('div')
+    Object.defineProperties(scrollContainer, {
+      scrollTop: { value: 100, writable: true },
+      scrollHeight: { value: 600, writable: true },
+      clientHeight: { value: 200, writable: true },
+    })
+    const scrollIntoView = vi.fn()
+
+    act(() => {
+      result.current.scrollContainerRef.current = scrollContainer
+      result.current.messageEndRef.current = { scrollIntoView } as unknown as HTMLDivElement
+      result.current.handleScroll()
+    })
+
+    act(() => {
+      result.current.scrollToMessageEnd('smooth')
+    })
+
+    expect(result.current.isPinnedToBottom).toBe(true)
+    expect(scrollIntoView).toHaveBeenCalledWith({
+      behavior: 'smooth',
+      block: 'end',
+    })
+  })
+})

--- a/projects/portfolio/tests/client/hooks/use-stream-processor.test.tsx
+++ b/projects/portfolio/tests/client/hooks/use-stream-processor.test.tsx
@@ -90,6 +90,45 @@ describe('useStreamProcessor', () => {
     })
   })
 
+  it('非 stream のリクエストに送信設定を含める', async () => {
+    const { useStreamProcessor, chatPostMock } = await importSubject()
+    chatPostMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        id: 'chatcmpl-1',
+        created: 1700000000,
+        model: 'gpt-test',
+        finishReason: 'stop',
+        message: {
+          content: 'answer',
+          reasoningContent: '',
+        },
+        usage: null,
+      }),
+    })
+
+    const { result } = renderHook(() => useStreamProcessor())
+
+    await act(async () => {
+      await result.current.submitChatCompletion({
+        ...request,
+        streamMode: false,
+        temperature: 0.4,
+        maxTokens: 256,
+      })
+    })
+
+    expect(chatPostMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        json: expect.objectContaining({
+          temperature: 0.4,
+          maxTokens: 256,
+        }),
+      }),
+      expect.anything()
+    )
+  })
+
   it('stream の reasoning-only 応答を保持する', async () => {
     const { useStreamProcessor, chatStreamPostMock } = await importSubject()
     const encoder = new TextEncoder()

--- a/projects/portfolio/tests/routes/chat.test.ts
+++ b/projects/portfolio/tests/routes/chat.test.ts
@@ -6,7 +6,7 @@ const readFileSyncMock = vi.fn((filePath: string) =>
 )
 
 const importSubject = async () => {
-  mockLogger()
+  const loggerMock = mockLogger()
   const completionsMock = vi.fn()
   const chatStubCompletionsMock = vi.fn()
   const chatStubStreamCompletionsMock = vi.fn()
@@ -50,6 +50,7 @@ const importSubject = async () => {
     completionsMock,
     chatStubCompletionsMock,
     chatStubStreamCompletionsMock,
+    loggerMock,
   }
 }
 
@@ -211,6 +212,61 @@ describe('chatRoutes', () => {
         expect.objectContaining({
           apiMode: 'chat_completions',
         })
+      )
+    })
+
+    it('debug ログに request と provider 向けパラメータを残す', async () => {
+      const { chatRoutes, completionsMock, loggerMock } = await importSubject()
+      completionsMock.mockResolvedValue({
+        id: 'chatcmpl-abc',
+        created: 1700000000,
+        model: 'gpt-test',
+        choices: [
+          {
+            index: 0,
+            message: { role: 'assistant', content: 'answer', refusal: null },
+            finish_reason: 'stop',
+            logprobs: null,
+          },
+        ],
+      })
+
+      const res = await chatRoutes.request('/api/chat', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'api-key': 'api-key',
+          'base-url': 'https://example.com',
+        },
+        body: JSON.stringify({
+          model: 'gpt-test',
+          messages: [{ role: 'user', content: 'hello' }],
+          temperature: 0.4,
+          maxTokens: 256,
+          reasoningEffort: 'high',
+        }),
+      })
+
+      expect(res.status).toBe(200)
+      expect(loggerMock.debug).toHaveBeenCalledWith(
+        {
+          request: expect.objectContaining({
+            baseURL: 'https://example.com',
+            apiMode: 'chat_completions',
+            appRequest: expect.objectContaining({
+              temperature: 0.4,
+              maxTokens: 256,
+              stream: false,
+            }),
+            providerRequest: expect.objectContaining({
+              temperature: 0.4,
+              max_tokens: 256,
+              reasoning_effort: 'high',
+              stream: false,
+            }),
+          }),
+        },
+        'Chat request received'
       )
     })
 

--- a/projects/portfolio/tests/types/chat.test.ts
+++ b/projects/portfolio/tests/types/chat.test.ts
@@ -1,4 +1,9 @@
-import { AssistantMetadataSchema, ConversationListResponseSchema, GeneratedCodeFileSchema } from '#/types'
+import {
+  AssistantMetadataSchema,
+  ConversationListResponseSchema,
+  GeneratedCodeFileSchema,
+  UserMetadataSchema,
+} from '#/types'
 import { describe, expect, it } from 'vitest'
 
 describe('chat types', () => {
@@ -96,6 +101,28 @@ describe('chat types', () => {
     it('generatedFiles 未指定の metadata も parse できる', () => {
       const parsed = AssistantMetadataSchema.parse({ model: 'gpt', usage: {} })
       expect(parsed.generatedFiles).toBeUndefined()
+    })
+  })
+
+  describe('UserMetadataSchema', () => {
+    it('送信設定を含む metadata を parse できる', () => {
+      const parsed = UserMetadataSchema.parse({
+        model: 'gpt-test',
+        apiMode: 'chat_completions',
+        stream: true,
+        temperature: 0.4,
+        maxTokens: 256,
+        reasoningEffort: 'high',
+      })
+
+      expect(parsed).toEqual({
+        model: 'gpt-test',
+        apiMode: 'chat_completions',
+        stream: true,
+        temperature: 0.4,
+        maxTokens: 256,
+        reasoningEffort: 'high',
+      })
     })
   })
 


### PR DESCRIPTION
## Issues

- None

## Why

ポートフォリオのチャット画面で、設定の保持、ストリーミング中の状態表示、下端への復帰操作など、利用感に関わる UI/UX をまとめて改善する必要があったためです。

## Summary

チャット設定まわりの表示と状態保持を見直し、ストリーミング中の視認性と操作性を改善します。あわせて jump-to-bottom の導線とスクロール挙動を調整し、関連する型・API・テストも更新しています。

## Changes

- チャット設定パネルの表示を調整し、リクエスト設定と reasoning effort メタデータを保持
- ストリーミング中の typing icon 表示と close/sidebar/jump-to-bottom 周辺 UI を改善
- jump-to-bottom ボタンのフェード、サイズ、スクロール挙動を調整
- 関連するサーバールート、型定義、テストを更新

## Checklist

- [x] `bun run test tests/client/hooks/use-message-scroll.test.tsx`
- [ ] `bun run lint`
- [ ] `bun run test`
