### PR TITLE
feat(simple-agent-poc): externalize agent definitions

### DIFF
--- a/projects/simple-agent-poc/.env.example
+++ b/projects/simple-agent-poc/.env.example
@@ -1,2 +1,3 @@
 OPENAI_API_KEY="your-api-key"
 OPENAI_BASE_URL="your-base-url"
+AGENTS_FILE="agents.yaml"

--- a/projects/simple-agent-poc/AGENTS.md
+++ b/projects/simple-agent-poc/AGENTS.md
@@ -10,9 +10,11 @@
 | **Testing** | pytest | Testing framework |
 | **Type Checking** | ty | Static type checking |
 | **LLM Integration** | LiteLLM | LLM provider integration |
+| **Config Parsing** | PyYAML | Agent definition file loading |
 | **Environment** | python-dotenv | Environment variable management |
 
 ## References
 
 - Project overview and setup: `README.md`
+- Default agent definitions: `agents.yaml`
 - Skills index: `.claude/skills/README.md`

--- a/projects/simple-agent-poc/Dockerfile
+++ b/projects/simple-agent-poc/Dockerfile
@@ -23,6 +23,7 @@ ARG COMMIT_HASH=""
 ENV COMMIT_HASH=${COMMIT_HASH}
 
 # Copy source code and tests
+COPY agents.yaml ./
 COPY src/ src/
 COPY tests/ tests/
 

--- a/projects/simple-agent-poc/README.md
+++ b/projects/simple-agent-poc/README.md
@@ -13,16 +13,23 @@ uv sync
 cp .env.example .env
 ```
 
-3. Edit `.env` and set your API credentials:
+3. Edit `.env` and set your API credentials and agent definition file:
 ```bash
 OPENAI_API_KEY="your-api-key"
 OPENAI_BASE_URL="your-base-url"
+AGENTS_FILE="agents.yaml"
 ```
 
 ## Usage
 
 ```bash
 uv run dev
+```
+
+Run the CLI with a specific agent from `agents.yaml`:
+
+```bash
+uv run dev --agent researcher
 ```
 
 ## API Usage
@@ -41,6 +48,14 @@ curl -X POST http://127.0.0.1:8000/api/chat \
   -d '{"message":"Hello"}'
 ```
 
+Send a request with a specific agent:
+
+```bash
+curl -X POST http://127.0.0.1:8000/api/chat \
+  -H "Content-Type: application/json" \
+  -d '{"message":"調べて","agent_id":"researcher"}'
+```
+
 Continue the same conversation by sending back the returned `session_id`:
 
 ```bash
@@ -53,6 +68,10 @@ curl -X POST http://127.0.0.1:8000/api/chat \
 `/api/chat` uses the `Session-Id` request header as the primary session transport.
 For compatibility, the JSON body still accepts an optional `session_id` for now. If both are
 sent, they must match; otherwise the API returns `400`.
+
+When continuing a session, use the same `agent_id` that created it. Changing agents for an
+existing session returns `400` because the stored conversation history belongs to the original
+agent definition.
 
 ## Architecture Direction
 
@@ -73,11 +92,51 @@ The session model lives under `src/simple_agent_poc/core/`.
 The CLI and HTTP adapters live under `src/simple_agent_poc/adapters/`.
 The process entrypoints live under `src/simple_agent_poc/entrypoints/`.
 
+## Agent Definitions
+
+Agent definitions are loaded from `agents.yaml` by default. Set `AGENTS_FILE` to point at
+another YAML file when running with a different definition set.
+
+```yaml
+agents:
+  default:
+    model: gpt-4.1-nano
+    system_prompt: |
+      You are an AI assistant.
+      Current datetime: {current_datetime}
+    temperature: 0.2
+    tools: []
+
+  researcher:
+    model: gpt-4.1-nano
+    system_prompt: |
+      You are a research-focused assistant.
+      Current datetime: {current_datetime}
+    temperature: 0.1
+    tools: []
+```
+
+The YAML file must contain `agents.default`. Each agent supports these fields:
+
+- `model`: required LiteLLM model name.
+- `system_prompt`: required prompt template. `{current_datetime}` is filled at session start.
+- `temperature`: optional numeric generation parameter.
+- `tools`: optional list reserved for future tool-calling support.
+
+Validation happens at startup for production wiring, and per request for unknown `agent_id`
+values. Unknown fields, missing required fields, invalid field types, and missing `default`
+agent definitions are rejected.
+
+`tools` is currently parsed and validated but is not passed to LiteLLM yet.
+
+Once a session is created, later requests for that `session_id` must use the same `agent_id`.
+
 ## Session Model
 
 - CLI keeps one in-process conversation and forwards the active `session_id` internally.
 - HTTP accepts `Session-Id` as the primary session transport and returns the effective `session_id` on every response.
 - HTTP request-body `session_id` remains temporarily supported for compatibility, but it must match `Session-Id` when both are present.
+- Each session stores the `agent_id` used at creation time, and subsequent calls must keep using it.
 - The initial implementation uses an in-memory `SessionStore`; durable persistence is a later step.
 
 ## Development

--- a/projects/simple-agent-poc/README.md
+++ b/projects/simple-agent-poc/README.md
@@ -104,7 +104,7 @@ agents:
     system_prompt: |
       You are an AI assistant.
       Current datetime: {current_datetime}
-    temperature: 0.2
+    temperature: null
     tools: []
 
   researcher:
@@ -112,7 +112,7 @@ agents:
     system_prompt: |
       You are a research-focused assistant.
       Current datetime: {current_datetime}
-    temperature: 0.1
+    temperature: null
     tools: []
 ```
 
@@ -120,7 +120,7 @@ The YAML file must contain `agents.default`. Each agent supports these fields:
 
 - `model`: required LiteLLM model name.
 - `system_prompt`: required prompt template. `{current_datetime}` is filled at session start.
-- `temperature`: optional numeric generation parameter.
+- `temperature`: optional numeric generation parameter. `null` or omission means it is not sent to the LLM API.
 - `tools`: optional list reserved for future tool-calling support.
 
 Validation happens at startup for production wiring, and per request for unknown `agent_id`

--- a/projects/simple-agent-poc/agents.yaml
+++ b/projects/simple-agent-poc/agents.yaml
@@ -12,7 +12,7 @@ agents:
       5. Use the current temporal context when relevant to the user's query.
 
       Current datetime: {current_datetime}
-    temperature: 0.2
+    temperature: null
     tools: []
 
   researcher:
@@ -20,5 +20,5 @@ agents:
     system_prompt: |
       You are a research-focused assistant.
       Current datetime: {current_datetime}
-    temperature: 0.1
+    temperature: null
     tools: []

--- a/projects/simple-agent-poc/agents.yaml
+++ b/projects/simple-agent-poc/agents.yaml
@@ -1,0 +1,24 @@
+agents:
+  default:
+    model: gpt-4.1-nano
+    system_prompt: |
+      You are an AI assistant designed to help users with various tasks.
+
+      Guidelines:
+      1. Be helpful, accurate, and concise
+      2. Provide clear explanations when needed
+      3. Admit when you don't know something
+      4. Maintain a professional and friendly tone
+      5. Use the current temporal context when relevant to the user's query.
+
+      Current datetime: {current_datetime}
+    temperature: 0.2
+    tools: []
+
+  researcher:
+    model: gpt-4.1-nano
+    system_prompt: |
+      You are a research-focused assistant.
+      Current datetime: {current_datetime}
+    temperature: 0.1
+    tools: []

--- a/projects/simple-agent-poc/pyproject.toml
+++ b/projects/simple-agent-poc/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "fastapi>=0.136.1",
     "litellm>=1.81.14",
     "python-dotenv>=1.2.1",
+    "pyyaml>=6.0.3",
     "uvicorn>=0.46.0",
 ]
 

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/cli/adapter.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/cli/adapter.py
@@ -32,6 +32,7 @@ class CLIAdapter:
         self,
         run_agent: RunAgentUseCase,
         *,
+        agent_id: str = "default",
         input_reader: Callable[[], str] = get_user_input,
         response_renderer: Callable[[RunAgentResponse], None] = show_agent_response,
         error_renderer: Callable[[Exception], None] = show_error,
@@ -40,6 +41,7 @@ class CLIAdapter:
         indicator_runner: IndicatorRunner = with_indicator,
     ) -> None:
         self._run_agent = run_agent
+        self._agent_id = agent_id
         self._input_reader = input_reader
         self._response_renderer = response_renderer
         self._error_renderer = error_renderer
@@ -64,6 +66,7 @@ class CLIAdapter:
                         RunAgentRequest(
                             message=user_input,
                             session_id=self._session_id,
+                            agent_id=self._agent_id,
                         )
                     ),
                 )

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/cli/adapter.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/cli/adapter.py
@@ -25,6 +25,12 @@ class IndicatorRunner(Protocol):
     ) -> RunAgentResponse: ...
 
 
+class WelcomeRenderer(Protocol):
+    """Render the CLI welcome banner."""
+
+    def __call__(self, agent_id: str = "default") -> None: ...
+
+
 class CLIAdapter:
     """Thin stdin/stdout adapter around the shared agent use case."""
 
@@ -36,7 +42,7 @@ class CLIAdapter:
         input_reader: Callable[[], str] = get_user_input,
         response_renderer: Callable[[RunAgentResponse], None] = show_agent_response,
         error_renderer: Callable[[Exception], None] = show_error,
-        welcome_renderer: Callable[[], None] = show_welcome,
+        welcome_renderer: WelcomeRenderer = show_welcome,
         exit_renderer: Callable[[], None] = show_exit_message,
         indicator_runner: IndicatorRunner = with_indicator,
     ) -> None:
@@ -52,7 +58,7 @@ class CLIAdapter:
 
     def run(self) -> None:
         """Start the interactive CLI loop."""
-        self._welcome_renderer()
+        self._welcome_renderer(self._agent_id)
 
         while True:
             try:

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/cli/renderer.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/cli/renderer.py
@@ -61,11 +61,12 @@ def show_error(error: Exception) -> None:
         print(f"⚠️  Error: An unexpected error occurred: {error}")
 
 
-def show_welcome() -> None:
+def show_welcome(agent_id: str = "default") -> None:
     """Display the welcome banner."""
     print("═" * 40)
     print("  ✨  Welcome to Simple Agent POC  ✨")
     print("     (Press Ctrl+C to exit)")
+    print(f"     AgentId: {agent_id}")
     print("═" * 40)
     print()
 

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/api.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/api.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, ConfigDict, field_validator
 
 from simple_agent_poc.application.dto import RunAgentRequest, RunAgentResponse
 from simple_agent_poc.application.use_cases import RunAgentUseCase
-from simple_agent_poc.core.types import SessionNotFoundError, Usage
+from simple_agent_poc.core.types import SessionNotFoundError, Usage, ValidationError
 from simple_agent_poc.entrypoints.bootstrap import create_run_agent_use_case_factory
 
 
@@ -19,6 +19,7 @@ class ChatRequest(BaseModel):
 
     message: str
     session_id: str | None = None
+    agent_id: str = "default"
 
     @field_validator("message")
     @classmethod
@@ -26,6 +27,14 @@ class ChatRequest(BaseModel):
         """Reject blank messages after trimming whitespace."""
         if not value:
             raise ValueError("message must not be blank")
+        return value
+
+    @field_validator("agent_id")
+    @classmethod
+    def validate_agent_id(cls, value: str) -> str:
+        """Reject blank agent ids after trimming whitespace."""
+        if not value:
+            raise ValueError("agent_id must not be blank")
         return value
 
 
@@ -100,11 +109,16 @@ def create_app(
                         header_session_id=session_id_header,
                         body_session_id=request.session_id,
                     ),
+                    agent_id=request.agent_id,
                 )
             )
         except SessionNotFoundError as error:
             raise HTTPException(
                 status_code=404, detail=error.display_message
+            ) from error
+        except ValidationError as error:
+            raise HTTPException(
+                status_code=400, detail=error.display_message
             ) from error
 
         return ChatResponse.from_use_case_response(response)

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/llm/litellm_client.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/llm/litellm_client.py
@@ -9,6 +9,7 @@ from litellm.exceptions import (
 )
 
 from simple_agent_poc.application.ports import LLMClient
+from simple_agent_poc.core.agent_definition import AgentDefinition
 from simple_agent_poc.core.types import (
     AuthenticationError,
     LLMError,
@@ -21,16 +22,22 @@ from simple_agent_poc.core.types import (
 class LiteLLMClient(LLMClient):
     """LLM client implementation using LiteLLM."""
 
-    def __init__(self, model: str) -> None:
+    def __init__(self, model: str, *, temperature: float | None = None) -> None:
         self.model = model
+        self.temperature = temperature
 
     def complete(self, messages: list[Message]) -> LLMResponse:
         start_time = time.perf_counter()
+        completion_params: dict[str, float] = {}
+        if self.temperature is not None:
+            completion_params["temperature"] = self.temperature
+
         try:
             response = completion(
                 model=self.model,
                 messages=messages,
                 stream=False,
+                **completion_params,
             )
         except LiteLLMAuthError as error:
             raise AuthenticationError(
@@ -69,3 +76,13 @@ class LiteLLMClient(LLMClient):
             "model": self.model,
             "response_time": elapsed,
         }
+
+
+class LiteLLMClientFactory:
+    """Create LiteLLM clients from agent definitions."""
+
+    def __call__(self, agent_definition: AgentDefinition) -> LiteLLMClient:
+        return LiteLLMClient(
+            model=agent_definition.model,
+            temperature=agent_definition.temperature,
+        )

--- a/projects/simple-agent-poc/src/simple_agent_poc/application/dto.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/application/dto.py
@@ -11,6 +11,7 @@ class RunAgentRequest:
 
     message: str
     session_id: str | None = None
+    agent_id: str = "default"
 
 
 @dataclass(frozen=True, slots=True)

--- a/projects/simple-agent-poc/src/simple_agent_poc/application/ports.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/application/ports.py
@@ -2,6 +2,7 @@
 
 from typing import Protocol
 
+from simple_agent_poc.core.agent_definition import AgentDefinition
 from simple_agent_poc.core.session import ConversationSession
 from simple_agent_poc.core.types import LLMResponse, Message
 
@@ -11,6 +12,13 @@ class LLMClient(Protocol):
 
     def complete(self, messages: list[Message]) -> LLMResponse:
         """Receive message history and return an LLM response."""
+
+
+class LLMClientFactory(Protocol):
+    """Factory for agent-specific LLM clients."""
+
+    def __call__(self, agent_definition: AgentDefinition, /) -> LLMClient:
+        """Create an LLM client for the selected agent."""
 
 
 class SessionStore(Protocol):

--- a/projects/simple-agent-poc/src/simple_agent_poc/application/use_cases.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/application/use_cases.py
@@ -1,9 +1,14 @@
 """Application use cases."""
 
+from datetime import datetime
 from uuid import uuid4
 
 from simple_agent_poc.application.dto import RunAgentRequest, RunAgentResponse
-from simple_agent_poc.application.ports import LLMClient, SessionStore
+from simple_agent_poc.application.ports import LLMClientFactory, SessionStore
+from simple_agent_poc.core.agent_definition import (
+    AgentDefinition,
+    AgentDefinitionRegistry,
+)
 from simple_agent_poc.core.session import ConversationSession
 from simple_agent_poc.core.types import SessionNotFoundError, ValidationError
 
@@ -14,23 +19,30 @@ class RunAgentUseCase:
     def __init__(
         self,
         *,
-        llm_client: LLMClient,
+        llm_client_factory: LLMClientFactory,
         session_store: SessionStore,
-        system_prompt: str,
+        agent_definitions: AgentDefinitionRegistry,
     ) -> None:
-        self._llm_client = llm_client
+        self._llm_client_factory = llm_client_factory
         self._session_store = session_store
-        self._system_prompt = system_prompt
+        self._agent_definitions = agent_definitions
 
     def execute(self, request: RunAgentRequest) -> RunAgentResponse:
         """Run the agent for a single user message."""
         if not request.message.strip():
             raise ValidationError("message must not be blank")
 
-        session = self._load_session(request.session_id)
+        agent_definition = self._agent_definitions.get(request.agent_id)
+        session = self._load_session(
+            request.session_id,
+            agent_definition=agent_definition,
+        )
+        if session.agent_id != agent_definition.agent_id:
+            raise ValidationError("agent_id cannot be changed for an existing session")
         session.append_user_message(request.message)
 
-        response = self._llm_client.complete(list(session.messages))
+        llm_client = self._llm_client_factory(agent_definition)
+        response = llm_client.complete(list(session.messages))
 
         session.append_assistant_message(response["content"])
         self._session_store.save(session)
@@ -38,11 +50,19 @@ class RunAgentUseCase:
             response, session_id=session.session_id
         )
 
-    def _load_session(self, session_id: str | None) -> ConversationSession:
+    def _load_session(
+        self,
+        session_id: str | None,
+        *,
+        agent_definition: AgentDefinition,
+    ) -> ConversationSession:
         if session_id is None:
             return ConversationSession.start(
                 session_id=uuid4().hex,
-                system_prompt=self._system_prompt,
+                agent_id=agent_definition.agent_id,
+                system_prompt=agent_definition.format_system_prompt(
+                    current_datetime=datetime.now().isoformat()
+                ),
             )
 
         session = self._session_store.get(session_id)

--- a/projects/simple-agent-poc/src/simple_agent_poc/core/agent_definition.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/core/agent_definition.py
@@ -25,7 +25,7 @@ class AgentDefinition:
 
     def format_system_prompt(self, *, current_datetime: str) -> str:
         """Format the system prompt with runtime context."""
-        return self.system_prompt.format(current_datetime=current_datetime)
+        return self.system_prompt.replace("{current_datetime}", current_datetime)
 
 
 @dataclass(frozen=True, slots=True)

--- a/projects/simple-agent-poc/src/simple_agent_poc/core/agent_definition.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/core/agent_definition.py
@@ -1,0 +1,155 @@
+"""Agent definition loading and validation."""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping, cast
+
+import yaml
+
+from simple_agent_poc.core.types import ValidationError
+
+_ROOT_FIELDS = frozenset({"agents"})
+_AGENT_FIELDS = frozenset({"model", "system_prompt", "temperature", "tools"})
+_REQUIRED_AGENT_FIELDS = frozenset({"model", "system_prompt"})
+
+
+@dataclass(frozen=True, slots=True)
+class AgentDefinition:
+    """Configuration for one selectable agent."""
+
+    agent_id: str
+    model: str
+    system_prompt: str
+    temperature: float | None = None
+    tools: list[dict[str, Any]] = field(default_factory=list)
+
+    def format_system_prompt(self, *, current_datetime: str) -> str:
+        """Format the system prompt with runtime context."""
+        return self.system_prompt.format(current_datetime=current_datetime)
+
+
+@dataclass(frozen=True, slots=True)
+class AgentDefinitionRegistry:
+    """Validated collection of agent definitions."""
+
+    _definitions: Mapping[str, AgentDefinition]
+
+    @classmethod
+    def from_yaml_file(cls, path: str | Path) -> "AgentDefinitionRegistry":
+        """Load agent definitions from a YAML file."""
+        config_path = Path(path)
+        try:
+            data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        except OSError as error:
+            raise ValidationError(
+                f"Failed to read agent definitions: {config_path}"
+            ) from error
+        except yaml.YAMLError as error:
+            raise ValidationError(
+                f"Invalid agent definitions YAML: {config_path}"
+            ) from error
+
+        return cls.from_mapping(data)
+
+    @classmethod
+    def from_mapping(cls, data: object) -> "AgentDefinitionRegistry":
+        """Build a registry from a parsed YAML mapping."""
+        root = _require_mapping(data, "root")
+        _reject_unknown_fields(root, _ROOT_FIELDS, "root")
+
+        agents = _require_mapping(root.get("agents"), "agents")
+        if "default" not in agents:
+            raise ValidationError("Agent definitions must include a default agent")
+
+        definitions = {
+            agent_id: _build_agent_definition(agent_id, raw_definition)
+            for agent_id, raw_definition in agents.items()
+        }
+        return cls(_definitions=definitions)
+
+    def get(self, agent_id: str) -> AgentDefinition:
+        """Return an agent definition by id."""
+        try:
+            return self._definitions[agent_id]
+        except KeyError as error:
+            raise ValidationError(f"Unknown agent_id: {agent_id}") from error
+
+
+def _build_agent_definition(
+    agent_id: object,
+    raw_definition: object,
+) -> AgentDefinition:
+    if not isinstance(agent_id, str) or not agent_id.strip():
+        raise ValidationError("Agent ids must be non-blank strings")
+
+    definition = _require_mapping(raw_definition, f"agents.{agent_id}")
+    _reject_unknown_fields(definition, _AGENT_FIELDS, f"agents.{agent_id}")
+
+    missing_fields = _REQUIRED_AGENT_FIELDS - definition.keys()
+    if missing_fields:
+        missing = ", ".join(sorted(missing_fields))
+        raise ValidationError(
+            f"agents.{agent_id} is missing required fields: {missing}"
+        )
+
+    model = _require_non_blank_string(definition["model"], f"agents.{agent_id}.model")
+    system_prompt = _require_non_blank_string(
+        definition["system_prompt"],
+        f"agents.{agent_id}.system_prompt",
+    )
+    temperature = _optional_float(
+        definition.get("temperature"),
+        f"agents.{agent_id}.temperature",
+    )
+    tools = _optional_tools(definition.get("tools"), f"agents.{agent_id}.tools")
+
+    return AgentDefinition(
+        agent_id=agent_id,
+        model=model,
+        system_prompt=system_prompt,
+        temperature=temperature,
+        tools=tools,
+    )
+
+
+def _require_mapping(value: object, path: str) -> Mapping[str, Any]:
+    if not isinstance(value, dict):
+        raise ValidationError(f"{path} must be a mapping")
+    if not all(isinstance(key, str) for key in value):
+        raise ValidationError(f"{path} keys must be strings")
+    return cast(Mapping[str, Any], value)
+
+
+def _reject_unknown_fields(
+    data: Mapping[str, Any],
+    allowed_fields: frozenset[str],
+    path: str,
+) -> None:
+    unknown_fields = data.keys() - allowed_fields
+    if unknown_fields:
+        unknown = ", ".join(sorted(unknown_fields))
+        raise ValidationError(f"{path} has unknown fields: {unknown}")
+
+
+def _require_non_blank_string(value: object, path: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValidationError(f"{path} must be a non-blank string")
+    return value
+
+
+def _optional_float(value: object, path: str) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise ValidationError(f"{path} must be a number")
+    return float(value)
+
+
+def _optional_tools(value: object, path: str) -> list[dict[str, Any]]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise ValidationError(f"{path} must be a list")
+    if not all(isinstance(item, dict) for item in value):
+        raise ValidationError(f"{path} items must be mappings")
+    return cast(list[dict[str, Any]], value)

--- a/projects/simple-agent-poc/src/simple_agent_poc/core/session.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/core/session.py
@@ -10,13 +10,21 @@ class ConversationSession:
     """Conversation history identified by a session id."""
 
     session_id: str
+    agent_id: str = "default"
     messages: list[Message] = field(default_factory=list)
 
     @classmethod
-    def start(cls, *, session_id: str, system_prompt: str) -> "ConversationSession":
+    def start(
+        cls,
+        *,
+        session_id: str,
+        agent_id: str = "default",
+        system_prompt: str,
+    ) -> "ConversationSession":
         """Create a new session with its initial system prompt."""
         return cls(
             session_id=session_id,
+            agent_id=agent_id,
             messages=[{"role": "system", "content": system_prompt}],
         )
 

--- a/projects/simple-agent-poc/src/simple_agent_poc/entrypoints/bootstrap.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/entrypoints/bootstrap.py
@@ -1,52 +1,51 @@
 """Shared dependency wiring for entrypoints."""
 
 import logging
+import os
 from collections.abc import Callable
-from datetime import datetime
+from pathlib import Path
 
 from dotenv import load_dotenv
 
-from simple_agent_poc.adapters.llm.litellm_client import LiteLLMClient
+from simple_agent_poc.adapters.llm.litellm_client import LiteLLMClientFactory
 from simple_agent_poc.adapters.session_store.in_memory import InMemorySessionStore
 from simple_agent_poc.application.ports import SessionStore
 from simple_agent_poc.application.use_cases import RunAgentUseCase
+from simple_agent_poc.core.agent_definition import AgentDefinitionRegistry
 
 logging.getLogger("litellm").setLevel(logging.CRITICAL)
 logging.getLogger("litellm").addHandler(logging.NullHandler())
 
 load_dotenv()
 
-DEFAULT_SYSTEM_PROMPT = """You are an AI assistant designed to help users with various tasks.
+DEFAULT_AGENT_ID = "default"
+DEFAULT_AGENTS_FILE = Path("agents.yaml")
 
-Guidelines:
-1. Be helpful, accurate, and concise
-2. Provide clear explanations when needed
-3. Admit when you don't know something
-4. Maintain a professional and friendly tone
-5. Use the current temporal context when relevant to the user's query.
 
-Current datetime: {current_datetime}
-"""
-
-DEFAULT_MODEL = "gpt-4.1-nano"
+def create_agent_definition_registry() -> AgentDefinitionRegistry:
+    """Load configured agent definitions."""
+    agents_file = Path(os.environ.get("AGENTS_FILE", DEFAULT_AGENTS_FILE))
+    return AgentDefinitionRegistry.from_yaml_file(agents_file)
 
 
 def create_run_agent_use_case(
     *,
     session_store: SessionStore | None = None,
+    agent_definitions: AgentDefinitionRegistry | None = None,
 ) -> RunAgentUseCase:
     """Create the shared use case with production dependencies."""
-    formatted_system_prompt = DEFAULT_SYSTEM_PROMPT.format(
-        current_datetime=datetime.now().isoformat()
-    )
     return RunAgentUseCase(
-        llm_client=LiteLLMClient(model=DEFAULT_MODEL),
+        llm_client_factory=LiteLLMClientFactory(),
         session_store=session_store or InMemorySessionStore(),
-        system_prompt=formatted_system_prompt,
+        agent_definitions=agent_definitions or create_agent_definition_registry(),
     )
 
 
 def create_run_agent_use_case_factory() -> Callable[[], RunAgentUseCase]:
     """Create a use case factory backed by a shared in-memory session store."""
     session_store = InMemorySessionStore()
-    return lambda: create_run_agent_use_case(session_store=session_store)
+    agent_definitions = create_agent_definition_registry()
+    return lambda: create_run_agent_use_case(
+        session_store=session_store,
+        agent_definitions=agent_definitions,
+    )

--- a/projects/simple-agent-poc/src/simple_agent_poc/entrypoints/main_cli.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/entrypoints/main_cli.py
@@ -1,19 +1,24 @@
 """CLI entry point wiring."""
 
+import argparse
+from collections.abc import Sequence
+
 from simple_agent_poc.adapters.cli.adapter import CLIAdapter
 from simple_agent_poc.entrypoints import bootstrap
 
-DEFAULT_MODEL = bootstrap.DEFAULT_MODEL
 
-
-def build_cli_adapter() -> CLIAdapter:
+def build_cli_adapter(*, agent_id: str = bootstrap.DEFAULT_AGENT_ID) -> CLIAdapter:
     """Create the CLI adapter with production dependencies."""
-    return CLIAdapter(bootstrap.create_run_agent_use_case())
+    return CLIAdapter(bootstrap.create_run_agent_use_case(), agent_id=agent_id)
 
 
-def main() -> None:
+def main(argv: Sequence[str] | None = None) -> None:
     """Run the CLI entry point."""
-    adapter = build_cli_adapter()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--agent", default=bootstrap.DEFAULT_AGENT_ID)
+    args = parser.parse_args(argv)
+
+    adapter = build_cli_adapter(agent_id=args.agent)
     adapter.run()
 
 

--- a/projects/simple-agent-poc/tests/test_agent_definition.py
+++ b/projects/simple-agent-poc/tests/test_agent_definition.py
@@ -61,6 +61,21 @@ agents:
 
         assert registry.get("default").model == "gpt-4.1-nano"
 
+    def test_allows_null_temperature(self) -> None:
+        registry = AgentDefinitionRegistry.from_mapping(
+            {
+                "agents": {
+                    "default": {
+                        "model": "gpt-5.4-mini",
+                        "system_prompt": "Prompt",
+                        "temperature": None,
+                    }
+                }
+            }
+        )
+
+        assert registry.get("default").temperature is None
+
     def test_rejects_missing_default_agent(self) -> None:
         with pytest.raises(ValidationError, match="default agent"):
             AgentDefinitionRegistry.from_mapping({"agents": {}})

--- a/projects/simple-agent-poc/tests/test_agent_definition.py
+++ b/projects/simple-agent-poc/tests/test_agent_definition.py
@@ -61,6 +61,26 @@ agents:
 
         assert registry.get("default").model == "gpt-4.1-nano"
 
+    def test_format_system_prompt_preserves_non_runtime_braces(self) -> None:
+        registry = AgentDefinitionRegistry.from_mapping(
+            {
+                "agents": {
+                    "default": {
+                        "model": "gpt-4.1-nano",
+                        "system_prompt": (
+                            'Now: {current_datetime}\nJSON example: {"ok": true}'
+                        ),
+                    }
+                }
+            }
+        )
+
+        formatted = registry.get("default").format_system_prompt(
+            current_datetime="2026-05-14T00:00:00"
+        )
+
+        assert formatted == 'Now: 2026-05-14T00:00:00\nJSON example: {"ok": true}'
+
     def test_allows_null_temperature(self) -> None:
         registry = AgentDefinitionRegistry.from_mapping(
             {

--- a/projects/simple-agent-poc/tests/test_agent_definition.py
+++ b/projects/simple-agent-poc/tests/test_agent_definition.py
@@ -1,0 +1,106 @@
+"""Tests for agent definition loading."""
+
+from pathlib import Path
+
+import pytest
+
+from simple_agent_poc.core.agent_definition import AgentDefinitionRegistry
+from simple_agent_poc.core.types import ValidationError
+
+
+def valid_config() -> dict[str, object]:
+    return {
+        "agents": {
+            "default": {
+                "model": "gpt-4.1-nano",
+                "system_prompt": "Default {current_datetime}",
+                "temperature": 0.2,
+                "tools": [],
+            },
+            "researcher": {
+                "model": "gpt-4.1-nano",
+                "system_prompt": "Research {current_datetime}",
+                "temperature": 0.1,
+                "tools": [],
+            },
+        }
+    }
+
+
+class TestAgentDefinitionRegistry:
+    """Tests for validated agent definition registries."""
+
+    def test_loads_multiple_agents(self) -> None:
+        registry = AgentDefinitionRegistry.from_mapping(valid_config())
+
+        default_agent = registry.get("default")
+        researcher = registry.get("researcher")
+
+        assert default_agent.model == "gpt-4.1-nano"
+        assert default_agent.temperature == 0.2
+        assert (
+            default_agent.format_system_prompt(current_datetime="2026-05-14T00:00:00")
+            == "Default 2026-05-14T00:00:00"
+        )
+        assert researcher.system_prompt == "Research {current_datetime}"
+
+    def test_loads_from_yaml_file(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "agents.yaml"
+        config_file.write_text(
+            """
+agents:
+  default:
+    model: gpt-4.1-nano
+    system_prompt: Default
+    tools: []
+""",
+            encoding="utf-8",
+        )
+
+        registry = AgentDefinitionRegistry.from_yaml_file(config_file)
+
+        assert registry.get("default").model == "gpt-4.1-nano"
+
+    def test_rejects_missing_default_agent(self) -> None:
+        with pytest.raises(ValidationError, match="default agent"):
+            AgentDefinitionRegistry.from_mapping({"agents": {}})
+
+    def test_rejects_missing_required_field(self) -> None:
+        with pytest.raises(ValidationError, match="missing required fields: model"):
+            AgentDefinitionRegistry.from_mapping(
+                {"agents": {"default": {"system_prompt": "Prompt"}}}
+            )
+
+    def test_rejects_unknown_agent_field(self) -> None:
+        with pytest.raises(ValidationError, match="unknown fields: unknown"):
+            AgentDefinitionRegistry.from_mapping(
+                {
+                    "agents": {
+                        "default": {
+                            "model": "gpt-4.1-nano",
+                            "system_prompt": "Prompt",
+                            "unknown": True,
+                        }
+                    }
+                }
+            )
+
+    def test_rejects_invalid_types(self) -> None:
+        with pytest.raises(ValidationError, match="temperature must be a number"):
+            AgentDefinitionRegistry.from_mapping(
+                {
+                    "agents": {
+                        "default": {
+                            "model": "gpt-4.1-nano",
+                            "system_prompt": "Prompt",
+                            "temperature": "warm",
+                        }
+                    }
+                }
+            )
+
+    def test_rejects_unknown_agent_id(self) -> None:
+        registry = AgentDefinitionRegistry.from_mapping(valid_config())
+
+        with pytest.raises(ValidationError, match="Unknown agent_id: missing"):
+            registry.get("missing")

--- a/projects/simple-agent-poc/tests/test_api.py
+++ b/projects/simple-agent-poc/tests/test_api.py
@@ -6,6 +6,7 @@ from simple_agent_poc.adapters.http.api import create_app
 from simple_agent_poc.adapters.session_store.in_memory import InMemorySessionStore
 from simple_agent_poc.application.ports import LLMClient
 from simple_agent_poc.application.use_cases import RunAgentUseCase
+from simple_agent_poc.core.agent_definition import AgentDefinitionRegistry
 from simple_agent_poc.core.types import LLMResponse, Message
 
 
@@ -33,9 +34,26 @@ class StubLLMClient(LLMClient):
 def unused_use_case_factory() -> RunAgentUseCase:
     """Build a minimal use case for requests that should fail validation first."""
     return RunAgentUseCase(
-        llm_client=StubLLMClient(reply="unused"),
+        llm_client_factory=lambda _agent_definition: StubLLMClient(reply="unused"),
         session_store=InMemorySessionStore(),
-        system_prompt="System prompt",
+        agent_definitions=build_registry(),
+    )
+
+
+def build_registry() -> AgentDefinitionRegistry:
+    return AgentDefinitionRegistry.from_mapping(
+        {
+            "agents": {
+                "default": {
+                    "model": "default-model",
+                    "system_prompt": "System prompt",
+                },
+                "researcher": {
+                    "model": "research-model",
+                    "system_prompt": "Research prompt",
+                },
+            }
+        }
     )
 
 
@@ -46,9 +64,9 @@ class TestAPI:
         llm_client = StubLLMClient(reply="Hello, user!")
         app = create_app(
             use_case_factory=lambda: RunAgentUseCase(
-                llm_client=llm_client,
+                llm_client_factory=lambda _agent_definition: llm_client,
                 session_store=InMemorySessionStore(),
-                system_prompt="System prompt",
+                agent_definitions=build_registry(),
             )
         )
         client = TestClient(app)
@@ -85,9 +103,9 @@ class TestAPI:
 
         app = create_app(
             use_case_factory=lambda: RunAgentUseCase(
-                llm_client=next(llm_clients),
+                llm_client_factory=lambda _agent_definition: next(llm_clients),
                 session_store=store,
-                system_prompt="System prompt",
+                agent_definitions=build_registry(),
             )
         )
         client = TestClient(app)
@@ -118,9 +136,9 @@ class TestAPI:
 
         app = create_app(
             use_case_factory=lambda: RunAgentUseCase(
-                llm_client=next(llm_clients),
+                llm_client_factory=lambda _agent_definition: next(llm_clients),
                 session_store=store,
-                system_prompt="System prompt",
+                agent_definitions=build_registry(),
             )
         )
         client = TestClient(app)
@@ -139,9 +157,11 @@ class TestAPI:
     def test_chat_returns_404_for_unknown_session_header(self) -> None:
         app = create_app(
             use_case_factory=lambda: RunAgentUseCase(
-                llm_client=StubLLMClient(reply="unused"),
+                llm_client_factory=lambda _agent_definition: StubLLMClient(
+                    reply="unused"
+                ),
                 session_store=InMemorySessionStore(),
-                system_prompt="System prompt",
+                agent_definitions=build_registry(),
             )
         )
         client = TestClient(app)
@@ -158,9 +178,11 @@ class TestAPI:
     def test_chat_returns_400_for_conflicting_session_transports(self) -> None:
         app = create_app(
             use_case_factory=lambda: RunAgentUseCase(
-                llm_client=StubLLMClient(reply="unused"),
+                llm_client_factory=lambda _agent_definition: StubLLMClient(
+                    reply="unused"
+                ),
                 session_store=InMemorySessionStore(),
-                system_prompt="System prompt",
+                agent_definitions=build_registry(),
             )
         )
         client = TestClient(app)
@@ -177,4 +199,64 @@ class TestAPI:
                 "Conflicting session_id values were provided in the "
                 "Session-Id header and request body."
             )
+        }
+
+    def test_chat_uses_body_agent_id(self) -> None:
+        llm_client = StubLLMClient(reply="Research reply")
+        app = create_app(
+            use_case_factory=lambda: RunAgentUseCase(
+                llm_client_factory=lambda _agent_definition: llm_client,
+                session_store=InMemorySessionStore(),
+                agent_definitions=build_registry(),
+            )
+        )
+        client = TestClient(app)
+
+        response = client.post(
+            "/api/chat",
+            json={"message": "Hello", "agent_id": "researcher"},
+        )
+
+        assert response.status_code == 200
+        assert llm_client.calls[0] == [
+            {"role": "system", "content": "Research prompt"},
+            {"role": "user", "content": "Hello"},
+        ]
+
+    def test_chat_returns_400_for_unknown_agent_id(self) -> None:
+        app = create_app(use_case_factory=unused_use_case_factory)
+        client = TestClient(app)
+
+        response = client.post(
+            "/api/chat",
+            json={"message": "Hello", "agent_id": "missing"},
+        )
+
+        assert response.status_code == 400
+        assert response.json() == {"detail": "Unknown agent_id: missing"}
+
+    def test_chat_returns_400_when_agent_changes_for_session(self) -> None:
+        store = InMemorySessionStore()
+        app = create_app(
+            use_case_factory=lambda: RunAgentUseCase(
+                llm_client_factory=lambda _agent_definition: StubLLMClient(
+                    reply="Reply"
+                ),
+                session_store=store,
+                agent_definitions=build_registry(),
+            )
+        )
+        client = TestClient(app)
+
+        first_response = client.post("/api/chat", json={"message": "Hello"})
+        session_id = first_response.json()["session_id"]
+        second_response = client.post(
+            "/api/chat",
+            headers={"Session-Id": session_id},
+            json={"message": "Again", "agent_id": "researcher"},
+        )
+
+        assert second_response.status_code == 400
+        assert second_response.json() == {
+            "detail": "agent_id cannot be changed for an existing session"
         }

--- a/projects/simple-agent-poc/tests/test_application.py
+++ b/projects/simple-agent-poc/tests/test_application.py
@@ -7,6 +7,7 @@ import pytest
 from simple_agent_poc.adapters.session_store.in_memory import InMemorySessionStore
 from simple_agent_poc.application.dto import RunAgentRequest, RunAgentResponse
 from simple_agent_poc.application.use_cases import RunAgentUseCase
+from simple_agent_poc.core.agent_definition import AgentDefinitionRegistry
 from simple_agent_poc.core.types import (
     LLMResponse,
     SessionNotFoundError,
@@ -22,6 +23,7 @@ class TestRunAgentRequest:
 
         assert request.message == "Hello"
         assert request.session_id is None
+        assert request.agent_id == "default"
 
 
 class TestRunAgentResponse:
@@ -54,6 +56,24 @@ class TestRunAgentResponse:
 class TestRunAgentUseCase:
     """Tests for the reusable agent execution path."""
 
+    def build_registry(self) -> AgentDefinitionRegistry:
+        return AgentDefinitionRegistry.from_mapping(
+            {
+                "agents": {
+                    "default": {
+                        "model": "default-model",
+                        "system_prompt": "System prompt",
+                    },
+                    "researcher": {
+                        "model": "research-model",
+                        "system_prompt": "Research prompt",
+                        "temperature": 0.1,
+                        "tools": [],
+                    },
+                }
+            }
+        )
+
     def test_execute_creates_new_session_and_saves_it(self) -> None:
         llm_client = MagicMock()
         llm_client.complete.return_value = {
@@ -67,10 +87,11 @@ class TestRunAgentUseCase:
             "response_time": 0.85,
         }
         store = InMemorySessionStore()
+        llm_client_factory = MagicMock(return_value=llm_client)
         use_case = RunAgentUseCase(
-            llm_client=llm_client,
+            llm_client_factory=llm_client_factory,
             session_store=store,
-            system_prompt="System prompt",
+            agent_definitions=self.build_registry(),
         )
 
         response = use_case.execute(RunAgentRequest(message="Hello"))
@@ -93,12 +114,48 @@ class TestRunAgentUseCase:
                 {"role": "user", "content": "Hello"},
             ]
         )
+        llm_client_factory.assert_called_once()
+        assert llm_client_factory.call_args.args[0].agent_id == "default"
         stored_session = store.get(response.session_id)
         assert stored_session is not None
+        assert stored_session.agent_id == "default"
         assert stored_session.messages[-1] == {
             "role": "assistant",
             "content": "Hello, user!",
         }
+
+    def test_execute_uses_requested_agent_definition(self) -> None:
+        llm_client = MagicMock()
+        llm_client.complete.return_value = {
+            "content": "Research reply",
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "total_tokens": 15,
+            },
+            "model": "research-model",
+            "response_time": 0.85,
+        }
+        llm_client_factory = MagicMock(return_value=llm_client)
+        use_case = RunAgentUseCase(
+            llm_client_factory=llm_client_factory,
+            session_store=InMemorySessionStore(),
+            agent_definitions=self.build_registry(),
+        )
+
+        response = use_case.execute(
+            RunAgentRequest(message="Hello", agent_id="researcher")
+        )
+
+        assert response.model == "research-model"
+        llm_client_factory.assert_called_once()
+        assert llm_client_factory.call_args.args[0].agent_id == "researcher"
+        llm_client.complete.assert_called_once_with(
+            [
+                {"role": "system", "content": "Research prompt"},
+                {"role": "user", "content": "Hello"},
+            ]
+        )
 
     def test_execute_reuses_existing_session(self) -> None:
         first_client = MagicMock()
@@ -124,15 +181,17 @@ class TestRunAgentUseCase:
             "response_time": 0.3,
         }
         store = InMemorySessionStore()
+        first_factory = MagicMock(return_value=first_client)
+        second_factory = MagicMock(return_value=second_client)
         first_use_case = RunAgentUseCase(
-            llm_client=first_client,
+            llm_client_factory=first_factory,
             session_store=store,
-            system_prompt="System prompt",
+            agent_definitions=self.build_registry(),
         )
         second_use_case = RunAgentUseCase(
-            llm_client=second_client,
+            llm_client_factory=second_factory,
             session_store=store,
-            system_prompt="System prompt",
+            agent_definitions=self.build_registry(),
         )
 
         first_response = first_use_case.execute(RunAgentRequest(message="Hello"))
@@ -150,11 +209,41 @@ class TestRunAgentUseCase:
             ]
         )
 
+    def test_execute_rejects_agent_change_for_existing_session(self) -> None:
+        llm_client = MagicMock()
+        llm_client.complete.return_value = {
+            "content": "First reply",
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "total_tokens": 15,
+            },
+            "model": "default-model",
+            "response_time": 0.2,
+        }
+        store = InMemorySessionStore()
+        use_case = RunAgentUseCase(
+            llm_client_factory=MagicMock(return_value=llm_client),
+            session_store=store,
+            agent_definitions=self.build_registry(),
+        )
+
+        first_response = use_case.execute(RunAgentRequest(message="Hello"))
+
+        with pytest.raises(ValidationError, match="agent_id cannot be changed"):
+            use_case.execute(
+                RunAgentRequest(
+                    message="Again",
+                    session_id=first_response.session_id,
+                    agent_id="researcher",
+                )
+            )
+
     def test_execute_rejects_unknown_session(self) -> None:
         use_case = RunAgentUseCase(
-            llm_client=MagicMock(),
+            llm_client_factory=MagicMock(return_value=MagicMock()),
             session_store=InMemorySessionStore(),
-            system_prompt="System prompt",
+            agent_definitions=self.build_registry(),
         )
 
         with pytest.raises(SessionNotFoundError, match="Session not found"):
@@ -164,10 +253,20 @@ class TestRunAgentUseCase:
 
     def test_execute_rejects_blank_message(self) -> None:
         use_case = RunAgentUseCase(
-            llm_client=MagicMock(),
+            llm_client_factory=MagicMock(return_value=MagicMock()),
             session_store=InMemorySessionStore(),
-            system_prompt="System prompt",
+            agent_definitions=self.build_registry(),
         )
 
         with pytest.raises(ValidationError, match="message must not be blank"):
             use_case.execute(RunAgentRequest(message="   "))
+
+    def test_execute_rejects_unknown_agent_id(self) -> None:
+        use_case = RunAgentUseCase(
+            llm_client_factory=MagicMock(return_value=MagicMock()),
+            session_store=InMemorySessionStore(),
+            agent_definitions=self.build_registry(),
+        )
+
+        with pytest.raises(ValidationError, match="Unknown agent_id: missing"):
+            use_case.execute(RunAgentRequest(message="Hello", agent_id="missing"))

--- a/projects/simple-agent-poc/tests/test_cli.py
+++ b/projects/simple-agent-poc/tests/test_cli.py
@@ -50,7 +50,7 @@ class TestCLIAdapter:
 
         adapter.run()
 
-        welcome_renderer.assert_called_once_with()
+        welcome_renderer.assert_called_once_with("default")
         run_agent.execute.assert_called_once()
         request = run_agent.execute.call_args.args[0]
         assert request.message == "Hello"
@@ -85,6 +85,34 @@ class TestCLIAdapter:
 
         request = run_agent.execute.call_args.args[0]
         assert request.agent_id == "researcher"
+
+    def test_run_passes_agent_id_to_welcome_renderer(self) -> None:
+        run_agent = MagicMock()
+        run_agent.execute.return_value = RunAgentResponse(
+            message="Hello, user!",
+            usage={
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "total_tokens": 15,
+            },
+            model="gpt-4o-mini",
+            response_time=0.85,
+            session_id="session-1",
+        )
+        input_reader = MagicMock(side_effect=["Hello", EOFError()])
+        welcome_renderer = MagicMock()
+
+        adapter = CLIAdapter(
+            run_agent,
+            agent_id="researcher",
+            input_reader=input_reader,
+            welcome_renderer=welcome_renderer,
+            indicator_runner=passthrough_indicator,
+        )
+
+        adapter.run()
+
+        welcome_renderer.assert_called_once_with("researcher")
 
     def test_run_reuses_session_id_on_later_turns(self) -> None:
         run_agent = MagicMock()

--- a/projects/simple-agent-poc/tests/test_cli.py
+++ b/projects/simple-agent-poc/tests/test_cli.py
@@ -55,8 +55,36 @@ class TestCLIAdapter:
         request = run_agent.execute.call_args.args[0]
         assert request.message == "Hello"
         assert request.session_id is None
+        assert request.agent_id == "default"
         response_renderer.assert_called_once_with(run_agent.execute.return_value)
         exit_renderer.assert_called_once_with()
+
+    def test_run_passes_configured_agent_id(self) -> None:
+        run_agent = MagicMock()
+        run_agent.execute.return_value = RunAgentResponse(
+            message="Hello, user!",
+            usage={
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "total_tokens": 15,
+            },
+            model="gpt-4o-mini",
+            response_time=0.85,
+            session_id="session-1",
+        )
+        input_reader = MagicMock(side_effect=["Hello", EOFError()])
+
+        adapter = CLIAdapter(
+            run_agent,
+            agent_id="researcher",
+            input_reader=input_reader,
+            indicator_runner=passthrough_indicator,
+        )
+
+        adapter.run()
+
+        request = run_agent.execute.call_args.args[0]
+        assert request.agent_id == "researcher"
 
     def test_run_reuses_session_id_on_later_turns(self) -> None:
         run_agent = MagicMock()

--- a/projects/simple-agent-poc/tests/test_llm_client.py
+++ b/projects/simple-agent-poc/tests/test_llm_client.py
@@ -78,6 +78,27 @@ class TestLiteLLMClient:
         )
 
     @patch("simple_agent_poc.adapters.llm.litellm_client.completion")
+    def test_complete_omits_null_temperature(self, mock_completion: MagicMock) -> None:
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Hello, world!"
+        mock_response.usage.prompt_tokens = 10
+        mock_response.usage.completion_tokens = 5
+        mock_response.usage.total_tokens = 15
+        mock_completion.return_value = mock_response
+
+        client = LiteLLMClient(model="gpt-5.4-mini", temperature=None)
+        messages: list[Message] = [{"role": "user", "content": "Hi"}]
+
+        client.complete(messages)
+
+        mock_completion.assert_called_once_with(
+            model="gpt-5.4-mini",
+            messages=messages,
+            stream=False,
+        )
+
+    @patch("simple_agent_poc.adapters.llm.litellm_client.completion")
     def test_complete_authentication_error(self, mock_completion: MagicMock) -> None:
         mock_completion.side_effect = LiteLLMAuthError(
             "Invalid API key",

--- a/projects/simple-agent-poc/tests/test_llm_client.py
+++ b/projects/simple-agent-poc/tests/test_llm_client.py
@@ -8,7 +8,11 @@ from litellm.exceptions import (
     RateLimitError as LiteLLMRateLimitError,
 )
 
-from simple_agent_poc.adapters.llm.litellm_client import LiteLLMClient
+from simple_agent_poc.adapters.llm.litellm_client import (
+    LiteLLMClient,
+    LiteLLMClientFactory,
+)
+from simple_agent_poc.core.agent_definition import AgentDefinition
 from simple_agent_poc.core.types import (
     AuthenticationError,
     LLMError,
@@ -21,8 +25,9 @@ class TestLiteLLMClient:
     """Tests for LiteLLMClient class."""
 
     def test_init(self) -> None:
-        client = LiteLLMClient(model="gpt-4")
+        client = LiteLLMClient(model="gpt-4", temperature=0.2)
         assert client.model == "gpt-4"
+        assert client.temperature == 0.2
 
     @patch("simple_agent_poc.adapters.llm.litellm_client.completion")
     def test_complete_success(self, mock_completion: MagicMock) -> None:
@@ -48,6 +53,28 @@ class TestLiteLLMClient:
             model="gpt-4",
             messages=messages,
             stream=False,
+        )
+
+    @patch("simple_agent_poc.adapters.llm.litellm_client.completion")
+    def test_complete_passes_temperature(self, mock_completion: MagicMock) -> None:
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Hello, world!"
+        mock_response.usage.prompt_tokens = 10
+        mock_response.usage.completion_tokens = 5
+        mock_response.usage.total_tokens = 15
+        mock_completion.return_value = mock_response
+
+        client = LiteLLMClient(model="gpt-4", temperature=0.2)
+        messages: list[Message] = [{"role": "user", "content": "Hi"}]
+
+        client.complete(messages)
+
+        mock_completion.assert_called_once_with(
+            model="gpt-4",
+            messages=messages,
+            stream=False,
+            temperature=0.2,
         )
 
     @patch("simple_agent_poc.adapters.llm.litellm_client.completion")
@@ -135,3 +162,17 @@ class TestLiteLLMClient:
             messages=messages,
             stream=False,
         )
+
+    def test_factory_uses_agent_definition(self) -> None:
+        factory = LiteLLMClientFactory()
+        agent_definition = AgentDefinition(
+            agent_id="researcher",
+            model="gpt-4",
+            system_prompt="Prompt",
+            temperature=0.1,
+        )
+
+        client = factory(agent_definition)
+
+        assert client.model == "gpt-4"
+        assert client.temperature == 0.1

--- a/projects/simple-agent-poc/tests/test_main.py
+++ b/projects/simple-agent-poc/tests/test_main.py
@@ -21,8 +21,22 @@ class TestBuildCLIAdapter:
             assert adapter is mock_cli_adapter.return_value
             mock_create_run_agent_use_case.assert_called_once_with()
             mock_cli_adapter.assert_called_once_with(
-                mock_create_run_agent_use_case.return_value
+                mock_create_run_agent_use_case.return_value,
+                agent_id="default",
             )
+
+    @patch("simple_agent_poc.entrypoints.main_cli.CLIAdapter")
+    def test_build_cli_adapter_passes_agent_id(
+        self,
+        mock_cli_adapter: MagicMock,
+    ) -> None:
+        with patch(
+            "simple_agent_poc.entrypoints.main_cli.bootstrap.create_run_agent_use_case"
+        ):
+            build_cli_adapter(agent_id="researcher")
+
+            mock_cli_adapter.assert_called_once()
+            assert mock_cli_adapter.call_args.kwargs["agent_id"] == "researcher"
 
 
 class TestMain:
@@ -32,7 +46,18 @@ class TestMain:
     def test_main_runs_built_adapter(self, mock_build_cli_adapter: MagicMock) -> None:
         adapter = mock_build_cli_adapter.return_value
 
-        main()
+        main([])
 
-        mock_build_cli_adapter.assert_called_once_with()
+        mock_build_cli_adapter.assert_called_once_with(agent_id="default")
+        adapter.run.assert_called_once_with()
+
+    @patch("simple_agent_poc.entrypoints.main_cli.build_cli_adapter")
+    def test_main_accepts_agent_argument(
+        self, mock_build_cli_adapter: MagicMock
+    ) -> None:
+        adapter = mock_build_cli_adapter.return_value
+
+        main(["--agent", "researcher"])
+
+        mock_build_cli_adapter.assert_called_once_with(agent_id="researcher")
         adapter.run.assert_called_once_with()

--- a/projects/simple-agent-poc/tests/test_renderer.py
+++ b/projects/simple-agent-poc/tests/test_renderer.py
@@ -56,7 +56,7 @@ class TestShowWelcome:
     def test_show_welcome(self, mock_print: MagicMock) -> None:
         show_welcome()
 
-        assert mock_print.call_count == 5
+        assert mock_print.call_count == 6
         calls = [
             call.args[0] if call.args else "" for call in mock_print.call_args_list
         ]
@@ -64,6 +64,17 @@ class TestShowWelcome:
         assert "═" * 40 in non_empty_calls[0]
         assert "Welcome to Simple Agent POC" in non_empty_calls[1]
         assert "Ctrl+C" in non_empty_calls[2]
+        assert "AgentId: default" in non_empty_calls[3]
+
+    @patch("builtins.print")
+    def test_show_welcome_with_configured_agent_id(self, mock_print: MagicMock) -> None:
+        show_welcome("researcher")
+
+        calls = [
+            call.args[0] if call.args else "" for call in mock_print.call_args_list
+        ]
+        non_empty_calls = [call for call in calls if call]
+        assert "AgentId: researcher" in non_empty_calls[3]
 
 
 class TestGetUserInput:

--- a/projects/simple-agent-poc/tests/test_session.py
+++ b/projects/simple-agent-poc/tests/test_session.py
@@ -14,7 +14,17 @@ class TestConversationSession:
         )
 
         assert session.session_id == "session-1"
+        assert session.agent_id == "default"
         assert session.messages == [{"role": "system", "content": "System prompt"}]
+
+    def test_start_records_agent_id(self) -> None:
+        session = ConversationSession.start(
+            session_id="session-1",
+            agent_id="researcher",
+            system_prompt="System prompt",
+        )
+
+        assert session.agent_id == "researcher"
 
     def test_appends_messages_in_order(self) -> None:
         session = ConversationSession.start(

--- a/projects/simple-agent-poc/uv.lock
+++ b/projects/simple-agent-poc/uv.lock
@@ -976,6 +976,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "litellm" },
     { name = "python-dotenv" },
+    { name = "pyyaml" },
     { name = "uvicorn" },
 ]
 
@@ -993,6 +994,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.136.1" },
     { name = "litellm", specifier = ">=1.81.14" },
     { name = "python-dotenv", specifier = ">=1.2.1" },
+    { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "uvicorn", specifier = ">=0.46.0" },
 ]
 


### PR DESCRIPTION
## Why

Agent定義の外だしに合わせて、CLI起動時に現在どのAgentを使っているかをすぐ確認できるようにするためです。

## Summary

Agent定義をYAMLから選べるようになったので、CLIの起動バナーにも選択中の `agent_id` を表示するようにしました。あわせて、welcome renderer まで `agent_id` を渡す配線とテストを更新しています。

## Changes

- AgentId を CLI の welcome バナーに表示
- CLIAdapter から welcome renderer へ configured `agent_id` を引き渡し
- renderer と adapter の表示テストを更新

## Checklist

- [x] `uv run pytest tests/test_renderer.py tests/test_cli.py tests/test_main.py`
- [x] `uv run ruff check src/simple_agent_poc/adapters/cli/renderer.py src/simple_agent_poc/adapters/cli/adapter.py tests/test_renderer.py tests/test_cli.py`
