### PR TITLE
Fix chat Enter submit during stream

### DIFF
--- a/projects/portfolio/src/client/components/chat/chat-main.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-main.tsx
@@ -44,6 +44,9 @@ export function ChatMain({
   const [messages, setMessages] = useState<Message[]>([])
   const [isSavingConversation, setIsSavingConversation] = useState(false)
   const [streamMessageId, setStreamMessageId] = useState<string | null>(null)
+  const { loading, stream, cancelStream, submitChatCompletion } = useStreamProcessor({
+    onSubmitting,
+  })
   const {
     input,
     uploadImages,
@@ -55,11 +58,8 @@ export function ChatMain({
     handleChangeComposition,
     buildChatMessages,
     resetAfterSubmit,
-  } = useChatForm({ initTrigger, formRef })
+  } = useChatForm({ initTrigger, formRef, submitDisabled: loading || !!stream })
   const { copiedId, copyMessage } = useMessageCopy()
-  const { loading, stream, cancelStream, submitChatCompletion } = useStreamProcessor({
-    onSubmitting,
-  })
   const {
     scrollContainerRef,
     bottomChatInputContainerRef,

--- a/projects/portfolio/src/client/components/chat/hooks/use-chat-form.ts
+++ b/projects/portfolio/src/client/components/chat/hooks/use-chat-form.ts
@@ -10,6 +10,7 @@ const MAX_TEXT_LINE_COUNT = 5
 interface UseChatFormParams {
   initTrigger?: number
   formRef: RefObject<HTMLFormElement | null>
+  submitDisabled?: boolean
 }
 
 interface BuildChatMessagesParams {
@@ -33,7 +34,7 @@ interface BuiltChatMessages {
   systemMessage?: Message
 }
 
-export function useChatForm({ initTrigger, formRef }: UseChatFormParams) {
+export function useChatForm({ initTrigger, formRef, submitDisabled = false }: UseChatFormParams) {
   const [input, setInput] = useState('')
   const [templateInput, setTemplateInput] = useState<TemplateInput | null>(null)
   const [uploadImages, setUploadImages] = useState<string[]>([])
@@ -79,7 +80,7 @@ export function useChatForm({ initTrigger, formRef }: UseChatFormParams) {
     const content = event.currentTarget.value.trim()
     if (event.key === 'Enter' && !event.shiftKey && !composing) {
       event.preventDefault()
-      if (content && formRef.current) {
+      if (!submitDisabled && content && formRef.current) {
         formRef.current.requestSubmit()
       }
     }

--- a/projects/portfolio/tests/client/hooks/use-chat-form.test.tsx
+++ b/projects/portfolio/tests/client/hooks/use-chat-form.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { act, renderHook } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 describe('useChatForm', () => {
   const importSubject = async () => {
@@ -11,6 +11,14 @@ describe('useChatForm', () => {
 
   const createChangeEvent = (value: string) =>
     ({ target: { value } }) as unknown as React.ChangeEvent<HTMLTextAreaElement>
+
+  const createKeyDownEvent = ({ key = 'Enter', shiftKey = false, value = 'hello' } = {}) =>
+    ({
+      key,
+      shiftKey,
+      currentTarget: { value },
+      preventDefault: vi.fn(),
+    }) as unknown as React.KeyboardEvent<HTMLTextAreaElement>
 
   it('送信設定を user message metadata に残す', async () => {
     const { useChatForm } = await importSubject()
@@ -40,5 +48,68 @@ describe('useChatForm', () => {
       maxTokens: 256,
       reasoningEffort: 'high',
     })
+  })
+
+  it('Enter でフォーム送信する', async () => {
+    const { useChatForm } = await importSubject()
+    const requestSubmit = vi.fn()
+    const formRef = { current: { requestSubmit } as unknown as HTMLFormElement }
+    const { result } = renderHook(() => useChatForm({ formRef }))
+    const event = createKeyDownEvent()
+
+    act(() => {
+      result.current.handleKeyDown(event)
+    })
+
+    expect(event.preventDefault).toHaveBeenCalledOnce()
+    expect(requestSubmit).toHaveBeenCalledOnce()
+  })
+
+  it('送信不可の Enter はフォーム送信しない', async () => {
+    const { useChatForm } = await importSubject()
+    const requestSubmit = vi.fn()
+    const formRef = { current: { requestSubmit } as unknown as HTMLFormElement }
+    const { result } = renderHook(() => useChatForm({ formRef, submitDisabled: true }))
+    const event = createKeyDownEvent()
+
+    act(() => {
+      result.current.handleKeyDown(event)
+    })
+
+    expect(event.preventDefault).toHaveBeenCalledOnce()
+    expect(requestSubmit).not.toHaveBeenCalled()
+  })
+
+  it('Shift+Enter はフォーム送信しない', async () => {
+    const { useChatForm } = await importSubject()
+    const requestSubmit = vi.fn()
+    const formRef = { current: { requestSubmit } as unknown as HTMLFormElement }
+    const { result } = renderHook(() => useChatForm({ formRef }))
+    const event = createKeyDownEvent({ shiftKey: true })
+
+    act(() => {
+      result.current.handleKeyDown(event)
+    })
+
+    expect(event.preventDefault).not.toHaveBeenCalled()
+    expect(requestSubmit).not.toHaveBeenCalled()
+  })
+
+  it('変換中の Enter はフォーム送信しない', async () => {
+    const { useChatForm } = await importSubject()
+    const requestSubmit = vi.fn()
+    const formRef = { current: { requestSubmit } as unknown as HTMLFormElement }
+    const { result } = renderHook(() => useChatForm({ formRef }))
+    const event = createKeyDownEvent()
+
+    act(() => {
+      result.current.handleChangeComposition(true)
+    })
+    act(() => {
+      result.current.handleKeyDown(event)
+    })
+
+    expect(event.preventDefault).not.toHaveBeenCalled()
+    expect(requestSubmit).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Issues

- Refs: none

## Why

Chat画面でストリーミング中にメッセージ入力後 Enter を押すと、送信ボタンは停止状態でもキーボード送信だけが通り、二重送信につながるため。

## Summary

ストリーミング中または送信中は、通常 Enter のフォーム送信を抑制します。Shift+Enter の改行と IME 変換中の Enter は既存挙動を維持します。

## Changes

- `useChatForm` に送信抑制フラグを追加
- `ChatMain` から `loading || stream` を渡してボタン状態と Enter 送信条件を同期
- Enter ハンドラの仕様テストを追加

## Checklist

- [x] `bun run test tests/client/hooks/use-chat-form.test.tsx`
- [x] `bun run test tests/client/components/chat-main.test.tsx`
- [x] `bun run lint`
