### PR TITLE
feat: add streaming chat sessions

### DIFF
--- a/projects/portfolio/.env.example
+++ b/projects/portfolio/.env.example
@@ -7,6 +7,9 @@ COOKIE_NAME=sid
 COOKIE_EXPIRES=1d
 DATABASE_URL=postgresql://{{ user }}:{{ password }}@localhost:5432/{{ database }}
 CHAT_CONVERSATION_ENABLED=TRUE
+CHAT_CACHE_URL=
+CHAT_SESSION_TTL_SECONDS=1800
+CHAT_DISCONNECT_GRACE_MS=30000
 
 # File-server 連携（assistant 生成コードの保存先）。
 # AUTH_DIR 有効時のみ動作。空なら連携を無効化する。

--- a/projects/portfolio/DEVELOPMENT.md
+++ b/projects/portfolio/DEVELOPMENT.md
@@ -54,6 +54,12 @@ bun run test:coverage
 bun run typegen
 ```
 
+## Chat Session Config
+
+- `CHAT_CACHE_URL`: 将来の Redis 互換 Cache 接続先です。未設定時はプロセス内 InMemory Cache を使います。
+- `CHAT_SESSION_TTL_SECONDS`: terminal 後にチャットセッションを Cache に残す秒数です。未ログイン session はこの TTL 後に破棄されます。
+- `CHAT_DISCONNECT_GRACE_MS`: SSE 切断後、再接続を待って生成を継続する猶予時間です。猶予超過かつ購読者なしの場合は生成をキャンセルします。
+
 ### Build
 
 ```sh

--- a/projects/portfolio/src/client/components/chat/chat-main.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-main.tsx
@@ -19,6 +19,7 @@ import { StopIcon } from '#/client/components/svg/stop-icon'
 import { UploadIcon } from '#/client/components/svg/upload-icon'
 import type { Settings } from '#/client/storage/remote-storage-settings'
 import type { Conversation, GeneratedCodeFile, Message } from '#/types'
+import type { ChatResponse } from '#/types/chat-api'
 import { type FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { uuidv7 } from 'uuidv7'
 
@@ -45,20 +46,74 @@ export function ChatMain({
 }: Props) {
   const formRef = useRef<HTMLFormElement>(null)
   const prevConversationIdRef = useRef<string | null>(null)
+  const sessionOwnedSnapshotRef = useRef<{ conversationId: string; messageIds: string[] } | null>(null)
 
   const [conversationId, setConversationId] = useState<string | null>(null)
   const [messages, setMessages] = useState<Message[]>([])
   const [isSavingConversation, setIsSavingConversation] = useState(false)
   const [streamMessageId, setStreamMessageId] = useState<string | null>(null)
   const resumeStartedRef = useRef(false)
+  const markSessionOwnedSnapshot = useCallback((conversation: Pick<Conversation, 'id' | 'messages'>) => {
+    sessionOwnedSnapshotRef.current = {
+      conversationId: conversation.id,
+      messageIds: conversation.messages.map(({ id }) => id).filter((id): id is string => !!id),
+    }
+  }, [])
   const handleSessionConversation = useCallback((conversation: Conversation, assistantMessageId: string) => {
+    markSessionOwnedSnapshot(conversation)
     setConversationId(conversation.id)
     setMessages(conversation.messages)
     setStreamMessageId(assistantMessageId)
-  }, [])
+  }, [markSessionOwnedSnapshot])
+  const buildAssistantMessage = useCallback(
+    (assistantMessageId: string, result: ChatResponse, responseTimeMs: number): Message => ({
+      id: assistantMessageId,
+      role: 'assistant' as const,
+      content: result.message.content,
+      reasoningContent: result.message.reasoningContent,
+      metadata: {
+        model: result.model,
+        apiMode: settings.apiMode,
+        finishReason: result.finishReason,
+        responseTimeMs,
+        usage: {
+          promptTokens: result.usage?.promptTokens || 0,
+          completionTokens: result.usage?.completionTokens || 0,
+          totalTokens: result.usage?.totalTokens || 0,
+          reasoningTokens: result.usage?.reasoningTokens,
+        },
+      },
+    }),
+    [settings.apiMode]
+  )
+  const handleSessionResult = useCallback(
+    ({
+      conversation,
+      assistantMessageId,
+      result,
+    }: {
+      conversation: Conversation
+      assistantMessageId: string
+      result: ChatResponse | null
+    }) => {
+      if (!result) return
+
+      const assistantMessage = buildAssistantMessage(assistantMessageId, result, 0)
+      const finalMessages = [...conversation.messages, assistantMessage]
+      markSessionOwnedSnapshot({
+        id: conversation.id,
+        messages: finalMessages,
+      })
+      setConversationId(conversation.id)
+      setMessages(finalMessages)
+      setStreamMessageId(null)
+    },
+    [buildAssistantMessage, markSessionOwnedSnapshot]
+  )
   const { loading, stream, cancelStream, submitChatCompletion, resumeActiveChatCompletion } = useStreamProcessor({
     onSubmitting,
     onSessionConversation: handleSessionConversation,
+    onSessionResult: handleSessionResult,
   })
   const {
     input,
@@ -88,6 +143,7 @@ export function ChatMain({
   })
 
   useEffect(() => {
+    sessionOwnedSnapshotRef.current = null
     setMessages([])
     setConversationId(null)
     setStreamMessageId(null)
@@ -104,31 +160,19 @@ export function ChatMain({
       if (!mounted || !resumed?.conversation) return
 
       const assistantMessage = resumed.result
-        ? {
-            id: resumed.assistantMessageId,
-            role: 'assistant' as const,
-            content: resumed.result.message.content,
-            reasoningContent: resumed.result.message.reasoningContent,
-            metadata: {
-              model: resumed.result.model,
-              apiMode: settings.apiMode,
-              finishReason: resumed.result.finishReason,
-              responseTimeMs: resumed.responseTimeMs,
-              usage: {
-                promptTokens: resumed.result.usage?.promptTokens || 0,
-                completionTokens: resumed.result.usage?.completionTokens || 0,
-                totalTokens: resumed.result.usage?.totalTokens || 0,
-                reasoningTokens: resumed.result.usage?.reasoningTokens,
-              },
-            },
-          }
+        ? buildAssistantMessage(resumed.assistantMessageId, resumed.result, resumed.responseTimeMs)
         : null
       const finalMessages = assistantMessage
         ? [...resumed.conversation.messages, assistantMessage]
         : resumed.conversation.messages
 
+      markSessionOwnedSnapshot({
+        id: resumed.conversation.id,
+        messages: finalMessages,
+      })
       setConversationId(resumed.conversation.id)
       setMessages(finalMessages)
+      setStreamMessageId(null)
 
       if (assistantMessage) {
         await onConversationChange?.({
@@ -141,12 +185,24 @@ export function ChatMain({
     return () => {
       mounted = false
     }
-  }, [onConversationChange, resumeActiveChatCompletion, settings.apiMode])
+  }, [buildAssistantMessage, markSessionOwnedSnapshot, onConversationChange, resumeActiveChatCompletion])
 
   // 選択された会話のメッセージを設定
   useEffect(() => {
     if (!currentConversation) {
       return
+    }
+
+    const sessionOwnedSnapshot = sessionOwnedSnapshotRef.current
+    if (sessionOwnedSnapshot) {
+      if (currentConversation.id === sessionOwnedSnapshot.conversationId) {
+        const currentMessageIds = new Set(currentConversation.messages.map(({ id }) => id).filter(Boolean))
+        const hasCaughtUp = sessionOwnedSnapshot.messageIds.every((id) => currentMessageIds.has(id))
+        if (!hasCaughtUp) {
+          return
+        }
+      }
+      sessionOwnedSnapshotRef.current = null
     }
 
     // 会話が選択された時、そのメッセージをドメイン型のまま設定（変換不要）
@@ -206,6 +262,7 @@ export function ChatMain({
             : '',
         messages: nextMessages,
       }
+      markSessionOwnedSnapshot(draftConversation)
       setConversationId(currentConversationId)
       setMessages(nextMessages)
       setStreamMessageId(assistantMessageId)
@@ -254,6 +311,10 @@ export function ChatMain({
             : null
 
           const finalMessages: Message[] = assistantMessage ? [...nextMessages, assistantMessage] : nextMessages
+          markSessionOwnedSnapshot({
+            id: currentConversationId,
+            messages: finalMessages,
+          })
           setMessages(finalMessages)
 
           // 親コンポーネントに更新されたメッセージを通知（ドメイン型をそのまま渡す）
@@ -276,6 +337,7 @@ export function ChatMain({
       buildChatMessages,
       conversationId,
       messages,
+      markSessionOwnedSnapshot,
       onConversationChange,
       resetAfterSubmit,
       settings.apiKey,
@@ -374,6 +436,7 @@ export function ChatMain({
         title: currentConversation?.title ?? nextText.trim().slice(0, CONVERSATION_TITLE_MAX_LENGTH),
         messages: editedMessages,
       }
+      markSessionOwnedSnapshot(draftConversation)
       setConversationId(draftConversationId)
       setMessages(editedMessages)
       setStreamMessageId(assistantMessageId)
@@ -419,6 +482,10 @@ export function ChatMain({
           : null
 
         const finalMessages = assistantMessage ? [...editedMessages, assistantMessage] : editedMessages
+        markSessionOwnedSnapshot({
+          id: draftConversationId,
+          messages: finalMessages,
+        })
         setMessages(finalMessages)
 
         setIsSavingConversation(true)
@@ -440,6 +507,7 @@ export function ChatMain({
       currentConversation?.title,
       isSavingConversation,
       loading,
+      markSessionOwnedSnapshot,
       messages,
       onConversationChange,
       settings.apiKey,

--- a/projects/portfolio/src/client/components/chat/chat-main.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-main.tsx
@@ -59,12 +59,15 @@ export function ChatMain({
       messageIds: conversation.messages.map(({ id }) => id).filter((id): id is string => !!id),
     }
   }, [])
-  const handleSessionConversation = useCallback((conversation: Conversation, assistantMessageId: string) => {
-    markSessionOwnedSnapshot(conversation)
-    setConversationId(conversation.id)
-    setMessages(conversation.messages)
-    setStreamMessageId(assistantMessageId)
-  }, [markSessionOwnedSnapshot])
+  const handleSessionConversation = useCallback(
+    (conversation: Conversation, assistantMessageId: string) => {
+      markSessionOwnedSnapshot(conversation)
+      setConversationId(conversation.id)
+      setMessages(conversation.messages)
+      setStreamMessageId(assistantMessageId)
+    },
+    [markSessionOwnedSnapshot]
+  )
   const buildAssistantMessage = useCallback(
     (assistantMessageId: string, result: ChatResponse, responseTimeMs: number): Message => ({
       id: assistantMessageId,

--- a/projects/portfolio/src/client/components/chat/chat-main.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-main.tsx
@@ -50,7 +50,7 @@ export function ChatMain({
   const [messages, setMessages] = useState<Message[]>([])
   const [isSavingConversation, setIsSavingConversation] = useState(false)
   const [streamMessageId, setStreamMessageId] = useState<string | null>(null)
-  const { loading, stream, cancelStream, submitChatCompletion } = useStreamProcessor({
+  const { loading, stream, cancelStream, submitChatCompletion, resumeActiveChatCompletion } = useStreamProcessor({
     onSubmitting,
   })
   const {
@@ -85,6 +85,62 @@ export function ChatMain({
     setConversationId(null)
     setStreamMessageId(null)
   }, [initTrigger])
+
+  useEffect(() => {
+    if (currentConversation || messages.length > 0 || loading) {
+      return
+    }
+
+    let mounted = true
+    void resumeActiveChatCompletion().then(async (resumed) => {
+      if (!mounted || !resumed?.conversation) return
+
+      const assistantMessage = resumed.result
+        ? {
+            id: resumed.assistantMessageId,
+            role: 'assistant' as const,
+            content: resumed.result.message.content,
+            reasoningContent: resumed.result.message.reasoningContent,
+            metadata: {
+              model: resumed.result.model,
+              apiMode: settings.apiMode,
+              finishReason: resumed.result.finishReason,
+              responseTimeMs: resumed.responseTimeMs,
+              usage: {
+                promptTokens: resumed.result.usage?.promptTokens || 0,
+                completionTokens: resumed.result.usage?.completionTokens || 0,
+                totalTokens: resumed.result.usage?.totalTokens || 0,
+                reasoningTokens: resumed.result.usage?.reasoningTokens,
+              },
+            },
+          }
+        : null
+      const finalMessages = assistantMessage
+        ? [...resumed.conversation.messages, assistantMessage]
+        : resumed.conversation.messages
+
+      setConversationId(resumed.conversation.id)
+      setMessages(finalMessages)
+
+      if (assistantMessage) {
+        await onConversationChange?.({
+          ...resumed.conversation,
+          messages: finalMessages,
+        })
+      }
+    })
+
+    return () => {
+      mounted = false
+    }
+  }, [
+    currentConversation,
+    loading,
+    messages.length,
+    onConversationChange,
+    resumeActiveChatCompletion,
+    settings.apiMode,
+  ])
 
   // 選択された会話のメッセージを設定
   useEffect(() => {
@@ -140,6 +196,16 @@ export function ChatMain({
           ? [...(params.systemMessage ? [params.systemMessage] : []), params.draftUserMessage]
           : [...messages, params.draftUserMessage]
       const assistantMessageId = uuidv7()
+      const currentConversationId = conversationId || uuidv7()
+      const draftConversation = {
+        id: currentConversationId,
+        title:
+          typeof params.draftUserMessage.content === 'string'
+            ? params.draftUserMessage.content.slice(0, CONVERSATION_TITLE_MAX_LENGTH)
+            : '',
+        messages: nextMessages,
+      }
+      setConversationId(currentConversationId)
       setMessages(nextMessages)
       setStreamMessageId(assistantMessageId)
       resetAfterSubmit()
@@ -153,6 +219,8 @@ export function ChatMain({
         model: params.model,
         messages: params.apiMessages,
         streamMode: settings.streamMode,
+        conversation: draftConversation,
+        assistantMessageId,
         temperature: form.temperature,
         maxTokens: form.maxTokens,
         reasoningEffort: settings.reasoningEffortEnabled ? settings.reasoningEffort : undefined,
@@ -186,15 +254,6 @@ export function ChatMain({
 
           const finalMessages: Message[] = assistantMessage ? [...nextMessages, assistantMessage] : nextMessages
           setMessages(finalMessages)
-
-          // 会話IDが指定されていない場合は会話IDを新規作成
-          const currentConversationId =
-            conversationId ||
-            (() => {
-              const newConversationId = uuidv7()
-              setConversationId(newConversationId)
-              return newConversationId
-            })()
 
           // 親コンポーネントに更新されたメッセージを通知（ドメイン型をそのまま渡す）
           setIsSavingConversation(true)
@@ -308,6 +367,13 @@ export function ChatMain({
       const sendMessages = buildEditedSendMessages(editedMessages, editedUserMessage.id, settings.includeChatHistory)
       const apiMessages = prepareApiMessages(sendMessages, editedUserMessage.id, settings.sendImagesOnlyOnce)
       const imageContext = summarizeImageContext(sendMessages, editedUserMessage.id, settings.sendImagesOnlyOnce)
+      const draftConversationId = conversationId || uuidv7()
+      const draftConversation = {
+        id: draftConversationId,
+        title: currentConversation?.title ?? nextText.trim().slice(0, CONVERSATION_TITLE_MAX_LENGTH),
+        messages: editedMessages,
+      }
+      setConversationId(draftConversationId)
       setMessages(editedMessages)
       setStreamMessageId(assistantMessageId)
 
@@ -321,6 +387,8 @@ export function ChatMain({
           model: settings.fakeMode ? 'fakemode' : settings.model,
           messages: apiMessages,
           streamMode: settings.streamMode,
+          conversation: draftConversation,
+          assistantMessageId,
           temperature: settings.temperatureEnabled ? settings.temperature : undefined,
           maxTokens: settings.maxTokens ? Number(settings.maxTokens) : undefined,
           reasoningEffort: settings.reasoningEffortEnabled ? settings.reasoningEffort : undefined,
@@ -352,14 +420,10 @@ export function ChatMain({
         const finalMessages = assistantMessage ? [...editedMessages, assistantMessage] : editedMessages
         setMessages(finalMessages)
 
-        if (!conversationId) {
-          return
-        }
-
         setIsSavingConversation(true)
         try {
           await onConversationChange?.({
-            id: conversationId,
+            id: draftConversationId,
             title: currentConversation?.title ?? nextText.trim().slice(0, CONVERSATION_TITLE_MAX_LENGTH),
             messages: finalMessages,
           })

--- a/projects/portfolio/src/client/components/chat/chat-main.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-main.tsx
@@ -10,7 +10,7 @@ import {
 import { useChatForm } from '#/client/components/chat/hooks/use-chat-form'
 import { useMessageCopy } from '#/client/components/chat/hooks/use-message-copy'
 import { useMessageScroll } from '#/client/components/chat/hooks/use-message-scroll'
-import { useStreamProcessor } from '#/client/components/chat/hooks/use-stream-processor'
+import { hasActiveChatSession, useStreamProcessor } from '#/client/components/chat/hooks/use-stream-processor'
 import { PromptTemplate, type TemplateInput } from '#/client/components/chat/prompt-template'
 import { FileImageInput, FileImagePreview } from '#/client/components/input/file-image-input'
 import { ArrowDownIcon } from '#/client/components/svg/arrow-down-icon'
@@ -50,13 +50,15 @@ export function ChatMain({
   const [messages, setMessages] = useState<Message[]>([])
   const [isSavingConversation, setIsSavingConversation] = useState(false)
   const [streamMessageId, setStreamMessageId] = useState<string | null>(null)
+  const resumeStartedRef = useRef(false)
+  const handleSessionConversation = useCallback((conversation: Conversation, assistantMessageId: string) => {
+    setConversationId(conversation.id)
+    setMessages(conversation.messages)
+    setStreamMessageId(assistantMessageId)
+  }, [])
   const { loading, stream, cancelStream, submitChatCompletion, resumeActiveChatCompletion } = useStreamProcessor({
     onSubmitting,
-    onSessionConversation: (conversation, assistantMessageId) => {
-      setConversationId(conversation.id)
-      setMessages(conversation.messages)
-      setStreamMessageId(assistantMessageId)
-    },
+    onSessionConversation: handleSessionConversation,
   })
   const {
     input,
@@ -92,10 +94,11 @@ export function ChatMain({
   }, [initTrigger])
 
   useEffect(() => {
-    if (currentConversation || messages.length > 0 || loading) {
+    if (resumeStartedRef.current || !hasActiveChatSession()) {
       return
     }
 
+    resumeStartedRef.current = true
     let mounted = true
     void resumeActiveChatCompletion().then(async (resumed) => {
       if (!mounted || !resumed?.conversation) return
@@ -138,14 +141,7 @@ export function ChatMain({
     return () => {
       mounted = false
     }
-  }, [
-    currentConversation,
-    loading,
-    messages.length,
-    onConversationChange,
-    resumeActiveChatCompletion,
-    settings.apiMode,
-  ])
+  }, [onConversationChange, resumeActiveChatCompletion, settings.apiMode])
 
   // 選択された会話のメッセージを設定
   useEffect(() => {

--- a/projects/portfolio/src/client/components/chat/chat-main.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-main.tsx
@@ -52,6 +52,11 @@ export function ChatMain({
   const [streamMessageId, setStreamMessageId] = useState<string | null>(null)
   const { loading, stream, cancelStream, submitChatCompletion, resumeActiveChatCompletion } = useStreamProcessor({
     onSubmitting,
+    onSessionConversation: (conversation, assistantMessageId) => {
+      setConversationId(conversation.id)
+      setMessages(conversation.messages)
+      setStreamMessageId(assistantMessageId)
+    },
   })
   const {
     input,

--- a/projects/portfolio/src/client/components/chat/hooks/use-stream-processor.ts
+++ b/projects/portfolio/src/client/components/chat/hooks/use-stream-processor.ts
@@ -27,9 +27,10 @@ interface SubmitChatCompletionParams {
 
 interface UseStreamProcessorParams {
   onSubmitting?: (submitting: boolean) => void
+  onSessionConversation?: (conversation: Conversation, assistantMessageId: string) => void
 }
 
-export function useStreamProcessor({ onSubmitting }: UseStreamProcessorParams = {}) {
+export function useStreamProcessor({ onSubmitting, onSessionConversation }: UseStreamProcessorParams = {}) {
   const abortControllerRef = useRef<AbortController | null>(null)
   const eventSourceRef = useRef<EventSource | null>(null)
   const activeSessionIdRef = useRef<string | null>(null)
@@ -82,6 +83,7 @@ export function useStreamProcessor({ onSubmitting }: UseStreamProcessorParams = 
               temperature,
               maxTokens,
               reasoningEffort,
+              onSessionConversation,
               onStream: (stream) => setStream(stream),
             })
           : await sendNonStreamCompletion({
@@ -122,6 +124,7 @@ export function useStreamProcessor({ onSubmitting }: UseStreamProcessorParams = 
         afterEventId: undefined,
         eventSourceRef,
         activeSessionIdRef,
+        onSessionConversation,
         onStream: (stream) => setStream(stream),
       })
       if (!result.conversation) return null
@@ -137,7 +140,7 @@ export function useStreamProcessor({ onSubmitting }: UseStreamProcessorParams = 
       setLoading(false)
       onSubmitting?.(false)
     }
-  }, [onSubmitting])
+  }, [onSessionConversation, onSubmitting])
 
   return {
     loading,
@@ -215,6 +218,7 @@ const sendStreamCompletion = async (
     assistantMessageId?: string
     eventSourceRef: MutableRefObject<EventSource | null>
     activeSessionIdRef: MutableRefObject<string | null>
+    onSessionConversation?: (conversation: Conversation, assistantMessageId: string) => void
     onStream?: (stream: ChatStreamState) => void
   }
 ): Promise<ChatResponse | null> => {
@@ -256,6 +260,7 @@ const sendStreamCompletion = async (
       sessionId: data.sessionId,
       eventSourceRef: req.eventSourceRef,
       activeSessionIdRef: req.activeSessionIdRef,
+      onSessionConversation: req.onSessionConversation,
       onStream: req.onStream,
     })
 
@@ -286,6 +291,7 @@ type ReceiveSessionEventsParams = {
   afterEventId?: string
   eventSourceRef: MutableRefObject<EventSource | null>
   activeSessionIdRef: MutableRefObject<string | null>
+  onSessionConversation?: (conversation: Conversation, assistantMessageId: string) => void
   onStream?: (stream: ChatStreamState) => void
 }
 
@@ -294,6 +300,7 @@ const receiveSessionEvents = ({
   afterEventId,
   eventSourceRef,
   activeSessionIdRef,
+  onSessionConversation,
   onStream,
 }: ReceiveSessionEventsParams): Promise<Omit<ResumeChatCompletionResult, 'responseTimeMs'>> =>
   new Promise((resolve, reject) => {
@@ -331,6 +338,7 @@ const receiveSessionEvents = ({
       if (sessionEvent.type === 'user_message') {
         conversation = sessionEvent.data.conversation
         assistantMessageId = sessionEvent.data.assistantMessageId
+        onSessionConversation?.(conversation, assistantMessageId)
         return
       }
 

--- a/projects/portfolio/src/client/components/chat/hooks/use-stream-processor.ts
+++ b/projects/portfolio/src/client/components/chat/hooks/use-stream-processor.ts
@@ -39,7 +39,11 @@ interface UseStreamProcessorParams {
   onSessionResult?: (result: Omit<ResumeChatCompletionResult, 'responseTimeMs'>) => void
 }
 
-export function useStreamProcessor({ onSubmitting, onSessionConversation, onSessionResult }: UseStreamProcessorParams = {}) {
+export function useStreamProcessor({
+  onSubmitting,
+  onSessionConversation,
+  onSessionResult,
+}: UseStreamProcessorParams = {}) {
   const abortControllerRef = useRef<AbortController | null>(null)
   const eventSourceRef = useRef<EventSource | null>(null)
   const activeSessionIdRef = useRef<string | null>(null)

--- a/projects/portfolio/src/client/components/chat/hooks/use-stream-processor.ts
+++ b/projects/portfolio/src/client/components/chat/hooks/use-stream-processor.ts
@@ -43,7 +43,7 @@ export function useStreamProcessor({ onSubmitting, onSessionConversation }: UseS
 
   const cancelStream = useCallback(() => {
     if (activeSessionIdRef.current) {
-      void fetch(`/api/chat/sessions/${activeSessionIdRef.current}/cancel`, { method: 'POST' })
+      void cancelChatSession(activeSessionIdRef.current)
     }
     eventSourceRef.current?.close()
     eventSourceRef.current = null
@@ -110,7 +110,7 @@ export function useStreamProcessor({ onSubmitting, onSessionConversation }: UseS
         onSubmitting?.(false)
       }
     },
-    [onSubmitting]
+    [onSessionConversation, onSubmitting]
   )
 
   const resumeActiveChatCompletion = useCallback(async (): Promise<ResumeChatCompletionResult | null> => {
@@ -118,6 +118,7 @@ export function useStreamProcessor({ onSubmitting, onSessionConversation }: UseS
     if (!activeSession) return null
 
     setLoading(true)
+    abortControllerRef.current = new AbortController()
     onSubmitting?.(true)
     activeSessionIdRef.current = activeSession.sessionId
     const requestStartTime = Date.now()
@@ -126,6 +127,7 @@ export function useStreamProcessor({ onSubmitting, onSessionConversation }: UseS
       const result = await receiveSessionEvents({
         sessionId: activeSession.sessionId,
         afterEventId: undefined,
+        abortSignal: abortControllerRef.current.signal,
         eventSourceRef,
         activeSessionIdRef,
         onSessionConversation,
@@ -138,6 +140,7 @@ export function useStreamProcessor({ onSubmitting, onSessionConversation }: UseS
         responseTimeMs: Date.now() - requestStartTime,
       }
     } finally {
+      abortControllerRef.current = null
       activeSessionIdRef.current = null
       eventSourceRef.current = null
       setStream(null)
@@ -231,25 +234,22 @@ const sendStreamCompletion = async (
   }
 
   try {
-    const res = await fetch('/api/chat/sessions', {
-      method: 'POST',
-      signal: req.abortController.signal,
-      headers: {
-        'content-type': 'application/json',
-        'api-key': req.header.apiKey,
-        'base-url': req.header.baseURL,
-      },
-      body: JSON.stringify({
-        conversation: req.conversation,
-        assistantMessageId: req.assistantMessageId,
-        messages: req.messages,
-        model: req.model,
-        apiMode: req.apiMode,
-        temperature: req.temperature,
-        maxTokens: req.maxTokens,
-        reasoningEffort: req.reasoningEffort,
-      }),
-    })
+    const res = await client.api.chat.sessions.$post(
+      {
+        header: buildChatHeaders(req.header),
+        json: {
+          conversation: req.conversation,
+          assistantMessageId: req.assistantMessageId,
+          messages: req.messages,
+          model: req.model,
+          apiMode: req.apiMode,
+          temperature: req.temperature,
+          maxTokens: req.maxTokens,
+          reasoningEffort: req.reasoningEffort,
+        },
+      } as never,
+      { init: { signal: req.abortController.signal } }
+    )
 
     if (!res.ok) {
       const error = (await res.json()) as { error?: string }
@@ -262,6 +262,7 @@ const sendStreamCompletion = async (
 
     const result = await receiveSessionEvents({
       sessionId: data.sessionId,
+      abortSignal: req.abortController.signal,
       eventSourceRef: req.eventSourceRef,
       activeSessionIdRef: req.activeSessionIdRef,
       onSessionConversation: req.onSessionConversation,
@@ -276,6 +277,27 @@ const sendStreamCompletion = async (
       throw error
     }
   }
+}
+
+const buildChatHeaders = ({ apiKey, baseURL }: SendCompletionParams['header']) => ({
+  'api-key': apiKey,
+  'base-url': baseURL,
+})
+
+async function cancelChatSession(sessionId: string): Promise<void> {
+  try {
+    await client.api.chat.sessions[':sessionId'].cancel.$post({
+      param: { sessionId },
+    } as never)
+  } catch {
+    // キャンセル時のネットワーク失敗は既存の AbortController 側でローカル停止する。
+  }
+}
+
+function buildChatSessionEventsUrl(sessionId: string, afterEventId?: string): string {
+  const url = new URL(`/api/chat/sessions/${encodeURIComponent(sessionId)}/events`, window.location.origin)
+  if (afterEventId) url.searchParams.set('afterEventId', afterEventId)
+  return url.toString()
 }
 
 type ActiveSession = {
@@ -293,6 +315,7 @@ type ResumeChatCompletionResult = {
 type ReceiveSessionEventsParams = {
   sessionId: string
   afterEventId?: string
+  abortSignal?: AbortSignal
   eventSourceRef: MutableRefObject<EventSource | null>
   activeSessionIdRef: MutableRefObject<string | null>
   onSessionConversation?: (conversation: Conversation, assistantMessageId: string) => void
@@ -302,6 +325,7 @@ type ReceiveSessionEventsParams = {
 const receiveSessionEvents = ({
   sessionId,
   afterEventId,
+  abortSignal,
   eventSourceRef,
   activeSessionIdRef,
   onSessionConversation,
@@ -317,16 +341,21 @@ const receiveSessionEvents = ({
     let usage: ChatUsage | null = null
     let conversation: Conversation | null = null
     let assistantMessageId = ''
+    let settled = false
 
-    const url = new URL(`/api/chat/sessions/${sessionId}/events`, window.location.origin)
-    if (afterEventId) url.searchParams.set('afterEventId', afterEventId)
-
-    const eventSource = new EventSource(url.toString())
+    const eventSource = new EventSource(buildChatSessionEventsUrl(sessionId, afterEventId))
     eventSourceRef.current = eventSource
 
-    const finish = (result: ChatResponse | null) => {
+    const cleanup = () => {
       eventSource.close()
       eventSourceRef.current = null
+      abortSignal?.removeEventListener('abort', handleAbort)
+    }
+
+    const finish = (result: ChatResponse | null) => {
+      if (settled) return
+      settled = true
+      cleanup()
       activeSessionIdRef.current = null
       clearActiveSession()
       resolve({
@@ -335,6 +364,23 @@ const receiveSessionEvents = ({
         result,
       })
     }
+
+    const fail = (error: unknown) => {
+      if (settled) return
+      settled = true
+      cleanup()
+      reject(error)
+    }
+
+    function handleAbort() {
+      finish(null)
+    }
+
+    if (abortSignal?.aborted) {
+      finish(null)
+      return
+    }
+    abortSignal?.addEventListener('abort', handleAbort, { once: true })
 
     const handleSessionEvent = (sessionEvent: ChatSessionEvent) => {
       saveActiveSession({ sessionId, lastEventId: sessionEvent.id })
@@ -397,8 +443,7 @@ const receiveSessionEvents = ({
       try {
         handleSessionEvent(ChatSessionEventSchema.parse(JSON.parse(message.data)))
       } catch (error) {
-        reject(error)
-        eventSource.close()
+        fail(error)
       }
     })
 
@@ -415,15 +460,13 @@ const receiveSessionEvents = ({
         try {
           handleSessionEvent(ChatSessionEventSchema.parse(JSON.parse(message.data)))
         } catch (error) {
-          reject(error)
-          eventSource.close()
+          fail(error)
         }
       })
     }
 
     eventSource.onerror = () => {
-      reject(new Error('Session event stream failed.'))
-      eventSource.close()
+      // EventSource は一時切断時も onerror 後に自動再接続するため、terminal event を待つ。
     }
   })
 
@@ -440,10 +483,7 @@ const sendLegacyStreamCompletion = async (
 
   const res = await client.api.chat.stream.$post(
     {
-      header: {
-        'api-key': req.header.apiKey,
-        'base-url': req.header.baseURL,
-      },
+      header: buildChatHeaders(req.header),
       json: {
         messages: req.messages,
         model: req.model,

--- a/projects/portfolio/src/client/components/chat/hooks/use-stream-processor.ts
+++ b/projects/portfolio/src/client/components/chat/hooks/use-stream-processor.ts
@@ -1,11 +1,12 @@
 import type { AppType } from '#/server/app.d'
-import type { ApiChatMessage, ApiMode } from '#/types'
-import type { ChatResponse, ChatUsage } from '#/types/chat-api'
+import type { ApiChatMessage, ApiMode, Conversation } from '#/types'
+import { ChatSessionEventSchema, type ChatResponse, type ChatSessionEvent, type ChatUsage } from '#/types/chat-api'
 import { hc } from 'hono/client'
-import { useCallback, useRef, useState } from 'react'
+import { type MutableRefObject, useCallback, useRef, useState } from 'react'
 import { type ChatStreamState, parseChatStreamEvent, updateChatStream } from './chat-response'
 
 const client = hc<AppType>('/')
+const ACTIVE_SESSION_STORAGE_KEY = 'portfolio.chat.activeSession'
 
 interface SubmitChatCompletionParams {
   header: {
@@ -17,6 +18,8 @@ interface SubmitChatCompletionParams {
   /** /api/chat wire 形式のメッセージ（toApiChatMessage で変換済み） */
   messages: ApiChatMessage[]
   streamMode: boolean
+  conversation?: Conversation
+  assistantMessageId?: string
   temperature?: number
   maxTokens?: number
   reasoningEffort?: 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'
@@ -28,14 +31,22 @@ interface UseStreamProcessorParams {
 
 export function useStreamProcessor({ onSubmitting }: UseStreamProcessorParams = {}) {
   const abortControllerRef = useRef<AbortController | null>(null)
+  const eventSourceRef = useRef<EventSource | null>(null)
+  const activeSessionIdRef = useRef<string | null>(null)
   const [loading, setLoading] = useState(false)
   const [stream, setStream] = useState<ChatStreamState | null>(null)
 
   const cancelStream = useCallback(() => {
+    if (activeSessionIdRef.current) {
+      void fetch(`/api/chat/sessions/${activeSessionIdRef.current}/cancel`, { method: 'POST' })
+    }
+    eventSourceRef.current?.close()
+    eventSourceRef.current = null
     if (abortControllerRef.current) {
       abortControllerRef.current.abort()
       abortControllerRef.current = null
     }
+    clearActiveSession()
   }, [])
 
   const submitChatCompletion = useCallback(
@@ -45,6 +56,8 @@ export function useStreamProcessor({ onSubmitting }: UseStreamProcessorParams = 
       model,
       messages,
       streamMode,
+      conversation,
+      assistantMessageId,
       temperature,
       maxTokens,
       reasoningEffort,
@@ -58,10 +71,14 @@ export function useStreamProcessor({ onSubmitting }: UseStreamProcessorParams = 
         const result = streamMode
           ? await sendStreamCompletion({
               abortController: abortControllerRef.current,
+              eventSourceRef,
+              activeSessionIdRef,
               header,
               apiMode,
               model,
               messages,
+              conversation,
+              assistantMessageId,
               temperature,
               maxTokens,
               reasoningEffort,
@@ -90,11 +107,44 @@ export function useStreamProcessor({ onSubmitting }: UseStreamProcessorParams = 
     [onSubmitting]
   )
 
+  const resumeActiveChatCompletion = useCallback(async (): Promise<ResumeChatCompletionResult | null> => {
+    const activeSession = readActiveSession()
+    if (!activeSession) return null
+
+    setLoading(true)
+    onSubmitting?.(true)
+    activeSessionIdRef.current = activeSession.sessionId
+    const requestStartTime = Date.now()
+
+    try {
+      const result = await receiveSessionEvents({
+        sessionId: activeSession.sessionId,
+        afterEventId: undefined,
+        eventSourceRef,
+        activeSessionIdRef,
+        onStream: (stream) => setStream(stream),
+      })
+      if (!result.conversation) return null
+
+      return {
+        ...result,
+        responseTimeMs: Date.now() - requestStartTime,
+      }
+    } finally {
+      activeSessionIdRef.current = null
+      eventSourceRef.current = null
+      setStream(null)
+      setLoading(false)
+      onSubmitting?.(false)
+    }
+  }, [onSubmitting])
+
   return {
     loading,
     stream,
     cancelStream,
     submitChatCompletion,
+    resumeActiveChatCompletion,
   }
 }
 
@@ -160,6 +210,212 @@ const sendNonStreamCompletion = async (req: SendCompletionParams): Promise<ChatR
 }
 
 const sendStreamCompletion = async (
+  req: SendCompletionParams & {
+    conversation?: Conversation
+    assistantMessageId?: string
+    eventSourceRef: MutableRefObject<EventSource | null>
+    activeSessionIdRef: MutableRefObject<string | null>
+    onStream?: (stream: ChatStreamState) => void
+  }
+): Promise<ChatResponse | null> => {
+  if (!req.conversation || !req.assistantMessageId) {
+    return sendLegacyStreamCompletion(req)
+  }
+
+  try {
+    const res = await fetch('/api/chat/sessions', {
+      method: 'POST',
+      signal: req.abortController.signal,
+      headers: {
+        'content-type': 'application/json',
+        'api-key': req.header.apiKey,
+        'base-url': req.header.baseURL,
+      },
+      body: JSON.stringify({
+        conversation: req.conversation,
+        assistantMessageId: req.assistantMessageId,
+        messages: req.messages,
+        model: req.model,
+        apiMode: req.apiMode,
+        temperature: req.temperature,
+        maxTokens: req.maxTokens,
+        reasoningEffort: req.reasoningEffort,
+      }),
+    })
+
+    if (!res.ok) {
+      const error = (await res.json()) as { error?: string }
+      return makeErrorResponse(error?.error || JSON.stringify(error))
+    }
+
+    const data = (await res.json()) as { sessionId: string }
+    saveActiveSession({ sessionId: data.sessionId })
+    req.activeSessionIdRef.current = data.sessionId
+
+    const result = await receiveSessionEvents({
+      sessionId: data.sessionId,
+      eventSourceRef: req.eventSourceRef,
+      activeSessionIdRef: req.activeSessionIdRef,
+      onStream: req.onStream,
+    })
+
+    return result.result
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      return null
+    } else {
+      throw error
+    }
+  }
+}
+
+type ActiveSession = {
+  sessionId: string
+  lastEventId?: string
+}
+
+type ResumeChatCompletionResult = {
+  conversation: Conversation
+  assistantMessageId: string
+  result: ChatResponse | null
+  responseTimeMs: number
+}
+
+type ReceiveSessionEventsParams = {
+  sessionId: string
+  afterEventId?: string
+  eventSourceRef: MutableRefObject<EventSource | null>
+  activeSessionIdRef: MutableRefObject<string | null>
+  onStream?: (stream: ChatStreamState) => void
+}
+
+const receiveSessionEvents = ({
+  sessionId,
+  afterEventId,
+  eventSourceRef,
+  activeSessionIdRef,
+  onStream,
+}: ReceiveSessionEventsParams): Promise<Omit<ResumeChatCompletionResult, 'responseTimeMs'>> =>
+  new Promise((resolve, reject) => {
+    let accumulated: ChatStreamState = { content: '', reasoningContent: '' }
+    let id = ''
+    let created = 0
+    let model = 'N/A'
+    let finishReason = ''
+    let receivedFinish = false
+    let usage: ChatUsage | null = null
+    let conversation: Conversation | null = null
+    let assistantMessageId = ''
+
+    const url = new URL(`/api/chat/sessions/${sessionId}/events`, window.location.origin)
+    if (afterEventId) url.searchParams.set('afterEventId', afterEventId)
+
+    const eventSource = new EventSource(url.toString())
+    eventSourceRef.current = eventSource
+
+    const finish = (result: ChatResponse | null) => {
+      eventSource.close()
+      eventSourceRef.current = null
+      activeSessionIdRef.current = null
+      clearActiveSession()
+      resolve({
+        conversation: conversation as Conversation,
+        assistantMessageId,
+        result,
+      })
+    }
+
+    const handleSessionEvent = (sessionEvent: ChatSessionEvent) => {
+      saveActiveSession({ sessionId, lastEventId: sessionEvent.id })
+
+      if (sessionEvent.type === 'user_message') {
+        conversation = sessionEvent.data.conversation
+        assistantMessageId = sessionEvent.data.assistantMessageId
+        return
+      }
+
+      if (sessionEvent.type === 'assistant_delta') {
+        accumulated = updateChatStream(accumulated, sessionEvent.data)
+        id = sessionEvent.data.id
+        created = sessionEvent.data.created
+        model = sessionEvent.data.model
+        onStream?.(accumulated)
+        return
+      }
+
+      if (sessionEvent.type === 'assistant_finish') {
+        finishReason = sessionEvent.data.finishReason
+        receivedFinish = true
+        return
+      }
+
+      if (sessionEvent.type === 'usage') {
+        usage = sessionEvent.data.usage
+        return
+      }
+
+      if (sessionEvent.type === 'cancelled') {
+        finish(null)
+        return
+      }
+
+      if (sessionEvent.type === 'error') {
+        finish(makeErrorResponse(sessionEvent.data.message))
+        return
+      }
+
+      if (sessionEvent.type === 'done') {
+        if (!receivedFinish || !hasAssistantOutput(accumulated)) {
+          finish(null)
+          return
+        }
+
+        finish({
+          id,
+          created,
+          model,
+          finishReason,
+          message: accumulated,
+          usage,
+        })
+      }
+    }
+
+    eventSource.addEventListener('message', (message) => {
+      try {
+        handleSessionEvent(ChatSessionEventSchema.parse(JSON.parse(message.data)))
+      } catch (error) {
+        reject(error)
+        eventSource.close()
+      }
+    })
+
+    for (const eventType of [
+      'user_message',
+      'assistant_delta',
+      'assistant_finish',
+      'usage',
+      'done',
+      'cancelled',
+      'error',
+    ]) {
+      eventSource.addEventListener(eventType, (message) => {
+        try {
+          handleSessionEvent(ChatSessionEventSchema.parse(JSON.parse(message.data)))
+        } catch (error) {
+          reject(error)
+          eventSource.close()
+        }
+      })
+    }
+
+    eventSource.onerror = () => {
+      reject(new Error('Session event stream failed.'))
+      eventSource.close()
+    }
+  })
+
+const sendLegacyStreamCompletion = async (
   req: SendCompletionParams & { onStream?: (stream: ChatStreamState) => void }
 ): Promise<ChatResponse | null> => {
   let accumulated: ChatStreamState = { content: '', reasoningContent: '' }
@@ -170,87 +426,72 @@ const sendStreamCompletion = async (
   let receivedFinish = false
   let usage: ChatUsage | null = null
 
-  try {
-    const res = await client.api.chat.stream.$post(
-      {
-        header: {
-          'api-key': req.header.apiKey,
-          'base-url': req.header.baseURL,
-        },
-        json: {
-          messages: req.messages,
-          model: req.model,
-          apiMode: req.apiMode,
-          temperature: req.temperature,
-          maxTokens: req.maxTokens,
-          reasoningEffort: req.reasoningEffort,
-        },
-      } as never,
-      { init: { signal: req.abortController.signal } }
-    )
+  const res = await client.api.chat.stream.$post(
+    {
+      header: {
+        'api-key': req.header.apiKey,
+        'base-url': req.header.baseURL,
+      },
+      json: {
+        messages: req.messages,
+        model: req.model,
+        apiMode: req.apiMode,
+        temperature: req.temperature,
+        maxTokens: req.maxTokens,
+        reasoningEffort: req.reasoningEffort,
+      },
+    } as never,
+    { init: { signal: req.abortController.signal } }
+  )
 
-    if (!res.ok) {
-      const error = (await res.json()) as { error?: string }
-      return makeErrorResponse(error?.error || JSON.stringify(error))
-    }
+  if (!res.ok) {
+    const error = (await res.json()) as { error?: string }
+    return makeErrorResponse(error?.error || JSON.stringify(error))
+  }
 
-    const reader = res.body?.getReader()
-    if (!reader) throw new Error('Failed to get reader from response body.')
+  const reader = res.body?.getReader()
+  if (!reader) throw new Error('Failed to get reader from response body.')
 
-    const decoder = new TextDecoder('utf-8')
-    let buffer = ''
-    let running = true
+  const decoder = new TextDecoder('utf-8')
+  let buffer = ''
+  let running = true
 
+  while (running) {
+    const { done, value } = await reader.read()
+    if (done) break
+
+    buffer += decoder.decode(value, { stream: true })
     while (running) {
-      const { done, value } = await reader.read()
-      if (done) break
+      const idx = buffer.indexOf('\n')
+      if (idx === -1) break
 
-      buffer += decoder.decode(value, { stream: true })
-      while (running) {
-        const idx = buffer.indexOf('\n')
-        if (idx === -1) break
+      const line = buffer.slice(0, idx).trim()
+      buffer = buffer.slice(idx + 1)
+      if (!line.startsWith('data: ')) continue
 
-        const line = buffer.slice(0, idx).trim()
-        buffer = buffer.slice(idx + 1)
-        if (!line.startsWith('data: ')) continue
-
-        const jsonStr = line.replace(/^data:\s*/, '')
-        if (jsonStr === '[DONE]') {
-          console.log('Stream completed.')
-          running = false
-          break
-        }
-
-        try {
-          const event = parseChatStreamEvent(jsonStr)
-          accumulated = updateChatStream(accumulated, event)
-
-          if (event.event === 'delta') {
-            id = event.id
-            created = event.created
-            model = event.model
-          }
-          if (event.event === 'finish') {
-            finishReason = event.finishReason
-            receivedFinish = true
-          }
-          if (event.event === 'usage') {
-            usage = event.usage
-          }
-
-          req.onStream?.(accumulated)
-        } catch (error) {
-          console.error('JSON parse error:', error)
-          running = false
-          break
-        }
+      const jsonStr = line.replace(/^data:\s*/, '')
+      if (jsonStr === '[DONE]') {
+        running = false
+        break
       }
-    }
-  } catch (error) {
-    if (error instanceof Error && error.name === 'AbortError') {
-      return null
-    } else {
-      throw error
+
+      const event = parseChatStreamEvent(jsonStr)
+      accumulated = updateChatStream(accumulated, event)
+
+      if (event.event === 'delta') {
+        id = event.id
+        created = event.created
+        model = event.model
+      }
+      if (event.event === 'finish') {
+        finishReason = event.finishReason
+        receivedFinish = true
+      }
+      if (event.event === 'usage') {
+        usage = event.usage
+      }
+
+      req.onStream?.(accumulated)
     }
   }
 
@@ -268,4 +509,24 @@ const sendStreamCompletion = async (
     },
     usage,
   }
+}
+
+function saveActiveSession(session: ActiveSession): void {
+  sessionStorage.setItem(ACTIVE_SESSION_STORAGE_KEY, JSON.stringify(session))
+}
+
+function readActiveSession(): ActiveSession | null {
+  const value = sessionStorage.getItem(ACTIVE_SESSION_STORAGE_KEY)
+  if (!value) return null
+
+  try {
+    return JSON.parse(value) as ActiveSession
+  } catch {
+    clearActiveSession()
+    return null
+  }
+}
+
+function clearActiveSession(): void {
+  sessionStorage.removeItem(ACTIVE_SESSION_STORAGE_KEY)
 }

--- a/projects/portfolio/src/client/components/chat/hooks/use-stream-processor.ts
+++ b/projects/portfolio/src/client/components/chat/hooks/use-stream-processor.ts
@@ -12,6 +12,10 @@ export function hasActiveChatSession(): boolean {
   return readActiveSession() !== null
 }
 
+export function clearActiveChatSession(): void {
+  clearActiveSession()
+}
+
 interface SubmitChatCompletionParams {
   header: {
     apiKey: string
@@ -32,9 +36,10 @@ interface SubmitChatCompletionParams {
 interface UseStreamProcessorParams {
   onSubmitting?: (submitting: boolean) => void
   onSessionConversation?: (conversation: Conversation, assistantMessageId: string) => void
+  onSessionResult?: (result: Omit<ResumeChatCompletionResult, 'responseTimeMs'>) => void
 }
 
-export function useStreamProcessor({ onSubmitting, onSessionConversation }: UseStreamProcessorParams = {}) {
+export function useStreamProcessor({ onSubmitting, onSessionConversation, onSessionResult }: UseStreamProcessorParams = {}) {
   const abortControllerRef = useRef<AbortController | null>(null)
   const eventSourceRef = useRef<EventSource | null>(null)
   const activeSessionIdRef = useRef<string | null>(null)
@@ -88,6 +93,7 @@ export function useStreamProcessor({ onSubmitting, onSessionConversation }: UseS
               maxTokens,
               reasoningEffort,
               onSessionConversation,
+              onSessionResult,
               onStream: (stream) => setStream(stream),
             })
           : await sendNonStreamCompletion({
@@ -110,7 +116,7 @@ export function useStreamProcessor({ onSubmitting, onSessionConversation }: UseS
         onSubmitting?.(false)
       }
     },
-    [onSessionConversation, onSubmitting]
+    [onSessionConversation, onSessionResult, onSubmitting]
   )
 
   const resumeActiveChatCompletion = useCallback(async (): Promise<ResumeChatCompletionResult | null> => {
@@ -131,6 +137,7 @@ export function useStreamProcessor({ onSubmitting, onSessionConversation }: UseS
         eventSourceRef,
         activeSessionIdRef,
         onSessionConversation,
+        onSessionResult,
         onStream: (stream) => setStream(stream),
       })
       if (!result.conversation) return null
@@ -147,7 +154,7 @@ export function useStreamProcessor({ onSubmitting, onSessionConversation }: UseS
       setLoading(false)
       onSubmitting?.(false)
     }
-  }, [onSessionConversation, onSubmitting])
+  }, [onSessionConversation, onSessionResult, onSubmitting])
 
   return {
     loading,
@@ -226,6 +233,7 @@ const sendStreamCompletion = async (
     eventSourceRef: MutableRefObject<EventSource | null>
     activeSessionIdRef: MutableRefObject<string | null>
     onSessionConversation?: (conversation: Conversation, assistantMessageId: string) => void
+    onSessionResult?: (result: Omit<ResumeChatCompletionResult, 'responseTimeMs'>) => void
     onStream?: (stream: ChatStreamState) => void
   }
 ): Promise<ChatResponse | null> => {
@@ -266,6 +274,7 @@ const sendStreamCompletion = async (
       eventSourceRef: req.eventSourceRef,
       activeSessionIdRef: req.activeSessionIdRef,
       onSessionConversation: req.onSessionConversation,
+      onSessionResult: req.onSessionResult,
       onStream: req.onStream,
     })
 
@@ -319,6 +328,7 @@ type ReceiveSessionEventsParams = {
   eventSourceRef: MutableRefObject<EventSource | null>
   activeSessionIdRef: MutableRefObject<string | null>
   onSessionConversation?: (conversation: Conversation, assistantMessageId: string) => void
+  onSessionResult?: (result: Omit<ResumeChatCompletionResult, 'responseTimeMs'>) => void
   onStream?: (stream: ChatStreamState) => void
 }
 
@@ -329,6 +339,7 @@ const receiveSessionEvents = ({
   eventSourceRef,
   activeSessionIdRef,
   onSessionConversation,
+  onSessionResult,
   onStream,
 }: ReceiveSessionEventsParams): Promise<Omit<ResumeChatCompletionResult, 'responseTimeMs'>> =>
   new Promise((resolve, reject) => {
@@ -357,7 +368,6 @@ const receiveSessionEvents = ({
       settled = true
       cleanup()
       activeSessionIdRef.current = null
-      clearActiveSession()
       resolve({
         conversation: conversation as Conversation,
         assistantMessageId,
@@ -428,14 +438,21 @@ const receiveSessionEvents = ({
           return
         }
 
-        finish({
+        const result = {
           id,
           created,
           model,
           finishReason,
           message: accumulated,
           usage,
-        })
+        }
+        const sessionResult = {
+          conversation: conversation as Conversation,
+          assistantMessageId,
+          result,
+        }
+        onSessionResult?.(sessionResult)
+        finish(sessionResult.result)
       }
     }
 

--- a/projects/portfolio/src/client/components/chat/hooks/use-stream-processor.ts
+++ b/projects/portfolio/src/client/components/chat/hooks/use-stream-processor.ts
@@ -6,7 +6,11 @@ import { type MutableRefObject, useCallback, useRef, useState } from 'react'
 import { type ChatStreamState, parseChatStreamEvent, updateChatStream } from './chat-response'
 
 const client = hc<AppType>('/')
-const ACTIVE_SESSION_STORAGE_KEY = 'portfolio.chat.activeSession'
+export const ACTIVE_SESSION_STORAGE_KEY = 'portfolio.chat.activeSession'
+
+export function hasActiveChatSession(): boolean {
+  return readActiveSession() !== null
+}
 
 interface SubmitChatCompletionParams {
   header: {
@@ -520,10 +524,13 @@ const sendLegacyStreamCompletion = async (
 }
 
 function saveActiveSession(session: ActiveSession): void {
+  if (typeof sessionStorage === 'undefined') return
   sessionStorage.setItem(ACTIVE_SESSION_STORAGE_KEY, JSON.stringify(session))
 }
 
 function readActiveSession(): ActiveSession | null {
+  if (typeof sessionStorage === 'undefined') return null
+
   const value = sessionStorage.getItem(ACTIVE_SESSION_STORAGE_KEY)
   if (!value) return null
 
@@ -536,5 +543,6 @@ function readActiveSession(): ActiveSession | null {
 }
 
 function clearActiveSession(): void {
+  if (typeof sessionStorage === 'undefined') return
   sessionStorage.removeItem(ACTIVE_SESSION_STORAGE_KEY)
 }

--- a/projects/portfolio/src/client/pages/chat/index.tsx
+++ b/projects/portfolio/src/client/pages/chat/index.tsx
@@ -2,6 +2,7 @@ import { ChatLayout } from '#/client/components/chat/chat-layout'
 import { ChatMain } from '#/client/components/chat/chat-main'
 import { ChatSettings } from '#/client/components/chat/chat-settings'
 import { ConversationHistory } from '#/client/components/chat/conversation-history'
+import { hasActiveChatSession } from '#/client/components/chat/hooks/use-stream-processor'
 import { SpinnerIcon } from '#/client/components/svg/spinner-icon'
 import { useChatPageState } from '#/client/pages/chat/use-chat-page-state'
 import { useMetaProps } from '#/client/pages/home'
@@ -48,7 +49,8 @@ export function Chat() {
 
   const conversations = query.data ?? []
   const currentConversation = conversations.find(({ id }) => id === selectedConversationId) || null
-  const isResolvingConversation = selectedConversationId !== null && currentConversation === null
+  const isResolvingConversation =
+    selectedConversationId !== null && currentConversation === null && !hasActiveChatSession()
   const navigateToNewConversation = useCallback(() => {
     startNewConversation()
     void navigate({

--- a/projects/portfolio/src/client/pages/chat/index.tsx
+++ b/projects/portfolio/src/client/pages/chat/index.tsx
@@ -2,7 +2,7 @@ import { ChatLayout } from '#/client/components/chat/chat-layout'
 import { ChatMain } from '#/client/components/chat/chat-main'
 import { ChatSettings } from '#/client/components/chat/chat-settings'
 import { ConversationHistory } from '#/client/components/chat/conversation-history'
-import { hasActiveChatSession } from '#/client/components/chat/hooks/use-stream-processor'
+import { clearActiveChatSession, hasActiveChatSession } from '#/client/components/chat/hooks/use-stream-processor'
 import { SpinnerIcon } from '#/client/components/svg/spinner-icon'
 import { useChatPageState } from '#/client/pages/chat/use-chat-page-state'
 import { useMetaProps } from '#/client/pages/home'
@@ -84,7 +84,7 @@ export function Chat() {
       return
     }
 
-    if (query.isLoading) {
+    if (query.isLoading || hasActiveChatSession()) {
       return
     }
 
@@ -154,17 +154,15 @@ export function Chat() {
     if (!email) return
 
     try {
+      if (conversation.id !== selectedConversationId) {
+        navigateToConversation(conversation.id, shouldReplace)
+      }
+
       const res = await client.api.conversations.$post({ json: conversation })
       if (res.status === 200) {
         // 成功した場合は、会話履歴を再取得
-        const refetched = await query.refetch()
-
-        if (
-          conversation.id !== selectedConversationId &&
-          (refetched.data ?? []).some(({ id }) => id === conversation.id)
-        ) {
-          navigateToConversation(conversation.id, shouldReplace)
-        }
+        await query.refetch()
+        clearActiveChatSession()
       }
     } catch (error) {
       console.error('Error updating conversation:', error)

--- a/projects/portfolio/src/server/app.d.ts
+++ b/projects/portfolio/src/server/app.d.ts
@@ -328,6 +328,540 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
         };
     };
 } & {
+    "/api/chat/sessions": {
+        $post: {
+            input: {
+                header: {
+                    'api-key': string;
+                    'base-url': string;
+                };
+            } & {
+                json: {
+                    messages: ({
+                        role: "user";
+                        content: string | ({
+                            type: "image_url";
+                            image_url: {
+                                url: string;
+                            };
+                        } | {
+                            type: "text";
+                            text: string;
+                        })[];
+                    } | {
+                        role: "assistant";
+                        content: string;
+                    } | {
+                        role: "system";
+                        content: string;
+                    })[];
+                    model: string;
+                    conversation: {
+                        id: string;
+                        title: string;
+                        messages: ({
+                            role: "user";
+                            content: string | ({
+                                type: "image_url";
+                                image_url: {
+                                    url: string;
+                                };
+                            } | {
+                                type: "text";
+                                text: string;
+                            })[];
+                            metadata: {
+                                model: string;
+                                apiMode?: "chat_completions" | "responses" | undefined;
+                                stream?: boolean | undefined;
+                                temperature?: number | undefined;
+                                maxTokens?: number | undefined;
+                                reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | undefined;
+                                sendImagesOnlyOnce?: boolean | undefined;
+                            };
+                            id?: string | undefined;
+                            reasoningContent?: string | undefined;
+                        } | {
+                            role: "assistant";
+                            content: string;
+                            metadata: {
+                                model: string;
+                                usage: {
+                                    completionTokens?: number | undefined;
+                                    promptTokens?: number | undefined;
+                                    totalTokens?: number | undefined;
+                                    reasoningTokens?: number | undefined;
+                                };
+                                apiMode?: "chat_completions" | "responses" | undefined;
+                                finishReason?: string | undefined;
+                                responseTimeMs?: number | undefined;
+                                generatedFiles?: {
+                                    blockIndex: number;
+                                    language: string;
+                                    fileName: string;
+                                    publicPath: string;
+                                    previewUrl: string;
+                                    contentType: string;
+                                    createdAt: string;
+                                }[] | undefined;
+                                imageContext?: {
+                                    policy: "send_once" | "full_history";
+                                    sent: number;
+                                    historyOnly: number;
+                                } | undefined;
+                                apiContextMessages?: ({
+                                    role: "user";
+                                    content: string | ({
+                                        type: "image_url";
+                                        image_url: {
+                                            url: string;
+                                        };
+                                    } | {
+                                        type: "text";
+                                        text: string;
+                                    })[];
+                                } | {
+                                    role: "assistant";
+                                    content: string;
+                                } | {
+                                    role: "system";
+                                    content: string;
+                                })[] | undefined;
+                            };
+                            id?: string | undefined;
+                            reasoningContent?: string | undefined;
+                        } | {
+                            role: "system";
+                            content: string;
+                            id?: string | undefined;
+                            reasoningContent?: string | undefined;
+                            metadata?: Record<string, never> | undefined;
+                        })[];
+                        updatedAt?: unknown;
+                    };
+                    assistantMessageId: string;
+                    apiMode?: "chat_completions" | "responses" | undefined;
+                    temperature?: number | undefined;
+                    maxTokens?: number | undefined;
+                    reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | undefined;
+                };
+            };
+            output: {
+                error: string;
+                code: "VALIDATION_ERROR";
+            };
+            outputFormat: "json";
+            status: 400;
+        } | {
+            input: {
+                header: {
+                    'api-key': string;
+                    'base-url': string;
+                };
+            } & {
+                json: {
+                    messages: ({
+                        role: "user";
+                        content: string | ({
+                            type: "image_url";
+                            image_url: {
+                                url: string;
+                            };
+                        } | {
+                            type: "text";
+                            text: string;
+                        })[];
+                    } | {
+                        role: "assistant";
+                        content: string;
+                    } | {
+                        role: "system";
+                        content: string;
+                    })[];
+                    model: string;
+                    conversation: {
+                        id: string;
+                        title: string;
+                        messages: ({
+                            role: "user";
+                            content: string | ({
+                                type: "image_url";
+                                image_url: {
+                                    url: string;
+                                };
+                            } | {
+                                type: "text";
+                                text: string;
+                            })[];
+                            metadata: {
+                                model: string;
+                                apiMode?: "chat_completions" | "responses" | undefined;
+                                stream?: boolean | undefined;
+                                temperature?: number | undefined;
+                                maxTokens?: number | undefined;
+                                reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | undefined;
+                                sendImagesOnlyOnce?: boolean | undefined;
+                            };
+                            id?: string | undefined;
+                            reasoningContent?: string | undefined;
+                        } | {
+                            role: "assistant";
+                            content: string;
+                            metadata: {
+                                model: string;
+                                usage: {
+                                    completionTokens?: number | undefined;
+                                    promptTokens?: number | undefined;
+                                    totalTokens?: number | undefined;
+                                    reasoningTokens?: number | undefined;
+                                };
+                                apiMode?: "chat_completions" | "responses" | undefined;
+                                finishReason?: string | undefined;
+                                responseTimeMs?: number | undefined;
+                                generatedFiles?: {
+                                    blockIndex: number;
+                                    language: string;
+                                    fileName: string;
+                                    publicPath: string;
+                                    previewUrl: string;
+                                    contentType: string;
+                                    createdAt: string;
+                                }[] | undefined;
+                                imageContext?: {
+                                    policy: "send_once" | "full_history";
+                                    sent: number;
+                                    historyOnly: number;
+                                } | undefined;
+                                apiContextMessages?: ({
+                                    role: "user";
+                                    content: string | ({
+                                        type: "image_url";
+                                        image_url: {
+                                            url: string;
+                                        };
+                                    } | {
+                                        type: "text";
+                                        text: string;
+                                    })[];
+                                } | {
+                                    role: "assistant";
+                                    content: string;
+                                } | {
+                                    role: "system";
+                                    content: string;
+                                })[] | undefined;
+                            };
+                            id?: string | undefined;
+                            reasoningContent?: string | undefined;
+                        } | {
+                            role: "system";
+                            content: string;
+                            id?: string | undefined;
+                            reasoningContent?: string | undefined;
+                            metadata?: Record<string, never> | undefined;
+                        })[];
+                        updatedAt?: unknown;
+                    };
+                    assistantMessageId: string;
+                    apiMode?: "chat_completions" | "responses" | undefined;
+                    temperature?: number | undefined;
+                    maxTokens?: number | undefined;
+                    reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | undefined;
+                };
+            };
+            output: {
+                error: string;
+                code: "VALIDATION_ERROR";
+            };
+            outputFormat: "json";
+            status: 400;
+        } | {
+            input: {
+                header: {
+                    'api-key': string;
+                    'base-url': string;
+                };
+            } & {
+                json: {
+                    messages: ({
+                        role: "user";
+                        content: string | ({
+                            type: "image_url";
+                            image_url: {
+                                url: string;
+                            };
+                        } | {
+                            type: "text";
+                            text: string;
+                        })[];
+                    } | {
+                        role: "assistant";
+                        content: string;
+                    } | {
+                        role: "system";
+                        content: string;
+                    })[];
+                    model: string;
+                    conversation: {
+                        id: string;
+                        title: string;
+                        messages: ({
+                            role: "user";
+                            content: string | ({
+                                type: "image_url";
+                                image_url: {
+                                    url: string;
+                                };
+                            } | {
+                                type: "text";
+                                text: string;
+                            })[];
+                            metadata: {
+                                model: string;
+                                apiMode?: "chat_completions" | "responses" | undefined;
+                                stream?: boolean | undefined;
+                                temperature?: number | undefined;
+                                maxTokens?: number | undefined;
+                                reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | undefined;
+                                sendImagesOnlyOnce?: boolean | undefined;
+                            };
+                            id?: string | undefined;
+                            reasoningContent?: string | undefined;
+                        } | {
+                            role: "assistant";
+                            content: string;
+                            metadata: {
+                                model: string;
+                                usage: {
+                                    completionTokens?: number | undefined;
+                                    promptTokens?: number | undefined;
+                                    totalTokens?: number | undefined;
+                                    reasoningTokens?: number | undefined;
+                                };
+                                apiMode?: "chat_completions" | "responses" | undefined;
+                                finishReason?: string | undefined;
+                                responseTimeMs?: number | undefined;
+                                generatedFiles?: {
+                                    blockIndex: number;
+                                    language: string;
+                                    fileName: string;
+                                    publicPath: string;
+                                    previewUrl: string;
+                                    contentType: string;
+                                    createdAt: string;
+                                }[] | undefined;
+                                imageContext?: {
+                                    policy: "send_once" | "full_history";
+                                    sent: number;
+                                    historyOnly: number;
+                                } | undefined;
+                                apiContextMessages?: ({
+                                    role: "user";
+                                    content: string | ({
+                                        type: "image_url";
+                                        image_url: {
+                                            url: string;
+                                        };
+                                    } | {
+                                        type: "text";
+                                        text: string;
+                                    })[];
+                                } | {
+                                    role: "assistant";
+                                    content: string;
+                                } | {
+                                    role: "system";
+                                    content: string;
+                                })[] | undefined;
+                            };
+                            id?: string | undefined;
+                            reasoningContent?: string | undefined;
+                        } | {
+                            role: "system";
+                            content: string;
+                            id?: string | undefined;
+                            reasoningContent?: string | undefined;
+                            metadata?: Record<string, never> | undefined;
+                        })[];
+                        updatedAt?: unknown;
+                    };
+                    assistantMessageId: string;
+                    apiMode?: "chat_completions" | "responses" | undefined;
+                    temperature?: number | undefined;
+                    maxTokens?: number | undefined;
+                    reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | undefined;
+                };
+            };
+            output: {
+                sessionId: string;
+                status: "error" | "running" | "completed" | "cancelled";
+            };
+            outputFormat: "json";
+            status: import('hono/utils/http-status').ContentfulStatusCode;
+        };
+    };
+} & {
+    "/api/chat/sessions/:sessionId": {
+        $get: {
+            input: {
+                param: {
+                    sessionId: string;
+                };
+            };
+            output: {
+                error: string;
+                code: "VALIDATION_ERROR";
+            };
+            outputFormat: "json";
+            status: 404;
+        } | {
+            input: {
+                param: {
+                    sessionId: string;
+                };
+            };
+            output: {
+                session: {
+                    id: string;
+                    status: "error" | "running" | "completed" | "cancelled";
+                    conversation: {
+                        id: string;
+                        title: string;
+                        messages: ({
+                            role: "user";
+                            content: string | ({
+                                type: "image_url";
+                                image_url: {
+                                    url: string;
+                                };
+                            } | {
+                                type: "text";
+                                text: string;
+                            })[];
+                            metadata: {
+                                model: string;
+                                apiMode?: "chat_completions" | "responses" | undefined;
+                                stream?: boolean | undefined;
+                                temperature?: number | undefined;
+                                maxTokens?: number | undefined;
+                                reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | undefined;
+                                sendImagesOnlyOnce?: boolean | undefined;
+                            };
+                            id?: string | undefined;
+                            reasoningContent?: string | undefined;
+                        } | {
+                            role: "assistant";
+                            content: string;
+                            metadata: {
+                                model: string;
+                                usage: {
+                                    completionTokens?: number | undefined;
+                                    promptTokens?: number | undefined;
+                                    totalTokens?: number | undefined;
+                                    reasoningTokens?: number | undefined;
+                                };
+                                apiMode?: "chat_completions" | "responses" | undefined;
+                                finishReason?: string | undefined;
+                                responseTimeMs?: number | undefined;
+                                generatedFiles?: {
+                                    blockIndex: number;
+                                    language: string;
+                                    fileName: string;
+                                    publicPath: string;
+                                    previewUrl: string;
+                                    contentType: string;
+                                    createdAt: string;
+                                }[] | undefined;
+                                imageContext?: {
+                                    policy: "send_once" | "full_history";
+                                    sent: number;
+                                    historyOnly: number;
+                                } | undefined;
+                                apiContextMessages?: ({
+                                    role: "user";
+                                    content: string | ({
+                                        type: "image_url";
+                                        image_url: {
+                                            url: string;
+                                        };
+                                    } | {
+                                        type: "text";
+                                        text: string;
+                                    })[];
+                                } | {
+                                    role: "assistant";
+                                    content: string;
+                                } | {
+                                    role: "system";
+                                    content: string;
+                                })[] | undefined;
+                            };
+                            id?: string | undefined;
+                            reasoningContent?: string | undefined;
+                        } | {
+                            role: "system";
+                            content: string;
+                            id?: string | undefined;
+                            reasoningContent?: string | undefined;
+                            metadata?: {} | undefined;
+                        })[];
+                        updatedAt?: string | undefined;
+                    };
+                    assistantMessageId: string;
+                    apiMode: "chat_completions" | "responses";
+                    model: string;
+                    email: string | null;
+                    createdAt: string;
+                    updatedAt: string;
+                    completedAt: string | null;
+                    error: string | null;
+                };
+            };
+            outputFormat: "json";
+            status: import('hono/utils/http-status').ContentfulStatusCode;
+        };
+    };
+} & {
+    "/api/chat/sessions/:sessionId/events": {
+        $get: {
+            input: {
+                param: {
+                    sessionId: string;
+                };
+            };
+            output: {};
+            outputFormat: string;
+            status: import('hono/utils/http-status').StatusCode;
+        };
+    };
+} & {
+    "/api/chat/sessions/:sessionId/cancel": {
+        $post: {
+            input: {
+                param: {
+                    sessionId: string;
+                };
+            };
+            output: {
+                error: string;
+                code: "VALIDATION_ERROR";
+            };
+            outputFormat: "json";
+            status: 404;
+        } | {
+            input: {
+                param: {
+                    sessionId: string;
+                };
+            };
+            output: {
+                status: "error" | "running" | "completed" | "cancelled";
+            };
+            outputFormat: "json";
+            status: import('hono/utils/http-status').ContentfulStatusCode;
+        };
+    };
+} & {
     "/api/chat/completions": {
         $post: {
             input: {
@@ -420,15 +954,17 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                             type: "text";
                             text: string;
                         })[];
-                        reasoningContent: string;
                         metadata: {
                             model: string;
                             apiMode?: "chat_completions" | "responses" | undefined;
                             stream?: boolean | undefined;
                             temperature?: number | undefined;
                             maxTokens?: number | undefined;
+                            reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | undefined;
+                            sendImagesOnlyOnce?: boolean | undefined;
                         };
                         id?: string | undefined;
+                        reasoningContent?: string | undefined;
                     } | {
                         role: "assistant";
                         content: string;
@@ -452,14 +988,37 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                                 contentType: string;
                                 createdAt: string;
                             }[] | undefined;
+                            imageContext?: {
+                                policy: "send_once" | "full_history";
+                                sent: number;
+                                historyOnly: number;
+                            } | undefined;
+                            apiContextMessages?: ({
+                                role: "user";
+                                content: string | ({
+                                    type: "image_url";
+                                    image_url: {
+                                        url: string;
+                                    };
+                                } | {
+                                    type: "text";
+                                    text: string;
+                                })[];
+                            } | {
+                                role: "assistant";
+                                content: string;
+                            } | {
+                                role: "system";
+                                content: string;
+                            })[] | undefined;
                         };
                         id?: string | undefined;
                         reasoningContent?: string | undefined;
                     } | {
                         role: "system";
                         content: string;
-                        reasoningContent: string;
                         id?: string | undefined;
+                        reasoningContent?: string | undefined;
                         metadata?: {} | undefined;
                     })[];
                     updatedAt?: string | undefined;
@@ -493,6 +1052,8 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                             stream?: boolean | undefined;
                             temperature?: number | undefined;
                             maxTokens?: number | undefined;
+                            reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | undefined;
+                            sendImagesOnlyOnce?: boolean | undefined;
                         };
                         id?: string | undefined;
                         reasoningContent?: string | undefined;
@@ -519,6 +1080,29 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                                 contentType: string;
                                 createdAt: string;
                             }[] | undefined;
+                            imageContext?: {
+                                policy: "send_once" | "full_history";
+                                sent: number;
+                                historyOnly: number;
+                            } | undefined;
+                            apiContextMessages?: ({
+                                role: "user";
+                                content: string | ({
+                                    type: "image_url";
+                                    image_url: {
+                                        url: string;
+                                    };
+                                } | {
+                                    type: "text";
+                                    text: string;
+                                })[];
+                            } | {
+                                role: "assistant";
+                                content: string;
+                            } | {
+                                role: "system";
+                                content: string;
+                            })[] | undefined;
                         };
                         id?: string | undefined;
                         reasoningContent?: string | undefined;
@@ -561,6 +1145,8 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                             stream?: boolean | undefined;
                             temperature?: number | undefined;
                             maxTokens?: number | undefined;
+                            reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | undefined;
+                            sendImagesOnlyOnce?: boolean | undefined;
                         };
                         id?: string | undefined;
                         reasoningContent?: string | undefined;
@@ -587,6 +1173,29 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                                 contentType: string;
                                 createdAt: string;
                             }[] | undefined;
+                            imageContext?: {
+                                policy: "send_once" | "full_history";
+                                sent: number;
+                                historyOnly: number;
+                            } | undefined;
+                            apiContextMessages?: ({
+                                role: "user";
+                                content: string | ({
+                                    type: "image_url";
+                                    image_url: {
+                                        url: string;
+                                    };
+                                } | {
+                                    type: "text";
+                                    text: string;
+                                })[];
+                            } | {
+                                role: "assistant";
+                                content: string;
+                            } | {
+                                role: "system";
+                                content: string;
+                            })[] | undefined;
                         };
                         id?: string | undefined;
                         reasoningContent?: string | undefined;
@@ -853,6 +1462,29 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                         contentType: string;
                         createdAt: string;
                     }[] | undefined;
+                    imageContext?: {
+                        policy: "send_once" | "full_history";
+                        sent: number;
+                        historyOnly: number;
+                    } | undefined;
+                    apiContextMessages?: ({
+                        role: "user";
+                        content: string | ({
+                            type: "image_url";
+                            image_url: {
+                                url: string;
+                            };
+                        } | {
+                            type: "text";
+                            text: string;
+                        })[];
+                    } | {
+                        role: "assistant";
+                        content: string;
+                    } | {
+                        role: "system";
+                        content: string;
+                    })[] | undefined;
                 };
             };
             outputFormat: "json";

--- a/projects/portfolio/src/server/features/chat-sessions/cache-store.ts
+++ b/projects/portfolio/src/server/features/chat-sessions/cache-store.ts
@@ -1,0 +1,88 @@
+import type { ChatSessionEvent, ChatSessionMeta } from '#/types/chat-api'
+
+export interface CacheStore {
+  createSession(session: ChatSessionMeta): Promise<void>
+  getSession(sessionId: string): Promise<ChatSessionMeta | null>
+  updateSession(sessionId: string, patch: Partial<ChatSessionMeta>): Promise<void>
+  appendEvent(event: ChatSessionEvent): Promise<void>
+  readEvents(sessionId: string, afterEventId?: string): Promise<ChatSessionEvent[]>
+  subscribe(sessionId: string, onEvent: (event: ChatSessionEvent) => void): Promise<() => void>
+  setSessionTtl(sessionId: string, seconds: number): Promise<void>
+}
+
+type SessionRecord = {
+  meta: ChatSessionMeta
+  events: ChatSessionEvent[]
+  ttlTimer: ReturnType<typeof setTimeout> | null
+  subscribers: Set<(event: ChatSessionEvent) => void>
+}
+
+export class InMemoryChatSessionStore implements CacheStore {
+  private readonly sessions = new Map<string, SessionRecord>()
+
+  async createSession(session: ChatSessionMeta): Promise<void> {
+    this.sessions.set(session.id, {
+      meta: session,
+      events: [],
+      ttlTimer: null,
+      subscribers: new Set(),
+    })
+  }
+
+  async getSession(sessionId: string): Promise<ChatSessionMeta | null> {
+    return this.sessions.get(sessionId)?.meta ?? null
+  }
+
+  async updateSession(sessionId: string, patch: Partial<ChatSessionMeta>): Promise<void> {
+    const record = this.sessions.get(sessionId)
+    if (!record) return
+
+    record.meta = {
+      ...record.meta,
+      ...patch,
+      updatedAt: patch.updatedAt ?? new Date().toISOString(),
+    }
+  }
+
+  async appendEvent(event: ChatSessionEvent): Promise<void> {
+    const record = this.sessions.get(event.sessionId)
+    if (!record) return
+
+    record.events.push(event)
+    for (const subscriber of record.subscribers) {
+      subscriber(event)
+    }
+  }
+
+  async readEvents(sessionId: string, afterEventId?: string): Promise<ChatSessionEvent[]> {
+    const events = this.sessions.get(sessionId)?.events ?? []
+    if (!afterEventId) return [...events]
+
+    const index = events.findIndex((event) => event.id === afterEventId)
+    if (index === -1) return [...events]
+
+    return events.slice(index + 1)
+  }
+
+  async subscribe(sessionId: string, onEvent: (event: ChatSessionEvent) => void): Promise<() => void> {
+    const record = this.sessions.get(sessionId)
+    if (!record) return () => {}
+
+    record.subscribers.add(onEvent)
+    return () => {
+      record.subscribers.delete(onEvent)
+    }
+  }
+
+  async setSessionTtl(sessionId: string, seconds: number): Promise<void> {
+    const record = this.sessions.get(sessionId)
+    if (!record) return
+
+    if (record.ttlTimer) clearTimeout(record.ttlTimer)
+    record.ttlTimer = setTimeout(() => {
+      this.sessions.delete(sessionId)
+    }, seconds * 1000)
+  }
+}
+
+export const chatSessionStore = new InMemoryChatSessionStore()

--- a/projects/portfolio/src/server/features/chat-sessions/session-manager.ts
+++ b/projects/portfolio/src/server/features/chat-sessions/session-manager.ts
@@ -1,0 +1,330 @@
+import { chatConversationRepository } from '#/server/features/chat-conversations/repository'
+import { chat } from '#/server/features/chat/chat'
+import { convertStreamChunks } from '#/server/features/chat/converter'
+import type { ResponsesStreamChunk, StreamChunk } from '#/server/features/chat/transport'
+import { logger } from '#/server/lib/logger'
+import type { ApiMode, AssistantMessage, Conversation } from '#/types'
+import type {
+  ChatSessionEvent,
+  ChatSessionMeta,
+  ChatSessionStartRequest,
+  ChatSessionStatus,
+  ChatStreamEvent,
+  ChatUsage,
+} from '#/types/chat-api'
+import { uuidv7 } from 'uuidv7'
+import type { CacheStore } from './cache-store'
+import { chatSessionStore } from './cache-store'
+
+type StartSessionParams = {
+  header: {
+    'api-key': string
+    'base-url': string
+  }
+  req: ChatSessionStartRequest
+  apiMode: ApiMode
+  email: string | null
+  databaseUrl?: string
+  ttlSeconds: number
+  disconnectGraceMs: number
+}
+
+type SessionRuntime = {
+  controller: AbortController | null
+  subscribers: number
+  graceTimer: ReturnType<typeof setTimeout> | null
+}
+
+const TERMINAL_EVENT_TYPES = new Set<ChatSessionEvent['type']>(['done', 'cancelled', 'error'])
+
+export class ChatSessionManager {
+  private readonly runtimes = new Map<string, SessionRuntime>()
+
+  constructor(private readonly store: CacheStore) {}
+
+  async startSession(params: StartSessionParams): Promise<ChatSessionMeta> {
+    const now = new Date().toISOString()
+    const session: ChatSessionMeta = {
+      id: uuidv7(),
+      status: 'running',
+      conversation: params.req.conversation,
+      assistantMessageId: params.req.assistantMessageId,
+      apiMode: params.apiMode,
+      model: params.req.model,
+      email: params.email,
+      createdAt: now,
+      updatedAt: now,
+      completedAt: null,
+      error: null,
+    }
+
+    await this.store.createSession(session)
+    await this.appendEvent(session.id, {
+      type: 'user_message',
+      data: {
+        conversation: params.req.conversation,
+        assistantMessageId: params.req.assistantMessageId,
+      },
+    })
+    this.runtimes.set(session.id, {
+      controller: null,
+      subscribers: 0,
+      graceTimer: null,
+    })
+
+    void this.runGeneration(session.id, params)
+
+    return session
+  }
+
+  async getSession(sessionId: string): Promise<ChatSessionMeta | null> {
+    return this.store.getSession(sessionId)
+  }
+
+  async readEvents(sessionId: string, afterEventId?: string): Promise<ChatSessionEvent[]> {
+    return this.store.readEvents(sessionId, afterEventId)
+  }
+
+  async subscribe(sessionId: string, onEvent: (event: ChatSessionEvent) => void): Promise<() => void> {
+    const runtime = this.ensureRuntime(sessionId)
+    runtime.subscribers += 1
+    if (runtime.graceTimer) {
+      clearTimeout(runtime.graceTimer)
+      runtime.graceTimer = null
+    }
+
+    const unsubscribe = await this.store.subscribe(sessionId, onEvent)
+
+    return () => {
+      unsubscribe()
+      runtime.subscribers = Math.max(0, runtime.subscribers - 1)
+    }
+  }
+
+  scheduleDisconnectGrace(sessionId: string, disconnectGraceMs: number): void {
+    const runtime = this.runtimes.get(sessionId)
+    if (!runtime || runtime.subscribers > 0 || runtime.graceTimer) return
+
+    runtime.graceTimer = setTimeout(() => {
+      runtime.graceTimer = null
+      if (runtime.subscribers === 0) {
+        void this.cancelSession(sessionId, 'disconnect_grace_expired')
+      }
+    }, disconnectGraceMs)
+  }
+
+  async cancelSession(sessionId: string, reason = 'cancelled'): Promise<ChatSessionMeta | null> {
+    const session = await this.store.getSession(sessionId)
+    if (!session || session.status !== 'running') return session
+
+    const runtime = this.runtimes.get(sessionId)
+    runtime?.controller?.abort()
+    await this.finishSession(sessionId, 'cancelled', { reason })
+
+    return this.store.getSession(sessionId)
+  }
+
+  private async runGeneration(sessionId: string, params: StartSessionParams): Promise<void> {
+    const runtime = this.ensureRuntime(sessionId)
+    const controller = new AbortController()
+    runtime.controller = controller
+
+    try {
+      const completion = await chat.completions(
+        {
+          apiKey: params.header['api-key'],
+          baseURL: params.header['base-url'],
+        },
+        {
+          apiMode: params.apiMode,
+          model: params.req.model,
+          messages: params.req.messages,
+          temperature: params.req.temperature,
+          maxTokens: params.req.maxTokens,
+          reasoningEffort: params.req.reasoningEffort,
+          stream: true,
+          includeUsage: true,
+        }
+      )
+
+      const streamCompletion = completion as StreamChunk | ResponsesStreamChunk
+      runtime.controller = streamCompletion.controller
+
+      for await (const event of convertStreamChunks(params.apiMode, streamCompletion)) {
+        if ((await this.store.getSession(sessionId))?.status !== 'running') return
+
+        await this.appendStreamEvent(sessionId, event)
+      }
+
+      if ((await this.store.getSession(sessionId))?.status === 'running') {
+        await this.finishSession(sessionId, 'completed')
+        await this.persistIfSignedIn(sessionId, params.databaseUrl, params.ttlSeconds)
+      }
+    } catch (err) {
+      if (controller.signal.aborted || runtime.controller?.signal.aborted) return
+
+      logger.error({ err, sessionId }, 'Session chat generation failed')
+      await this.finishSession(sessionId, 'error', {
+        message: err instanceof Error ? err.message : 'Upstream error',
+      })
+      await this.persistIfSignedIn(sessionId, params.databaseUrl, params.ttlSeconds)
+    } finally {
+      runtime.controller = null
+      await this.store.setSessionTtl(sessionId, params.ttlSeconds)
+    }
+  }
+
+  private async appendStreamEvent(sessionId: string, event: ChatStreamEvent): Promise<void> {
+    if (event.event === 'delta') {
+      await this.appendEvent(sessionId, {
+        type: 'assistant_delta',
+        data: event,
+      })
+      return
+    }
+
+    if (event.event === 'finish') {
+      await this.appendEvent(sessionId, {
+        type: 'assistant_finish',
+        data: event,
+      })
+      return
+    }
+
+    await this.appendEvent(sessionId, {
+      type: 'usage',
+      data: event,
+    })
+  }
+
+  private async finishSession(
+    sessionId: string,
+    status: Exclude<ChatSessionStatus, 'running'>,
+    data: { reason?: string; message?: string } = {}
+  ): Promise<void> {
+    await this.store.updateSession(sessionId, {
+      status,
+      completedAt: new Date().toISOString(),
+      error: data.message ?? null,
+    })
+
+    if (status === 'completed') {
+      await this.appendEvent(sessionId, { type: 'done', data: {} })
+      return
+    }
+
+    if (status === 'cancelled') {
+      await this.appendEvent(sessionId, {
+        type: 'cancelled',
+        data: {
+          reason: data.reason ?? 'cancelled',
+        },
+      })
+      return
+    }
+
+    await this.appendEvent(sessionId, {
+      type: 'error',
+      data: {
+        message: data.message ?? 'Upstream error',
+      },
+    })
+  }
+
+  private async appendEvent(sessionId: string, event: Omit<ChatSessionEvent, 'id' | 'sessionId' | 'createdAt'>) {
+    await this.store.appendEvent({
+      ...event,
+      id: uuidv7(),
+      sessionId,
+      createdAt: new Date().toISOString(),
+    } as ChatSessionEvent)
+  }
+
+  private async persistIfSignedIn(
+    sessionId: string,
+    databaseUrl: string | undefined,
+    ttlSeconds: number
+  ): Promise<void> {
+    const session = await this.store.getSession(sessionId)
+    if (!session || !session.email || !databaseUrl) return
+
+    const events = await this.store.readEvents(sessionId)
+    const conversation = foldSessionEvents(session, events)
+    await chatConversationRepository.upsert(databaseUrl, session.email, conversation)
+    await this.store.setSessionTtl(sessionId, ttlSeconds)
+  }
+
+  private ensureRuntime(sessionId: string): SessionRuntime {
+    const existing = this.runtimes.get(sessionId)
+    if (existing) return existing
+
+    const runtime = {
+      controller: null,
+      subscribers: 0,
+      graceTimer: null,
+    }
+    this.runtimes.set(sessionId, runtime)
+    return runtime
+  }
+}
+
+export function foldSessionEvents(session: ChatSessionMeta, events: ChatSessionEvent[]): Conversation {
+  let content = ''
+  let reasoningContent = ''
+  let finishReason = ''
+  let usage: ChatUsage | null = null
+  let id = ''
+  let created = 0
+  let model = session.model
+
+  for (const event of events) {
+    if (event.type === 'assistant_delta') {
+      content += event.data.content ?? ''
+      reasoningContent += event.data.reasoningContent ?? ''
+      id = event.data.id || id
+      created = event.data.created || created
+      model = event.data.model || model
+    }
+
+    if (event.type === 'assistant_finish') {
+      finishReason = event.data.finishReason
+      id = event.data.id || id
+      created = event.data.created || created
+      model = event.data.model || model
+    }
+
+    if (event.type === 'usage') {
+      usage = event.data.usage
+    }
+  }
+
+  const assistantMessage: AssistantMessage = {
+    id: session.assistantMessageId,
+    role: 'assistant',
+    content,
+    reasoningContent,
+    metadata: {
+      model,
+      apiMode: session.apiMode,
+      finishReason,
+      responseTimeMs: Date.now() - new Date(session.createdAt).getTime(),
+      usage: {
+        promptTokens: usage?.promptTokens ?? 0,
+        completionTokens: usage?.completionTokens ?? 0,
+        totalTokens: usage?.totalTokens ?? 0,
+        reasoningTokens: usage?.reasoningTokens,
+      },
+    },
+  }
+
+  return {
+    ...session.conversation,
+    messages: [...session.conversation.messages, assistantMessage],
+  }
+}
+
+export function isTerminalSessionEvent(event: ChatSessionEvent): boolean {
+  return TERMINAL_EVENT_TYPES.has(event.type)
+}
+
+export const chatSessionManager = new ChatSessionManager(chatSessionStore)

--- a/projects/portfolio/src/server/routes/chat.ts
+++ b/projects/portfolio/src/server/routes/chat.ts
@@ -1,19 +1,25 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import { chatSessionManager, isTerminalSessionEvent } from '#/server/features/chat-sessions/session-manager'
 import { chatStub } from '#/server/features/chat-stub/chat-stub'
 import { chat } from '#/server/features/chat/chat'
 import { convertCompletion, convertStreamChunks } from '#/server/features/chat/converter'
 import type { CompletionChunk, ResponsesStreamChunk, StreamChunk } from '#/server/features/chat/transport'
 import { logger } from '#/server/lib/logger'
 import { ApiChatMessageSchema, type ApiMode } from '#/types'
-import { ChatApiRequestSchema, type ChatApiRequest } from '#/types/chat-api'
+import {
+  ChatApiRequestSchema,
+  ChatSessionStartRequestSchema,
+  type ChatApiRequest,
+  type ChatSessionEvent,
+} from '#/types/chat-api'
 import { sValidator } from '@hono/standard-validator'
 import { Hono } from 'hono'
 import { streamSSE } from 'hono/streaming'
 import { validator } from 'hono/validator'
 import { z } from 'zod'
 import type { HonoEnv } from './shared'
-import { getServerEnv } from './shared'
+import { getServerEnv, getSignedInEmail } from './shared'
 
 const ChatHeaderSchema = z.object({
   'api-key': z.string().min(1),
@@ -92,6 +98,21 @@ const chatBodyValidator = sValidator('json', ChatApiRequestSchema, (result, c) =
   )
 })
 
+const chatSessionStartBodyValidator = sValidator('json', ChatSessionStartRequestSchema, (result, c) => {
+  if (result.success) return
+
+  const issue = result.error[0]
+  const fieldName = formatValidationPath(issue?.path)
+
+  return c.json(
+    {
+      error: `Invalid request body '${fieldName}'`,
+      code: 'VALIDATION_ERROR' as const,
+    },
+    400
+  )
+})
+
 function normalizeApiMode(apiMode: ApiMode | undefined): ApiMode {
   return apiMode ?? 'chat_completions'
 }
@@ -139,6 +160,27 @@ function buildChatRequestLog({
     },
     providerRequest,
   }
+}
+
+function getChatSessionTtlSeconds(c: Parameters<typeof getServerEnv>[0]): number {
+  const value = Number(getServerEnv(c).CHAT_SESSION_TTL_SECONDS)
+  return Number.isFinite(value) && value > 0 ? value : 60 * 30
+}
+
+function getChatDisconnectGraceMs(c: Parameters<typeof getServerEnv>[0]): number {
+  const value = Number(getServerEnv(c).CHAT_DISCONNECT_GRACE_MS)
+  return Number.isFinite(value) && value >= 0 ? value : 30_000
+}
+
+async function writeSessionEvent(
+  stream: Parameters<Parameters<typeof streamSSE>[1]>[0],
+  event: ChatSessionEvent
+): Promise<void> {
+  await stream.writeSSE({
+    id: event.id,
+    event: event.type,
+    data: JSON.stringify(event),
+  })
 }
 
 const streamStubCompletion = (
@@ -288,6 +330,132 @@ const chatRoutes = new Hono<HonoEnv>()
         await stream.writeSSE({ data: '[DONE]' })
       }
     })
+  })
+  .post('/api/chat/sessions', chatHeaderValidator, chatSessionStartBodyValidator, async (c) => {
+    const header = c.req.valid('header')
+    const req = c.req.valid('json')
+    const apiMode = normalizeApiMode(req.apiMode)
+    const requestLogger = c.var.logger ?? logger
+    const { DATABASE_URL } = getServerEnv(c)
+    const email = await getSignedInEmail(c)
+
+    requestLogger.debug(
+      {
+        request: buildChatRequestLog({
+          header,
+          req,
+          apiMode,
+          stream: true,
+          includeUsage: true,
+        }),
+      },
+      'Session chat request received'
+    )
+
+    const session = await chatSessionManager.startSession({
+      header,
+      req: {
+        ...req,
+        apiMode,
+      },
+      apiMode,
+      email,
+      databaseUrl: DATABASE_URL,
+      ttlSeconds: getChatSessionTtlSeconds(c),
+      disconnectGraceMs: getChatDisconnectGraceMs(c),
+    })
+
+    return c.json({ sessionId: session.id, status: session.status })
+  })
+  .get('/api/chat/sessions/:sessionId', async (c) => {
+    const sessionId = c.req.param('sessionId')
+    const session = await chatSessionManager.getSession(sessionId)
+
+    if (!session) {
+      return c.json({ error: 'Session not found', code: 'VALIDATION_ERROR' as const }, 404)
+    }
+
+    return c.json({ session })
+  })
+  .get('/api/chat/sessions/:sessionId/events', async (c) => {
+    const sessionId = c.req.param('sessionId')
+    const session = await chatSessionManager.getSession(sessionId)
+
+    if (!session) {
+      return c.json({ error: 'Session not found', code: 'VALIDATION_ERROR' as const }, 404)
+    }
+
+    const afterEventId = c.req.header('Last-Event-ID') || c.req.query('afterEventId') || undefined
+    const disconnectGraceMs = getChatDisconnectGraceMs(c)
+
+    return streamSSE(c, async (stream) => {
+      let closed = false
+      let unsubscribe: (() => void) | null = null
+
+      const close = () => {
+        if (closed) return
+        closed = true
+        unsubscribe?.()
+        chatSessionManager.scheduleDisconnectGrace(sessionId, disconnectGraceMs)
+      }
+
+      stream.onAbort(close)
+
+      let lastEventId = afterEventId
+      for (const event of await chatSessionManager.readEvents(sessionId, afterEventId)) {
+        await writeSessionEvent(stream, event)
+        lastEventId = event.id
+        if (isTerminalSessionEvent(event)) {
+          close()
+          return
+        }
+      }
+
+      if ((await chatSessionManager.getSession(sessionId))?.status !== 'running') {
+        close()
+        return
+      }
+
+      await new Promise<void>((resolve, reject) => {
+        void chatSessionManager
+          .subscribe(sessionId, (event) => {
+            void writeSessionEvent(stream, event).then(() => {
+              lastEventId = event.id
+              if (isTerminalSessionEvent(event)) {
+                close()
+                resolve()
+              }
+            })
+          })
+          .then((nextUnsubscribe) => {
+            unsubscribe = nextUnsubscribe
+            void chatSessionManager.readEvents(sessionId, lastEventId).then(async (events) => {
+              for (const event of events) {
+                await writeSessionEvent(stream, event)
+                lastEventId = event.id
+                if (isTerminalSessionEvent(event)) {
+                  close()
+                  resolve()
+                  return
+                }
+              }
+            })
+          })
+          .catch(reject)
+      })
+
+      close()
+    })
+  })
+  .post('/api/chat/sessions/:sessionId/cancel', async (c) => {
+    const sessionId = c.req.param('sessionId')
+    const session = await chatSessionManager.cancelSession(sessionId, 'user_requested')
+
+    if (!session) {
+      return c.json({ error: 'Session not found', code: 'VALIDATION_ERROR' as const }, 404)
+    }
+
+    return c.json({ status: session.status })
   })
   // Stub endpoint (OpenAI 互換、変更なし)
   .post('/api/chat/completions', sValidator('json', StubChatRequestSchema), async (c) => {

--- a/projects/portfolio/src/server/routes/shared.ts
+++ b/projects/portfolio/src/server/routes/shared.ts
@@ -16,6 +16,9 @@ export type Env = Partial<{
   FILE_SERVER_PUBLIC_URL: string
   FILE_SERVER_ADMIN_USERNAME: string
   FILE_SERVER_ADMIN_PASSWORD: string
+  CHAT_CACHE_URL: string
+  CHAT_SESSION_TTL_SECONDS: string
+  CHAT_DISCONNECT_GRACE_MS: string
 }>
 
 export type HonoEnv = {

--- a/projects/portfolio/src/types/chat-api.ts
+++ b/projects/portfolio/src/types/chat-api.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { ApiChatMessageSchema, ApiModeSchema, ReasoningEffortSchema } from './chat'
+import { ApiChatMessageSchema, ApiModeSchema, ConversationSchema, ReasoningEffortSchema } from './chat'
 
 // ============================================
 // /api/chat, /api/chat/stream 公開コントラクト
@@ -90,6 +90,90 @@ export const ChatStreamEventSchema = z.discriminatedUnion('event', [
 ])
 
 export type ChatStreamEvent = z.infer<typeof ChatStreamEventSchema>
+
+// ============================================
+// セッション管理付きストリーム
+// ============================================
+
+export const ChatSessionStatusSchema = z.enum(['running', 'completed', 'cancelled', 'error'])
+
+export type ChatSessionStatus = z.infer<typeof ChatSessionStatusSchema>
+
+export const ChatSessionStartRequestSchema = ChatApiRequestSchema.extend({
+  conversation: ConversationSchema,
+  assistantMessageId: z.string().min(1),
+})
+
+export type ChatSessionStartRequest = z.infer<typeof ChatSessionStartRequestSchema>
+
+export const ChatSessionStartResponseSchema = z.object({
+  sessionId: z.string(),
+  status: ChatSessionStatusSchema,
+})
+
+export type ChatSessionStartResponse = z.infer<typeof ChatSessionStartResponseSchema>
+
+export const ChatSessionMetaSchema = z.object({
+  id: z.string(),
+  status: ChatSessionStatusSchema,
+  conversation: ConversationSchema,
+  assistantMessageId: z.string(),
+  apiMode: ApiModeSchema,
+  model: z.string(),
+  email: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  completedAt: z.string().nullable(),
+  error: z.string().nullable(),
+})
+
+export type ChatSessionMeta = z.infer<typeof ChatSessionMetaSchema>
+
+const ChatSessionEventBaseSchema = z.object({
+  id: z.string(),
+  sessionId: z.string(),
+  createdAt: z.string(),
+})
+
+export const ChatSessionEventSchema = z.discriminatedUnion('type', [
+  ChatSessionEventBaseSchema.extend({
+    type: z.literal('user_message'),
+    data: z.object({
+      conversation: ConversationSchema,
+      assistantMessageId: z.string(),
+    }),
+  }),
+  ChatSessionEventBaseSchema.extend({
+    type: z.literal('assistant_delta'),
+    data: ChatStreamDeltaEventSchema,
+  }),
+  ChatSessionEventBaseSchema.extend({
+    type: z.literal('assistant_finish'),
+    data: ChatStreamFinishEventSchema,
+  }),
+  ChatSessionEventBaseSchema.extend({
+    type: z.literal('usage'),
+    data: ChatStreamUsageEventSchema,
+  }),
+  ChatSessionEventBaseSchema.extend({
+    type: z.literal('done'),
+    data: z.object({}),
+  }),
+  ChatSessionEventBaseSchema.extend({
+    type: z.literal('cancelled'),
+    data: z.object({
+      reason: z.string(),
+    }),
+  }),
+  ChatSessionEventBaseSchema.extend({
+    type: z.literal('error'),
+    data: z.object({
+      message: z.string(),
+    }),
+  }),
+])
+
+export type ChatSessionEvent = z.infer<typeof ChatSessionEventSchema>
 
 // ============================================
 // 統一エラーレスポンス

--- a/projects/portfolio/tests/client/components/chat-main.test.tsx
+++ b/projects/portfolio/tests/client/components/chat-main.test.tsx
@@ -8,6 +8,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const useMessageScrollMock = vi.fn()
 const scrollToMessageEndMock = vi.fn()
 const submitChatCompletionMock = vi.fn()
+const resumeActiveChatCompletionMock = vi.fn()
+let hasActiveChatSessionMock = false
+let streamProcessorParams: Record<string, unknown> | null = null
 let chatMessageListProps: Record<string, unknown> | null = null
 
 vi.mock('#/client/components/chat/chat-input', () => ({
@@ -48,12 +51,17 @@ vi.mock('#/client/components/chat/hooks/use-message-scroll', () => ({
 }))
 
 vi.mock('#/client/components/chat/hooks/use-stream-processor', () => ({
-  useStreamProcessor: () => ({
-    loading: false,
-    stream: null,
-    cancelStream: vi.fn(),
-    submitChatCompletion: submitChatCompletionMock,
-  }),
+  hasActiveChatSession: () => hasActiveChatSessionMock,
+  useStreamProcessor: (params: Record<string, unknown>) => {
+    streamProcessorParams = params
+    return {
+      loading: false,
+      stream: null,
+      cancelStream: vi.fn(),
+      submitChatCompletion: submitChatCompletionMock,
+      resumeActiveChatCompletion: resumeActiveChatCompletionMock,
+    }
+  },
 }))
 
 vi.mock('#/client/components/chat/prompt-template', () => ({
@@ -118,6 +126,9 @@ const settings: Settings = {
 describe('ChatMain', () => {
   beforeEach(() => {
     chatMessageListProps = null
+    streamProcessorParams = null
+    hasActiveChatSessionMock = false
+    resumeActiveChatCompletionMock.mockResolvedValue(null)
     submitChatCompletionMock.mockResolvedValue({
       result: {
         message: {
@@ -147,6 +158,81 @@ describe('ChatMain', () => {
   afterEach(() => {
     cleanup()
     vi.clearAllMocks()
+  })
+
+  it('active session がある場合は既存会話表示中でも復元を開始する', async () => {
+    hasActiveChatSessionMock = true
+    const resumedConversation: Conversation = {
+      id: 'conversation-1',
+      title: '会話',
+      messages: [...currentConversation.messages, createUserMessage('message-3', '続きの質問')],
+    }
+    resumeActiveChatCompletionMock.mockResolvedValue({
+      conversation: resumedConversation,
+      assistantMessageId: 'message-4',
+      result: {
+        id: 'chunk-1',
+        created: 1700000000,
+        model: 'gpt-test',
+        finishReason: 'stop',
+        message: {
+          content: '続きの回答',
+          reasoningContent: '',
+        },
+        usage: null,
+      },
+      responseTimeMs: 123,
+    })
+    const onConversationChange = vi.fn()
+    const { ChatMain } = await import('#/client/components/chat/chat-main')
+
+    render(
+      <ChatMain
+        settings={settings}
+        currentConversation={currentConversation}
+        onConversationChange={onConversationChange}
+      />
+    )
+
+    await waitFor(() => {
+      expect(resumeActiveChatCompletionMock).toHaveBeenCalled()
+    })
+    await waitFor(() => {
+      expect(onConversationChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'conversation-1',
+          messages: [
+            expect.objectContaining({ id: 'message-1' }),
+            expect.objectContaining({ id: 'message-2' }),
+            expect.objectContaining({ id: 'message-3' }),
+            expect.objectContaining({ id: 'message-4', content: '続きの回答' }),
+          ],
+        })
+      )
+    })
+  })
+
+  it('session replay 中に user_message を受けたら入力済みメッセージを即時表示する', async () => {
+    const resumedConversation: Conversation = {
+      id: 'conversation-1',
+      title: '会話',
+      messages: [createUserMessage('message-1', '送信済み質問')],
+    }
+    const { ChatMain } = await import('#/client/components/chat/chat-main')
+
+    render(<ChatMain settings={settings} />)
+
+    const onSessionConversation = streamProcessorParams?.onSessionConversation as
+      | ((conversation: Conversation, assistantMessageId: string) => void)
+      | undefined
+    expect(onSessionConversation).toBeTypeOf('function')
+
+    onSessionConversation?.(resumedConversation, 'message-2')
+
+    await waitFor(() => {
+      expect(chatMessageListProps?.messages).toEqual(resumedConversation.messages)
+      expect(chatMessageListProps?.streamMessageId).toBe('message-2')
+    })
   })
 
   it('最下端に吸着している間は最新へ移動ボタンを表示しない', async () => {

--- a/projects/portfolio/tests/client/components/chat-main.test.tsx
+++ b/projects/portfolio/tests/client/components/chat-main.test.tsx
@@ -235,6 +235,126 @@ describe('ChatMain', () => {
     })
   })
 
+  it('session replay 完了イベントを受けたら Promise 解決前に assistant メッセージを確定表示する', async () => {
+    const resumedConversation: Conversation = {
+      id: 'conversation-1',
+      title: '会話',
+      messages: [createUserMessage('message-1', '送信済み質問')],
+    }
+    const { ChatMain } = await import('#/client/components/chat/chat-main')
+
+    render(<ChatMain settings={settings} />)
+
+    const onSessionConversation = streamProcessorParams?.onSessionConversation as
+      | ((conversation: Conversation, assistantMessageId: string) => void)
+      | undefined
+    const onSessionResult = streamProcessorParams?.onSessionResult as
+      | ((result: {
+          conversation: Conversation
+          assistantMessageId: string
+          result: {
+            id: string
+            created: number
+            model: string
+            finishReason: string
+            message: { content: string; reasoningContent: string }
+            usage: null
+          } | null
+        }) => void)
+      | undefined
+    expect(onSessionConversation).toBeTypeOf('function')
+    expect(onSessionResult).toBeTypeOf('function')
+
+    onSessionConversation?.(resumedConversation, 'message-2')
+    onSessionResult?.({
+      conversation: resumedConversation,
+      assistantMessageId: 'message-2',
+      result: {
+        id: 'chunk-1',
+        created: 1700000000,
+        model: 'gpt-test',
+        finishReason: 'stop',
+        message: {
+          content: '復元後の回答',
+          reasoningContent: '',
+        },
+        usage: null,
+      },
+    })
+
+    await waitFor(() => {
+      expect(chatMessageListProps?.messages).toEqual([
+        expect.objectContaining({ id: 'message-1', role: 'user' }),
+        expect.objectContaining({ id: 'message-2', role: 'assistant', content: '復元後の回答' }),
+      ])
+      expect(chatMessageListProps?.streamMessageId).toBeNull()
+    })
+  })
+
+  it('session replay 復元後は同じ会話の古い currentConversation で上書きしない', async () => {
+    const resumedConversation: Conversation = {
+      id: 'conversation-1',
+      title: '会話',
+      messages: [...currentConversation.messages, createUserMessage('message-3', '続きの質問')],
+    }
+    const { ChatMain } = await import('#/client/components/chat/chat-main')
+
+    const view = render(<ChatMain settings={settings} currentConversation={null} />)
+
+    const onSessionConversation = streamProcessorParams?.onSessionConversation as
+      | ((conversation: Conversation, assistantMessageId: string) => void)
+      | undefined
+    expect(onSessionConversation).toBeTypeOf('function')
+
+    onSessionConversation?.(resumedConversation, 'message-4')
+
+    await waitFor(() => {
+      expect(chatMessageListProps?.messages).toEqual(resumedConversation.messages)
+      expect(chatMessageListProps?.streamMessageId).toBe('message-4')
+    })
+
+    view.rerender(<ChatMain settings={settings} currentConversation={currentConversation} />)
+
+    await waitFor(() => {
+      expect(chatMessageListProps?.messages).toEqual(resumedConversation.messages)
+      expect(chatMessageListProps?.streamMessageId).toBe('message-4')
+    })
+  })
+
+  it('session replay 復元後も別会話へ切り替えたら currentConversation を表示する', async () => {
+    const resumedConversation: Conversation = {
+      id: 'conversation-1',
+      title: '会話',
+      messages: [...currentConversation.messages, createUserMessage('message-3', '続きの質問')],
+    }
+    const nextConversation: Conversation = {
+      id: 'conversation-2',
+      title: '別会話',
+      messages: [createUserMessage('message-5', '別の質問')],
+    }
+    const { ChatMain } = await import('#/client/components/chat/chat-main')
+
+    const view = render(<ChatMain settings={settings} currentConversation={null} />)
+
+    const onSessionConversation = streamProcessorParams?.onSessionConversation as
+      | ((conversation: Conversation, assistantMessageId: string) => void)
+      | undefined
+    expect(onSessionConversation).toBeTypeOf('function')
+
+    onSessionConversation?.(resumedConversation, 'message-4')
+
+    await waitFor(() => {
+      expect(chatMessageListProps?.messages).toEqual(resumedConversation.messages)
+    })
+
+    view.rerender(<ChatMain settings={settings} currentConversation={nextConversation} />)
+
+    await waitFor(() => {
+      expect(chatMessageListProps?.messages).toEqual(nextConversation.messages)
+      expect(chatMessageListProps?.streamMessageId).toBeNull()
+    })
+  })
+
   it('最下端に吸着している間は最新へ移動ボタンを表示しない', async () => {
     const { ChatMain } = await import('#/client/components/chat/chat-main')
 

--- a/projects/portfolio/tests/client/hooks/use-stream-processor.test.tsx
+++ b/projects/portfolio/tests/client/hooks/use-stream-processor.test.tsx
@@ -1,11 +1,13 @@
 // @vitest-environment jsdom
 
-import { act, renderHook } from '@testing-library/react'
+import { act, renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 describe('useStreamProcessor', () => {
   beforeEach(() => {
     vi.resetModules()
+    sessionStorage.clear()
+    vi.unstubAllGlobals()
   })
 
   const importSubject = async () => {
@@ -230,5 +232,120 @@ describe('useStreamProcessor', () => {
       result: null,
       responseTimeMs: expect.any(Number),
     })
+  })
+
+  it('session replay の user_message で会話を復元する', async () => {
+    const { useStreamProcessor } = await importSubject()
+    const onSessionConversation = vi.fn()
+    const conversation = {
+      id: 'conversation-1',
+      title: 'hello',
+      messages: [
+        {
+          id: 'message-user-1',
+          role: 'user' as const,
+          content: 'hello',
+          metadata: {
+            model: 'gpt-test',
+          },
+        },
+      ],
+    }
+    const eventSources: FakeEventSource[] = []
+
+    class FakeEventSource {
+      listeners = new Map<string, Array<(message: MessageEvent) => void>>()
+      onerror: (() => void) | null = null
+      url: string
+
+      constructor(url: string) {
+        this.url = url
+        eventSources.push(this)
+      }
+
+      addEventListener(type: string, listener: (message: MessageEvent) => void) {
+        this.listeners.set(type, [...(this.listeners.get(type) ?? []), listener])
+      }
+
+      emit(type: string, data: unknown) {
+        for (const listener of this.listeners.get(type) ?? []) {
+          listener(new MessageEvent(type, { data: JSON.stringify(data) }))
+        }
+      }
+
+      close() {}
+    }
+
+    vi.stubGlobal('EventSource', FakeEventSource)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ sessionId: 'session-1' }),
+      })
+    )
+
+    const { result } = renderHook(() => useStreamProcessor({ onSessionConversation }))
+
+    let response: Awaited<ReturnType<typeof result.current.submitChatCompletion>> | undefined
+    void act(async () => {
+      response = await result.current.submitChatCompletion({
+        ...request,
+        streamMode: true,
+        conversation,
+        assistantMessageId: 'message-assistant-1',
+      })
+    })
+
+    await waitFor(() => expect(eventSources).toHaveLength(1))
+
+    act(() => {
+      eventSources[0].emit('user_message', {
+        id: 'event-1',
+        sessionId: 'session-1',
+        type: 'user_message',
+        createdAt: '2026-05-10T00:00:00.000Z',
+        data: {
+          conversation,
+          assistantMessageId: 'message-assistant-1',
+        },
+      })
+      eventSources[0].emit('assistant_delta', {
+        id: 'event-2',
+        sessionId: 'session-1',
+        type: 'assistant_delta',
+        createdAt: '2026-05-10T00:00:01.000Z',
+        data: {
+          event: 'delta',
+          id: 'chunk-1',
+          created: 1700000000,
+          model: 'gpt-test',
+          content: 'answer',
+        },
+      })
+      eventSources[0].emit('assistant_finish', {
+        id: 'event-3',
+        sessionId: 'session-1',
+        type: 'assistant_finish',
+        createdAt: '2026-05-10T00:00:02.000Z',
+        data: {
+          event: 'finish',
+          id: 'chunk-1',
+          created: 1700000000,
+          model: 'gpt-test',
+          finishReason: 'stop',
+        },
+      })
+      eventSources[0].emit('done', {
+        id: 'event-4',
+        sessionId: 'session-1',
+        type: 'done',
+        createdAt: '2026-05-10T00:00:03.000Z',
+        data: {},
+      })
+    })
+
+    await waitFor(() => expect(response?.result?.message.content).toBe('answer'))
+    expect(onSessionConversation).toHaveBeenCalledWith(conversation, 'message-assistant-1')
   })
 })

--- a/projects/portfolio/tests/client/hooks/use-stream-processor.test.tsx
+++ b/projects/portfolio/tests/client/hooks/use-stream-processor.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
-import { act, renderHook, waitFor } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 describe('useStreamProcessor', () => {
   beforeEach(() => {
@@ -10,9 +10,15 @@ describe('useStreamProcessor', () => {
     vi.unstubAllGlobals()
   })
 
+  afterEach(() => {
+    cleanup()
+  })
+
   const importSubject = async () => {
     const chatPostMock = vi.fn()
     const chatStreamPostMock = vi.fn()
+    const chatSessionPostMock = vi.fn()
+    const chatSessionCancelPostMock = vi.fn()
 
     vi.doMock('hono/client', () => ({
       hc: () => ({
@@ -21,6 +27,14 @@ describe('useStreamProcessor', () => {
             $post: chatPostMock,
             stream: {
               $post: chatStreamPostMock,
+            },
+            sessions: {
+              $post: chatSessionPostMock,
+              ':sessionId': {
+                cancel: {
+                  $post: chatSessionCancelPostMock,
+                },
+              },
             },
           },
         },
@@ -33,6 +47,8 @@ describe('useStreamProcessor', () => {
       useStreamProcessor: mod.useStreamProcessor,
       chatPostMock,
       chatStreamPostMock,
+      chatSessionPostMock,
+      chatSessionCancelPostMock,
     }
   }
 
@@ -47,6 +63,37 @@ describe('useStreamProcessor', () => {
     temperature: undefined,
     maxTokens: undefined,
     reasoningEffort: undefined,
+  }
+
+  const stubEventSource = () => {
+    const eventSources: FakeEventSource[] = []
+
+    class FakeEventSource {
+      listeners = new Map<string, Array<(message: MessageEvent) => void>>()
+      onerror: (() => void) | null = null
+      url: string
+
+      constructor(url: string) {
+        this.url = url
+        eventSources.push(this)
+      }
+
+      addEventListener(type: string, listener: (message: MessageEvent) => void) {
+        this.listeners.set(type, [...(this.listeners.get(type) ?? []), listener])
+      }
+
+      emit(type: string, data: unknown) {
+        for (const listener of this.listeners.get(type) ?? []) {
+          listener(new MessageEvent(type, { data: JSON.stringify(data) }))
+        }
+      }
+
+      close() {}
+    }
+
+    vi.stubGlobal('EventSource', FakeEventSource)
+
+    return eventSources
   }
 
   it('非 stream の reasoning-only 応答を保持する', async () => {
@@ -235,7 +282,7 @@ describe('useStreamProcessor', () => {
   })
 
   it('session replay の user_message で会話を復元する', async () => {
-    const { useStreamProcessor } = await importSubject()
+    const { useStreamProcessor, chatSessionPostMock } = await importSubject()
     const onSessionConversation = vi.fn()
     const conversation = {
       id: 'conversation-1',
@@ -251,45 +298,18 @@ describe('useStreamProcessor', () => {
         },
       ],
     }
-    const eventSources: FakeEventSource[] = []
-
-    class FakeEventSource {
-      listeners = new Map<string, Array<(message: MessageEvent) => void>>()
-      onerror: (() => void) | null = null
-      url: string
-
-      constructor(url: string) {
-        this.url = url
-        eventSources.push(this)
-      }
-
-      addEventListener(type: string, listener: (message: MessageEvent) => void) {
-        this.listeners.set(type, [...(this.listeners.get(type) ?? []), listener])
-      }
-
-      emit(type: string, data: unknown) {
-        for (const listener of this.listeners.get(type) ?? []) {
-          listener(new MessageEvent(type, { data: JSON.stringify(data) }))
-        }
-      }
-
-      close() {}
-    }
-
-    vi.stubGlobal('EventSource', FakeEventSource)
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({
-        ok: true,
-        json: async () => ({ sessionId: 'session-1' }),
-      })
-    )
+    const eventSources = stubEventSource()
+    chatSessionPostMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ sessionId: 'session-1' }),
+    })
 
     const { result } = renderHook(() => useStreamProcessor({ onSessionConversation }))
 
-    let response: Awaited<ReturnType<typeof result.current.submitChatCompletion>> | undefined
-    void act(async () => {
-      response = await result.current.submitChatCompletion({
+    const submitChatCompletion = result.current.submitChatCompletion
+    let responsePromise: ReturnType<typeof submitChatCompletion> | undefined
+    act(() => {
+      responsePromise = submitChatCompletion({
         ...request,
         streamMode: true,
         conversation,
@@ -345,7 +365,179 @@ describe('useStreamProcessor', () => {
       })
     })
 
-    await waitFor(() => expect(response?.result?.message.content).toBe('answer'))
+    await expect(responsePromise).resolves.toMatchObject({
+      result: {
+        message: {
+          content: 'answer',
+        },
+      },
+    })
     expect(onSessionConversation).toHaveBeenCalledWith(conversation, 'message-assistant-1')
+    expect(chatSessionPostMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        header: {
+          'api-key': 'api-key',
+          'base-url': 'https://example.com',
+        },
+        json: expect.objectContaining({
+          conversation,
+          assistantMessageId: 'message-assistant-1',
+        }),
+      }),
+      expect.anything()
+    )
+  })
+
+  it('session event stream の一時的な onerror 後も terminal event まで待つ', async () => {
+    const { useStreamProcessor, chatSessionPostMock } = await importSubject()
+    const conversation = {
+      id: 'conversation-1',
+      title: 'hello',
+      messages: [
+        {
+          id: 'message-user-1',
+          role: 'user' as const,
+          content: 'hello',
+          metadata: {
+            model: 'gpt-test',
+          },
+        },
+      ],
+    }
+    const eventSources = stubEventSource()
+    chatSessionPostMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ sessionId: 'session-1' }),
+    })
+
+    const { result } = renderHook(() => useStreamProcessor())
+
+    const submitChatCompletion = result.current.submitChatCompletion
+    let responseSettled = false
+    let responsePromise: ReturnType<typeof submitChatCompletion> | undefined
+    act(() => {
+      responsePromise = submitChatCompletion({
+        ...request,
+        streamMode: true,
+        conversation,
+        assistantMessageId: 'message-assistant-1',
+      })
+      responsePromise.finally(() => {
+        responseSettled = true
+      })
+    })
+
+    await waitFor(() => expect(eventSources).toHaveLength(1))
+
+    act(() => {
+      eventSources[0].onerror?.()
+    })
+    expect(responseSettled).toBe(false)
+
+    act(() => {
+      eventSources[0].emit('user_message', {
+        id: 'event-1',
+        sessionId: 'session-1',
+        type: 'user_message',
+        createdAt: '2026-05-10T00:00:00.000Z',
+        data: {
+          conversation,
+          assistantMessageId: 'message-assistant-1',
+        },
+      })
+      eventSources[0].emit('assistant_delta', {
+        id: 'event-2',
+        sessionId: 'session-1',
+        type: 'assistant_delta',
+        createdAt: '2026-05-10T00:00:01.000Z',
+        data: {
+          event: 'delta',
+          id: 'chunk-1',
+          created: 1700000000,
+          model: 'gpt-test',
+          content: 'answer after reconnect',
+        },
+      })
+      eventSources[0].emit('assistant_finish', {
+        id: 'event-3',
+        sessionId: 'session-1',
+        type: 'assistant_finish',
+        createdAt: '2026-05-10T00:00:02.000Z',
+        data: {
+          event: 'finish',
+          id: 'chunk-1',
+          created: 1700000000,
+          model: 'gpt-test',
+          finishReason: 'stop',
+        },
+      })
+      eventSources[0].emit('done', {
+        id: 'event-4',
+        sessionId: 'session-1',
+        type: 'done',
+        createdAt: '2026-05-10T00:00:03.000Z',
+        data: {},
+      })
+    })
+
+    await expect(responsePromise).resolves.toMatchObject({
+      result: {
+        message: {
+          content: 'answer after reconnect',
+        },
+      },
+    })
+  })
+
+  it('session stream の cancel は RPC で通知し、ローカルでも null 完了する', async () => {
+    const { useStreamProcessor, chatSessionPostMock, chatSessionCancelPostMock } = await importSubject()
+    const conversation = {
+      id: 'conversation-1',
+      title: 'hello',
+      messages: [
+        {
+          id: 'message-user-1',
+          role: 'user' as const,
+          content: 'hello',
+          metadata: {
+            model: 'gpt-test',
+          },
+        },
+      ],
+    }
+    const eventSources = stubEventSource()
+    chatSessionPostMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ sessionId: 'session-1' }),
+    })
+    chatSessionCancelPostMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ status: 'cancelled' }),
+    })
+
+    const { result } = renderHook(() => useStreamProcessor())
+    const submitChatCompletion = result.current.submitChatCompletion
+    const cancelStream = result.current.cancelStream
+    let responsePromise: ReturnType<typeof submitChatCompletion> | undefined
+
+    act(() => {
+      responsePromise = submitChatCompletion({
+        ...request,
+        streamMode: true,
+        conversation,
+        assistantMessageId: 'message-assistant-1',
+      })
+    })
+
+    await waitFor(() => expect(eventSources).toHaveLength(1))
+
+    act(() => {
+      cancelStream()
+    })
+
+    await expect(responsePromise).resolves.toMatchObject({ result: null })
+    expect(chatSessionCancelPostMock).toHaveBeenCalledWith({
+      param: { sessionId: 'session-1' },
+    })
   })
 })

--- a/projects/portfolio/tests/client/hooks/use-stream-processor.test.tsx
+++ b/projects/portfolio/tests/client/hooks/use-stream-processor.test.tsx
@@ -373,6 +373,7 @@ describe('useStreamProcessor', () => {
       },
     })
     expect(onSessionConversation).toHaveBeenCalledWith(conversation, 'message-assistant-1')
+    expect(sessionStorage.getItem('portfolio.chat.activeSession')).toContain('session-1')
     expect(chatSessionPostMock).toHaveBeenCalledWith(
       expect.objectContaining({
         header: {

--- a/projects/portfolio/tests/client/pages/chat.test.tsx
+++ b/projects/portfolio/tests/client/pages/chat.test.tsx
@@ -51,6 +51,7 @@ const conversationsGetMock = vi.fn()
 const conversationsPostMock = vi.fn()
 const conversationsDeleteMock = vi.fn()
 const messagesDeleteMock = vi.fn()
+const clearActiveChatSessionMock = vi.fn()
 let hasActiveChatSessionMock = false
 
 let chatMainProps: Record<string, unknown> | null = null
@@ -116,6 +117,7 @@ vi.mock('#/client/components/chat/chat-main', () => ({
 }))
 
 vi.mock('#/client/components/chat/hooks/use-stream-processor', () => ({
+  clearActiveChatSession: clearActiveChatSessionMock,
   hasActiveChatSession: () => hasActiveChatSessionMock,
 }))
 
@@ -228,7 +230,7 @@ describe('Chat page', () => {
     })
   })
 
-  it('初回保存では refetch 完了まで conversationId 付き URL へ遷移しない', async () => {
+  it('初回保存では refetch 完了を待たずに conversationId 付き URL へ遷移する', async () => {
     const deferred = createDeferred<{ data: typeof conversations }>()
     const refetchMock = vi.fn().mockReturnValue(deferred.promise)
     useQueryMock.mockReturnValue({
@@ -249,16 +251,17 @@ describe('Chat page', () => {
 
     const savePromise = onConversationChange?.(conversations[0])
 
-    expect(navigateMock).not.toHaveBeenCalled()
-
-    deferred.resolve({ data: conversations })
-    await savePromise
-
     expect(navigateMock).toHaveBeenCalledWith({
       to: '/chat',
       search: { conversationId: 'conversation-1' },
       replace: true,
     })
+    expect(clearActiveChatSessionMock).not.toHaveBeenCalled()
+
+    deferred.resolve({ data: conversations })
+    await savePromise
+
+    expect(clearActiveChatSessionMock).toHaveBeenCalledTimes(1)
   })
 
   it('会話履歴選択時は conversationId 付き URL へ遷移する', async () => {
@@ -311,5 +314,26 @@ describe('Chat page', () => {
 
     expect(chatMainProps).not.toBeNull()
     expect(view.queryByText('会話を読み込み中...')).toBeNull()
+  })
+
+  it('active session がある場合は DB 未反映の conversationId でも URL を消さない', async () => {
+    hasActiveChatSessionMock = true
+    useSearchMock.mockReturnValue({ conversationId: 'conversation-1' })
+    useQueryMock.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isFetching: false,
+      refetch: vi.fn(),
+    })
+
+    const { Chat } = await import('#/client/pages/chat')
+    render(<Chat />)
+
+    expect(chatMainProps).not.toBeNull()
+    expect(navigateMock).not.toHaveBeenCalledWith({
+      to: '/chat',
+      search: { conversationId: undefined },
+      replace: true,
+    })
   })
 })

--- a/projects/portfolio/tests/client/pages/chat.test.tsx
+++ b/projects/portfolio/tests/client/pages/chat.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 
-import { render, waitFor } from '@testing-library/react'
+import { cleanup, render, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const STORAGE_KEY = 'portfolio.chat-settings'
 
@@ -51,6 +51,7 @@ const conversationsGetMock = vi.fn()
 const conversationsPostMock = vi.fn()
 const conversationsDeleteMock = vi.fn()
 const messagesDeleteMock = vi.fn()
+let hasActiveChatSessionMock = false
 
 let chatMainProps: Record<string, unknown> | null = null
 let conversationHistoryProps: Record<string, unknown> | null = null
@@ -114,6 +115,10 @@ vi.mock('#/client/components/chat/chat-main', () => ({
   },
 }))
 
+vi.mock('#/client/components/chat/hooks/use-stream-processor', () => ({
+  hasActiveChatSession: () => hasActiveChatSessionMock,
+}))
+
 vi.mock('#/client/components/chat/conversation-history', () => ({
   ConversationHistory: (props: Record<string, unknown>) => {
     conversationHistoryProps = props
@@ -148,6 +153,7 @@ describe('Chat page', () => {
     )
     vi.resetModules()
     vi.clearAllMocks()
+    hasActiveChatSessionMock = false
     chatMainProps = null
     conversationHistoryProps = null
     useMetaPropsMock.mockReturnValue({ email: 'test@example.com' })
@@ -164,6 +170,10 @@ describe('Chat page', () => {
     conversationsPostMock.mockResolvedValue({ status: 200 })
     conversationsDeleteMock.mockResolvedValue({ status: 200 })
     messagesDeleteMock.mockResolvedValue({ status: 200 })
+  })
+
+  afterEach(() => {
+    cleanup()
   })
 
   it('URL の conversationId に対応する会話を ChatMain に渡す', async () => {
@@ -284,5 +294,22 @@ describe('Chat page', () => {
 
     expect(chatMainProps).toBeNull()
     expect(view.getAllByText('会話を読み込み中...').length).toBeGreaterThan(0)
+  })
+
+  it('active session がある場合は conversationId 解決中でも ChatMain を表示する', async () => {
+    hasActiveChatSessionMock = true
+    useSearchMock.mockReturnValue({ conversationId: 'conversation-1' })
+    useQueryMock.mockReturnValue({
+      data: [],
+      isLoading: true,
+      isFetching: true,
+      refetch: vi.fn(),
+    })
+
+    const { Chat } = await import('#/client/pages/chat')
+    const view = render(<Chat />)
+
+    expect(chatMainProps).not.toBeNull()
+    expect(view.queryByText('会話を読み込み中...')).toBeNull()
   })
 })

--- a/projects/portfolio/tests/features/chat-sessions/cache-store.test.ts
+++ b/projects/portfolio/tests/features/chat-sessions/cache-store.test.ts
@@ -1,0 +1,80 @@
+import type { ChatSessionEvent, ChatSessionMeta } from '#/types/chat-api'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+describe('InMemoryChatSessionStore', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  const createSession = (): ChatSessionMeta => ({
+    id: 'session-1',
+    status: 'running',
+    conversation: {
+      id: 'conversation-1',
+      title: 'hello',
+      messages: [],
+    },
+    assistantMessageId: 'message-assistant-1',
+    apiMode: 'chat_completions',
+    model: 'gpt-test',
+    email: null,
+    createdAt: '2026-05-10T00:00:00.000Z',
+    updatedAt: '2026-05-10T00:00:00.000Z',
+    completedAt: null,
+    error: null,
+  })
+
+  const createEvent = (id: string, content: string): ChatSessionEvent => ({
+    id,
+    sessionId: 'session-1',
+    type: 'assistant_delta',
+    createdAt: '2026-05-10T00:00:01.000Z',
+    data: {
+      event: 'delta',
+      id: 'chunk-1',
+      created: 1700000000,
+      model: 'gpt-test',
+      content,
+    },
+  })
+
+  it('append したイベントを replay し、afterEventId 以降だけ読める', async () => {
+    const { InMemoryChatSessionStore } = await import('#/server/features/chat-sessions/cache-store')
+    const store = new InMemoryChatSessionStore()
+
+    await store.createSession(createSession())
+    await store.appendEvent(createEvent('event-1', 'hello'))
+    await store.appendEvent(createEvent('event-2', ' world'))
+
+    await expect(store.readEvents('session-1')).resolves.toHaveLength(2)
+    await expect(store.readEvents('session-1', 'event-1')).resolves.toEqual([createEvent('event-2', ' world')])
+  })
+
+  it('subscriber に live event を配信し、unsubscribe 後は止める', async () => {
+    const { InMemoryChatSessionStore } = await import('#/server/features/chat-sessions/cache-store')
+    const store = new InMemoryChatSessionStore()
+    const onEvent = vi.fn()
+
+    await store.createSession(createSession())
+    const unsubscribe = await store.subscribe('session-1', onEvent)
+    await store.appendEvent(createEvent('event-1', 'hello'))
+    unsubscribe()
+    await store.appendEvent(createEvent('event-2', ' world'))
+
+    expect(onEvent).toHaveBeenCalledTimes(1)
+    expect(onEvent).toHaveBeenCalledWith(createEvent('event-1', 'hello'))
+  })
+
+  it('TTL 超過後に session を破棄する', async () => {
+    vi.useFakeTimers()
+    const { InMemoryChatSessionStore } = await import('#/server/features/chat-sessions/cache-store')
+    const store = new InMemoryChatSessionStore()
+
+    await store.createSession(createSession())
+    await store.setSessionTtl('session-1', 1)
+
+    await vi.advanceTimersByTimeAsync(1000)
+
+    await expect(store.getSession('session-1')).resolves.toBeNull()
+  })
+})

--- a/projects/portfolio/tests/features/chat-sessions/session-manager.test.ts
+++ b/projects/portfolio/tests/features/chat-sessions/session-manager.test.ts
@@ -1,0 +1,236 @@
+import type { ChatSessionStartRequest } from '#/types/chat-api'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('ChatSessionManager', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  const request: ChatSessionStartRequest = {
+    conversation: {
+      id: 'conversation-1',
+      title: 'hello',
+      messages: [
+        {
+          id: 'message-user-1',
+          role: 'user',
+          content: 'hello',
+          metadata: {
+            model: 'gpt-test',
+          },
+        },
+      ],
+    },
+    assistantMessageId: 'message-assistant-1',
+    messages: [{ role: 'user', content: 'hello' }],
+    model: 'gpt-test',
+    apiMode: 'chat_completions',
+  }
+
+  const importSubject = async () => {
+    const completionsMock = vi.fn()
+    const upsertMock = vi.fn()
+
+    vi.doMock('#/server/features/chat/chat', () => ({
+      chat: {
+        completions: completionsMock,
+      },
+    }))
+    vi.doMock('#/server/features/chat-conversations/repository', () => ({
+      chatConversationRepository: {
+        upsert: upsertMock,
+      },
+    }))
+
+    const [{ InMemoryChatSessionStore }, { ChatSessionManager, foldSessionEvents, isTerminalSessionEvent }] =
+      await Promise.all([
+        import('#/server/features/chat-sessions/cache-store'),
+        import('#/server/features/chat-sessions/session-manager'),
+      ])
+
+    const store = new InMemoryChatSessionStore()
+    const manager = new ChatSessionManager(store)
+
+    return {
+      store,
+      manager,
+      completionsMock,
+      upsertMock,
+      foldSessionEvents,
+      isTerminalSessionEvent,
+    }
+  }
+
+  const createStreamChunk = async function* () {
+    yield {
+      id: 'chunk-1',
+      object: 'chat.completion.chunk',
+      created: 1700000000,
+      model: 'gpt-test',
+      choices: [
+        {
+          index: 0,
+          delta: {
+            content: 'hello',
+          },
+          finish_reason: null,
+        },
+      ],
+      usage: null,
+    }
+    yield {
+      id: 'chunk-2',
+      object: 'chat.completion.chunk',
+      created: 1700000000,
+      model: 'gpt-test',
+      choices: [
+        {
+          index: 0,
+          delta: {},
+          finish_reason: 'stop',
+        },
+      ],
+      usage: {
+        prompt_tokens: 1,
+        completion_tokens: 2,
+        total_tokens: 3,
+      },
+    }
+  }
+
+  it('stream 完了時に event log を作り、ログイン済みなら保存する', async () => {
+    const { manager, completionsMock, upsertMock } = await importSubject()
+    completionsMock.mockResolvedValue({
+      controller: { abort: vi.fn() },
+      [Symbol.asyncIterator]: createStreamChunk,
+    })
+
+    const session = await manager.startSession({
+      header: {
+        'api-key': 'api-key',
+        'base-url': 'https://example.com',
+      },
+      req: request,
+      apiMode: 'chat_completions',
+      email: 'test@example.com',
+      databaseUrl: 'postgres://example',
+      ttlSeconds: 1800,
+      disconnectGraceMs: 30000,
+    })
+
+    await vi.waitFor(async () => {
+      await expect(manager.getSession(session.id)).resolves.toMatchObject({ status: 'completed' })
+    })
+
+    const events = await manager.readEvents(session.id)
+    expect(events.map((event) => event.type)).toEqual([
+      'user_message',
+      'assistant_delta',
+      'assistant_finish',
+      'usage',
+      'done',
+    ])
+    expect(upsertMock).toHaveBeenCalledWith(
+      'postgres://example',
+      'test@example.com',
+      expect.objectContaining({
+        id: 'conversation-1',
+        messages: expect.arrayContaining([
+          expect.objectContaining({
+            id: 'message-assistant-1',
+            role: 'assistant',
+            content: 'hello',
+          }),
+        ]),
+      })
+    )
+  })
+
+  it('cancel で cancelled event を追加し、terminal event を判定できる', async () => {
+    const { store, manager, isTerminalSessionEvent } = await importSubject()
+    await store.createSession({
+      id: 'session-1',
+      status: 'running',
+      conversation: request.conversation,
+      assistantMessageId: 'message-assistant-1',
+      apiMode: 'chat_completions',
+      model: 'gpt-test',
+      email: null,
+      createdAt: '2026-05-10T00:00:00.000Z',
+      updatedAt: '2026-05-10T00:00:00.000Z',
+      completedAt: null,
+      error: null,
+    })
+
+    await manager.cancelSession('session-1', 'user_requested')
+    const events = await manager.readEvents('session-1')
+
+    expect(events.at(-1)).toMatchObject({
+      type: 'cancelled',
+      data: {
+        reason: 'user_requested',
+      },
+    })
+    expect(isTerminalSessionEvent(events.at(-1)!)).toBe(true)
+  })
+
+  it('event log を assistant message へ fold する', async () => {
+    const { foldSessionEvents } = await importSubject()
+
+    const conversation = foldSessionEvents(
+      {
+        id: 'session-1',
+        status: 'completed',
+        conversation: request.conversation,
+        assistantMessageId: 'message-assistant-1',
+        apiMode: 'chat_completions',
+        model: 'gpt-test',
+        email: 'test@example.com',
+        createdAt: '2026-05-10T00:00:00.000Z',
+        updatedAt: '2026-05-10T00:00:00.000Z',
+        completedAt: '2026-05-10T00:00:01.000Z',
+        error: null,
+      },
+      [
+        {
+          id: 'event-1',
+          sessionId: 'session-1',
+          type: 'assistant_delta',
+          createdAt: '2026-05-10T00:00:00.000Z',
+          data: {
+            event: 'delta',
+            id: 'chunk-1',
+            created: 1700000000,
+            model: 'gpt-test',
+            content: 'hello',
+            reasoningContent: 'thinking',
+          },
+        },
+        {
+          id: 'event-2',
+          sessionId: 'session-1',
+          type: 'assistant_finish',
+          createdAt: '2026-05-10T00:00:01.000Z',
+          data: {
+            event: 'finish',
+            id: 'chunk-1',
+            created: 1700000000,
+            model: 'gpt-test',
+            finishReason: 'stop',
+          },
+        },
+      ]
+    )
+
+    expect(conversation.messages.at(-1)).toMatchObject({
+      id: 'message-assistant-1',
+      role: 'assistant',
+      content: 'hello',
+      reasoningContent: 'thinking',
+      metadata: {
+        model: 'gpt-test',
+        finishReason: 'stop',
+      },
+    })
+  })
+})

--- a/projects/portfolio/tests/routes/chat.test.ts
+++ b/projects/portfolio/tests/routes/chat.test.ts
@@ -11,6 +11,7 @@ const importSubject = async () => {
   const chatStubCompletionsMock = vi.fn()
   const chatStubStreamCompletionsMock = vi.fn()
   const getSignedCookieMock = vi.fn().mockResolvedValue('test@example.com')
+  const upsertConversationMock = vi.fn()
 
   vi.doMock('#/server/features/chat/chat', async () => {
     const actual = await vi.importActual<typeof import('#/server/features/chat/chat')>('#/server/features/chat/chat')
@@ -42,6 +43,11 @@ const importSubject = async () => {
       deleteCookie: vi.fn(),
     }
   })
+  vi.doMock('#/server/features/chat-conversations/repository', () => ({
+    chatConversationRepository: {
+      upsert: upsertConversationMock,
+    },
+  }))
 
   const { chatRoutes } = await import('#/server/routes/chat')
 
@@ -50,6 +56,8 @@ const importSubject = async () => {
     completionsMock,
     chatStubCompletionsMock,
     chatStubStreamCompletionsMock,
+    getSignedCookieMock,
+    upsertConversationMock,
     loggerMock,
   }
 }
@@ -57,6 +65,7 @@ const importSubject = async () => {
 describe('chatRoutes', () => {
   beforeEach(() => {
     vi.resetModules()
+    vi.unstubAllEnvs()
     vi.useRealTimers()
   })
 
@@ -542,6 +551,178 @@ describe('chatRoutes', () => {
         error: "Invalid request body 'model'",
         code: 'VALIDATION_ERROR',
       })
+    })
+  })
+
+  describe('/api/chat/sessions', () => {
+    const conversation = {
+      id: 'conversation-1',
+      title: 'hello',
+      messages: [
+        {
+          id: 'message-user-1',
+          role: 'user',
+          content: 'hello',
+          metadata: {
+            model: 'gpt-test',
+          },
+        },
+      ],
+    }
+
+    const createStreamChunk = async function* () {
+      yield {
+        id: 'chunk-1',
+        object: 'chat.completion.chunk',
+        created: 1700000000,
+        model: 'gpt-test',
+        choices: [
+          {
+            index: 0,
+            delta: {
+              content: 'hello',
+            },
+            finish_reason: null,
+          },
+        ],
+        usage: null,
+      }
+      yield {
+        id: 'chunk-2',
+        object: 'chat.completion.chunk',
+        created: 1700000000,
+        model: 'gpt-test',
+        choices: [
+          {
+            index: 0,
+            delta: {},
+            finish_reason: 'stop',
+          },
+        ],
+        usage: null,
+      }
+    }
+
+    const waitForCompletedSession = async (
+      chatRoutes: Awaited<ReturnType<typeof importSubject>>['chatRoutes'],
+      sessionId: string
+    ) => {
+      await vi.waitFor(async () => {
+        const res = await chatRoutes.request(`/api/chat/sessions/${sessionId}`)
+        const body = (await res.json()) as { session: { status: string } }
+        expect(body.session.status).toBe('completed')
+      })
+    }
+
+    it('session を作成し、SSE events で replay できる', async () => {
+      const { chatRoutes, completionsMock } = await importSubject()
+      completionsMock.mockResolvedValue({
+        controller: { abort: vi.fn() },
+        [Symbol.asyncIterator]: createStreamChunk,
+      })
+
+      const startRes = await chatRoutes.request('/api/chat/sessions', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'api-key': 'api-key',
+          'base-url': 'https://example.com',
+        },
+        body: JSON.stringify({
+          conversation,
+          assistantMessageId: 'message-assistant-1',
+          model: 'gpt-test',
+          messages: [{ role: 'user', content: 'hello' }],
+        }),
+      })
+
+      expect(startRes.status).toBe(200)
+      const { sessionId } = (await startRes.json()) as { sessionId: string }
+      await waitForCompletedSession(chatRoutes, sessionId)
+      const eventsRes = await chatRoutes.request(`/api/chat/sessions/${sessionId}/events`)
+      const body = await eventsRes.text()
+
+      expect(eventsRes.headers.get('content-type')).toContain('text/event-stream')
+      expect(body).toContain('event: user_message')
+      expect(body).toContain('event: assistant_delta')
+      expect(body).toContain('event: assistant_finish')
+      expect(body).toContain('event: done')
+    })
+
+    it('ログイン時は terminal 後に会話を保存する', async () => {
+      vi.stubEnv('DATABASE_URL', 'postgres://example')
+      const { chatRoutes, completionsMock, upsertConversationMock } = await importSubject()
+      completionsMock.mockResolvedValue({
+        controller: { abort: vi.fn() },
+        [Symbol.asyncIterator]: createStreamChunk,
+      })
+
+      const startRes = await chatRoutes.request('/api/chat/sessions', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'api-key': 'api-key',
+          'base-url': 'https://example.com',
+        },
+        body: JSON.stringify({
+          conversation,
+          assistantMessageId: 'message-assistant-1',
+          model: 'gpt-test',
+          messages: [{ role: 'user', content: 'hello' }],
+        }),
+      })
+      const { sessionId } = (await startRes.json()) as { sessionId: string }
+
+      await waitForCompletedSession(chatRoutes, sessionId)
+      const eventsRes = await chatRoutes.request(`/api/chat/sessions/${sessionId}/events`)
+      await eventsRes.text()
+
+      expect(upsertConversationMock).toHaveBeenCalledWith(
+        'postgres://example',
+        'test@example.com',
+        expect.objectContaining({
+          id: 'conversation-1',
+          messages: expect.arrayContaining([
+            expect.objectContaining({
+              id: 'message-assistant-1',
+              role: 'assistant',
+              content: 'hello',
+            }),
+          ]),
+        })
+      )
+    })
+
+    it('未ログイン時は terminal 後に会話を保存しない', async () => {
+      vi.stubEnv('DATABASE_URL', 'postgres://example')
+      const { chatRoutes, completionsMock, getSignedCookieMock, upsertConversationMock } = await importSubject()
+      getSignedCookieMock.mockResolvedValue(null)
+      completionsMock.mockResolvedValue({
+        controller: { abort: vi.fn() },
+        [Symbol.asyncIterator]: createStreamChunk,
+      })
+
+      const startRes = await chatRoutes.request('/api/chat/sessions', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'api-key': 'api-key',
+          'base-url': 'https://example.com',
+        },
+        body: JSON.stringify({
+          conversation,
+          assistantMessageId: 'message-assistant-1',
+          model: 'gpt-test',
+          messages: [{ role: 'user', content: 'hello' }],
+        }),
+      })
+      const { sessionId } = (await startRes.json()) as { sessionId: string }
+
+      await waitForCompletedSession(chatRoutes, sessionId)
+      const eventsRes = await chatRoutes.request(`/api/chat/sessions/${sessionId}/events`)
+      await eventsRes.text()
+
+      expect(upsertConversationMock).not.toHaveBeenCalled()
     })
   })
 


### PR DESCRIPTION
## Issues

- Close #862

## Why

生成中の SSE 接続が切れたときに、サーバー側で再送できるイベントログとセッション状態がないため、リロードや瞬断で stream state が失われていました。

## Summary

チャット stream を server-managed session と SSE replay に移行する基盤を追加しました。v1 は WebSocket ではなく SSE を使い、未ログイン時は同じタブの `sessionStorage` に保存した sessionId で復元し、ログイン時のみ terminal 後に既存の会話履歴へ保存します。

## Changes

- `CacheStore` interface と InMemory chat session store を追加
- `/api/chat/sessions`, `/events`, `/cancel` を追加し、`Last-Event-ID` / `afterEventId` replay と cancel を実装
- terminal event 到達時に event log を fold し、ログイン済み session のみ PostgreSQL へ保存
- フロントの stream 経路を session start + `EventSource` 購読へ変更し、active session を `sessionStorage` に保持
- 未ログイン session の DB 保存スキップと TTL 破棄を追加
- `.env.example` / `DEVELOPMENT.md` に chat session 関連設定を追加
- Hono RPC 型を `bun run typegen` で更新

## Verification

- `bun run typegen` - passed
- `bun run lint` - passed
- `bun run test` - passed
