### PR TITLE
feat: edit posted chat user messages

### DIFF
--- a/projects/portfolio/src/client/components/chat/chat-main.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-main.tsx
@@ -1,6 +1,7 @@
 import type { SaveGeneratedFileRequest } from '#/client/components/chat/assistant-code-block'
 import { ChatInput } from '#/client/components/chat/chat-input'
 import { ChatMessageList } from '#/client/components/chat/chat-message-list'
+import { buildEditedHistory, prepareApiMessages, summarizeImageContext } from '#/client/components/chat/edit-message'
 import { useChatForm } from '#/client/components/chat/hooks/use-chat-form'
 import { useMessageCopy } from '#/client/components/chat/hooks/use-message-copy'
 import { useMessageScroll } from '#/client/components/chat/hooks/use-message-scroll'
@@ -286,6 +287,107 @@ export function ChatMain({
     [canSaveGeneratedFile, conversationId, messages]
   )
 
+  const handleEditMessage = useCallback(
+    async (index: number, nextText: string): Promise<void> => {
+      if (loading || stream || isSavingConversation) {
+        return
+      }
+
+      const editedMessages = buildEditedHistory(messages, index, nextText)
+      const editedUserMessage = editedMessages?.at(-1)
+      if (!editedMessages || !editedUserMessage || editedUserMessage.role !== 'user') {
+        return
+      }
+
+      const assistantMessageId = uuidv7()
+      const apiMessages = prepareApiMessages(editedMessages, editedUserMessage.id, settings.sendImagesOnlyOnce)
+      const imageContext = summarizeImageContext(editedMessages, editedUserMessage.id, settings.sendImagesOnlyOnce)
+      setMessages(editedMessages)
+      setStreamMessageId(assistantMessageId)
+
+      try {
+        const { result, responseTimeMs } = await submitChatCompletion({
+          header: {
+            apiKey: settings.fakeMode ? 'fakemode' : settings.apiKey,
+            baseURL: settings.fakeMode ? 'fakemode' : settings.baseURL,
+          },
+          apiMode: settings.apiMode,
+          model: settings.fakeMode ? 'fakemode' : settings.model,
+          messages: apiMessages,
+          streamMode: settings.streamMode,
+          temperature: settings.temperatureEnabled ? settings.temperature : undefined,
+          maxTokens: settings.maxTokens ? Number(settings.maxTokens) : undefined,
+          reasoningEffort: settings.reasoningEffortEnabled ? settings.reasoningEffort : undefined,
+        })
+
+        const assistantMessage: Message | null = result
+          ? {
+              id: assistantMessageId,
+              role: 'assistant' as const,
+              content: result.message.content,
+              reasoningContent: result.message.reasoningContent,
+              metadata: {
+                model: result.model,
+                apiMode: settings.apiMode,
+                finishReason: result.finishReason,
+                responseTimeMs,
+                usage: {
+                  promptTokens: result.usage?.promptTokens || 0,
+                  completionTokens: result.usage?.completionTokens || 0,
+                  totalTokens: result.usage?.totalTokens || 0,
+                  reasoningTokens: result.usage?.reasoningTokens,
+                },
+                imageContext,
+                apiContextMessages: apiMessages,
+              },
+            }
+          : null
+
+        const finalMessages = assistantMessage ? [...editedMessages, assistantMessage] : editedMessages
+        setMessages(finalMessages)
+
+        if (!conversationId) {
+          return
+        }
+
+        setIsSavingConversation(true)
+        try {
+          await onConversationChange?.({
+            id: conversationId,
+            title: currentConversation?.title ?? nextText.trim().slice(0, CONVERSATION_TITLE_MAX_LENGTH),
+            messages: finalMessages,
+          })
+        } finally {
+          setIsSavingConversation(false)
+        }
+      } finally {
+        setStreamMessageId(null)
+      }
+    },
+    [
+      conversationId,
+      currentConversation?.title,
+      isSavingConversation,
+      loading,
+      messages,
+      onConversationChange,
+      settings.apiKey,
+      settings.apiMode,
+      settings.baseURL,
+      settings.fakeMode,
+      settings.maxTokens,
+      settings.model,
+      settings.reasoningEffort,
+      settings.reasoningEffortEnabled,
+      settings.sendImagesOnlyOnce,
+      settings.streamMode,
+      settings.temperature,
+      settings.temperatureEnabled,
+      stream,
+      submitChatCompletion,
+    ]
+  )
+
   const handleClickDeleteMessage = useCallback(
     (index: number) => {
       if (confirm('本当に削除しますか？')) {
@@ -396,6 +498,7 @@ export function ChatMain({
             messageEndRef={messageEndRef}
             onCopyMessage={copyMessage}
             onDeleteMessage={handleClickDeleteMessage}
+            onEditMessage={handleEditMessage}
             onSaveGeneratedFile={handleSaveGeneratedFile}
           />
         )}

--- a/projects/portfolio/src/client/components/chat/chat-main.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-main.tsx
@@ -1,7 +1,12 @@
 import type { SaveGeneratedFileRequest } from '#/client/components/chat/assistant-code-block'
 import { ChatInput } from '#/client/components/chat/chat-input'
 import { ChatMessageList } from '#/client/components/chat/chat-message-list'
-import { buildEditedHistory, prepareApiMessages, summarizeImageContext } from '#/client/components/chat/edit-message'
+import {
+  buildEditedHistory,
+  buildEditedSendMessages,
+  prepareApiMessages,
+  summarizeImageContext,
+} from '#/client/components/chat/edit-message'
 import { useChatForm } from '#/client/components/chat/hooks/use-chat-form'
 import { useMessageCopy } from '#/client/components/chat/hooks/use-message-copy'
 import { useMessageScroll } from '#/client/components/chat/hooks/use-message-scroll'
@@ -300,8 +305,9 @@ export function ChatMain({
       }
 
       const assistantMessageId = uuidv7()
-      const apiMessages = prepareApiMessages(editedMessages, editedUserMessage.id, settings.sendImagesOnlyOnce)
-      const imageContext = summarizeImageContext(editedMessages, editedUserMessage.id, settings.sendImagesOnlyOnce)
+      const sendMessages = buildEditedSendMessages(editedMessages, editedUserMessage.id, settings.interactiveMode)
+      const apiMessages = prepareApiMessages(sendMessages, editedUserMessage.id, settings.sendImagesOnlyOnce)
+      const imageContext = summarizeImageContext(sendMessages, editedUserMessage.id, settings.sendImagesOnlyOnce)
       setMessages(editedMessages)
       setStreamMessageId(assistantMessageId)
 
@@ -375,6 +381,7 @@ export function ChatMain({
       settings.apiMode,
       settings.baseURL,
       settings.fakeMode,
+      settings.interactiveMode,
       settings.maxTokens,
       settings.model,
       settings.reasoningEffort,

--- a/projects/portfolio/src/client/components/chat/chat-message-list.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-message-list.tsx
@@ -38,6 +38,7 @@ interface ChatMessageListProps {
   messageEndRef: RefObject<HTMLDivElement | null>
   onCopyMessage: (message: string, index: number) => void
   onDeleteMessage: (index: number) => void
+  onEditMessage?: (index: number, nextText: string) => Promise<void> | void
   onSaveGeneratedFile?: (messageIndex: number, params: SaveGeneratedFileRequest) => Promise<GeneratedCodeFile | null>
 }
 
@@ -55,6 +56,7 @@ export function ChatMessageList({
   messageEndRef,
   onCopyMessage,
   onDeleteMessage,
+  onEditMessage,
   onSaveGeneratedFile,
 }: ChatMessageListProps) {
   const streamCodeBlockCursorRef = useRef({ current: 0 })
@@ -86,10 +88,11 @@ export function ChatMessageList({
           markdownPreview={markdownPreview}
           sendImagesOnlyOnce={sendImagesOnlyOnce}
           copiedId={copiedId}
-          disabled={loading || !!stream}
+          disabled={loading || !!stream || !!savingConversation}
           savingConversation={savingConversation}
           onCopyMessage={onCopyMessage}
           onDeleteMessage={onDeleteMessage}
+          onEditMessage={onEditMessage}
           onSaveGeneratedFile={onSaveGeneratedFile}
           codeBlockOpenBlocks={codeBlockOpenBlocks}
           onCodeBlockOpenChange={handleCodeBlockOpenChange}
@@ -163,6 +166,7 @@ interface MessageHistoryProps {
   onCodeBlockOpenChange: CodeBlockOpenChangeHandler
   onCopyMessage: (message: string, index: number) => void
   onDeleteMessage: (index: number) => void
+  onEditMessage?: (index: number, nextText: string) => Promise<void> | void
   onSaveGeneratedFile?: (messageIndex: number, params: SaveGeneratedFileRequest) => Promise<GeneratedCodeFile | null>
 }
 
@@ -179,6 +183,7 @@ const MessageHistory = memo(function MessageHistory({
   onCodeBlockOpenChange,
   onCopyMessage,
   onDeleteMessage,
+  onEditMessage,
   onSaveGeneratedFile,
 }: MessageHistoryProps) {
   return messages.map((message, index) => (
@@ -198,6 +203,7 @@ const MessageHistory = memo(function MessageHistory({
       onCodeBlockOpenChange={onCodeBlockOpenChange}
       onCopyMessage={onCopyMessage}
       onDeleteMessage={onDeleteMessage}
+      onEditMessage={onEditMessage}
       onSaveGeneratedFile={onSaveGeneratedFile}
     />
   ))

--- a/projects/portfolio/src/client/components/chat/edit-message.ts
+++ b/projects/portfolio/src/client/components/chat/edit-message.ts
@@ -41,6 +41,28 @@ export function prepareApiMessages(
   return messages.map((message) => toApiChatMessage(stripImagesFromHistory(message, currentUserMessageId)))
 }
 
+export function buildEditedSendMessages(
+  editedMessages: Message[],
+  currentUserMessageId: string | undefined,
+  interactiveMode: boolean
+): Message[] {
+  if (interactiveMode) {
+    return editedMessages
+  }
+
+  const currentUserMessageIndex = editedMessages.findIndex(
+    (message) => message.role === 'user' && message.id === currentUserMessageId
+  )
+  const currentUserMessage = editedMessages[currentUserMessageIndex]
+  if (!currentUserMessage) {
+    return []
+  }
+
+  const previousMessages = editedMessages.slice(0, currentUserMessageIndex)
+  const systemPrefix = previousMessages.every((message) => message.role === 'system') ? previousMessages : []
+  return [...systemPrefix, currentUserMessage]
+}
+
 export function summarizeImageContext(
   messages: Message[],
   currentUserMessageId: string | undefined,

--- a/projects/portfolio/src/client/components/chat/edit-message.ts
+++ b/projects/portfolio/src/client/components/chat/edit-message.ts
@@ -1,0 +1,120 @@
+import type { ApiChatMessage, ImageContent, ImageContextSummary, Message, TextContent, UserMessage } from '#/types'
+import { isImageContentArray, toApiChatMessage } from '#/types'
+
+export function getUserMessageText(message: UserMessage): string {
+  if (typeof message.content === 'string') {
+    return message.content
+  }
+
+  return message.content
+    .filter((content): content is TextContent => content.type === 'text')
+    .map((content) => content.text)
+    .join('\n')
+}
+
+export function buildEditedHistory(messages: Message[], index: number, nextText: string): Message[] | null {
+  const target = messages[index]
+  const trimmedText = nextText.trim()
+
+  if (!target || target.role !== 'user' || trimmedText.length <= 0) {
+    return null
+  }
+
+  return [
+    ...messages.slice(0, index),
+    {
+      ...target,
+      content: replaceUserTextContent(target.content, trimmedText),
+    },
+  ]
+}
+
+export function prepareApiMessages(
+  messages: Message[],
+  currentUserMessageId: string | undefined,
+  sendImagesOnlyOnce: boolean
+): ApiChatMessage[] {
+  if (!sendImagesOnlyOnce) {
+    return messages.map(toApiChatMessage)
+  }
+
+  return messages.map((message) => toApiChatMessage(stripImagesFromHistory(message, currentUserMessageId)))
+}
+
+export function summarizeImageContext(
+  messages: Message[],
+  currentUserMessageId: string | undefined,
+  sendImagesOnlyOnce: boolean
+): ImageContextSummary {
+  const totalImages = messages.reduce((count, message) => count + countImages(message), 0)
+  const currentImages = messages.reduce((count, message) => {
+    if (message.role !== 'user' || message.id !== currentUserMessageId) {
+      return count
+    }
+    return count + countImages(message)
+  }, 0)
+
+  if (!sendImagesOnlyOnce) {
+    return {
+      policy: 'full_history',
+      sent: totalImages,
+      historyOnly: 0,
+    }
+  }
+
+  return {
+    policy: 'send_once',
+    sent: currentImages,
+    historyOnly: totalImages - currentImages,
+  }
+}
+
+function replaceUserTextContent(content: UserMessage['content'], nextText: string): UserMessage['content'] {
+  if (typeof content === 'string') {
+    return nextText
+  }
+
+  let replaced = false
+  const nextContent = content.map((item) => {
+    if (item.type !== 'text') {
+      return item
+    }
+
+    replaced = true
+    return {
+      ...item,
+      text: nextText,
+    }
+  })
+
+  return replaced ? nextContent : [{ type: 'text', text: nextText }, ...nextContent]
+}
+
+function stripImagesFromHistory(message: Message, currentUserMessageId: string | undefined): Message {
+  if (message.role !== 'user' || message.id === currentUserMessageId || !isImageContentArray(message.content)) {
+    return message
+  }
+
+  const textContent = message.content.filter((content): content is TextContent => content.type === 'text')
+  const nonEmptyTextContent = textContent.filter((content) => content.text.trim().length > 0)
+
+  if (nonEmptyTextContent.length === 0) {
+    return {
+      ...message,
+      content: '[image omitted from context]',
+    }
+  }
+
+  return {
+    ...message,
+    content: nonEmptyTextContent,
+  }
+}
+
+function countImages(message: Message): number {
+  if (message.role !== 'user' || !isImageContentArray(message.content)) {
+    return 0
+  }
+
+  return message.content.filter((content): content is ImageContent => content.type === 'image_url').length
+}

--- a/projects/portfolio/src/client/components/chat/hooks/use-chat-form.ts
+++ b/projects/portfolio/src/client/components/chat/hooks/use-chat-form.ts
@@ -1,14 +1,6 @@
+import { prepareApiMessages, summarizeImageContext } from '#/client/components/chat/edit-message'
 import type { TemplateInput } from '#/client/components/chat/prompt-template'
-import type {
-  ApiChatMessage,
-  ApiMode,
-  ImageContent,
-  ImageContextSummary,
-  Message,
-  ReasoningEffort,
-  TextContent,
-} from '#/types'
-import { isImageContentArray, toApiChatMessage } from '#/types'
+import type { ApiChatMessage, ApiMode, ImageContextSummary, Message, ReasoningEffort } from '#/types'
 import { type ChangeEvent, type KeyboardEvent, type RefObject, useEffect, useState } from 'react'
 import { uuidv7 } from 'uuidv7'
 
@@ -275,72 +267,4 @@ const createTemplateMessage = (
     systemMessage,
     imageContext,
   }
-}
-
-function prepareApiMessages(
-  messages: Message[],
-  currentUserMessageId: string | undefined,
-  sendImagesOnlyOnce: boolean
-) {
-  if (!sendImagesOnlyOnce) {
-    return messages.map(toApiChatMessage)
-  }
-
-  return messages.map((message) => toApiChatMessage(stripImagesFromHistory(message, currentUserMessageId)))
-}
-
-function stripImagesFromHistory(message: Message, currentUserMessageId: string | undefined): Message {
-  if (message.role !== 'user' || message.id === currentUserMessageId || !isImageContentArray(message.content)) {
-    return message
-  }
-
-  const textContent = message.content.filter((content): content is TextContent => content.type === 'text')
-  const nonEmptyTextContent = textContent.filter((content) => content.text.trim().length > 0)
-
-  if (nonEmptyTextContent.length === 0) {
-    return {
-      ...message,
-      content: '[image omitted from context]',
-    }
-  }
-
-  return {
-    ...message,
-    content: nonEmptyTextContent,
-  }
-}
-
-function summarizeImageContext(
-  messages: Message[],
-  currentUserMessageId: string | undefined,
-  sendImagesOnlyOnce: boolean
-): ImageContextSummary {
-  const totalImages = messages.reduce((count, message) => count + countImages(message), 0)
-  const currentImages = messages.reduce((count, message) => {
-    if (message.role !== 'user' || message.id !== currentUserMessageId) {
-      return count
-    }
-    return count + countImages(message)
-  }, 0)
-
-  if (!sendImagesOnlyOnce) {
-    return {
-      policy: 'full_history',
-      sent: totalImages,
-      historyOnly: 0,
-    }
-  }
-
-  return {
-    policy: 'send_once',
-    sent: currentImages,
-    historyOnly: totalImages - currentImages,
-  }
-}
-
-function countImages(message: Message): number {
-  if (message.role !== 'user' || !isImageContentArray(message.content)) {
-    return 0
-  }
-  return message.content.filter((content): content is ImageContent => content.type === 'image_url').length
 }

--- a/projects/portfolio/src/client/components/chat/message-renderer.tsx
+++ b/projects/portfolio/src/client/components/chat/message-renderer.tsx
@@ -10,14 +10,17 @@ import {
   type CodeBlockOpenBlocks,
   type CodeBlockOpenChangeHandler,
 } from '#/client/components/chat/code-block-renderer'
+import { getUserMessageText } from '#/client/components/chat/edit-message'
 import { ReasoningSection } from '#/client/components/chat/reasoning-section'
 import { ChatbotIcon } from '#/client/components/svg/chatbot-icon'
 import { CheckIcon } from '#/client/components/svg/check-icon'
+import { CloseIcon } from '#/client/components/svg/close-icon'
 import { CopyIcon } from '#/client/components/svg/copy-icon'
 import { DeleteIcon } from '#/client/components/svg/delete-icon'
+import { EditIcon } from '#/client/components/svg/edit-icon'
 import type { GeneratedCodeFile, Message } from '#/types'
 import { isImageContentArray } from '#/types'
-import { Fragment, memo, type ReactNode, useRef } from 'react'
+import { Fragment, memo, type ReactNode, useRef, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkCjkFriendly from 'remark-cjk-friendly'
 import remarkCjkFriendlyGfmStrikethrough from 'remark-cjk-friendly-gfm-strikethrough'
@@ -60,6 +63,7 @@ interface MessageRendererProps {
   onCodeBlockOpenChange?: CodeBlockOpenChangeHandler
   onCopyMessage: (message: string, index: number) => void
   onDeleteMessage?: (index: number) => void
+  onEditMessage?: (index: number, nextText: string) => Promise<void> | void
   onSaveGeneratedFile?: (messageIndex: number, params: SaveGeneratedFileRequest) => Promise<GeneratedCodeFile | null>
 }
 
@@ -135,6 +139,7 @@ function MessageRendererComponent({
   onCodeBlockOpenChange,
   onCopyMessage,
   onDeleteMessage,
+  onEditMessage,
   onSaveGeneratedFile,
 }: MessageRendererProps) {
   // fenced code block 用の cursor。render のたびに 0 にリセットし、
@@ -143,48 +148,119 @@ function MessageRendererComponent({
   cursorRef.current.current = 0
   const codeBlockCursorRef = useRef({ current: 0 })
   codeBlockCursorRef.current.current = 0
+  const [isEditing, setIsEditing] = useState(false)
+  const [editText, setEditText] = useState(() => (message.role === 'user' ? getUserMessageText(message) : ''))
+  const [isSavingEdit, setIsSavingEdit] = useState(false)
 
   if (message.role === 'system') {
     return null
   }
 
   if (message.role === 'user') {
+    const canSaveEdit = editText.trim().length > 0 && !disabled && !isSavingEdit
+    const userMessageText = getUserMessageText(message)
+
+    const handleStartEdit = () => {
+      setEditText(userMessageText)
+      setIsEditing(true)
+    }
+
+    const handleCancelEdit = () => {
+      setEditText(userMessageText)
+      setIsEditing(false)
+    }
+
+    const handleSaveEdit = async () => {
+      if (!canSaveEdit) {
+        return
+      }
+
+      setIsSavingEdit(true)
+      try {
+        await onEditMessage?.(index, editText)
+        setIsEditing(false)
+      } finally {
+        setIsSavingEdit(false)
+      }
+    }
+
     return (
       <div className='message mt-2 text-right'>
         <div className='group'>
-          <div className='inline-block whitespace-pre-wrap break-all rounded-t-3xl rounded-l-3xl bg-gray-100 px-4 py-2 text-left dark:bg-gray-600 dark:text-white'>
-            {typeof message.content === 'string'
-              ? message.content
-              : isImageContentArray(message.content) &&
-                message.content.map((value, contentIndex) => {
-                  return (
-                    <Fragment key={contentIndex}>
-                      <div>{value.type === 'text' && value.text}</div>
-                      {value.type === 'image_url' && (
-                        <div className='my-1 inline-flex flex-col items-start'>
-                          <img src={value.image_url.url} alt='upload-img' className='max-w-3xs border' />
-                          <ImageContextBadge
-                            sendImagesOnlyOnce={message.metadata.sendImagesOnlyOnce ?? sendImagesOnlyOnce}
-                          />
-                        </div>
-                      )}
-                    </Fragment>
-                  )
-                })}
+          <div className='inline-block max-w-full whitespace-pre-wrap break-all rounded-t-3xl rounded-l-3xl bg-gray-100 px-4 py-2 text-left dark:bg-gray-600 dark:text-white'>
+            {isEditing ? (
+              <textarea
+                aria-label='Edit message text'
+                value={editText}
+                rows={Math.min(Math.max(editText.split('\n').length, 2), 8)}
+                className='min-w-72 max-w-full resize-y rounded-lg border border-gray-300 bg-white px-3 py-2 text-gray-900 outline-none focus:border-primary-700 focus:ring-2 focus:ring-primary-200 dark:border-gray-500 dark:bg-gray-700 dark:text-gray-100 dark:focus:border-primary-500 dark:focus:ring-primary-800'
+                disabled={disabled || isSavingEdit}
+                onChange={(event) => setEditText(event.currentTarget.value)}
+              />
+            ) : typeof message.content === 'string' ? (
+              message.content
+            ) : (
+              isImageContentArray(message.content) &&
+              message.content.map((value, contentIndex) => {
+                return (
+                  <Fragment key={contentIndex}>
+                    <div>{value.type === 'text' && value.text}</div>
+                    {value.type === 'image_url' && (
+                      <div className='my-1 inline-flex flex-col items-start'>
+                        <img src={value.image_url.url} alt='upload-img' className='max-w-3xs border' />
+                        <ImageContextBadge
+                          sendImagesOnlyOnce={message.metadata.sendImagesOnlyOnce ?? sendImagesOnlyOnce}
+                        />
+                      </div>
+                    )}
+                  </Fragment>
+                )
+              })
+            )}
           </div>
           <MessageActionBar copied={copied} disabled={disabled} align='right'>
-            <CopyMessageButton
-              copied={copied}
-              onClick={() => onCopyMessage(typeof message.content === 'string' ? message.content : '', index)}
-            />
-            <button
-              type='button'
-              className='flex h-8 w-8 cursor-pointer items-center justify-center rounded-full text-gray-500 transition-[background-color,color] duration-200 ease-out hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white dark:focus-visible:ring-gray-500'
-              onClick={() => onDeleteMessage?.(index)}
-              aria-label='Delete message'
-            >
-              <DeleteIcon size={20} />
-            </button>
+            {isEditing ? (
+              <>
+                <button
+                  type='button'
+                  className='flex h-8 w-8 cursor-pointer items-center justify-center rounded-full text-gray-500 transition-[background-color,color] duration-200 ease-out hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 disabled:cursor-default disabled:opacity-50 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white dark:focus-visible:ring-gray-500'
+                  onClick={handleSaveEdit}
+                  disabled={!canSaveEdit}
+                  aria-label='Save edited message'
+                >
+                  <CheckIcon size={20} className='stroke-current' />
+                </button>
+                <button
+                  type='button'
+                  className='flex h-8 w-8 cursor-pointer items-center justify-center rounded-full text-gray-500 transition-[background-color,color] duration-200 ease-out hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 disabled:cursor-default disabled:opacity-50 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white dark:focus-visible:ring-gray-500'
+                  onClick={handleCancelEdit}
+                  disabled={isSavingEdit}
+                  aria-label='Cancel editing message'
+                >
+                  <CloseIcon size={20} className='fill-current' />
+                </button>
+              </>
+            ) : (
+              <>
+                <CopyMessageButton copied={copied} onClick={() => onCopyMessage(userMessageText, index)} />
+                <button
+                  type='button'
+                  className='flex h-8 w-8 cursor-pointer items-center justify-center rounded-full text-gray-500 transition-[background-color,color] duration-200 ease-out hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white dark:focus-visible:ring-gray-500'
+                  onClick={handleStartEdit}
+                  aria-label='Edit message'
+                >
+                  <EditIcon size={20} className='stroke-current' />
+                </button>
+                <button
+                  type='button'
+                  className='flex h-8 w-8 cursor-pointer items-center justify-center rounded-full text-gray-500 transition-[background-color,color] duration-200 ease-out hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white dark:focus-visible:ring-gray-500'
+                  onClick={() => onDeleteMessage?.(index)}
+                  aria-label='Delete message'
+                >
+                  <DeleteIcon size={20} />
+                </button>
+              </>
+            )}
           </MessageActionBar>
         </div>
       </div>
@@ -270,5 +346,6 @@ export const MessageRenderer = memo(
     prevProps.onCodeBlockOpenChange === nextProps.onCodeBlockOpenChange &&
     prevProps.onCopyMessage === nextProps.onCopyMessage &&
     prevProps.onDeleteMessage === nextProps.onDeleteMessage &&
+    prevProps.onEditMessage === nextProps.onEditMessage &&
     prevProps.onSaveGeneratedFile === nextProps.onSaveGeneratedFile
 )

--- a/projects/portfolio/src/client/components/chat/message-renderer.tsx
+++ b/projects/portfolio/src/client/components/chat/message-renderer.tsx
@@ -20,7 +20,7 @@ import { DeleteIcon } from '#/client/components/svg/delete-icon'
 import { EditIcon } from '#/client/components/svg/edit-icon'
 import type { GeneratedCodeFile, Message } from '#/types'
 import { isImageContentArray } from '#/types'
-import { Fragment, memo, type ReactNode, useRef, useState } from 'react'
+import { Fragment, memo, type ReactNode, useEffect, useRef, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkCjkFriendly from 'remark-cjk-friendly'
 import remarkCjkFriendlyGfmStrikethrough from 'remark-cjk-friendly-gfm-strikethrough'
@@ -152,6 +152,17 @@ function MessageRendererComponent({
   const [editText, setEditText] = useState(() => (message.role === 'user' ? getUserMessageText(message) : ''))
   const [isSavingEdit, setIsSavingEdit] = useState(false)
 
+  useEffect(() => {
+    if (!isEditing || !disabled) {
+      return
+    }
+
+    if (message.role === 'user') {
+      setEditText(getUserMessageText(message))
+    }
+    setIsEditing(false)
+  }, [disabled, isEditing, message])
+
   if (message.role === 'system') {
     return null
   }
@@ -175,10 +186,10 @@ function MessageRendererComponent({
         return
       }
 
+      setIsEditing(false)
       setIsSavingEdit(true)
       try {
         await onEditMessage?.(index, editText)
-        setIsEditing(false)
       } finally {
         setIsSavingEdit(false)
       }

--- a/projects/portfolio/src/client/components/svg/edit-icon.tsx
+++ b/projects/portfolio/src/client/components/svg/edit-icon.tsx
@@ -1,0 +1,22 @@
+import { type IconProps, SvgIcon } from './icon-base'
+
+export function EditIcon({ size = 24, className = 'stroke-black dark:stroke-white' }: IconProps) {
+  return (
+    <SvgIcon size={size} title='edit-icon'>
+      <path
+        d='M4 20H8L18.5 9.5C19.3284 8.67157 19.3284 7.32843 18.5 6.5L17.5 5.5C16.6716 4.67157 15.3284 4.67157 14.5 5.5L4 16V20Z'
+        className={className}
+        strokeWidth='1.5'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+      />
+      <path
+        d='M13.5 6.5L17.5 10.5'
+        className={className}
+        strokeWidth='1.5'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+      />
+    </SvgIcon>
+  )
+}

--- a/projects/portfolio/tests/client/components/chat-main.test.tsx
+++ b/projects/portfolio/tests/client/components/chat-main.test.tsx
@@ -216,4 +216,50 @@ describe('ChatMain', () => {
       )
     })
   })
+
+  it('非インタラクティブモードの編集時は送信対象を編集中メッセージに絞る', async () => {
+    const conversation: Conversation = {
+      ...currentConversation,
+      messages: [
+        createUserMessage('message-1', '最初の質問'),
+        createAssistantMessage('message-2', '最初の回答'),
+        createUserMessage('message-3', '次の質問'),
+        createAssistantMessage('message-4', '次の回答'),
+      ],
+    }
+    const onConversationChange = vi.fn()
+    const { ChatMain } = await import('#/client/components/chat/chat-main')
+
+    render(
+      <ChatMain
+        settings={{ ...settings, interactiveMode: false }}
+        currentConversation={conversation}
+        onConversationChange={onConversationChange}
+      />
+    )
+
+    await waitFor(() => {
+      expect(chatMessageListProps?.onEditMessage).toBeTypeOf('function')
+    })
+    const onEditMessage = chatMessageListProps?.onEditMessage as (index: number, nextText: string) => Promise<void>
+    await onEditMessage(2, '編集した次の質問')
+
+    expect(submitChatCompletionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: [{ role: 'user', content: '編集した次の質問' }],
+      })
+    )
+    await waitFor(() => {
+      expect(onConversationChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messages: [
+            expect.objectContaining({ id: 'message-1', role: 'user', content: '最初の質問' }),
+            expect.objectContaining({ id: 'message-2', role: 'assistant', content: '最初の回答' }),
+            expect.objectContaining({ id: 'message-3', role: 'user', content: '編集した次の質問' }),
+            expect.objectContaining({ role: 'assistant', content: '編集後の回答' }),
+          ],
+        })
+      )
+    })
+  })
 })

--- a/projects/portfolio/tests/client/components/chat-main.test.tsx
+++ b/projects/portfolio/tests/client/components/chat-main.test.tsx
@@ -7,13 +7,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const useMessageScrollMock = vi.fn()
 const scrollToMessageEndMock = vi.fn()
+const submitChatCompletionMock = vi.fn()
+let chatMessageListProps: Record<string, unknown> | null = null
 
 vi.mock('#/client/components/chat/chat-input', () => ({
   ChatInput: () => <div data-testid='chat-input' />,
 }))
 
 vi.mock('#/client/components/chat/chat-message-list', () => ({
-  ChatMessageList: () => <div data-testid='chat-message-list' />,
+  ChatMessageList: (props: Record<string, unknown>) => {
+    chatMessageListProps = props
+    return <div data-testid='chat-message-list' />
+  },
 }))
 
 vi.mock('#/client/components/chat/hooks/use-chat-form', () => ({
@@ -47,7 +52,7 @@ vi.mock('#/client/components/chat/hooks/use-stream-processor', () => ({
     loading: false,
     stream: null,
     cancelStream: vi.fn(),
-    submitChatCompletion: vi.fn(),
+    submitChatCompletion: submitChatCompletionMock,
   }),
 }))
 
@@ -112,6 +117,23 @@ const settings: Settings = {
 
 describe('ChatMain', () => {
   beforeEach(() => {
+    chatMessageListProps = null
+    submitChatCompletionMock.mockResolvedValue({
+      result: {
+        message: {
+          content: '編集後の回答',
+          reasoningContent: '',
+        },
+        model: 'gpt-test',
+        finishReason: 'stop',
+        usage: {
+          promptTokens: 1,
+          completionTokens: 2,
+          totalTokens: 3,
+        },
+      },
+      responseTimeMs: 123,
+    })
     useMessageScrollMock.mockReturnValue({
       scrollContainerRef: { current: null },
       bottomChatInputContainerRef: { current: null },
@@ -156,5 +178,42 @@ describe('ChatMain', () => {
     fireEvent.click(button)
 
     expect(scrollToMessageEndMock).toHaveBeenCalledWith('smooth')
+  })
+
+  it('ユーザーメッセージ編集時は後続履歴を切り捨てて再生成結果を保存する', async () => {
+    const onConversationChange = vi.fn()
+    const { ChatMain } = await import('#/client/components/chat/chat-main')
+
+    render(
+      <ChatMain
+        settings={settings}
+        currentConversation={currentConversation}
+        onConversationChange={onConversationChange}
+      />
+    )
+
+    await waitFor(() => {
+      expect(chatMessageListProps?.onEditMessage).toBeTypeOf('function')
+    })
+    const onEditMessage = chatMessageListProps?.onEditMessage as (index: number, nextText: string) => Promise<void>
+    await onEditMessage(0, '編集した質問')
+
+    expect(submitChatCompletionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: [{ role: 'user', content: '編集した質問' }],
+      })
+    )
+    await waitFor(() => {
+      expect(onConversationChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'conversation-1',
+          title: '会話',
+          messages: [
+            expect.objectContaining({ id: 'message-1', role: 'user', content: '編集した質問' }),
+            expect.objectContaining({ role: 'assistant', content: '編集後の回答' }),
+          ],
+        })
+      )
+    })
   })
 })

--- a/projects/portfolio/tests/client/components/edit-message.test.ts
+++ b/projects/portfolio/tests/client/components/edit-message.test.ts
@@ -1,5 +1,10 @@
-import { buildEditedHistory, getUserMessageText, prepareApiMessages } from '#/client/components/chat/edit-message'
-import type { AssistantMessage, Message, UserMessage } from '#/types'
+import {
+  buildEditedHistory,
+  buildEditedSendMessages,
+  getUserMessageText,
+  prepareApiMessages,
+} from '#/client/components/chat/edit-message'
+import type { AssistantMessage, Message, SystemMessage, UserMessage } from '#/types'
 import { describe, expect, it } from 'vitest'
 
 const createUserMessage = (id: string, content: UserMessage['content']): UserMessage => ({
@@ -14,6 +19,12 @@ const createAssistantMessage = (id: string, content: string): AssistantMessage =
   role: 'assistant',
   content,
   metadata: { model: 'gpt-test', usage: {} },
+})
+
+const createSystemMessage = (id: string, content: string): SystemMessage => ({
+  id,
+  role: 'system',
+  content,
 })
 
 describe('edit-message', () => {
@@ -58,6 +69,34 @@ describe('edit-message', () => {
 
       expect(buildEditedHistory(messages, 0, 'edited')).toBeNull()
       expect(buildEditedHistory([createUserMessage('user-1', 'before')], 0, '   ')).toBeNull()
+    })
+  })
+
+  describe('buildEditedSendMessages', () => {
+    it('インタラクティブモードでは編集済み履歴全体を送る', () => {
+      const messages: Message[] = [
+        createUserMessage('user-1', 'first'),
+        createAssistantMessage('assistant-1', 'answer'),
+        createUserMessage('user-2', 'second'),
+      ]
+
+      expect(buildEditedSendMessages(messages, 'user-2', true)).toEqual(messages)
+    })
+
+    it('非インタラクティブモードでは編集中ユーザーメッセージだけを送る', () => {
+      const messages: Message[] = [
+        createUserMessage('user-1', 'first'),
+        createAssistantMessage('assistant-1', 'answer'),
+        createUserMessage('user-2', 'second'),
+      ]
+
+      expect(buildEditedSendMessages(messages, 'user-2', false)).toEqual([messages[2]])
+    })
+
+    it('非インタラクティブモードでも system prefix だけが前にある場合は保持する', () => {
+      const messages: Message[] = [createSystemMessage('system-1', 'prompt'), createUserMessage('user-1', 'first')]
+
+      expect(buildEditedSendMessages(messages, 'user-1', false)).toEqual(messages)
     })
   })
 

--- a/projects/portfolio/tests/client/components/edit-message.test.ts
+++ b/projects/portfolio/tests/client/components/edit-message.test.ts
@@ -1,0 +1,103 @@
+import { buildEditedHistory, getUserMessageText, prepareApiMessages } from '#/client/components/chat/edit-message'
+import type { AssistantMessage, Message, UserMessage } from '#/types'
+import { describe, expect, it } from 'vitest'
+
+const createUserMessage = (id: string, content: UserMessage['content']): UserMessage => ({
+  id,
+  role: 'user',
+  content,
+  metadata: { model: 'gpt-test' },
+})
+
+const createAssistantMessage = (id: string, content: string): AssistantMessage => ({
+  id,
+  role: 'assistant',
+  content,
+  metadata: { model: 'gpt-test', usage: {} },
+})
+
+describe('edit-message', () => {
+  describe('buildEditedHistory', () => {
+    it('対象ユーザーメッセージ以降を切り捨てる', () => {
+      const messages: Message[] = [
+        createUserMessage('user-1', 'first'),
+        createAssistantMessage('assistant-1', 'answer'),
+        createUserMessage('user-2', 'second'),
+      ]
+
+      expect(buildEditedHistory(messages, 0, 'edited')).toEqual([
+        expect.objectContaining({
+          id: 'user-1',
+          role: 'user',
+          content: 'edited',
+        }),
+      ])
+    })
+
+    it('画像付きメッセージは画像を保持してテキストだけ差し替える', () => {
+      const messages: Message[] = [
+        createUserMessage('user-1', [
+          { type: 'text', text: 'before' },
+          { type: 'image_url', image_url: { url: 'data:image/png;base64,xxx' } },
+        ]),
+        createAssistantMessage('assistant-1', 'answer'),
+      ]
+
+      expect(buildEditedHistory(messages, 0, 'after')).toEqual([
+        expect.objectContaining({
+          content: [
+            { type: 'text', text: 'after' },
+            { type: 'image_url', image_url: { url: 'data:image/png;base64,xxx' } },
+          ],
+        }),
+      ])
+    })
+
+    it('空文字やユーザー以外は編集結果を作らない', () => {
+      const messages: Message[] = [createAssistantMessage('assistant-1', 'answer')]
+
+      expect(buildEditedHistory(messages, 0, 'edited')).toBeNull()
+      expect(buildEditedHistory([createUserMessage('user-1', 'before')], 0, '   ')).toBeNull()
+    })
+  })
+
+  describe('prepareApiMessages', () => {
+    it('過去画像は送信対象から外し、編集中メッセージの画像は保持する', () => {
+      const messages: Message[] = [
+        createUserMessage('user-1', [
+          { type: 'text', text: 'old' },
+          { type: 'image_url', image_url: { url: 'old-image' } },
+        ]),
+        createUserMessage('user-2', [
+          { type: 'text', text: 'current' },
+          { type: 'image_url', image_url: { url: 'current-image' } },
+        ]),
+      ]
+
+      expect(prepareApiMessages(messages, 'user-2', true)).toEqual([
+        { role: 'user', content: [{ type: 'text', text: 'old' }] },
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'current' },
+            { type: 'image_url', image_url: { url: 'current-image' } },
+          ],
+        },
+      ])
+    })
+  })
+
+  describe('getUserMessageText', () => {
+    it('配列コンテンツからテキストだけを取り出す', () => {
+      expect(
+        getUserMessageText(
+          createUserMessage('user-1', [
+            { type: 'text', text: 'first' },
+            { type: 'image_url', image_url: { url: 'image' } },
+            { type: 'text', text: 'second' },
+          ])
+        )
+      ).toBe('first\nsecond')
+    })
+  })
+})

--- a/projects/portfolio/tests/client/components/message-renderer.test.tsx
+++ b/projects/portfolio/tests/client/components/message-renderer.test.tsx
@@ -2,7 +2,7 @@
 
 import { MessageRenderer } from '#/client/components/chat/message-renderer'
 import type { AssistantMessage, UserMessage } from '#/types'
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('react-syntax-highlighter', () => ({
@@ -35,6 +35,77 @@ function createAssistantMessage(
 }
 
 describe('MessageRenderer', () => {
+  describe('ユーザーメッセージ編集', () => {
+    const userMessage: UserMessage = {
+      id: 'user-1',
+      role: 'user',
+      content: '修正前',
+      metadata: { model: 'gpt-test' },
+    }
+
+    it('保存クリック直後に編集表示を閉じる', async () => {
+      const onEditMessage = vi.fn(() => new Promise<void>(() => undefined))
+
+      render(
+        <MessageRenderer
+          message={userMessage}
+          index={0}
+          messages={[userMessage]}
+          conversationId='conversation-1'
+          markdownPreview={true}
+          copied={false}
+          onCopyMessage={vi.fn()}
+          onEditMessage={onEditMessage}
+        />
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: 'Edit message' }))
+      fireEvent.change(screen.getByLabelText('Edit message text'), { target: { value: '修正後' } })
+      fireEvent.click(screen.getByRole('button', { name: 'Save edited message' }))
+
+      await waitFor(() => {
+        expect(screen.queryByLabelText('Edit message text')).toBeNull()
+      })
+      expect(onEditMessage).toHaveBeenCalledWith(0, '修正後')
+    })
+
+    it('チャット送信開始などで無効化されたら編集表示を閉じる', async () => {
+      const { rerender } = render(
+        <MessageRenderer
+          message={userMessage}
+          index={0}
+          messages={[userMessage]}
+          conversationId='conversation-1'
+          markdownPreview={true}
+          copied={false}
+          onCopyMessage={vi.fn()}
+          onEditMessage={vi.fn()}
+        />
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: 'Edit message' }))
+      expect(screen.getByLabelText('Edit message text')).toBeTruthy()
+
+      rerender(
+        <MessageRenderer
+          message={userMessage}
+          index={0}
+          messages={[userMessage]}
+          conversationId='conversation-1'
+          markdownPreview={true}
+          copied={false}
+          disabled={true}
+          onCopyMessage={vi.fn()}
+          onEditMessage={vi.fn()}
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.queryByLabelText('Edit message text')).toBeNull()
+      })
+    })
+  })
+
   describe('画像コンテキスト表示', () => {
     const renderUserMessage = (message: UserMessage, sendImagesOnlyOnce: boolean) =>
       render(


### PR DESCRIPTION
## Issues

- Close #882

## Why

投稿済みユーザーメッセージの入力ミスや前提変更を、同じ会話内で線形履歴として編集・再生成できるようにするため。

## Summary

チャット画面でユーザーメッセージだけを編集できるようにし、保存時に対象メッセージ以降の履歴を切り捨ててAI応答を再生成します。

## Changes

- ユーザーメッセージの編集ボタン、編集 textarea、保存/キャンセル操作を追加
- 編集保存時に履歴を切り捨て、既存の chat completion と conversation upsert 経由で保存
- 画像付きメッセージの画像と metadata を保持し、テキストだけを差し替える編集ヘルパーを追加
- 編集ロジックと ChatMain の再生成保存フローのテストを追加

## Verification

- `bun run format` - passed
- `bun run test tests/client/components/edit-message.test.ts tests/client/components/chat-main.test.tsx tests/client/components/chat-message-list.test.tsx` - passed
- `bun run test` - passed
- `bun run lint` - passed
