### PR TITLE
Add portal container view toggle

### DIFF
--- a/projects/portal/src/components/ContainerCard.tsx
+++ b/projects/portal/src/components/ContainerCard.tsx
@@ -155,4 +155,75 @@ export function ContainerCard({ container }: ContainerCardProps) {
   );
 }
 
+/**
+ * コンテナリスト行コンポーネント
+ */
+export function ContainerListItem({ container }: ContainerCardProps) {
+  const { config } = useConfig();
+  const host = config?.host || "localhost";
+  const shortId = container.id.slice(0, 12);
+
+  return (
+    <div
+      className="relative group rounded-xl border border-slate-700/50 bg-slate-800/50
+                 backdrop-blur-sm overflow-hidden
+                 hover:border-cyan-500/50 hover:shadow-[0_0_24px_rgba(6,182,212,0.12)]
+                 transition-all duration-300"
+    >
+      <div
+        className="absolute inset-0 bg-linear-to-r from-cyan-500/5 via-transparent to-purple-500/5
+                   opacity-0 group-hover:opacity-100 transition-opacity duration-500"
+      />
+
+      <div className="relative p-4">
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(220px,1.2fr)_minmax(260px,1fr)_minmax(220px,1fr)] lg:items-center">
+          <div className="flex min-w-0 items-start justify-between gap-3">
+            <div className="min-w-0">
+              <h3
+                className="truncate text-base font-semibold text-slate-100
+                           group-hover:text-cyan-400 transition-colors"
+                title={container.name}
+              >
+                {container.name}
+              </h3>
+              <p className="mt-0.5 text-xs font-mono text-slate-500">{shortId}</p>
+            </div>
+            <div className="flex shrink-0 items-center gap-2 lg:hidden">
+              <span className={getStatusDotClass(container.state)}>
+                <span className="block w-2 h-2 rounded-full" />
+              </span>
+              <span className={getStatusBadgeClass(container.state)}>{container.state}</span>
+            </div>
+          </div>
+
+          <div className="min-w-0 space-y-1">
+            <p className="truncate text-sm text-slate-400">
+              <span className="text-slate-500">Image:</span>{" "}
+              <span className="font-mono text-slate-300">{container.image}</span>
+            </p>
+            <p className="truncate text-sm text-slate-400">
+              <span className="text-slate-500">Status:</span> <span>{container.status}</span>
+            </p>
+          </div>
+
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+            <div className="min-w-0">
+              <p className="mb-2 text-xs font-medium uppercase tracking-wider text-slate-500 lg:hidden">
+                Ports
+              </p>
+              <PortLinks ports={container.ports} host={host} />
+            </div>
+            <div className="hidden shrink-0 items-center gap-2 lg:flex">
+              <span className={getStatusDotClass(container.state)}>
+                <span className="block w-2 h-2 rounded-full" />
+              </span>
+              <span className={getStatusBadgeClass(container.state)}>{container.state}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export default ContainerCard;

--- a/projects/portal/src/components/ContainerList.tsx
+++ b/projects/portal/src/components/ContainerList.tsx
@@ -1,8 +1,8 @@
-// ContainerList Component - コンテナ一覧をグリッドレイアウトで表示
+// ContainerList Component - コンテナ一覧をグリッド/リストで表示
 
 import { useState, useEffect } from "react";
 import type { Container, ContainerFilter } from "../types/container";
-import { ContainerCard } from "./ContainerCard";
+import { ContainerCard, ContainerListItem } from "./ContainerCard";
 
 interface ContainerListProps {
   filter?: ContainerFilter;
@@ -16,10 +16,59 @@ interface FetchState {
   lastUpdated: Date | null;
 }
 
+type ViewMode = "grid" | "list";
+
+const VIEW_MODE_STORAGE_KEY = "portal.containerViewMode";
+
+/**
+ * 表示切り替えボタンコンポーネント
+ */
+function ViewModeButton({
+  active,
+  label,
+  title,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  label: string;
+  title: string;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      aria-pressed={active}
+      title={title}
+      onClick={onClick}
+      className={`
+        inline-flex h-9 w-9 items-center justify-center rounded-lg border transition-all duration-200
+        ${
+          active
+            ? "border-cyan-500/50 bg-cyan-500/20 text-cyan-300 shadow-[0_0_15px_rgba(6,182,212,0.22)]"
+            : "border-slate-700/50 bg-slate-800/50 text-slate-500 hover:border-slate-600 hover:text-slate-300"
+        }
+      `}
+    >
+      {children}
+    </button>
+  );
+}
+
 /**
  * コンテナ一覧コンポーネント
  */
 export function ContainerList({ filter = "all", refreshInterval = 30000 }: ContainerListProps) {
+  const [viewMode, setViewMode] = useState<ViewMode>(() => {
+    if (typeof window === "undefined") {
+      return "grid";
+    }
+
+    const savedMode = window.localStorage.getItem(VIEW_MODE_STORAGE_KEY);
+    return savedMode === "list" ? "list" : "grid";
+  });
   const [state, setState] = useState<FetchState>({
     containers: [],
     loading: true,
@@ -64,6 +113,10 @@ export function ContainerList({ filter = "all", refreshInterval = 30000 }: Conta
       return () => clearInterval(interval);
     }
   }, [filter, refreshInterval]);
+
+  useEffect(() => {
+    window.localStorage.setItem(VIEW_MODE_STORAGE_KEY, viewMode);
+  }, [viewMode]);
 
   // ローディング状態
   if (state.loading && state.containers.length === 0) {
@@ -154,30 +207,71 @@ export function ContainerList({ filter = "all", refreshInterval = 30000 }: Conta
   return (
     <div className="space-y-4">
       {/* ヘッダー: カウントと最終更新 */}
-      <div className="flex items-center justify-between px-1">
+      <div className="flex flex-col gap-3 px-1 sm:flex-row sm:items-center sm:justify-between">
         <p className="text-sm text-slate-400">
           <span className="font-semibold text-slate-200">{state.containers.length}</span>{" "}
           {state.containers.length === 1 ? "container" : "containers"}
           {filter !== "all" && <span className="text-slate-500"> ({filter})</span>}
         </p>
-        {state.lastUpdated && (
-          <p className="text-xs text-slate-500">
-            Updated{" "}
-            {state.lastUpdated.toLocaleTimeString([], {
-              hour: "2-digit",
-              minute: "2-digit",
-              second: "2-digit",
-            })}
-          </p>
-        )}
+        <div className="flex items-center gap-3">
+          {state.lastUpdated && (
+            <p className="text-xs text-slate-500">
+              Updated{" "}
+              {state.lastUpdated.toLocaleTimeString([], {
+                hour: "2-digit",
+                minute: "2-digit",
+                second: "2-digit",
+              })}
+            </p>
+          )}
+          <div className="flex items-center gap-1 rounded-xl border border-slate-700/50 bg-slate-900/40 p-1">
+            <ViewModeButton
+              active={viewMode === "grid"}
+              label="Grid view"
+              title="カード表示"
+              onClick={() => setViewMode("grid")}
+            >
+              <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M4 4h6v6H4V4zm10 0h6v6h-6V4zM4 14h6v6H4v-6zm10 0h6v6h-6v-6z"
+                />
+              </svg>
+            </ViewModeButton>
+            <ViewModeButton
+              active={viewMode === "list"}
+              label="List view"
+              title="リスト表示"
+              onClick={() => setViewMode("list")}
+            >
+              <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M8 6h12M8 12h12M8 18h12M4 6h.01M4 12h.01M4 18h.01"
+                />
+              </svg>
+            </ViewModeButton>
+          </div>
+        </div>
       </div>
 
-      {/* グリッドレイアウト */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-        {state.containers.map((container) => (
-          <ContainerCard key={container.id} container={container} />
-        ))}
-      </div>
+      {viewMode === "grid" ? (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+          {state.containers.map((container) => (
+            <ContainerCard key={container.id} container={container} />
+          ))}
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {state.containers.map((container) => (
+            <ContainerListItem key={container.id} container={container} />
+          ))}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Issues

- Refs none

## Why

portal のコンテナ一覧はカードグリッド表示のみで、件数が多い場合に一覧性を確保しづらい状態でした。利用者が用途に応じてカード表示と一般的なリスト表示を切り替えられるようにします。

## Summary

コンテナ一覧に Grid/List の表示切り替えを追加します。選択した表示モードは localStorage に保存され、再読み込み後も維持されます。

## Changes

- コンテナ一覧ヘッダーに Grid/List の切り替えボタンを追加
- 横長のリスト表示用コンテナ行コンポーネントを追加
- 表示モードを localStorage に保存して復元

## Checklist

- [x] `bun run lint`
- [x] `bun run format:check`
