### PR TITLE
feat(portfolio): show login expiration duration

### DIFF
--- a/projects/portfolio/src/client/pages/home/index.tsx
+++ b/projects/portfolio/src/client/pages/home/index.tsx
@@ -6,7 +6,7 @@ const client = hc<AppType>('/')
 
 export function Home() {
   const [error, setError] = useState<string | null>(null)
-  const { email } = useMetaProps()
+  const { email, loginExpiresLabel } = useMetaProps()
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault()
@@ -64,6 +64,12 @@ export function Home() {
               <span className='font-semibold'>User：</span>
               <span className='break-all font-mono text-gray-600 dark:text-gray-400'>{email}</span>
             </p>
+            {loginExpiresLabel && (
+              <p className='text-center text-gray-500 text-sm dark:text-gray-400'>
+                <span className='font-medium'>ログイン有効期限：</span>
+                <span>{loginExpiresLabel}</span>
+              </p>
+            )}
             <button
               type='button'
               onClick={handleSignOut}
@@ -115,6 +121,7 @@ export function Home() {
 
 type Props = {
   email?: string
+  loginExpiresLabel?: string | null
 }
 
 export function useMetaProps(): Props {

--- a/projects/portfolio/src/server/features/cookie/cookie.ts
+++ b/projects/portfolio/src/server/features/cookie/cookie.ts
@@ -64,3 +64,27 @@ export function parseDurationToSeconds(duration: string): number {
       return 0
   }
 }
+
+export function formatDurationLabel(duration: string): string | null {
+  if (!duration || typeof duration !== 'string') return null
+
+  const regex = /^(\d+)(d|h|m|s)$/i
+  const match = duration.match(regex)
+  if (!match) return null
+
+  const value = Number(match[1])
+  const unit = match[2].toLowerCase()
+
+  switch (unit) {
+    case 'd':
+      return `${value}日`
+    case 'h':
+      return `${value}時間`
+    case 'm':
+      return `${value}分`
+    case 's':
+      return `${value}秒`
+    default:
+      return null
+  }
+}

--- a/projects/portfolio/src/server/routes/html.tsx
+++ b/projects/portfolio/src/server/routes/html.tsx
@@ -1,12 +1,14 @@
 import { Hono } from 'hono'
 import { renderToString } from 'react-dom/server'
+import { formatDurationLabel } from '../features/cookie/cookie'
 import type { HonoEnv } from './shared'
 import { getServerEnv, getSignedInEmail } from './shared'
 
 const htmlRoutes = new Hono<HonoEnv>().get('*', async (c) => {
-  const { NODE_ENV } = getServerEnv(c)
+  const { NODE_ENV, COOKIE_EXPIRES = '1d' } = getServerEnv(c)
   const prod = NODE_ENV === 'production'
   const email = await getSignedInEmail(c)
+  const loginExpiresLabel = formatDurationLabel(COOKIE_EXPIRES)
 
   return c.html(
     renderToString(
@@ -14,7 +16,7 @@ const htmlRoutes = new Hono<HonoEnv>().get('*', async (c) => {
         <head>
           <meta charSet='utf-8' />
           <meta name='viewport' content='width=device-width, initial-scale=1' />
-          <meta name='props' content={`${JSON.stringify({ email })}`} />
+          <meta name='props' content={`${JSON.stringify({ email, loginExpiresLabel })}`} />
           <title>Portfolio</title>
           <link rel='icon' href={prod ? '/static/favicon.ico' : 'favicon.ico'} />
           <script

--- a/projects/portfolio/tests/client/pages/home.test.tsx
+++ b/projects/portfolio/tests/client/pages/home.test.tsx
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+
+import { render } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('hono/client', () => ({
+  hc: () => ({
+    api: {
+      signin: {
+        $post: vi.fn(),
+      },
+      signout: {
+        $post: vi.fn(),
+      },
+    },
+  }),
+}))
+
+import { Home } from '#/client/pages/home'
+
+describe('Home page', () => {
+  it('ログイン済みの場合はログイン有効期限を表示する', () => {
+    document.head.innerHTML = ''
+    const meta = document.createElement('meta')
+    meta.name = 'props'
+    meta.content = JSON.stringify({
+      email: 'test@example.com',
+      loginExpiresLabel: '1日',
+    })
+    document.head.append(meta)
+
+    const { container } = render(<Home />)
+
+    expect(container.textContent).toContain('test@example.com')
+    expect(container.textContent).toContain('ログイン有効期限：1日')
+  })
+})

--- a/projects/portfolio/tests/features/cookie/cookie.test.ts
+++ b/projects/portfolio/tests/features/cookie/cookie.test.ts
@@ -1,4 +1,4 @@
-import { cookie, parseDurationToSeconds } from '#/server/features/cookie/cookie'
+import { cookie, formatDurationLabel, parseDurationToSeconds } from '#/server/features/cookie/cookie'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 describe('parseDurationToSeconds', () => {
@@ -13,6 +13,21 @@ describe('parseDurationToSeconds', () => {
     expect(parseDurationToSeconds('')).toBe(0)
     expect(parseDurationToSeconds('10x')).toBe(0)
     expect(parseDurationToSeconds('abc')).toBe(0)
+  })
+})
+
+describe('formatDurationLabel', () => {
+  it('日・時間・分・秒を日本語の表示へ変換する', () => {
+    expect(formatDurationLabel('1d')).toBe('1日')
+    expect(formatDurationLabel('2h')).toBe('2時間')
+    expect(formatDurationLabel('30m')).toBe('30分')
+    expect(formatDurationLabel('45s')).toBe('45秒')
+  })
+
+  it('不正な値は null を返す', () => {
+    expect(formatDurationLabel('')).toBeNull()
+    expect(formatDurationLabel('10x')).toBeNull()
+    expect(formatDurationLabel('abc')).toBeNull()
   })
 })
 

--- a/projects/portfolio/tests/routes/html.test.tsx
+++ b/projects/portfolio/tests/routes/html.test.tsx
@@ -18,6 +18,7 @@ import { htmlRoutes } from '#/server/routes/html'
 describe('htmlRoutes', () => {
   it('development では src 配下の asset を返す', async () => {
     vi.stubEnv('NODE_ENV', 'development')
+    vi.stubEnv('COOKIE_EXPIRES', '1d')
     getSignedCookieMock.mockResolvedValue('test@example.com')
 
     const res = await htmlRoutes.request('/')
@@ -26,6 +27,7 @@ describe('htmlRoutes', () => {
     expect(html).toContain('/src/client/main.css')
     expect(html).toContain('/src/client/main.tsx')
     expect(html).toContain('test@example.com')
+    expect(html).toContain('&quot;loginExpiresLabel&quot;:&quot;1日&quot;')
   })
 
   it('production では static asset を返す', async () => {


### PR DESCRIPTION
## Issues

- なし

## Why

ログイン済みの利用者が、環境変数 `COOKIE_EXPIRES` で設定されているログイン有効期間を Home 画面で確認できるようにするため。

## Summary

Home 画面のログイン済み表示に、ログイン有効期限の表示を追加します。`COOKIE_EXPIRES=1d` のような duration 指定をサーバー側で日本語表示へ変換し、meta props 経由でクライアントへ渡します。

## Changes

- `COOKIE_EXPIRES` を `1日` などの表示用ラベルへ変換する関数を追加
- `htmlRoutes` の meta props に `loginExpiresLabel` を追加
- Home 画面のログイン済み状態で「ログイン有効期限」を表示
- cookie 変換、HTML props、Home 画面表示のテストを追加・更新

## Checklist

- [x] `bun run test`
- [x] `bun run lint`
- [x] `bun run format:check`

## Details

実際の失効日時ではなく、`COOKIE_EXPIRES` に設定された有効期間を表示します。不正な duration は `null` として扱い、画面には表示しません。
