### PR TITLE
fix: hide empty image context label in chat results

### DIFF
--- a/projects/portfolio/src/client/components/chat/chat-results.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-results.tsx
@@ -60,6 +60,7 @@ function ChatResultsComponent({ metadata, messages }: ChatResultsProps) {
 
   const { model, finishReason, responseTimeMs, usage, imageContext, apiContextMessages } = metadata
   const dumpApiContextMessages = apiContextMessages ?? buildApiContextDump(messages, imageContext)
+  const showImageContext = imageContext && (imageContext.sent > 0 || imageContext.historyOnly > 0)
 
   return (
     <div className='mt-2'>
@@ -90,7 +91,7 @@ function ChatResultsComponent({ metadata, messages }: ChatResultsProps) {
           <span>messages: ({messages.length})</span>
           <EyeIcon size={14} className='stroke-current' />
         </button>
-        {imageContext && (
+        {showImageContext && (
           <span className='rounded-md bg-gray-100 px-2 py-1 text-xs text-gray-400 dark:bg-gray-700 dark:text-gray-400'>
             images: {imageContext.sent} sent / {imageContext.historyOnly} history-only
           </span>


### PR DESCRIPTION
## Why

画像コンテキストが 0 件でも `images: 0 sent / 0 history-only` が表示されており、チャット結果の補助情報としてはノイズになっていました。

## Summary

`ChatResults` の画像コンテキスト表示に条件を追加し、`sent` と `historyOnly` の両方が 0 の場合はラベルを非表示にしました。

## Changes

- `showImageContext` を追加して画像ラベルの表示条件を集約
- 画像件数が両方 0 の場合は `images` ラベルを描画しないよう変更

## Checklist

- [x] `bun run format src/client/components/chat/chat-results.tsx`
- [x] `bun run lint`
