### PR TITLE
feat(simple-agent-poc): rename researcher to kansaiben agent

### DIFF
--- a/projects/simple-agent-poc/README.md
+++ b/projects/simple-agent-poc/README.md
@@ -29,7 +29,7 @@ uv run dev
 Run the CLI with a specific agent from `agents.yaml`:
 
 ```bash
-uv run dev --agent researcher
+uv run dev --agent kansaiben
 ```
 
 ## API Usage
@@ -53,7 +53,7 @@ Send a request with a specific agent:
 ```bash
 curl -X POST http://127.0.0.1:8000/api/chat \
   -H "Content-Type: application/json" \
-  -d '{"message":"調べて","agent_id":"researcher"}'
+  -d '{"message":"調べて","agent_id":"kansaiben"}'
 ```
 
 Continue the same conversation by sending back the returned `session_id`:
@@ -97,26 +97,7 @@ The process entrypoints live under `src/simple_agent_poc/entrypoints/`.
 Agent definitions are loaded from `agents.yaml` by default. Set `AGENTS_FILE` to point at
 another YAML file when running with a different definition set.
 
-```yaml
-agents:
-  default:
-    model: gpt-4.1-nano
-    system_prompt: |
-      You are an AI assistant.
-      Current datetime: {current_datetime}
-    temperature: null
-    tools: []
-
-  researcher:
-    model: gpt-4.1-nano
-    system_prompt: |
-      You are a research-focused assistant.
-      Current datetime: {current_datetime}
-    temperature: null
-    tools: []
-```
-
-The YAML file must contain `agents.default`. Each agent supports these fields:
+Each agent supports these fields:
 
 - `model`: required LiteLLM model name.
 - `system_prompt`: required prompt template. `{current_datetime}` is filled at session start.

--- a/projects/simple-agent-poc/agents.yaml
+++ b/projects/simple-agent-poc/agents.yaml
@@ -15,10 +15,11 @@ agents:
     temperature: null
     tools: []
 
-  researcher:
+  kansaiben:
     model: gpt-4.1-nano
     system_prompt: |
-      You are a research-focused assistant.
+      あんたはおしゃべり好きなエージェントや。
+      なんでも関西弁で気軽に話しかけてや。
       Current datetime: {current_datetime}
     temperature: null
     tools: []


### PR DESCRIPTION
## Why

`researcher` エージェントを関西弁エージェント (`kansaiben`) に置き換え。README から YAML 構造の重複管理を排除し、`agents.yaml` を唯一の参照元とする。

## Summary

- `agents.yaml`: `researcher` → `kansaiben` に名称変更、関西弁の system_prompt に差し替え
- `README.md`: インライン YAML ブロックを削除、例示の agent_id を `kansaiben` に更新

## Changes

- `agents.yaml` の `researcher` を `kansaiben` に renamed
- `README.md` から具体的な YAML 構造を削除（二重管理防止）
- CLI/API 使用例の agent_id を `researcher` → `kansaiben` に修正
