### PR TITLE
fix: improve about page dark mode and mobile scroll

### DIFF
--- a/projects/portfolio/src/client/components/app-layout.tsx
+++ b/projects/portfolio/src/client/components/app-layout.tsx
@@ -18,9 +18,9 @@ export const AppLayout: FC<Props> = ({ version, menuItems, children }: Props) =>
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
 
   return (
-    <div className={'flex h-screen overflow-hidden'}>
+    <div className='flex min-h-dvh overflow-hidden md:h-dvh'>
       {/* デスクトップサイドバー */}
-      <div className='hidden md:flex h-screen w-16 flex-col justify-between border-r bg-gray-100 px-2 py-4 dark:border-gray-700 dark:bg-gray-800'>
+      <div className='hidden h-dvh w-16 flex-col justify-between border-r bg-gray-100 px-2 py-4 dark:border-gray-700 dark:bg-gray-800 md:flex'>
         {/* メニューリスト */}
         <nav className='flex flex-col space-y-2'>
           {menuItems.map((menuItem) => (
@@ -84,9 +84,7 @@ export const AppLayout: FC<Props> = ({ version, menuItems, children }: Props) =>
       )}
 
       {/* メインコンテンツ */}
-      <main className='min-w-0 flex-1 overflow-y-hidden bg-white md:overflow-y-auto dark:bg-gray-900 pt-14 md:pt-0'>
-        {children}
-      </main>
+      <main className='min-h-0 min-w-0 flex-1 overflow-y-auto bg-white pt-14 dark:bg-gray-900 md:pt-0'>{children}</main>
     </div>
   )
 }

--- a/projects/portfolio/src/client/pages/about/index.tsx
+++ b/projects/portfolio/src/client/pages/about/index.tsx
@@ -45,9 +45,11 @@ Portfolio へようこそ！
 
 export function About() {
   return (
-    <div className='min-h-screen overflow-y-auto bg-white p-4 dark:bg-gray-900'>
-      <div className='prose-sm md:prose dark:prose-invert'>
-        <Markdown remarkPlugins={[remarkGfm]}>{source}</Markdown>
+    <div className='min-h-full bg-white px-4 py-6 dark:bg-gray-900 md:px-8 md:py-8'>
+      <div className='mx-auto max-w-3xl'>
+        <div className='prose prose-sm max-w-none text-gray-700 prose-headings:text-gray-900 prose-strong:text-gray-900 prose-a:text-blue-700 prose-code:text-gray-800 prose-pre:bg-gray-950 md:prose-base dark:prose-invert dark:text-gray-200 dark:prose-headings:text-white dark:prose-strong:text-white dark:prose-a:text-blue-300 dark:prose-code:text-gray-100'>
+          <Markdown remarkPlugins={[remarkGfm]}>{source}</Markdown>
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Issues

- N/A

## Why

`about` ページでダークモード時の本文コントラストが不足し、モバイルでは縦スクロールできない状態になっていました。

## Summary

`about` ページのタイポグラフィ指定を見直してライト/ダーク両方で可読性を確保しました。あわせて共通レイアウトのメイン領域をモバイルでもスクロール可能にし、ビューポート高さを `dvh` ベースへ寄せています。

## Changes

- `about` ページに `prose` 基底クラスと明示的なライト/ダーク配色を追加
- `about` ページの余白と最大幅を調整して読みやすさを改善
- `AppLayout` のメイン領域を `overflow-y-auto` に変更
- ルートレイアウトの高さ指定を `dvh` ベースに変更してモバイル表示の欠けを抑制

## Checklist

- [x] `bun run lint`
- [x] `bun run test`
