### PR TITLE
fix(portfolio): fix mobile chat message scroll visibility

### DIFF
--- a/projects/portfolio/src/client/components/chat/chat-main.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-main.tsx
@@ -306,7 +306,7 @@ export function ChatMain({
   const emptyMessage = messages.filter((m) => m.role !== 'system').length === 0
 
   return (
-    <form ref={formRef} onSubmit={handleSubmit} className='flex h-full min-h-0 flex-1 flex-col'>
+    <form ref={formRef} onSubmit={handleSubmit} className='flex min-h-0 flex-1 flex-col'>
       {emptyMessage && (
         <div className='flex min-h-0 flex-1 items-center justify-center'>
           <div className='container mx-auto flex max-w-(--breakpoint-lg) flex-1 items-center justify-center'>
@@ -368,26 +368,28 @@ export function ChatMain({
           </div>
         </div>
       )}
-      <div className={emptyMessage ? 'hidden' : 'min-h-0 flex-1 overflow-hidden'}>
-        <div ref={scrollContainerRef} onScroll={handleScroll} className='min-h-0 h-full overflow-y-auto'>
-          {!emptyMessage && (
-            <ChatMessageList
-              messages={messages}
-              conversationId={conversationId}
-              canSaveGeneratedFile={canSaveGeneratedFile}
-              markdownPreview={settings.markdownPreview}
-              loading={loading}
-              stream={stream}
-              streamMessageId={streamMessageId}
-              copiedId={copiedId}
-              savingConversation={isSavingConversation}
-              messageEndRef={messageEndRef}
-              onCopyMessage={copyMessage}
-              onDeleteMessage={handleClickDeleteMessage}
-              onSaveGeneratedFile={handleSaveGeneratedFile}
-            />
-          )}
-        </div>
+      <div
+        ref={scrollContainerRef}
+        onScroll={handleScroll}
+        className={emptyMessage ? 'hidden' : 'min-h-0 flex-1 overflow-y-auto overflow-x-hidden'}
+      >
+        {!emptyMessage && (
+          <ChatMessageList
+            messages={messages}
+            conversationId={conversationId}
+            canSaveGeneratedFile={canSaveGeneratedFile}
+            markdownPreview={settings.markdownPreview}
+            loading={loading}
+            stream={stream}
+            streamMessageId={streamMessageId}
+            copiedId={copiedId}
+            savingConversation={isSavingConversation}
+            messageEndRef={messageEndRef}
+            onCopyMessage={copyMessage}
+            onDeleteMessage={handleClickDeleteMessage}
+            onSaveGeneratedFile={handleSaveGeneratedFile}
+          />
+        )}
       </div>
 
       <div


### PR DESCRIPTION
## Issues

- Fixes mobile chat message scroll visibility issue where messages were hidden under the ChatSettings header

## Why

On mobile browsers (especially iOS Safari), when users sent long messages, the scroll container's `clientHeight` calculation was incorrect due to a nested wrapper structure with h-full. This caused `scrollHeight - clientHeight` calculations to be inaccurate, resulting in auto-scroll positioning messages behind the chat header instead of below it.

## Summary

Simplified the scroll container layout by removing the unnecessary outer wrapper and making the scroll container a direct flex-1 child of the form. This eliminates the percentage-height resolution chain that was causing height calculation variance across mobile browsers.

## Changes

- Removed `h-full` from the ChatMain form to rely on flex-1 sizing
- Merged the outer wrapper div (`overflow-hidden`) with the inner scroll container
- Applied `overflow-y-auto overflow-x-hidden` directly to the scroll container as a flex-1 child
- Simplified the DOM structure by one level

## Test

- [x] Tests pass (`bun run test -- --run chat-main`)
- [x] Lint clean (`bun run lint`)
- [x] No type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
