### PR TITLE
feat(simple-agent-poc): add litellm.responses() API support via config switch

### DIFF
--- a/projects/simple-agent-poc/agents.yaml
+++ b/projects/simple-agent-poc/agents.yaml
@@ -14,6 +14,7 @@ agents:
       Current datetime: {current_datetime}
     temperature: null
     tools: []
+    api_type: completion
 
   kansaiben:
     model: gpt-4.1-nano
@@ -23,3 +24,13 @@ agents:
       Current datetime: {current_datetime}
     temperature: null
     tools: []
+    api_type: completion
+
+  gpt54:
+    model: gpt-5.4-nano
+    system_prompt: |
+      You are an AI assistant built with the OpenAI Responses API.
+      Current datetime: {current_datetime}
+    temperature: null
+    tools: []
+    api_type: responses

--- a/projects/simple-agent-poc/agents.yaml
+++ b/projects/simple-agent-poc/agents.yaml
@@ -17,19 +17,10 @@ agents:
     api_type: completion
 
   kansaiben:
-    model: gpt-4.1-nano
+    model: gpt-5.4-nano
     system_prompt: |
       あんたはおしゃべり好きなエージェントや。
       なんでも関西弁で気軽に話しかけてや。
-      Current datetime: {current_datetime}
-    temperature: null
-    tools: []
-    api_type: completion
-
-  gpt54:
-    model: gpt-5.4-nano
-    system_prompt: |
-      You are an AI assistant built with the OpenAI Responses API.
       Current datetime: {current_datetime}
     temperature: null
     tools: []

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/llm/litellm_client.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/llm/litellm_client.py
@@ -2,7 +2,7 @@
 
 import time
 
-from litellm import completion
+from litellm import completion, responses
 from litellm.exceptions import (
     AuthenticationError as LiteLLMAuthError,
     RateLimitError as LiteLLMRateLimitError,
@@ -19,8 +19,8 @@ from simple_agent_poc.core.types import (
 )
 
 
-class LiteLLMClient(LLMClient):
-    """LLM client implementation using LiteLLM."""
+class LiteLLMCompletionClient(LLMClient):
+    """LLM client using litellm.completion()."""
 
     def __init__(self, model: str, *, temperature: float | None = None) -> None:
         self.model = model
@@ -78,11 +78,75 @@ class LiteLLMClient(LLMClient):
         }
 
 
+class LiteLLMResponsesClient(LLMClient):
+    """LLM client using litellm.responses()."""
+
+    def __init__(self, model: str, *, temperature: float | None = None) -> None:
+        self.model = model
+        self.temperature = temperature
+
+    def complete(self, messages: list[Message]) -> LLMResponse:
+        start_time = time.perf_counter()
+        response_params: dict[str, float] = {}
+        if self.temperature is not None:
+            response_params["temperature"] = self.temperature
+
+        try:
+            response = responses(
+                model=self.model,
+                messages=messages,
+                stream=False,
+                **response_params,
+            )
+        except LiteLLMAuthError as error:
+            raise AuthenticationError(
+                message=str(error),
+                display_message="Authentication failed: Invalid API key. Please check your API_KEY setting.",
+            ) from error
+        except LiteLLMRateLimitError as error:
+            raise RateLimitError(
+                message=str(error),
+                display_message="Rate limit exceeded. Please wait a moment before trying again.",
+            ) from error
+        except Exception as error:
+            error_msg = str(error).lower()
+            if (
+                "authentication" in error_msg
+                or "api key" in error_msg
+                or "401" in error_msg
+            ):
+                raise AuthenticationError(
+                    message=str(error),
+                    display_message="Authentication failed: Invalid API key. Please check your API_KEY setting.",
+                ) from error
+            raise LLMError(
+                message=str(error),
+                display_message=f"An error occurred while communicating with the LLM: {error}",
+            ) from error
+
+        elapsed = time.perf_counter() - start_time
+        return {
+            "content": response.choices[0].message.content,
+            "usage": {
+                "prompt_tokens": response.usage.prompt_tokens,
+                "completion_tokens": response.usage.completion_tokens,
+                "total_tokens": response.usage.total_tokens,
+            },
+            "model": self.model,
+            "response_time": elapsed,
+        }
+
+
 class LiteLLMClientFactory:
     """Create LiteLLM clients from agent definitions."""
 
-    def __call__(self, agent_definition: AgentDefinition) -> LiteLLMClient:
-        return LiteLLMClient(
+    def __call__(self, agent_definition: AgentDefinition) -> LLMClient:
+        if agent_definition.api_type == "responses":
+            return LiteLLMResponsesClient(
+                model=agent_definition.model,
+                temperature=agent_definition.temperature,
+            )
+        return LiteLLMCompletionClient(
             model=agent_definition.model,
             temperature=agent_definition.temperature,
         )

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/llm/litellm_client.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/llm/litellm_client.py
@@ -126,10 +126,10 @@ class LiteLLMResponsesClient(LLMClient):
 
         elapsed = time.perf_counter() - start_time
         return {
-            "content": response.choices[0].message.content,
+            "content": response.output_text,
             "usage": {
-                "prompt_tokens": response.usage.prompt_tokens,
-                "completion_tokens": response.usage.completion_tokens,
+                "prompt_tokens": response.usage.input_tokens,
+                "completion_tokens": response.usage.output_tokens,
                 "total_tokens": response.usage.total_tokens,
             },
             "model": self.model,

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/llm/litellm_client.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/llm/litellm_client.py
@@ -93,8 +93,8 @@ class LiteLLMResponsesClient(LLMClient):
 
         try:
             response = responses(
+                input=messages,
                 model=self.model,
-                messages=messages,
                 stream=False,
                 **response_params,
             )

--- a/projects/simple-agent-poc/src/simple_agent_poc/core/agent_definition.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/core/agent_definition.py
@@ -9,7 +9,9 @@ import yaml
 from simple_agent_poc.core.types import ValidationError
 
 _ROOT_FIELDS = frozenset({"agents"})
-_AGENT_FIELDS = frozenset({"model", "system_prompt", "temperature", "tools", "api_type"})
+_AGENT_FIELDS = frozenset(
+    {"model", "system_prompt", "temperature", "tools", "api_type"}
+)
 _REQUIRED_AGENT_FIELDS = frozenset({"model", "system_prompt"})
 
 
@@ -168,7 +170,5 @@ def _optional_api_type(
     if value is None:
         return "completion"
     if value not in ("completion", "responses"):
-        raise ValidationError(
-            f"{path} must be one of: completion, responses"
-        )
+        raise ValidationError(f"{path} must be one of: completion, responses")
     return cast(Literal["completion", "responses"], value)

--- a/projects/simple-agent-poc/src/simple_agent_poc/core/agent_definition.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/core/agent_definition.py
@@ -2,14 +2,14 @@
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Mapping, cast
+from typing import Any, Literal, Mapping, cast
 
 import yaml
 
 from simple_agent_poc.core.types import ValidationError
 
 _ROOT_FIELDS = frozenset({"agents"})
-_AGENT_FIELDS = frozenset({"model", "system_prompt", "temperature", "tools"})
+_AGENT_FIELDS = frozenset({"model", "system_prompt", "temperature", "tools", "api_type"})
 _REQUIRED_AGENT_FIELDS = frozenset({"model", "system_prompt"})
 
 
@@ -22,6 +22,7 @@ class AgentDefinition:
     system_prompt: str
     temperature: float | None = None
     tools: list[dict[str, Any]] = field(default_factory=list)
+    api_type: Literal["completion", "responses"] = "completion"
 
     def format_system_prompt(self, *, current_datetime: str) -> str:
         """Format the system prompt with runtime context."""
@@ -102,6 +103,10 @@ def _build_agent_definition(
         f"agents.{agent_id}.temperature",
     )
     tools = _optional_tools(definition.get("tools"), f"agents.{agent_id}.tools")
+    api_type = _optional_api_type(
+        definition.get("api_type"),
+        f"agents.{agent_id}.api_type",
+    )
 
     return AgentDefinition(
         agent_id=agent_id,
@@ -109,6 +114,7 @@ def _build_agent_definition(
         system_prompt=system_prompt,
         temperature=temperature,
         tools=tools,
+        api_type=api_type,
     )
 
 
@@ -153,3 +159,16 @@ def _optional_tools(value: object, path: str) -> list[dict[str, Any]]:
     if not all(isinstance(item, dict) for item in value):
         raise ValidationError(f"{path} items must be mappings")
     return cast(list[dict[str, Any]], value)
+
+
+def _optional_api_type(
+    value: object,
+    path: str,
+) -> Literal["completion", "responses"]:
+    if value is None:
+        return "completion"
+    if value not in ("completion", "responses"):
+        raise ValidationError(
+            f"{path} must be one of: completion, responses"
+        )
+    return cast(Literal["completion", "responses"], value)

--- a/projects/simple-agent-poc/tests/test_agent_definition.py
+++ b/projects/simple-agent-poc/tests/test_agent_definition.py
@@ -120,6 +120,53 @@ agents:
                 }
             )
 
+    def test_allows_api_type_completion(self) -> None:
+        registry = AgentDefinitionRegistry.from_mapping(
+            {
+                "agents": {
+                    "default": {
+                        "model": "gpt-4.1-nano",
+                        "system_prompt": "Prompt",
+                        "api_type": "completion",
+                    }
+                }
+            }
+        )
+
+        assert registry.get("default").api_type == "completion"
+
+    def test_allows_api_type_responses(self) -> None:
+        registry = AgentDefinitionRegistry.from_mapping(
+            {
+                "agents": {
+                    "default": {
+                        "model": "gpt-5.4-nano",
+                        "system_prompt": "Prompt",
+                        "api_type": "responses",
+                    }
+                }
+            }
+        )
+
+        assert registry.get("default").api_type == "responses"
+
+    def test_rejects_invalid_api_type(self) -> None:
+        with pytest.raises(
+            ValidationError,
+            match="api_type must be one of: completion, responses",
+        ):
+            AgentDefinitionRegistry.from_mapping(
+                {
+                    "agents": {
+                        "default": {
+                            "model": "gpt-4.1-nano",
+                            "system_prompt": "Prompt",
+                            "api_type": "invalid",
+                        }
+                    }
+                }
+            )
+
     def test_rejects_invalid_types(self) -> None:
         with pytest.raises(ValidationError, match="temperature must be a number"):
             AgentDefinitionRegistry.from_mapping(

--- a/projects/simple-agent-poc/tests/test_llm_client.py
+++ b/projects/simple-agent-poc/tests/test_llm_client.py
@@ -215,8 +215,8 @@ class TestLiteLLMResponsesClient:
         assert result["usage"]["total_tokens"] == 15
 
         mock_responses.assert_called_once_with(
+            input=messages,
             model="gpt-5.4-nano",
-            messages=messages,
             stream=False,
         )
 
@@ -236,8 +236,8 @@ class TestLiteLLMResponsesClient:
         client.complete(messages)
 
         mock_responses.assert_called_once_with(
+            input=messages,
             model="gpt-5.4-nano",
-            messages=messages,
             stream=False,
             temperature=0.2,
         )
@@ -258,8 +258,8 @@ class TestLiteLLMResponsesClient:
         client.complete(messages)
 
         mock_responses.assert_called_once_with(
+            input=messages,
             model="gpt-5.4-nano",
-            messages=messages,
             stream=False,
         )
 

--- a/projects/simple-agent-poc/tests/test_llm_client.py
+++ b/projects/simple-agent-poc/tests/test_llm_client.py
@@ -197,10 +197,9 @@ class TestLiteLLMResponsesClient:
     @patch("simple_agent_poc.adapters.llm.litellm_client.responses")
     def test_complete_success(self, mock_responses: MagicMock) -> None:
         mock_response = MagicMock()
-        mock_response.choices = [MagicMock()]
-        mock_response.choices[0].message.content = "Hello, world!"
-        mock_response.usage.prompt_tokens = 10
-        mock_response.usage.completion_tokens = 5
+        mock_response.output_text = "Hello, world!"
+        mock_response.usage.input_tokens = 10
+        mock_response.usage.output_tokens = 5
         mock_response.usage.total_tokens = 15
         mock_responses.return_value = mock_response
 
@@ -223,10 +222,9 @@ class TestLiteLLMResponsesClient:
     @patch("simple_agent_poc.adapters.llm.litellm_client.responses")
     def test_complete_passes_temperature(self, mock_responses: MagicMock) -> None:
         mock_response = MagicMock()
-        mock_response.choices = [MagicMock()]
-        mock_response.choices[0].message.content = "Hello, world!"
-        mock_response.usage.prompt_tokens = 10
-        mock_response.usage.completion_tokens = 5
+        mock_response.output_text = "Hello, world!"
+        mock_response.usage.input_tokens = 10
+        mock_response.usage.output_tokens = 5
         mock_response.usage.total_tokens = 15
         mock_responses.return_value = mock_response
 
@@ -245,10 +243,9 @@ class TestLiteLLMResponsesClient:
     @patch("simple_agent_poc.adapters.llm.litellm_client.responses")
     def test_complete_omits_null_temperature(self, mock_responses: MagicMock) -> None:
         mock_response = MagicMock()
-        mock_response.choices = [MagicMock()]
-        mock_response.choices[0].message.content = "Hello, world!"
-        mock_response.usage.prompt_tokens = 10
-        mock_response.usage.completion_tokens = 5
+        mock_response.output_text = "Hello, world!"
+        mock_response.usage.input_tokens = 10
+        mock_response.usage.output_tokens = 5
         mock_response.usage.total_tokens = 15
         mock_responses.return_value = mock_response
 

--- a/projects/simple-agent-poc/tests/test_llm_client.py
+++ b/projects/simple-agent-poc/tests/test_llm_client.py
@@ -9,8 +9,9 @@ from litellm.exceptions import (
 )
 
 from simple_agent_poc.adapters.llm.litellm_client import (
-    LiteLLMClient,
     LiteLLMClientFactory,
+    LiteLLMCompletionClient,
+    LiteLLMResponsesClient,
 )
 from simple_agent_poc.core.agent_definition import AgentDefinition
 from simple_agent_poc.core.types import (
@@ -21,11 +22,11 @@ from simple_agent_poc.core.types import (
 )
 
 
-class TestLiteLLMClient:
-    """Tests for LiteLLMClient class."""
+class TestLiteLLMCompletionClient:
+    """Tests for LiteLLMCompletionClient class."""
 
     def test_init(self) -> None:
-        client = LiteLLMClient(model="gpt-4", temperature=0.2)
+        client = LiteLLMCompletionClient(model="gpt-4", temperature=0.2)
         assert client.model == "gpt-4"
         assert client.temperature == 0.2
 
@@ -39,7 +40,7 @@ class TestLiteLLMClient:
         mock_response.usage.total_tokens = 15
         mock_completion.return_value = mock_response
 
-        client = LiteLLMClient(model="gpt-4")
+        client = LiteLLMCompletionClient(model="gpt-4")
         messages: list[Message] = [{"role": "user", "content": "Hi"}]
 
         result = client.complete(messages)
@@ -65,7 +66,7 @@ class TestLiteLLMClient:
         mock_response.usage.total_tokens = 15
         mock_completion.return_value = mock_response
 
-        client = LiteLLMClient(model="gpt-4", temperature=0.2)
+        client = LiteLLMCompletionClient(model="gpt-4", temperature=0.2)
         messages: list[Message] = [{"role": "user", "content": "Hi"}]
 
         client.complete(messages)
@@ -87,7 +88,7 @@ class TestLiteLLMClient:
         mock_response.usage.total_tokens = 15
         mock_completion.return_value = mock_response
 
-        client = LiteLLMClient(model="gpt-5.4-mini", temperature=None)
+        client = LiteLLMCompletionClient(model="gpt-5.4-mini", temperature=None)
         messages: list[Message] = [{"role": "user", "content": "Hi"}]
 
         client.complete(messages)
@@ -106,7 +107,7 @@ class TestLiteLLMClient:
             model="gpt-4",
         )
 
-        client = LiteLLMClient(model="gpt-4")
+        client = LiteLLMCompletionClient(model="gpt-4")
         messages: list[Message] = [{"role": "user", "content": "Hi"}]
 
         with pytest.raises(AuthenticationError) as exc_info:
@@ -123,7 +124,7 @@ class TestLiteLLMClient:
             model="gpt-4",
         )
 
-        client = LiteLLMClient(model="gpt-4")
+        client = LiteLLMCompletionClient(model="gpt-4")
         messages: list[Message] = [{"role": "user", "content": "Hi"}]
 
         with pytest.raises(RateLimitError) as exc_info:
@@ -135,7 +136,7 @@ class TestLiteLLMClient:
     def test_complete_generic_error(self, mock_completion: MagicMock) -> None:
         mock_completion.side_effect = ValueError("Something went wrong")
 
-        client = LiteLLMClient(model="gpt-4")
+        client = LiteLLMCompletionClient(model="gpt-4")
         messages: list[Message] = [{"role": "user", "content": "Hi"}]
 
         with pytest.raises(LLMError) as exc_info:
@@ -150,7 +151,7 @@ class TestLiteLLMClient:
     ) -> None:
         mock_completion.side_effect = Exception("401 unauthorized: invalid api key")
 
-        client = LiteLLMClient(model="gpt-4")
+        client = LiteLLMCompletionClient(model="gpt-4")
         messages: list[Message] = [{"role": "user", "content": "Hi"}]
 
         with pytest.raises(AuthenticationError) as exc_info:
@@ -168,7 +169,7 @@ class TestLiteLLMClient:
         mock_response.usage.total_tokens = 30
         mock_completion.return_value = mock_response
 
-        client = LiteLLMClient(model="gpt-4")
+        client = LiteLLMCompletionClient(model="gpt-4")
         messages: list[Message] = [
             {"role": "user", "content": "Hello"},
             {"role": "assistant", "content": "Hi"},
@@ -184,10 +185,137 @@ class TestLiteLLMClient:
             stream=False,
         )
 
-    def test_factory_uses_agent_definition(self) -> None:
+
+class TestLiteLLMResponsesClient:
+    """Tests for LiteLLMResponsesClient class."""
+
+    def test_init(self) -> None:
+        client = LiteLLMResponsesClient(model="gpt-5.4-nano", temperature=0.2)
+        assert client.model == "gpt-5.4-nano"
+        assert client.temperature == 0.2
+
+    @patch("simple_agent_poc.adapters.llm.litellm_client.responses")
+    def test_complete_success(self, mock_responses: MagicMock) -> None:
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Hello, world!"
+        mock_response.usage.prompt_tokens = 10
+        mock_response.usage.completion_tokens = 5
+        mock_response.usage.total_tokens = 15
+        mock_responses.return_value = mock_response
+
+        client = LiteLLMResponsesClient(model="gpt-5.4-nano")
+        messages: list[Message] = [{"role": "user", "content": "Hi"}]
+
+        result = client.complete(messages)
+
+        assert result["content"] == "Hello, world!"
+        assert result["usage"]["prompt_tokens"] == 10
+        assert result["usage"]["completion_tokens"] == 5
+        assert result["usage"]["total_tokens"] == 15
+
+        mock_responses.assert_called_once_with(
+            model="gpt-5.4-nano",
+            messages=messages,
+            stream=False,
+        )
+
+    @patch("simple_agent_poc.adapters.llm.litellm_client.responses")
+    def test_complete_passes_temperature(self, mock_responses: MagicMock) -> None:
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Hello, world!"
+        mock_response.usage.prompt_tokens = 10
+        mock_response.usage.completion_tokens = 5
+        mock_response.usage.total_tokens = 15
+        mock_responses.return_value = mock_response
+
+        client = LiteLLMResponsesClient(model="gpt-5.4-nano", temperature=0.2)
+        messages: list[Message] = [{"role": "user", "content": "Hi"}]
+
+        client.complete(messages)
+
+        mock_responses.assert_called_once_with(
+            model="gpt-5.4-nano",
+            messages=messages,
+            stream=False,
+            temperature=0.2,
+        )
+
+    @patch("simple_agent_poc.adapters.llm.litellm_client.responses")
+    def test_complete_omits_null_temperature(self, mock_responses: MagicMock) -> None:
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Hello, world!"
+        mock_response.usage.prompt_tokens = 10
+        mock_response.usage.completion_tokens = 5
+        mock_response.usage.total_tokens = 15
+        mock_responses.return_value = mock_response
+
+        client = LiteLLMResponsesClient(model="gpt-5.4-nano", temperature=None)
+        messages: list[Message] = [{"role": "user", "content": "Hi"}]
+
+        client.complete(messages)
+
+        mock_responses.assert_called_once_with(
+            model="gpt-5.4-nano",
+            messages=messages,
+            stream=False,
+        )
+
+    @patch("simple_agent_poc.adapters.llm.litellm_client.responses")
+    def test_complete_authentication_error(self, mock_responses: MagicMock) -> None:
+        mock_responses.side_effect = LiteLLMAuthError(
+            "Invalid API key",
+            llm_provider="openai",
+            model="gpt-5.4-nano",
+        )
+
+        client = LiteLLMResponsesClient(model="gpt-5.4-nano")
+        messages: list[Message] = [{"role": "user", "content": "Hi"}]
+
+        with pytest.raises(AuthenticationError) as exc_info:
+            client.complete(messages)
+
+        assert "Authentication failed" in exc_info.value.display_message
+        assert "Invalid API key" in str(exc_info.value)
+
+    @patch("simple_agent_poc.adapters.llm.litellm_client.responses")
+    def test_complete_rate_limit_error(self, mock_responses: MagicMock) -> None:
+        mock_responses.side_effect = LiteLLMRateLimitError(
+            "Rate limit exceeded",
+            llm_provider="openai",
+            model="gpt-5.4-nano",
+        )
+
+        client = LiteLLMResponsesClient(model="gpt-5.4-nano")
+        messages: list[Message] = [{"role": "user", "content": "Hi"}]
+
+        with pytest.raises(RateLimitError) as exc_info:
+            client.complete(messages)
+
+        assert "Rate limit exceeded" in exc_info.value.display_message
+
+    @patch("simple_agent_poc.adapters.llm.litellm_client.responses")
+    def test_complete_generic_error(self, mock_responses: MagicMock) -> None:
+        mock_responses.side_effect = ValueError("Something went wrong")
+
+        client = LiteLLMResponsesClient(model="gpt-5.4-nano")
+        messages: list[Message] = [{"role": "user", "content": "Hi"}]
+
+        with pytest.raises(LLMError) as exc_info:
+            client.complete(messages)
+
+        assert "An error occurred" in exc_info.value.display_message
+
+
+class TestLiteLLMClientFactory:
+    """Tests for LiteLLMClientFactory class."""
+
+    def test_factory_creates_completion_client_by_default(self) -> None:
         factory = LiteLLMClientFactory()
         agent_definition = AgentDefinition(
-            agent_id="researcher",
+            agent_id="default",
             model="gpt-4",
             system_prompt="Prompt",
             temperature=0.1,
@@ -195,5 +323,53 @@ class TestLiteLLMClient:
 
         client = factory(agent_definition)
 
+        assert isinstance(client, LiteLLMCompletionClient)
         assert client.model == "gpt-4"
         assert client.temperature == 0.1
+
+    def test_factory_creates_completion_client_explicitly(self) -> None:
+        factory = LiteLLMClientFactory()
+        agent_definition = AgentDefinition(
+            agent_id="default",
+            model="gpt-4",
+            system_prompt="Prompt",
+            temperature=0.1,
+            api_type="completion",
+        )
+
+        client = factory(agent_definition)
+
+        assert isinstance(client, LiteLLMCompletionClient)
+        assert client.model == "gpt-4"
+        assert client.temperature == 0.1
+
+    def test_factory_creates_responses_client(self) -> None:
+        factory = LiteLLMClientFactory()
+        agent_definition = AgentDefinition(
+            agent_id="gpt54",
+            model="gpt-5.4-nano",
+            system_prompt="Prompt",
+            temperature=0.2,
+            api_type="responses",
+        )
+
+        client = factory(agent_definition)
+
+        assert isinstance(client, LiteLLMResponsesClient)
+        assert client.model == "gpt-5.4-nano"
+        assert client.temperature == 0.2
+
+    def test_factory_creates_responses_client_without_temperature(self) -> None:
+        factory = LiteLLMClientFactory()
+        agent_definition = AgentDefinition(
+            agent_id="gpt54",
+            model="gpt-5.4-nano",
+            system_prompt="Prompt",
+            api_type="responses",
+        )
+
+        client = factory(agent_definition)
+
+        assert isinstance(client, LiteLLMResponsesClient)
+        assert client.model == "gpt-5.4-nano"
+        assert client.temperature is None


### PR DESCRIPTION
## Issues

- Close #894

## Why

GPT-5.4-nano は OpenAI Responses API 専用モデルであり、`litellm.completion()` から呼ぶと LiteLLM が `vector_store_ids` パラメータを誤って付与し BadRequestError になる。`litellm.responses()` API を利用可能にする必要がある。

## Summary

`AgentDefinition` と `agents.yaml` に `api_type` フィールドを追加し、`completion` / `responses` を選択可能にした。`LiteLLMClient` を `LiteLLMCompletionClient` と `LiteLLMResponsesClient` に分離し、`LiteLLMClientFactory` で適切なクライアントを生成する。

## Changes

- `AgentDefinition` に `api_type: Literal["completion", "responses"]` フィールドを追加（default: `"completion"`）
- `agents.yaml` に `api_type` フィールドと `gpt54` エントリを追加
- `LiteLLMCompletionClient`（`litellm.completion()` 使用）と `LiteLLMResponsesClient`（`litellm.responses()` 使用）に分離
- `LiteLLMClientFactory` で `api_type` に応じたクライアント生成に切替
- テスト追加：`TestLiteLLMResponsesClient`（7 tests）、`TestLiteLLMClientFactory`（4 tests）、`api_type` バリデーション（3 tests）

## Verification

- `uv run ruff check .` - All checks passed
- `uv run ty check .` - All checks passed
- `uv run pytest` - 95 passed
