### PR TITLE
chore(deps): upgrade portal to typescript 6

### DIFF
--- a/projects/portal/bun-env.d.ts
+++ b/projects/portal/bun-env.d.ts
@@ -15,3 +15,5 @@ declare module "*.module.css" {
   const classes: { readonly [key: string]: string };
   export = classes;
 }
+
+declare module "*.css" {}

--- a/projects/portal/bun.lock
+++ b/projects/portal/bun.lock
@@ -6,17 +6,17 @@
       "name": "portal",
       "dependencies": {
         "bun-plugin-tailwind": "^0.1.2",
-        "react": "^19.2.5",
-        "react-dom": "^19.2.5",
-        "tailwindcss": "^4.2.2",
+        "react": "^19.2.6",
+        "react-dom": "^19.2.6",
+        "tailwindcss": "^4.3.0",
       },
       "devDependencies": {
-        "@types/bun": "^1.3.11",
+        "@types/bun": "^1.3.13",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "oxfmt": "^0.32.0",
-        "oxlint": "^1.59.0",
-        "typescript": "^5.9.3",
+        "oxlint": "^1.63.0",
+        "typescript": "^6.0.3",
       },
     },
   },
@@ -149,7 +149,7 @@
 
     "tinypool": ["tinypool@2.1.0", "", {}, "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
   }

--- a/projects/portal/package.json
+++ b/projects/portal/package.json
@@ -25,6 +25,6 @@
     "@types/react-dom": "^19.2.3",
     "oxfmt": "^0.32.0",
     "oxlint": "^1.63.0",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   }
 }

--- a/projects/portal/tsconfig.json
+++ b/projects/portal/tsconfig.json
@@ -21,11 +21,6 @@
     "noUncheckedIndexedAccess": true,
     "noImplicitOverride": true,
 
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["./src/*"]
-    },
-
     // Some stricter flags (disabled by default)
     "noUnusedLocals": false,
     "noUnusedParameters": false,


### PR DESCRIPTION
## Issues

- Refs N/A

## Why

Portal を TypeScript 6 系へ上げ、TypeScript 7 で動かなくなる `tsconfig` 設定を先に整理します。

## Summary

TypeScript を 6.0.3 へ更新し、`baseUrl` の非推奨対応を行いました。あわせて TypeScript 6 で厳密化された side-effect CSS import の型宣言を追加しています。

## Changes

- `typescript` を `^6.0.3` へ更新
- `tsconfig.json` から未使用の `baseUrl` と `paths` を削除
- `bun-env.d.ts` に `*.css` のモジュール宣言を追加
- `bun.lock` を更新

## Checklist

- [x] `bun run lint`
- [ ] `bun test` はスクリプト未定義のため未実行
