### PR TITLE
feat(portal): add container start stop actions

### DIFF
--- a/projects/portal/src/components/ContainerCard.tsx
+++ b/projects/portal/src/components/ContainerCard.tsx
@@ -3,8 +3,12 @@
 import type { Container } from "../types/container";
 import { useConfig } from "../hooks/useConfig";
 
+export type ContainerAction = "start" | "stop";
+
 interface ContainerCardProps {
   container: Container;
+  pendingAction?: ContainerAction | null;
+  onAction?: (container: Container, action: ContainerAction) => void;
 }
 
 /**
@@ -92,13 +96,68 @@ function PortLinks({ ports, host }: { ports: Container["ports"]; host: string })
   );
 }
 
+function getContainerAction(container: Container): ContainerAction | null {
+  if (container.state === "exited") {
+    return "start";
+  }
+
+  if (container.state === "running") {
+    return "stop";
+  }
+
+  return null;
+}
+
+function ContainerActionButton({
+  action,
+  pending,
+  onClick,
+}: {
+  action: ContainerAction;
+  pending: boolean;
+  onClick: () => void;
+}) {
+  const isStart = action === "start";
+  const label = isStart ? "Start" : "Stop";
+  const pendingLabel = isStart ? "Starting" : "Stopping";
+
+  return (
+    <button
+      type="button"
+      disabled={pending}
+      onClick={onClick}
+      className={`
+        inline-flex h-9 items-center justify-center gap-2 rounded-lg border px-3 text-sm font-medium
+        transition-all duration-200 disabled:cursor-not-allowed disabled:opacity-60
+        ${
+          isStart
+            ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-300 hover:border-emerald-400/50 hover:bg-emerald-500/20"
+            : "border-red-500/30 bg-red-500/10 text-red-300 hover:border-red-400/50 hover:bg-red-500/20"
+        }
+      `}
+    >
+      {isStart ? (
+        <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M8 5v14l11-7z" />
+        </svg>
+      ) : (
+        <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M7 7h10v10H7z" />
+        </svg>
+      )}
+      <span>{pending ? pendingLabel : label}</span>
+    </button>
+  );
+}
+
 /**
  * コンテナカードコンポーネント
  */
-export function ContainerCard({ container }: ContainerCardProps) {
+export function ContainerCard({ container, pendingAction, onAction }: ContainerCardProps) {
   const { config } = useConfig();
   const host = config?.host || "localhost";
   const shortId = container.id.slice(0, 12);
+  const action = getContainerAction(container);
 
   return (
     <div
@@ -150,6 +209,16 @@ export function ContainerCard({ container }: ContainerCardProps) {
           <p className="text-xs font-medium text-slate-500 uppercase tracking-wider mb-2">Ports</p>
           <PortLinks ports={container.ports} host={host} />
         </div>
+
+        {action && onAction && (
+          <div className="mt-4 border-t border-slate-700/50 pt-4">
+            <ContainerActionButton
+              action={action}
+              pending={pendingAction === action}
+              onClick={() => onAction(container, action)}
+            />
+          </div>
+        )}
       </div>
     </div>
   );
@@ -158,10 +227,11 @@ export function ContainerCard({ container }: ContainerCardProps) {
 /**
  * コンテナリスト行コンポーネント
  */
-export function ContainerListItem({ container }: ContainerCardProps) {
+export function ContainerListItem({ container, pendingAction, onAction }: ContainerCardProps) {
   const { config } = useConfig();
   const host = config?.host || "localhost";
   const shortId = container.id.slice(0, 12);
+  const action = getContainerAction(container);
 
   return (
     <div
@@ -176,7 +246,7 @@ export function ContainerListItem({ container }: ContainerCardProps) {
       />
 
       <div className="relative p-4">
-        <div className="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(220px,1.2fr)_minmax(260px,1fr)_minmax(220px,1fr)] lg:items-center">
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(220px,1.2fr)_minmax(260px,1fr)_minmax(220px,1fr)_auto] lg:items-center">
           <div className="flex min-w-0 items-start justify-between gap-3">
             <div className="min-w-0">
               <h3
@@ -220,6 +290,16 @@ export function ContainerListItem({ container }: ContainerCardProps) {
               <span className={getStatusBadgeClass(container.state)}>{container.state}</span>
             </div>
           </div>
+
+          {action && onAction && (
+            <div className="flex justify-start lg:justify-end">
+              <ContainerActionButton
+                action={action}
+                pending={pendingAction === action}
+                onClick={() => onAction(container, action)}
+              />
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/projects/portal/src/components/ContainerList.tsx
+++ b/projects/portal/src/components/ContainerList.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react";
 import type { Container, ContainerFilter } from "../types/container";
-import { ContainerCard, ContainerListItem } from "./ContainerCard";
+import { ContainerCard, ContainerListItem, type ContainerAction } from "./ContainerCard";
 
 interface ContainerListProps {
   filter?: ContainerFilter;
@@ -13,12 +13,54 @@ interface FetchState {
   containers: Container[];
   loading: boolean;
   error: string | null;
+  actionError: string | null;
   lastUpdated: Date | null;
 }
 
 type ViewMode = "grid" | "list";
 
 const VIEW_MODE_STORAGE_KEY = "portal.containerViewMode";
+
+function matchesFilter(container: Container, filter: ContainerFilter): boolean {
+  if (filter === "running") {
+    return container.state === "running";
+  }
+
+  if (filter === "stopped") {
+    return container.state === "exited" || container.state === "dead";
+  }
+
+  return true;
+}
+
+function applyMockAction(
+  containers: Container[],
+  containerId: string,
+  action: ContainerAction,
+  filter: ContainerFilter,
+): Container[] {
+  const updatedContainers = containers.map((container) => {
+    if (container.id !== containerId) {
+      return container;
+    }
+
+    if (action === "start") {
+      return {
+        ...container,
+        state: "running" as const,
+        status: "Up just now",
+      };
+    }
+
+    return {
+      ...container,
+      state: "exited" as const,
+      status: "Exited (0) just now",
+    };
+  });
+
+  return updatedContainers.filter((container) => matchesFilter(container, filter));
+}
 
 /**
  * 表示切り替えボタンコンポーネント
@@ -73,8 +115,13 @@ export function ContainerList({ filter = "all", refreshInterval = 30000 }: Conta
     containers: [],
     loading: true,
     error: null,
+    actionError: null,
     lastUpdated: null,
   });
+  const [pendingAction, setPendingAction] = useState<{
+    containerId: string;
+    action: ContainerAction;
+  } | null>(null);
 
   const fetchContainers = async () => {
     try {
@@ -92,6 +139,7 @@ export function ContainerList({ filter = "all", refreshInterval = 30000 }: Conta
         containers: data.containers || [],
         loading: false,
         error: null,
+        actionError: null,
         lastUpdated: new Date(),
       });
     } catch (error) {
@@ -101,6 +149,48 @@ export function ContainerList({ filter = "all", refreshInterval = 30000 }: Conta
         loading: false,
         error: error instanceof Error ? error.message : "Failed to fetch containers",
       }));
+    }
+  };
+
+  const runContainerAction = async (container: Container, action: ContainerAction) => {
+    const actionLabel = action === "start" ? "start" : "stop";
+    const confirmed = window.confirm(`Are you sure you want to ${actionLabel} ${container.name}?`);
+
+    if (!confirmed) {
+      return;
+    }
+
+    try {
+      setPendingAction({ containerId: container.id, action });
+      setState((prev) => ({ ...prev, actionError: null }));
+
+      const response = await fetch(`/api/containers/${container.id}/${action}`, {
+        method: "POST",
+      });
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.message || `HTTP error! status: ${response.status}`);
+      }
+
+      if (data.mock) {
+        setState((prev) => ({
+          ...prev,
+          containers: applyMockAction(prev.containers, container.id, action, filter),
+          lastUpdated: new Date(),
+        }));
+        return;
+      }
+
+      await fetchContainers();
+    } catch (error) {
+      console.error(`Failed to ${action} container:`, error);
+      setState((prev) => ({
+        ...prev,
+        actionError: error instanceof Error ? error.message : `Failed to ${action} container`,
+      }));
+    } finally {
+      setPendingAction(null);
     }
   };
 
@@ -259,16 +349,32 @@ export function ContainerList({ filter = "all", refreshInterval = 30000 }: Conta
         </div>
       </div>
 
+      {state.actionError && (
+        <div className="rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+          {state.actionError}
+        </div>
+      )}
+
       {viewMode === "grid" ? (
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
           {state.containers.map((container) => (
-            <ContainerCard key={container.id} container={container} />
+            <ContainerCard
+              key={container.id}
+              container={container}
+              pendingAction={pendingAction?.containerId === container.id ? pendingAction.action : null}
+              onAction={runContainerAction}
+            />
           ))}
         </div>
       ) : (
         <div className="space-y-3">
           {state.containers.map((container) => (
-            <ContainerListItem key={container.id} container={container} />
+            <ContainerListItem
+              key={container.id}
+              container={container}
+              pendingAction={pendingAction?.containerId === container.id ? pendingAction.action : null}
+              onAction={runContainerAction}
+            />
           ))}
         </div>
       )}

--- a/projects/portal/src/index.ts
+++ b/projects/portal/src/index.ts
@@ -1,6 +1,12 @@
 import { serve } from "bun";
 import index from "./index.html";
-import { fetchContainers, filterContainers } from "./services/docker";
+import {
+  ContainerActionError,
+  fetchContainers,
+  filterContainers,
+  runContainerAction,
+  type ContainerAction,
+} from "./services/docker";
 
 // モックモード表示
 const isMockMode = process.env.USE_MOCK_DATA === "true";
@@ -36,6 +42,44 @@ const server = serve({
               message: error instanceof Error ? error.message : "Unknown error",
             },
             { status: 500 },
+          );
+        }
+      },
+    },
+
+    "/api/containers/:id/:action": {
+      async POST(req) {
+        const { id, action } = req.params;
+
+        if (action !== "start" && action !== "stop") {
+          return Response.json(
+            {
+              error: "Invalid container action",
+              message: "Action must be start or stop",
+            },
+            { status: 400 },
+          );
+        }
+
+        try {
+          await runContainerAction(id, action as ContainerAction);
+
+          return Response.json({
+            success: true,
+            action,
+            containerId: id,
+            mock: process.env.USE_MOCK_DATA === "true",
+          });
+        } catch (error) {
+          console.error(`Error running container action ${action}:`, error);
+
+          const status = error instanceof ContainerActionError ? error.status : 500;
+          return Response.json(
+            {
+              error: "Failed to run container action",
+              message: error instanceof Error ? error.message : "Unknown error",
+            },
+            { status },
           );
         }
       },

--- a/projects/portal/src/services/docker.test.ts
+++ b/projects/portal/src/services/docker.test.ts
@@ -1,7 +1,15 @@
 // Dockerサービスのユニットテスト
 
-import { test, expect, mock, describe } from "bun:test";
-import { parsePorts, normalizeName, parseContainer, filterContainers } from "./docker";
+import { afterEach, test, expect, mock, describe } from "bun:test";
+import {
+  ContainerActionError,
+  filterContainers,
+  normalizeName,
+  parseContainer,
+  parsePorts,
+  runContainerAction,
+  validateContainerAction,
+} from "./docker";
 import type { Container, DockerContainerRaw } from "../types/container";
 
 // Bun.$ のモック
@@ -279,5 +287,72 @@ describe("filterContainers", () => {
   test("空の配列に対しても動作する", () => {
     const result = filterContainers([], "all");
     expect(result).toEqual([]);
+  });
+});
+
+describe("container actions", () => {
+  afterEach(() => {
+    delete process.env.USE_MOCK_DATA;
+  });
+
+  test("startはexited状態のコンテナを許可する", async () => {
+    process.env.USE_MOCK_DATA = "true";
+
+    const container = await validateContainerAction("ghi012jkl345678", "start");
+
+    expect(container.name).toBe("redis-cache");
+    expect(container.state).toBe("exited");
+  });
+
+  test("stopはrunning状態のコンテナを許可する", async () => {
+    process.env.USE_MOCK_DATA = "true";
+
+    const container = await validateContainerAction("abc123def456789", "stop");
+
+    expect(container.name).toBe("nginx-proxy");
+    expect(container.state).toBe("running");
+  });
+
+  test("存在しないコンテナは404エラー", async () => {
+    process.env.USE_MOCK_DATA = "true";
+
+    await expect(validateContainerAction("missing-container", "start")).rejects.toMatchObject({
+      name: "ContainerActionError",
+      status: 404,
+    });
+  });
+
+  test("状態不一致のstartは409エラー", async () => {
+    process.env.USE_MOCK_DATA = "true";
+
+    await expect(validateContainerAction("abc123def456789", "start")).rejects.toMatchObject({
+      name: "ContainerActionError",
+      status: 409,
+    });
+  });
+
+  test("状態不一致のstopは409エラー", async () => {
+    process.env.USE_MOCK_DATA = "true";
+
+    await expect(validateContainerAction("ghi012jkl345678", "stop")).rejects.toMatchObject({
+      name: "ContainerActionError",
+      status: 409,
+    });
+  });
+
+  test("モックモードではDockerコマンドを呼ばず成功する", async () => {
+    process.env.USE_MOCK_DATA = "true";
+
+    await expect(runContainerAction("ghi012jkl345678", "start")).resolves.toBeUndefined();
+  });
+
+  test("操作エラーはContainerActionErrorとして扱える", async () => {
+    process.env.USE_MOCK_DATA = "true";
+
+    try {
+      await validateContainerAction("missing-container", "stop");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ContainerActionError);
+    }
   });
 });

--- a/projects/portal/src/services/docker.ts
+++ b/projects/portal/src/services/docker.ts
@@ -3,6 +3,18 @@
 import type { Container, PortMapping, DockerContainerRaw } from "../types/container";
 import { mockContainers, isMockMode } from "./mockData";
 
+export type ContainerAction = "start" | "stop";
+
+export class ContainerActionError extends Error {
+  constructor(
+    message: string,
+    public status: number,
+  ) {
+    super(message);
+    this.name = "ContainerActionError";
+  }
+}
+
 /**
  * ポート文字列をパースする
  * "0.0.0.0:3000->80/tcp, 0.0.0.0:4000->443/tcp" のような形式を解析
@@ -122,6 +134,60 @@ export async function fetchContainers(all: boolean = false): Promise<Container[]
     console.error("Failed to fetch containers:", error);
     throw new Error(
       `Docker command failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+    );
+  }
+}
+
+/**
+ * コンテナ操作の実行前チェック
+ */
+export async function validateContainerAction(
+  containerId: string,
+  action: ContainerAction,
+): Promise<Container> {
+  const containers = await fetchContainers(true);
+  const container = containers.find((c) => c.id === containerId);
+
+  if (!container) {
+    throw new ContainerActionError(`Container not found: ${containerId}`, 404);
+  }
+
+  if (action === "start" && container.state !== "exited") {
+    throw new ContainerActionError(`Container must be exited to start: ${container.name}`, 409);
+  }
+
+  if (action === "stop" && container.state !== "running") {
+    throw new ContainerActionError(`Container must be running to stop: ${container.name}`, 409);
+  }
+
+  return container;
+}
+
+/**
+ * Dockerコンテナを起動/停止
+ */
+export async function runContainerAction(
+  containerId: string,
+  action: ContainerAction,
+): Promise<void> {
+  await validateContainerAction(containerId, action);
+
+  if (isMockMode()) {
+    console.log(`[MOCK MODE] ${action} container: ${containerId}`);
+    return;
+  }
+
+  try {
+    if (action === "start") {
+      await Bun.$`docker start ${containerId}`;
+      return;
+    }
+
+    await Bun.$`docker stop ${containerId}`;
+  } catch (error) {
+    console.error(`Failed to ${action} container:`, error);
+    throw new Error(
+      `Docker ${action} failed: ${error instanceof Error ? error.message : "Unknown error"}`,
     );
   }
 }


### PR DESCRIPTION
## Issues

- Refs user request

## Why

Portal should support basic container lifecycle operations from the UI, so stopped containers can be started and running containers can be stopped without leaving the page.

## Summary

This PR adds confirmed Start/Stop actions for Docker containers in the portal. It also adds backend endpoints, Docker service validation, mock-mode UI behavior, and tests for the action rules.

## Changes

- Add `POST /api/containers/:id/start` and `POST /api/containers/:id/stop`
- Show Start for `exited` containers and Stop for `running` containers in both grid and list views
- Add confirmation prompts, pending button state, and action error display
- Validate container existence/state before running Docker actions
- Add mock-mode success behavior and unit tests for lifecycle actions

## Checklist

- [x] Added container start/stop API endpoints
- [x] Added Start/Stop controls with confirmation
- [x] Added service tests for allowed/disallowed actions
- [x] Ran `bun test`
- [x] Ran `bun run lint`
