### PR TITLE
feat: add streaming support for CLI and HTTP API

### DIFF
--- a/projects/simple-agent-poc/.claude/skills/architecture/SKILL.md
+++ b/projects/simple-agent-poc/.claude/skills/architecture/SKILL.md
@@ -166,6 +166,6 @@ src/simple_agent_poc/
 ## Non-goals
 
 - Do not introduce every future layer immediately.
-- Do not redesign the runtime around async or streaming yet.
+- Do not redesign the runtime around async yet.
 - Do not change the CLI-first development workflow.
 - Do not couple future persistence work to FastAPI or terminal concerns.

--- a/projects/simple-agent-poc/agents.yaml
+++ b/projects/simple-agent-poc/agents.yaml
@@ -19,7 +19,7 @@ agents:
 
   kansaiben:
     model: gpt-5.4-nano
-    stream: false
+    stream: true
     system_prompt: |
       あんたはおしゃべり好きなエージェントや。
       なんでも関西弁で気軽に話しかけてや。

--- a/projects/simple-agent-poc/agents.yaml
+++ b/projects/simple-agent-poc/agents.yaml
@@ -1,6 +1,7 @@
 agents:
   default:
     model: gpt-4.1-nano
+    stream: false
     system_prompt: |
       You are an AI assistant designed to help users with various tasks.
 
@@ -18,6 +19,7 @@ agents:
 
   kansaiben:
     model: gpt-5.4-nano
+    stream: false
     system_prompt: |
       あんたはおしゃべり好きなエージェントや。
       なんでも関西弁で気軽に話しかけてや。

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/cli/adapter.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/cli/adapter.py
@@ -1,18 +1,25 @@
 """CLI adapter for the application flow."""
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from typing import Protocol
 
-from simple_agent_poc.application.dto import RunAgentRequest, RunAgentResponse
+from simple_agent_poc.application.dto import (
+    ContentDelta,
+    RunAgentRequest,
+    RunAgentResponse,
+    StreamComplete,
+)
 from simple_agent_poc.application.use_cases import RunAgentUseCase
 from simple_agent_poc.adapters.cli.renderer import (
     get_user_input,
     show_agent_response,
     show_error,
     show_exit_message,
+    show_streaming_response,
     show_welcome,
     with_indicator,
 )
+from simple_agent_poc.core.agent_definition import AgentDefinitionRegistry
 
 
 class IndicatorRunner(Protocol):
@@ -23,6 +30,15 @@ class IndicatorRunner(Protocol):
         message: str,
         operation: Callable[[], RunAgentResponse],
     ) -> RunAgentResponse: ...
+
+
+class StreamingRenderer(Protocol):
+    """Render a streaming response."""
+
+    def __call__(
+        self,
+        stream: Iterator[ContentDelta | StreamComplete],
+    ) -> StreamComplete: ...
 
 
 class WelcomeRenderer(Protocol):
@@ -39,8 +55,10 @@ class CLIAdapter:
         run_agent: RunAgentUseCase,
         *,
         agent_id: str = "default",
+        agent_definitions: AgentDefinitionRegistry | None = None,
         input_reader: Callable[[], str] = get_user_input,
         response_renderer: Callable[[RunAgentResponse], None] = show_agent_response,
+        streaming_renderer: StreamingRenderer = show_streaming_response,
         error_renderer: Callable[[Exception], None] = show_error,
         welcome_renderer: WelcomeRenderer = show_welcome,
         exit_renderer: Callable[[], None] = show_exit_message,
@@ -48,8 +66,10 @@ class CLIAdapter:
     ) -> None:
         self._run_agent = run_agent
         self._agent_id = agent_id
+        self._agent_definitions = agent_definitions
         self._input_reader = input_reader
         self._response_renderer = response_renderer
+        self._streaming_renderer = streaming_renderer
         self._error_renderer = error_renderer
         self._welcome_renderer = welcome_renderer
         self._exit_renderer = exit_renderer
@@ -59,6 +79,11 @@ class CLIAdapter:
     def run(self) -> None:
         """Start the interactive CLI loop."""
         self._welcome_renderer(self._agent_id)
+        agent_def = (
+            self._agent_definitions.get(self._agent_id)
+            if self._agent_definitions
+            else None
+        )
 
         while True:
             try:
@@ -66,18 +91,30 @@ class CLIAdapter:
                 if not user_input.strip():
                     continue
 
-                response = self._indicator_runner(
-                    "Thinking",
-                    lambda: self._run_agent.execute(
-                        RunAgentRequest(
-                            message=user_input,
-                            session_id=self._session_id,
-                            agent_id=self._agent_id,
+                if agent_def and agent_def.stream:
+                    complete = self._streaming_renderer(
+                        self._run_agent.execute_stream(
+                            RunAgentRequest(
+                                message=user_input,
+                                session_id=self._session_id,
+                                agent_id=self._agent_id,
+                            )
                         )
-                    ),
-                )
-                self._session_id = response.session_id
-                self._response_renderer(response)
+                    )
+                    self._session_id = complete.session_id
+                else:
+                    response = self._indicator_runner(
+                        "Thinking",
+                        lambda: self._run_agent.execute(
+                            RunAgentRequest(
+                                message=user_input,
+                                session_id=self._session_id,
+                                agent_id=self._agent_id,
+                            )
+                        ),
+                    )
+                    self._session_id = response.session_id
+                    self._response_renderer(response)
             except KeyboardInterrupt:
                 self._exit_renderer()
                 break

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/cli/renderer.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/cli/renderer.py
@@ -147,12 +147,15 @@ def show_streaming_response(
                     model = model.split("/")[-1]
 
                 usage = complete.usage
-                stats = (
-                    f"Model: {model} │ "
-                    f"Time: {time_str} │ "
-                    f"Tokens: {usage['prompt_tokens']} → {usage['completion_tokens']} "
-                    f"(total: {usage['total_tokens']})"
-                )
+                if usage is not None:
+                    stats = (
+                        f"Model: {model} │ "
+                        f"Time: {time_str} │ "
+                        f"Tokens: {usage['prompt_tokens']} → {usage['completion_tokens']} "
+                        f"(total: {usage['total_tokens']})"
+                    )
+                else:
+                    stats = f"Model: {model} │ Time: {time_str}"
                 print(f"  └─ {stats}")
 
         if complete is None:

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/cli/renderer.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/cli/renderer.py
@@ -3,9 +3,14 @@
 import sys
 import threading
 import time
+from collections.abc import Iterator
 from typing import Callable
 
-from simple_agent_poc.application.dto import RunAgentResponse
+from simple_agent_poc.application.dto import (
+    ContentDelta,
+    RunAgentResponse,
+    StreamComplete,
+)
 from simple_agent_poc.core.types import AgentError
 
 
@@ -104,3 +109,55 @@ def show_agent_response(response: RunAgentResponse) -> None:
 def show_exit_message() -> None:
     """Display the exit message."""
     print("\nExiting...")
+
+
+def show_streaming_response(
+    stream: Iterator[ContentDelta | StreamComplete],
+) -> StreamComplete:
+    """Display a streaming response with live output."""
+    indicator = LoadingIndicator()
+    indicator.start()
+    try:
+        complete: StreamComplete | None = None
+        started = False
+        for event in stream:
+            if isinstance(event, ContentDelta):
+                if not started:
+                    indicator.stop()
+                    sys.stdout.write("Agent: ")
+                    started = True
+                sys.stdout.write(event.delta)
+                sys.stdout.flush()
+            elif isinstance(event, StreamComplete):
+                complete = event
+                if not started:
+                    indicator.stop()
+                    sys.stdout.write("Agent: ")
+                sys.stdout.write("\n")
+                sys.stdout.flush()
+
+                elapsed = complete.response_time
+                if elapsed < 1:
+                    time_str = f"{elapsed * 1000:.0f}ms"
+                else:
+                    time_str = f"{elapsed:.2f}s"
+
+                model = complete.model
+                if "/" in model:
+                    model = model.split("/")[-1]
+
+                usage = complete.usage
+                stats = (
+                    f"Model: {model} │ "
+                    f"Time: {time_str} │ "
+                    f"Tokens: {usage['prompt_tokens']} → {usage['completion_tokens']} "
+                    f"(total: {usage['total_tokens']})"
+                )
+                print(f"  └─ {stats}")
+
+        if complete is None:
+            raise RuntimeError("Stream ended without StreamComplete event")
+        return complete
+    except Exception:
+        indicator.stop()
+        raise

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/api.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/api.py
@@ -1,12 +1,20 @@
 """HTTP API adapter."""
 
+import json
+from dataclasses import asdict
 from collections.abc import Callable
 from typing import Annotated
 
 from fastapi import Depends, FastAPI, Header, HTTPException
 from pydantic import BaseModel, ConfigDict, field_validator
+from starlette.responses import StreamingResponse
 
-from simple_agent_poc.application.dto import RunAgentRequest, RunAgentResponse
+from simple_agent_poc.application.dto import (
+    ContentDelta,
+    RunAgentRequest,
+    RunAgentResponse,
+    StreamComplete,
+)
 from simple_agent_poc.application.use_cases import RunAgentUseCase
 from simple_agent_poc.core.types import SessionNotFoundError, Usage, ValidationError
 from simple_agent_poc.entrypoints.bootstrap import create_run_agent_use_case_factory
@@ -122,5 +130,41 @@ def create_app(
             ) from error
 
         return ChatResponse.from_use_case_response(response)
+
+    @app.post("/api/chat/stream")
+    async def chat_stream(
+        request: ChatRequest,
+        run_agent: Annotated[RunAgentUseCase, Depends(get_run_agent_use_case)],
+        *,
+        session_id_header: Annotated[
+            str | None,
+            Header(alias="Session-Id"),
+        ] = None,
+    ):
+        async def event_stream():
+            try:
+                for event in run_agent.execute_stream(
+                    RunAgentRequest(
+                        message=request.message,
+                        session_id=resolve_session_id(
+                            header_session_id=session_id_header,
+                            body_session_id=request.session_id,
+                        ),
+                        agent_id=request.agent_id,
+                    )
+                ):
+                    if isinstance(event, ContentDelta):
+                        yield f"event: delta\ndata: {json.dumps({'content': event.delta})}\n\n"
+                    elif isinstance(event, StreamComplete):
+                        yield f"event: complete\ndata: {json.dumps(asdict(event))}\n\n"
+                yield "event: done\ndata: {}\n\n"
+            except SessionNotFoundError as error:
+                yield f"event: error\ndata: {json.dumps({'detail': error.display_message})}\n\n"
+            except ValidationError as error:
+                yield f"event: error\ndata: {json.dumps({'detail': error.display_message})}\n\n"
+            except Exception as error:
+                yield f"event: error\ndata: {json.dumps({'detail': str(error)})}\n\n"
+
+        return StreamingResponse(event_stream(), media_type="text/event-stream")
 
     return app

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/api.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/api.py
@@ -156,16 +156,16 @@ def create_app(
                     )
                 ):
                     if isinstance(event, ContentDelta):
-                        yield f"event: delta\ndata: {json.dumps({'content': event.delta})}\n\n"
+                        yield f"event: delta\ndata: {json.dumps({'content': event.delta}, ensure_ascii=False)}\n\n"
                     elif isinstance(event, StreamComplete):
-                        yield f"event: complete\ndata: {json.dumps(asdict(event))}\n\n"
+                        yield f"event: complete\ndata: {json.dumps(asdict(event), ensure_ascii=False)}\n\n"
                 yield "event: done\ndata: {}\n\n"
             except SessionNotFoundError as error:
-                yield f"event: error\ndata: {json.dumps({'detail': error.display_message})}\n\n"
+                yield f"event: error\ndata: {json.dumps({'detail': error.display_message}, ensure_ascii=False)}\n\n"
             except ValidationError as error:
-                yield f"event: error\ndata: {json.dumps({'detail': error.display_message})}\n\n"
+                yield f"event: error\ndata: {json.dumps({'detail': error.display_message}, ensure_ascii=False)}\n\n"
             except Exception as error:
-                yield f"event: error\ndata: {json.dumps({'detail': str(error)})}\n\n"
+                yield f"event: error\ndata: {json.dumps({'detail': str(error)}, ensure_ascii=False)}\n\n"
 
         return StreamingResponse(event_stream(), media_type="text/event-stream")
 

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/api.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/api.py
@@ -132,7 +132,7 @@ def create_app(
         return ChatResponse.from_use_case_response(response)
 
     @app.post("/api/chat/stream")
-    async def chat_stream(
+    def chat_stream(
         request: ChatRequest,
         run_agent: Annotated[RunAgentUseCase, Depends(get_run_agent_use_case)],
         *,
@@ -141,15 +141,17 @@ def create_app(
             Header(alias="Session-Id"),
         ] = None,
     ):
-        async def event_stream():
+        session_id = resolve_session_id(
+            header_session_id=session_id_header,
+            body_session_id=request.session_id,
+        )
+
+        def event_stream():
             try:
                 for event in run_agent.execute_stream(
                     RunAgentRequest(
                         message=request.message,
-                        session_id=resolve_session_id(
-                            header_session_id=session_id_header,
-                            body_session_id=request.session_id,
-                        ),
+                        session_id=session_id,
                         agent_id=request.agent_id,
                     )
                 ):

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/llm/litellm_client.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/llm/litellm_client.py
@@ -1,6 +1,7 @@
 """LLM client implementation."""
 
 import time
+import warnings
 from collections.abc import Iterator
 
 from litellm import completion, responses
@@ -18,6 +19,11 @@ from simple_agent_poc.core.types import (
     LLMStreamChunk,
     Message,
     RateLimitError,
+)
+
+warnings.filterwarnings(
+    "ignore",
+    message="Pydantic serializ",
 )
 
 

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/llm/litellm_client.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/llm/litellm_client.py
@@ -120,9 +120,10 @@ class LiteLLMCompletionClient(LLMClient):
 
         for chunk in response:
             chunk_data: LLMStreamChunk = {"content_delta": None}
-            delta = chunk.choices[0].delta.content
-            if delta:
-                chunk_data["content_delta"] = delta
+            if chunk.choices:
+                delta = chunk.choices[0].delta.content
+                if delta:
+                    chunk_data["content_delta"] = delta
             if hasattr(chunk, "usage") and chunk.usage is not None:
                 chunk_data["usage"] = {
                     "prompt_tokens": chunk.usage.prompt_tokens,

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/llm/litellm_client.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/llm/litellm_client.py
@@ -1,6 +1,7 @@
 """LLM client implementation."""
 
 import time
+from collections.abc import Iterator
 
 from litellm import completion, responses
 from litellm.exceptions import (
@@ -14,6 +15,7 @@ from simple_agent_poc.core.types import (
     AuthenticationError,
     LLMError,
     LLMResponse,
+    LLMStreamChunk,
     Message,
     RateLimitError,
 )
@@ -77,6 +79,49 @@ class LiteLLMCompletionClient(LLMClient):
             "response_time": elapsed,
         }
 
+    def complete_stream(self, messages: list[Message]) -> Iterator[LLMStreamChunk]:
+        completion_params: dict[str, float] = {}
+        if self.temperature is not None:
+            completion_params["temperature"] = self.temperature
+
+        try:
+            response = completion(
+                model=self.model,
+                messages=messages,
+                stream=True,
+                **completion_params,
+            )
+        except LiteLLMAuthError as error:
+            raise AuthenticationError(
+                message=str(error),
+                display_message="Authentication failed: Invalid API key. Please check your API_KEY setting.",
+            ) from error
+        except LiteLLMRateLimitError as error:
+            raise RateLimitError(
+                message=str(error),
+                display_message="Rate limit exceeded. Please wait a moment before trying again.",
+            ) from error
+        except Exception as error:
+            error_msg = str(error).lower()
+            if (
+                "authentication" in error_msg
+                or "api key" in error_msg
+                or "401" in error_msg
+            ):
+                raise AuthenticationError(
+                    message=str(error),
+                    display_message="Authentication failed: Invalid API key. Please check your API_KEY setting.",
+                ) from error
+            raise LLMError(
+                message=str(error),
+                display_message=f"An error occurred while communicating with the LLM: {error}",
+            ) from error
+
+        for chunk in response:
+            delta = chunk.choices[0].delta.content
+            if delta:
+                yield {"content_delta": delta}
+
 
 class LiteLLMResponsesClient(LLMClient):
     """LLM client using litellm.responses()."""
@@ -135,6 +180,48 @@ class LiteLLMResponsesClient(LLMClient):
             "model": self.model,
             "response_time": elapsed,
         }
+
+    def complete_stream(self, messages: list[Message]) -> Iterator[LLMStreamChunk]:
+        response_params: dict[str, float] = {}
+        if self.temperature is not None:
+            response_params["temperature"] = self.temperature
+
+        try:
+            response = responses(
+                input=messages,
+                model=self.model,
+                stream=True,
+                **response_params,
+            )
+        except LiteLLMAuthError as error:
+            raise AuthenticationError(
+                message=str(error),
+                display_message="Authentication failed: Invalid API key. Please check your API_KEY setting.",
+            ) from error
+        except LiteLLMRateLimitError as error:
+            raise RateLimitError(
+                message=str(error),
+                display_message="Rate limit exceeded. Please wait a moment before trying again.",
+            ) from error
+        except Exception as error:
+            error_msg = str(error).lower()
+            if (
+                "authentication" in error_msg
+                or "api key" in error_msg
+                or "401" in error_msg
+            ):
+                raise AuthenticationError(
+                    message=str(error),
+                    display_message="Authentication failed: Invalid API key. Please check your API_KEY setting.",
+                ) from error
+            raise LLMError(
+                message=str(error),
+                display_message=f"An error occurred while communicating with the LLM: {error}",
+            ) from error
+
+        for event in response:
+            if hasattr(event, "delta") and event.delta:
+                yield {"content_delta": event.delta}
 
 
 class LiteLLMClientFactory:

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/llm/litellm_client.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/llm/litellm_client.py
@@ -89,6 +89,7 @@ class LiteLLMCompletionClient(LLMClient):
                 model=self.model,
                 messages=messages,
                 stream=True,
+                stream_options={"include_usage": True},
                 **completion_params,
             )
         except LiteLLMAuthError as error:
@@ -118,9 +119,18 @@ class LiteLLMCompletionClient(LLMClient):
             ) from error
 
         for chunk in response:
+            chunk_data: LLMStreamChunk = {"content_delta": None}
             delta = chunk.choices[0].delta.content
             if delta:
-                yield {"content_delta": delta}
+                chunk_data["content_delta"] = delta
+            if hasattr(chunk, "usage") and chunk.usage is not None:
+                chunk_data["usage"] = {
+                    "prompt_tokens": chunk.usage.prompt_tokens,
+                    "completion_tokens": chunk.usage.completion_tokens,
+                    "total_tokens": chunk.usage.total_tokens,
+                }
+            if chunk_data["content_delta"] is not None or "usage" in chunk_data:
+                yield chunk_data
 
 
 class LiteLLMResponsesClient(LLMClient):
@@ -220,8 +230,19 @@ class LiteLLMResponsesClient(LLMClient):
             ) from error
 
         for event in response:
+            chunk_data: LLMStreamChunk = {"content_delta": None}
             if hasattr(event, "delta") and event.delta:
-                yield {"content_delta": event.delta}
+                chunk_data["content_delta"] = event.delta
+            if hasattr(event, "response") and hasattr(event.response, "usage"):
+                usage_obj = event.response.usage
+                if usage_obj is not None:
+                    chunk_data["usage"] = {
+                        "prompt_tokens": usage_obj.input_tokens,
+                        "completion_tokens": usage_obj.output_tokens,
+                        "total_tokens": usage_obj.total_tokens,
+                    }
+            if chunk_data["content_delta"] is not None or "usage" in chunk_data:
+                yield chunk_data
 
 
 class LiteLLMClientFactory:

--- a/projects/simple-agent-poc/src/simple_agent_poc/application/dto.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/application/dto.py
@@ -53,6 +53,6 @@ class StreamComplete:
     """Metadata emitted when a stream finishes successfully."""
 
     session_id: str
-    usage: Usage
+    usage: Usage | None
     model: str
     response_time: float

--- a/projects/simple-agent-poc/src/simple_agent_poc/application/dto.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/application/dto.py
@@ -39,3 +39,20 @@ class RunAgentResponse:
             response_time=response["response_time"],
             session_id=session_id,
         )
+
+
+@dataclass(frozen=True, slots=True)
+class ContentDelta:
+    """Partial text emitted during streaming."""
+
+    delta: str
+
+
+@dataclass(frozen=True, slots=True)
+class StreamComplete:
+    """Metadata emitted when a stream finishes successfully."""
+
+    session_id: str
+    usage: Usage
+    model: str
+    response_time: float

--- a/projects/simple-agent-poc/src/simple_agent_poc/application/ports.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/application/ports.py
@@ -1,10 +1,11 @@
 """Application ports."""
 
+from collections.abc import Iterator
 from typing import Protocol
 
 from simple_agent_poc.core.agent_definition import AgentDefinition
 from simple_agent_poc.core.session import ConversationSession
-from simple_agent_poc.core.types import LLMResponse, Message
+from simple_agent_poc.core.types import LLMResponse, LLMStreamChunk, Message
 
 
 class LLMClient(Protocol):
@@ -12,6 +13,9 @@ class LLMClient(Protocol):
 
     def complete(self, messages: list[Message]) -> LLMResponse:
         """Receive message history and return an LLM response."""
+
+    def complete_stream(self, messages: list[Message]) -> Iterator[LLMStreamChunk]:
+        """Receive message history and yield streaming chunks."""
 
 
 class LLMClientFactory(Protocol):

--- a/projects/simple-agent-poc/src/simple_agent_poc/application/use_cases.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/application/use_cases.py
@@ -17,7 +17,7 @@ from simple_agent_poc.core.agent_definition import (
     AgentDefinitionRegistry,
 )
 from simple_agent_poc.core.session import ConversationSession
-from simple_agent_poc.core.types import SessionNotFoundError, ValidationError
+from simple_agent_poc.core.types import SessionNotFoundError, Usage, ValidationError
 
 
 class RunAgentUseCase:
@@ -77,7 +77,7 @@ class RunAgentUseCase:
         start_time = time.perf_counter()
         accumulated_text = ""
         model = agent_definition.model
-        usage = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+        usage: Usage = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
 
         try:
             for chunk in llm_client.complete_stream(list(session.messages)):

--- a/projects/simple-agent-poc/src/simple_agent_poc/application/use_cases.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/application/use_cases.py
@@ -77,20 +77,22 @@ class RunAgentUseCase:
         start_time = time.perf_counter()
         accumulated_text = ""
         model = agent_definition.model
-        usage: Usage = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
 
         try:
+            usage_from_stream: Usage | None = None
             for chunk in llm_client.complete_stream(list(session.messages)):
                 delta = chunk.get("content_delta")
                 if delta:
                     accumulated_text += delta
                     yield ContentDelta(delta=delta)
+                if "usage" in chunk:
+                    usage_from_stream = chunk["usage"]
 
             session.append_assistant_message(accumulated_text)
             elapsed = time.perf_counter() - start_time
             yield StreamComplete(
                 session_id=session.session_id,
-                usage=usage,
+                usage=usage_from_stream,
                 model=model,
                 response_time=elapsed,
             )

--- a/projects/simple-agent-poc/src/simple_agent_poc/application/use_cases.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/application/use_cases.py
@@ -1,9 +1,16 @@
 """Application use cases."""
 
+import time
+from collections.abc import Generator
 from datetime import datetime
 from uuid import uuid4
 
-from simple_agent_poc.application.dto import RunAgentRequest, RunAgentResponse
+from simple_agent_poc.application.dto import (
+    ContentDelta,
+    RunAgentRequest,
+    RunAgentResponse,
+    StreamComplete,
+)
 from simple_agent_poc.application.ports import LLMClientFactory, SessionStore
 from simple_agent_poc.core.agent_definition import (
     AgentDefinition,
@@ -49,6 +56,54 @@ class RunAgentUseCase:
         return RunAgentResponse.from_llm_response(
             response, session_id=session.session_id
         )
+
+    def execute_stream(
+        self, request: RunAgentRequest
+    ) -> Generator[ContentDelta | StreamComplete, None, None]:
+        """Run the agent for a single user message with streaming."""
+        if not request.message.strip():
+            raise ValidationError("message must not be blank")
+
+        agent_definition = self._agent_definitions.get(request.agent_id)
+        session = self._load_session(
+            request.session_id,
+            agent_definition=agent_definition,
+        )
+        if session.agent_id != agent_definition.agent_id:
+            raise ValidationError("agent_id cannot be changed for an existing session")
+        session.append_user_message(request.message)
+
+        llm_client = self._llm_client_factory(agent_definition)
+        start_time = time.perf_counter()
+        accumulated_text = ""
+        model = agent_definition.model
+        usage = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+
+        try:
+            for chunk in llm_client.complete_stream(list(session.messages)):
+                delta = chunk.get("content_delta")
+                if delta:
+                    accumulated_text += delta
+                    yield ContentDelta(delta=delta)
+
+            session.append_assistant_message(accumulated_text)
+            elapsed = time.perf_counter() - start_time
+            yield StreamComplete(
+                session_id=session.session_id,
+                usage=usage,
+                model=model,
+                response_time=elapsed,
+            )
+        except Exception:
+            if accumulated_text:
+                session.append_assistant_message(
+                    f"{accumulated_text}\n\n[stream interrupted]"
+                )
+            else:
+                session.append_assistant_message("[stream interrupted]")
+            raise
+        finally:
+            self._session_store.save(session)
 
     def _load_session(
         self,

--- a/projects/simple-agent-poc/src/simple_agent_poc/core/agent_definition.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/core/agent_definition.py
@@ -10,7 +10,7 @@ from simple_agent_poc.core.types import ValidationError
 
 _ROOT_FIELDS = frozenset({"agents"})
 _AGENT_FIELDS = frozenset(
-    {"model", "system_prompt", "temperature", "tools", "api_type"}
+    {"model", "system_prompt", "temperature", "tools", "api_type", "stream"}
 )
 _REQUIRED_AGENT_FIELDS = frozenset({"model", "system_prompt"})
 
@@ -25,6 +25,7 @@ class AgentDefinition:
     temperature: float | None = None
     tools: list[dict[str, Any]] = field(default_factory=list)
     api_type: Literal["completion", "responses"] = "completion"
+    stream: bool = False
 
     def format_system_prompt(self, *, current_datetime: str) -> str:
         """Format the system prompt with runtime context."""
@@ -109,6 +110,10 @@ def _build_agent_definition(
         definition.get("api_type"),
         f"agents.{agent_id}.api_type",
     )
+    stream = _optional_bool(
+        definition.get("stream"),
+        f"agents.{agent_id}.stream",
+    )
 
     return AgentDefinition(
         agent_id=agent_id,
@@ -117,6 +122,7 @@ def _build_agent_definition(
         temperature=temperature,
         tools=tools,
         api_type=api_type,
+        stream=stream,
     )
 
 
@@ -172,3 +178,11 @@ def _optional_api_type(
     if value not in ("completion", "responses"):
         raise ValidationError(f"{path} must be one of: completion, responses")
     return cast(Literal["completion", "responses"], value)
+
+
+def _optional_bool(value: object, path: str) -> bool:
+    if value is None:
+        return False
+    if not isinstance(value, bool):
+        raise ValidationError(f"{path} must be a boolean")
+    return value

--- a/projects/simple-agent-poc/src/simple_agent_poc/core/types.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/core/types.py
@@ -1,6 +1,6 @@
 """Shared core types and domain errors."""
 
-from typing import Literal, TypedDict
+from typing import Literal, NotRequired, TypedDict
 
 
 class AgentError(Exception):
@@ -54,3 +54,4 @@ class LLMResponse(TypedDict):
 
 class LLMStreamChunk(TypedDict):
     content_delta: str | None
+    usage: NotRequired[Usage]

--- a/projects/simple-agent-poc/src/simple_agent_poc/core/types.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/core/types.py
@@ -50,3 +50,7 @@ class LLMResponse(TypedDict):
     usage: Usage
     model: str
     response_time: float
+
+
+class LLMStreamChunk(TypedDict):
+    content_delta: str | None

--- a/projects/simple-agent-poc/src/simple_agent_poc/entrypoints/main_cli.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/entrypoints/main_cli.py
@@ -9,7 +9,12 @@ from simple_agent_poc.entrypoints import bootstrap
 
 def build_cli_adapter(*, agent_id: str = bootstrap.DEFAULT_AGENT_ID) -> CLIAdapter:
     """Create the CLI adapter with production dependencies."""
-    return CLIAdapter(bootstrap.create_run_agent_use_case(), agent_id=agent_id)
+    agent_definitions = bootstrap.create_agent_definition_registry()
+    return CLIAdapter(
+        bootstrap.create_run_agent_use_case(agent_definitions=agent_definitions),
+        agent_id=agent_id,
+        agent_definitions=agent_definitions,
+    )
 
 
 def main(argv: Sequence[str] | None = None) -> None:

--- a/projects/simple-agent-poc/tests/test_agent_definition.py
+++ b/projects/simple-agent-poc/tests/test_agent_definition.py
@@ -186,3 +186,76 @@ agents:
 
         with pytest.raises(ValidationError, match="Unknown agent_id: missing"):
             registry.get("missing")
+
+    def test_allows_stream_true(self) -> None:
+        registry = AgentDefinitionRegistry.from_mapping(
+            {
+                "agents": {
+                    "default": {
+                        "model": "gpt-4.1-nano",
+                        "system_prompt": "Prompt",
+                        "stream": True,
+                    }
+                }
+            }
+        )
+
+        assert registry.get("default").stream is True
+
+    def test_allows_stream_false(self) -> None:
+        registry = AgentDefinitionRegistry.from_mapping(
+            {
+                "agents": {
+                    "default": {
+                        "model": "gpt-4.1-nano",
+                        "system_prompt": "Prompt",
+                        "stream": False,
+                    }
+                }
+            }
+        )
+
+        assert registry.get("default").stream is False
+
+    def test_stream_defaults_to_false(self) -> None:
+        registry = AgentDefinitionRegistry.from_mapping(
+            {
+                "agents": {
+                    "default": {
+                        "model": "gpt-4.1-nano",
+                        "system_prompt": "Prompt",
+                    }
+                }
+            }
+        )
+
+        assert registry.get("default").stream is False
+
+    def test_stream_defaults_to_false_when_null(self) -> None:
+        registry = AgentDefinitionRegistry.from_mapping(
+            {
+                "agents": {
+                    "default": {
+                        "model": "gpt-4.1-nano",
+                        "system_prompt": "Prompt",
+                        "stream": None,
+                    }
+                }
+            }
+        )
+
+        assert registry.get("default").stream is False
+
+    def test_rejects_non_bool_stream(self) -> None:
+        with pytest.raises(ValidationError, match="stream must be a boolean"):
+            AgentDefinitionRegistry.from_mapping(
+                {
+                    "agents": {
+                        "default": {
+                            "model": "gpt-4.1-nano",
+                            "system_prompt": "Prompt",
+                            "stream": "yes",
+                        }
+                    }
+                }
+            )

--- a/projects/simple-agent-poc/tests/test_http_stream_api.py
+++ b/projects/simple-agent-poc/tests/test_http_stream_api.py
@@ -9,7 +9,7 @@ from simple_agent_poc.adapters.http.api import create_app
 from simple_agent_poc.adapters.session_store.in_memory import InMemorySessionStore
 from simple_agent_poc.application.use_cases import RunAgentUseCase
 from simple_agent_poc.core.agent_definition import AgentDefinitionRegistry
-from simple_agent_poc.core.types import LLMStreamChunk, Message
+from simple_agent_poc.core.types import LLMResponse, LLMStreamChunk, Message
 
 
 class StreamingStubLLMClient:
@@ -18,7 +18,7 @@ class StreamingStubLLMClient:
     def __init__(self, chunks: list[LLMStreamChunk]) -> None:
         self.chunks = chunks
 
-    def complete(self, messages: list[Message]) -> dict:
+    def complete(self, messages: list[Message]) -> LLMResponse:
         raise NotImplementedError
 
     def complete_stream(self, messages: list[Message]) -> Iterator[LLMStreamChunk]:

--- a/projects/simple-agent-poc/tests/test_http_stream_api.py
+++ b/projects/simple-agent-poc/tests/test_http_stream_api.py
@@ -1,0 +1,151 @@
+"""Tests for the HTTP streaming API adapter."""
+
+import json
+from collections.abc import Iterator
+
+from fastapi.testclient import TestClient
+
+from simple_agent_poc.adapters.http.api import create_app
+from simple_agent_poc.adapters.session_store.in_memory import InMemorySessionStore
+from simple_agent_poc.application.use_cases import RunAgentUseCase
+from simple_agent_poc.core.agent_definition import AgentDefinitionRegistry
+from simple_agent_poc.core.types import LLMStreamChunk, Message
+
+
+class StreamingStubLLMClient:
+    """Stub LLM client for streaming HTTP tests."""
+
+    def __init__(self, chunks: list[LLMStreamChunk]) -> None:
+        self.chunks = chunks
+
+    def complete(self, messages: list[Message]) -> dict:
+        raise NotImplementedError
+
+    def complete_stream(self, messages: list[Message]) -> Iterator[LLMStreamChunk]:
+        yield from self.chunks
+
+
+def build_registry() -> AgentDefinitionRegistry:
+    return AgentDefinitionRegistry.from_mapping(
+        {
+            "agents": {
+                "default": {
+                    "model": "default-model",
+                    "system_prompt": "System prompt",
+                },
+            }
+        }
+    )
+
+
+def parse_sse_events(data: str) -> list[dict[str, str]]:
+    """Parse SSE response text into a list of event dicts."""
+    events: list[dict[str, str]] = []
+    current: dict[str, str] = {}
+    for line in data.splitlines():
+        if not line:
+            if current:
+                events.append(current)
+                current = {}
+            continue
+        if ":" in line:
+            key, _, value = line.partition(":")
+            current[key.strip()] = value.strip()
+    if current:
+        events.append(current)
+    return events
+
+
+class TestStreamAPI:
+    """Tests for the streaming HTTP endpoint."""
+
+    def test_chat_stream_returns_sse_events(self) -> None:
+        chunks: list[LLMStreamChunk] = [
+            {"content_delta": "Hello"},
+            {"content_delta": " world"},
+        ]
+        llm_client = StreamingStubLLMClient(chunks=chunks)
+        app = create_app(
+            use_case_factory=lambda: RunAgentUseCase(
+                llm_client_factory=lambda _agent_definition: llm_client,
+                session_store=InMemorySessionStore(),
+                agent_definitions=build_registry(),
+            )
+        )
+        client = TestClient(app)
+
+        response = client.post("/api/chat/stream", json={"message": "Hello"})
+
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/event-stream")
+        events = parse_sse_events(response.text)
+        assert events == [
+            {"event": "delta", "data": '{"content": "Hello"}'},
+            {"event": "delta", "data": '{"content": " world"}'},
+            {"event": "complete", "data": events[2]["data"]},
+            {"event": "done", "data": "{}"},
+        ]
+        complete_data = json.loads(events[2]["data"])
+        assert complete_data["model"] == "default-model"
+        assert "session_id" in complete_data
+        assert "usage" in complete_data
+        assert "response_time" in complete_data
+
+    def test_chat_stream_error_for_blank_message(self) -> None:
+        app = create_app(
+            use_case_factory=lambda: RunAgentUseCase(
+                llm_client_factory=lambda _agent_definition: StreamingStubLLMClient(
+                    chunks=[]
+                ),
+                session_store=InMemorySessionStore(),
+                agent_definitions=build_registry(),
+            )
+        )
+        client = TestClient(app)
+
+        response = client.post("/api/chat/stream", json={"message": "   "})
+
+        assert response.status_code == 422
+
+    def test_chat_stream_error_for_unknown_agent(self) -> None:
+        app = create_app(
+            use_case_factory=lambda: RunAgentUseCase(
+                llm_client_factory=lambda _agent_definition: StreamingStubLLMClient(
+                    chunks=[]
+                ),
+                session_store=InMemorySessionStore(),
+                agent_definitions=build_registry(),
+            )
+        )
+        client = TestClient(app)
+
+        response = client.post(
+            "/api/chat/stream",
+            json={"message": "Hello", "agent_id": "missing"},
+        )
+
+        assert response.status_code == 200
+        events = parse_sse_events(response.text)
+        assert events[0]["event"] == "error"
+
+    def test_chat_stream_returns_streaming_response(self) -> None:
+        chunks: list[LLMStreamChunk] = [
+            {"content_delta": "Streaming reply"},
+        ]
+        llm_client = StreamingStubLLMClient(chunks=chunks)
+        app = create_app(
+            use_case_factory=lambda: RunAgentUseCase(
+                llm_client_factory=lambda _agent_definition: llm_client,
+                session_store=InMemorySessionStore(),
+                agent_definitions=build_registry(),
+            )
+        )
+        client = TestClient(app)
+
+        response = client.post("/api/chat/stream", json={"message": "Hello"})
+
+        assert response.status_code == 200
+        events = parse_sse_events(response.text)
+        assert any(e["event"] == "delta" for e in events)
+        assert any(e["event"] == "complete" for e in events)
+        assert any(e["event"] == "done" for e in events)

--- a/projects/simple-agent-poc/tests/test_llm_client.py
+++ b/projects/simple-agent-poc/tests/test_llm_client.py
@@ -370,3 +370,198 @@ class TestLiteLLMClientFactory:
         assert isinstance(client, LiteLLMResponsesClient)
         assert client.model == "gpt-5.4-nano"
         assert client.temperature is None
+
+
+class TestLiteLLMCompletionClientStream:
+    """Tests for complete_stream method of LiteLLMCompletionClient."""
+
+    @patch("simple_agent_poc.adapters.llm.litellm_client.completion")
+    def test_complete_stream_yields_content_deltas(
+        self,
+        mock_completion: MagicMock,
+    ) -> None:
+        chunk1 = MagicMock()
+        chunk1.choices = [MagicMock()]
+        chunk1.choices[0].delta.content = "Hello"
+        chunk2 = MagicMock()
+        chunk2.choices = [MagicMock()]
+        chunk2.choices[0].delta.content = ", world!"
+        empty_chunk = MagicMock()
+        empty_chunk.choices = [MagicMock()]
+        empty_chunk.choices[0].delta.content = ""
+        mock_completion.return_value = [chunk1, chunk2, empty_chunk]
+
+        client = LiteLLMCompletionClient(model="gpt-4")
+        messages: list[Message] = [{"role": "user", "content": "Hi"}]
+
+        result = list(client.complete_stream(messages))
+
+        assert result == [
+            {"content_delta": "Hello"},
+            {"content_delta": ", world!"},
+        ]
+        mock_completion.assert_called_once_with(
+            model="gpt-4",
+            messages=messages,
+            stream=True,
+        )
+
+    @patch("simple_agent_poc.adapters.llm.litellm_client.completion")
+    def test_complete_stream_passes_temperature(
+        self,
+        mock_completion: MagicMock,
+    ) -> None:
+        mock_completion.return_value = []
+
+        client = LiteLLMCompletionClient(model="gpt-4", temperature=0.2)
+        messages: list[Message] = [{"role": "user", "content": "Hi"}]
+
+        list(client.complete_stream(messages))
+
+        mock_completion.assert_called_once_with(
+            model="gpt-4",
+            messages=messages,
+            stream=True,
+            temperature=0.2,
+        )
+
+    @patch("simple_agent_poc.adapters.llm.litellm_client.completion")
+    def test_complete_stream_authentication_error(
+        self,
+        mock_completion: MagicMock,
+    ) -> None:
+        mock_completion.side_effect = LiteLLMAuthError(
+            "Invalid API key",
+            llm_provider="openai",
+            model="gpt-4",
+        )
+
+        client = LiteLLMCompletionClient(model="gpt-4")
+        messages: list[Message] = [{"role": "user", "content": "Hi"}]
+
+        with pytest.raises(AuthenticationError):
+            list(client.complete_stream(messages))
+
+    @patch("simple_agent_poc.adapters.llm.litellm_client.completion")
+    def test_complete_stream_rate_limit_error(
+        self,
+        mock_completion: MagicMock,
+    ) -> None:
+        mock_completion.side_effect = LiteLLMRateLimitError(
+            "Rate limit exceeded",
+            llm_provider="openai",
+            model="gpt-4",
+        )
+
+        client = LiteLLMCompletionClient(model="gpt-4")
+        messages: list[Message] = [{"role": "user", "content": "Hi"}]
+
+        with pytest.raises(RateLimitError):
+            list(client.complete_stream(messages))
+
+    @patch("simple_agent_poc.adapters.llm.litellm_client.completion")
+    def test_complete_stream_generic_error(
+        self,
+        mock_completion: MagicMock,
+    ) -> None:
+        mock_completion.side_effect = ValueError("Something went wrong")
+
+        client = LiteLLMCompletionClient(model="gpt-4")
+        messages: list[Message] = [{"role": "user", "content": "Hi"}]
+
+        with pytest.raises(LLMError):
+            list(client.complete_stream(messages))
+
+    @patch("simple_agent_poc.adapters.llm.litellm_client.completion")
+    def test_complete_stream_auth_from_generic_exception(
+        self,
+        mock_completion: MagicMock,
+    ) -> None:
+        mock_completion.side_effect = Exception("401 unauthorized")
+
+        client = LiteLLMCompletionClient(model="gpt-4")
+        messages: list[Message] = [{"role": "user", "content": "Hi"}]
+
+        with pytest.raises(AuthenticationError):
+            list(client.complete_stream(messages))
+
+
+class TestLiteLLMResponsesClientStream:
+    """Tests for complete_stream method of LiteLLMResponsesClient."""
+
+    @patch("simple_agent_poc.adapters.llm.litellm_client.responses")
+    def test_complete_stream_yields_content_deltas(
+        self,
+        mock_responses: MagicMock,
+    ) -> None:
+        event1 = MagicMock()
+        event1.delta = "Hello"
+        event2 = MagicMock()
+        event2.delta = ", world!"
+        event3 = MagicMock()
+        del event3.delta
+        mock_responses.return_value = [event1, event2, event3]
+
+        client = LiteLLMResponsesClient(model="gpt-5.4-nano")
+        messages: list[Message] = [{"role": "user", "content": "Hi"}]
+
+        result = list(client.complete_stream(messages))
+
+        assert result == [
+            {"content_delta": "Hello"},
+            {"content_delta": ", world!"},
+        ]
+        mock_responses.assert_called_once_with(
+            input=messages,
+            model="gpt-5.4-nano",
+            stream=True,
+        )
+
+    @patch("simple_agent_poc.adapters.llm.litellm_client.responses")
+    def test_complete_stream_passes_temperature(
+        self,
+        mock_responses: MagicMock,
+    ) -> None:
+        mock_responses.return_value = []
+
+        client = LiteLLMResponsesClient(model="gpt-5.4-nano", temperature=0.2)
+        messages: list[Message] = [{"role": "user", "content": "Hi"}]
+
+        list(client.complete_stream(messages))
+
+        mock_responses.assert_called_once_with(
+            input=messages,
+            model="gpt-5.4-nano",
+            stream=True,
+            temperature=0.2,
+        )
+
+    @patch("simple_agent_poc.adapters.llm.litellm_client.responses")
+    def test_complete_stream_authentication_error(
+        self,
+        mock_responses: MagicMock,
+    ) -> None:
+        mock_responses.side_effect = LiteLLMAuthError(
+            "Invalid API key",
+            llm_provider="openai",
+            model="gpt-5.4-nano",
+        )
+
+        client = LiteLLMResponsesClient(model="gpt-5.4-nano")
+        messages: list[Message] = [{"role": "user", "content": "Hi"}]
+
+        with pytest.raises(AuthenticationError):
+            list(client.complete_stream(messages))
+
+    @patch("simple_agent_poc.adapters.llm.litellm_client.responses")
+    def test_complete_stream_generic_error(
+        self,
+        mock_responses: MagicMock,
+    ) -> None:
+        mock_responses.side_effect = ValueError("Something went wrong")
+
+        client = LiteLLMResponsesClient(model="gpt-5.4-nano")
+        messages: list[Message] = [{"role": "user", "content": "Hi"}]
+
+        with pytest.raises(LLMError):
+            list(client.complete_stream(messages))

--- a/projects/simple-agent-poc/tests/test_llm_client.py
+++ b/projects/simple-agent-poc/tests/test_llm_client.py
@@ -383,12 +383,15 @@ class TestLiteLLMCompletionClientStream:
         chunk1 = MagicMock()
         chunk1.choices = [MagicMock()]
         chunk1.choices[0].delta.content = "Hello"
+        chunk1.usage = None
         chunk2 = MagicMock()
         chunk2.choices = [MagicMock()]
         chunk2.choices[0].delta.content = ", world!"
+        chunk2.usage = None
         empty_chunk = MagicMock()
         empty_chunk.choices = [MagicMock()]
         empty_chunk.choices[0].delta.content = ""
+        empty_chunk.usage = None
         mock_completion.return_value = [chunk1, chunk2, empty_chunk]
 
         client = LiteLLMCompletionClient(model="gpt-4")
@@ -404,7 +407,45 @@ class TestLiteLLMCompletionClientStream:
             model="gpt-4",
             messages=messages,
             stream=True,
+            stream_options={"include_usage": True},
         )
+
+    @patch("simple_agent_poc.adapters.llm.litellm_client.completion")
+    def test_complete_stream_yields_usage_from_last_chunk(
+        self,
+        mock_completion: MagicMock,
+    ) -> None:
+        usage_mock = MagicMock()
+        usage_mock.prompt_tokens = 10
+        usage_mock.completion_tokens = 5
+        usage_mock.total_tokens = 15
+
+        content_chunk = MagicMock()
+        content_chunk.choices = [MagicMock()]
+        content_chunk.choices[0].delta.content = "Hello"
+        content_chunk.usage = None
+
+        usage_chunk = MagicMock()
+        usage_chunk.choices = [MagicMock()]
+        usage_chunk.choices[0].delta.content = ""
+        usage_chunk.usage = usage_mock
+
+        mock_completion.return_value = [content_chunk, usage_chunk]
+
+        client = LiteLLMCompletionClient(model="gpt-4")
+        result = list(client.complete_stream([{"role": "user", "content": "Hi"}]))
+
+        assert result == [
+            {"content_delta": "Hello"},
+            {
+                "content_delta": None,
+                "usage": {
+                    "prompt_tokens": 10,
+                    "completion_tokens": 5,
+                    "total_tokens": 15,
+                },
+            },
+        ]
 
     @patch("simple_agent_poc.adapters.llm.litellm_client.completion")
     def test_complete_stream_passes_temperature(
@@ -422,6 +463,7 @@ class TestLiteLLMCompletionClientStream:
             model="gpt-4",
             messages=messages,
             stream=True,
+            stream_options={"include_usage": True},
             temperature=0.2,
         )
 
@@ -496,10 +538,13 @@ class TestLiteLLMResponsesClientStream:
     ) -> None:
         event1 = MagicMock()
         event1.delta = "Hello"
+        del event1.response
         event2 = MagicMock()
         event2.delta = ", world!"
+        del event2.response
         event3 = MagicMock()
         del event3.delta
+        del event3.response
         mock_responses.return_value = [event1, event2, event3]
 
         client = LiteLLMResponsesClient(model="gpt-5.4-nano")
@@ -516,6 +561,42 @@ class TestLiteLLMResponsesClientStream:
             model="gpt-5.4-nano",
             stream=True,
         )
+
+    @patch("simple_agent_poc.adapters.llm.litellm_client.responses")
+    def test_complete_stream_yields_usage_from_last_event(
+        self,
+        mock_responses: MagicMock,
+    ) -> None:
+        usage_mock = MagicMock()
+        usage_mock.input_tokens = 10
+        usage_mock.output_tokens = 5
+        usage_mock.total_tokens = 15
+
+        content_event = MagicMock()
+        content_event.delta = "Hello"
+        del content_event.response
+
+        usage_event = MagicMock()
+        del usage_event.delta
+        usage_event.response = MagicMock()
+        usage_event.response.usage = usage_mock
+
+        mock_responses.return_value = [content_event, usage_event]
+
+        client = LiteLLMResponsesClient(model="gpt-5.4-nano")
+        result = list(client.complete_stream([{"role": "user", "content": "Hi"}]))
+
+        assert result == [
+            {"content_delta": "Hello"},
+            {
+                "content_delta": None,
+                "usage": {
+                    "prompt_tokens": 10,
+                    "completion_tokens": 5,
+                    "total_tokens": 15,
+                },
+            },
+        ]
 
     @patch("simple_agent_poc.adapters.llm.litellm_client.responses")
     def test_complete_stream_passes_temperature(

--- a/projects/simple-agent-poc/tests/test_main.py
+++ b/projects/simple-agent-poc/tests/test_main.py
@@ -13,11 +13,14 @@ class TestBuildCLIAdapter:
         self,
         mock_cli_adapter: MagicMock,
     ) -> None:
-        with patch(
-            "simple_agent_poc.entrypoints.main_cli.bootstrap.create_run_agent_use_case"
-        ) as mock_create_run_agent_use_case, patch(
-            "simple_agent_poc.entrypoints.main_cli.bootstrap.create_agent_definition_registry"
-        ) as mock_create_registry:
+        with (
+            patch(
+                "simple_agent_poc.entrypoints.main_cli.bootstrap.create_run_agent_use_case"
+            ) as mock_create_run_agent_use_case,
+            patch(
+                "simple_agent_poc.entrypoints.main_cli.bootstrap.create_agent_definition_registry"
+            ) as mock_create_registry,
+        ):
             adapter = build_cli_adapter()
 
             assert adapter is mock_cli_adapter.return_value
@@ -36,10 +39,13 @@ class TestBuildCLIAdapter:
         self,
         mock_cli_adapter: MagicMock,
     ) -> None:
-        with patch(
-            "simple_agent_poc.entrypoints.main_cli.bootstrap.create_run_agent_use_case"
-        ), patch(
-            "simple_agent_poc.entrypoints.main_cli.bootstrap.create_agent_definition_registry"
+        with (
+            patch(
+                "simple_agent_poc.entrypoints.main_cli.bootstrap.create_run_agent_use_case"
+            ),
+            patch(
+                "simple_agent_poc.entrypoints.main_cli.bootstrap.create_agent_definition_registry"
+            ),
         ):
             build_cli_adapter(agent_id="researcher")
 

--- a/projects/simple-agent-poc/tests/test_main.py
+++ b/projects/simple-agent-poc/tests/test_main.py
@@ -15,14 +15,20 @@ class TestBuildCLIAdapter:
     ) -> None:
         with patch(
             "simple_agent_poc.entrypoints.main_cli.bootstrap.create_run_agent_use_case"
-        ) as mock_create_run_agent_use_case:
+        ) as mock_create_run_agent_use_case, patch(
+            "simple_agent_poc.entrypoints.main_cli.bootstrap.create_agent_definition_registry"
+        ) as mock_create_registry:
             adapter = build_cli_adapter()
 
             assert adapter is mock_cli_adapter.return_value
-            mock_create_run_agent_use_case.assert_called_once_with()
+            mock_create_registry.assert_called_once_with()
+            mock_create_run_agent_use_case.assert_called_once_with(
+                agent_definitions=mock_create_registry.return_value,
+            )
             mock_cli_adapter.assert_called_once_with(
                 mock_create_run_agent_use_case.return_value,
                 agent_id="default",
+                agent_definitions=mock_create_registry.return_value,
             )
 
     @patch("simple_agent_poc.entrypoints.main_cli.CLIAdapter")
@@ -32,6 +38,8 @@ class TestBuildCLIAdapter:
     ) -> None:
         with patch(
             "simple_agent_poc.entrypoints.main_cli.bootstrap.create_run_agent_use_case"
+        ), patch(
+            "simple_agent_poc.entrypoints.main_cli.bootstrap.create_agent_definition_registry"
         ):
             build_cli_adapter(agent_id="researcher")
 

--- a/projects/simple-agent-poc/tests/test_use_cases_stream.py
+++ b/projects/simple-agent-poc/tests/test_use_cases_stream.py
@@ -18,6 +18,7 @@ from simple_agent_poc.core.types import (
     LLMStreamChunk,
     Message,
     SessionNotFoundError,
+    Usage,
     ValidationError,
 )
 
@@ -294,3 +295,41 @@ class TestExecuteStream:
                     RunAgentRequest(message="Hello", agent_id="missing")
                 )
             )
+
+    def test_execute_stream_captures_usage_from_last_chunk(self) -> None:
+        usage_from_stream: Usage = {
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "total_tokens": 15,
+        }
+        chunks: list[LLMStreamChunk] = [
+            {"content_delta": "Hello"},
+            {"content_delta": None, "usage": usage_from_stream},
+        ]
+        llm_client = StreamingStubLLMClient(chunks=chunks)
+        use_case = RunAgentUseCase(
+            llm_client_factory=MagicMock(return_value=llm_client),
+            session_store=InMemorySessionStore(),
+            agent_definitions=build_registry(stream=True),
+        )
+
+        events = list(use_case.execute_stream(RunAgentRequest(message="Hello")))
+
+        complete = events[-1]
+        assert isinstance(complete, StreamComplete)
+        assert complete.usage == usage_from_stream
+
+    def test_execute_stream_usage_is_none_when_not_provided(self) -> None:
+        chunks: list[LLMStreamChunk] = [{"content_delta": "Hello"}]
+        llm_client = StreamingStubLLMClient(chunks=chunks)
+        use_case = RunAgentUseCase(
+            llm_client_factory=MagicMock(return_value=llm_client),
+            session_store=InMemorySessionStore(),
+            agent_definitions=build_registry(stream=True),
+        )
+
+        events = list(use_case.execute_stream(RunAgentRequest(message="Hello")))
+
+        complete = events[-1]
+        assert isinstance(complete, StreamComplete)
+        assert complete.usage is None

--- a/projects/simple-agent-poc/tests/test_use_cases_stream.py
+++ b/projects/simple-agent-poc/tests/test_use_cases_stream.py
@@ -14,6 +14,7 @@ from simple_agent_poc.application.dto import (
 from simple_agent_poc.application.use_cases import RunAgentUseCase
 from simple_agent_poc.core.agent_definition import AgentDefinitionRegistry
 from simple_agent_poc.core.types import (
+    LLMResponse,
     LLMStreamChunk,
     Message,
     SessionNotFoundError,
@@ -28,7 +29,7 @@ class StreamingStubLLMClient:
         self.chunks = chunks
         self.calls: list[list[Message]] = []
 
-    def complete(self, messages: list[Message]) -> dict:
+    def complete(self, messages: list[Message]) -> LLMResponse:
         raise NotImplementedError
 
     def complete_stream(self, messages: list[Message]) -> Iterator[LLMStreamChunk]:
@@ -115,10 +116,10 @@ class TestExecuteStream:
             def __init__(self) -> None:
                 self.chunks = chunks
 
-            def complete(self, messages: list[Message]) -> dict:
+            def complete(self, messages: list[Message]) -> LLMResponse:
                 raise NotImplementedError
 
-            def complete_stream(
+            def complete_stream(  # type: ignore[return-type]
                 self, messages: list[Message]
             ) -> Iterator[LLMStreamChunk]:
                 yield from self.chunks
@@ -146,14 +147,14 @@ class TestExecuteStream:
 
     def test_execute_stream_saves_interrupted_marker_on_empty_error(self) -> None:
         class ErrorStreamingClient:
-            def complete(self, messages: list[Message]) -> dict:
+            def complete(self, messages: list[Message]) -> LLMResponse:
                 raise NotImplementedError
 
-            def complete_stream(
+            def complete_stream(  # type: ignore[return-type]
                 self, messages: list[Message]
             ) -> Iterator[LLMStreamChunk]:
                 raise RuntimeError("Connection lost")
-                yield  # unreachable
+                yield  # pragma: no cover
 
         llm_client = ErrorStreamingClient()
         store = InMemorySessionStore()

--- a/projects/simple-agent-poc/tests/test_use_cases_stream.py
+++ b/projects/simple-agent-poc/tests/test_use_cases_stream.py
@@ -6,7 +6,11 @@ from unittest.mock import MagicMock
 import pytest
 
 from simple_agent_poc.adapters.session_store.in_memory import InMemorySessionStore
-from simple_agent_poc.application.dto import ContentDelta, RunAgentRequest, StreamComplete
+from simple_agent_poc.application.dto import (
+    ContentDelta,
+    RunAgentRequest,
+    StreamComplete,
+)
 from simple_agent_poc.application.use_cases import RunAgentUseCase
 from simple_agent_poc.core.agent_definition import AgentDefinitionRegistry
 from simple_agent_poc.core.types import (
@@ -114,7 +118,9 @@ class TestExecuteStream:
             def complete(self, messages: list[Message]) -> dict:
                 raise NotImplementedError
 
-            def complete_stream(self, messages: list[Message]) -> Iterator[LLMStreamChunk]:
+            def complete_stream(
+                self, messages: list[Message]
+            ) -> Iterator[LLMStreamChunk]:
                 yield from self.chunks
                 raise RuntimeError("Connection lost")
 
@@ -143,7 +149,9 @@ class TestExecuteStream:
             def complete(self, messages: list[Message]) -> dict:
                 raise NotImplementedError
 
-            def complete_stream(self, messages: list[Message]) -> Iterator[LLMStreamChunk]:
+            def complete_stream(
+                self, messages: list[Message]
+            ) -> Iterator[LLMStreamChunk]:
                 raise RuntimeError("Connection lost")
                 yield  # unreachable
 
@@ -168,12 +176,8 @@ class TestExecuteStream:
         }
 
     def test_execute_stream_reuses_existing_session(self) -> None:
-        first_client = StreamingStubLLMClient(
-            chunks=[{"content_delta": "First"}]
-        )
-        second_client = StreamingStubLLMClient(
-            chunks=[{"content_delta": "Second"}]
-        )
+        first_client = StreamingStubLLMClient(chunks=[{"content_delta": "First"}])
+        second_client = StreamingStubLLMClient(chunks=[{"content_delta": "Second"}])
         store = InMemorySessionStore()
         first_use_case = RunAgentUseCase(
             llm_client_factory=MagicMock(return_value=first_client),
@@ -253,9 +257,7 @@ class TestExecuteStream:
             )
 
     def test_execute_stream_rejects_agent_change(self) -> None:
-        llm_client = StreamingStubLLMClient(
-            chunks=[{"content_delta": "First"}]
-        )
+        llm_client = StreamingStubLLMClient(chunks=[{"content_delta": "First"}])
         store = InMemorySessionStore()
         use_case = RunAgentUseCase(
             llm_client_factory=MagicMock(return_value=llm_client),
@@ -263,9 +265,7 @@ class TestExecuteStream:
             agent_definitions=build_registry(stream=True),
         )
 
-        first_events = list(
-            use_case.execute_stream(RunAgentRequest(message="Hello"))
-        )
+        first_events = list(use_case.execute_stream(RunAgentRequest(message="Hello")))
         first_complete = first_events[-1]
         assert isinstance(first_complete, StreamComplete)
 

--- a/projects/simple-agent-poc/tests/test_use_cases_stream.py
+++ b/projects/simple-agent-poc/tests/test_use_cases_stream.py
@@ -1,0 +1,295 @@
+"""Tests for streaming use case."""
+
+from collections.abc import Iterator
+from unittest.mock import MagicMock
+
+import pytest
+
+from simple_agent_poc.adapters.session_store.in_memory import InMemorySessionStore
+from simple_agent_poc.application.dto import ContentDelta, RunAgentRequest, StreamComplete
+from simple_agent_poc.application.use_cases import RunAgentUseCase
+from simple_agent_poc.core.agent_definition import AgentDefinitionRegistry
+from simple_agent_poc.core.types import (
+    LLMStreamChunk,
+    Message,
+    SessionNotFoundError,
+    ValidationError,
+)
+
+
+class StreamingStubLLMClient:
+    """Stub LLM client for streaming tests."""
+
+    def __init__(self, chunks: list[LLMStreamChunk]) -> None:
+        self.chunks = chunks
+        self.calls: list[list[Message]] = []
+
+    def complete(self, messages: list[Message]) -> dict:
+        raise NotImplementedError
+
+    def complete_stream(self, messages: list[Message]) -> Iterator[LLMStreamChunk]:
+        self.calls.append(list(messages))
+        yield from self.chunks
+
+
+def build_registry(*, stream: bool = False) -> AgentDefinitionRegistry:
+    return AgentDefinitionRegistry.from_mapping(
+        {
+            "agents": {
+                "default": {
+                    "model": "default-model",
+                    "system_prompt": "System prompt",
+                    "stream": stream,
+                },
+                "researcher": {
+                    "model": "research-model",
+                    "system_prompt": "Research prompt",
+                    "stream": stream,
+                },
+            }
+        }
+    )
+
+
+class TestExecuteStream:
+    """Tests for execute_stream use case."""
+
+    def test_execute_stream_yields_content_deltas_and_complete(self) -> None:
+        chunks: list[LLMStreamChunk] = [
+            {"content_delta": "Hello"},
+            {"content_delta": ", world!"},
+        ]
+        llm_client = StreamingStubLLMClient(chunks=chunks)
+        store = InMemorySessionStore()
+        use_case = RunAgentUseCase(
+            llm_client_factory=MagicMock(return_value=llm_client),
+            session_store=store,
+            agent_definitions=build_registry(stream=True),
+        )
+
+        events = list(use_case.execute_stream(RunAgentRequest(message="Hello")))
+
+        # Last element is StreamComplete, preceded by ContentDelta events
+        assert len(events) == 3
+        assert events[0] == ContentDelta(delta="Hello")
+        assert events[1] == ContentDelta(delta=", world!")
+        complete = events[2]
+        assert isinstance(complete, StreamComplete)
+        assert complete.model == "default-model"
+
+    def test_execute_stream_saves_session_on_success(self) -> None:
+        chunks: list[LLMStreamChunk] = [
+            {"content_delta": "Hello"},
+            {"content_delta": ", world!"},
+        ]
+        llm_client = StreamingStubLLMClient(chunks=chunks)
+        store = InMemorySessionStore()
+        use_case = RunAgentUseCase(
+            llm_client_factory=MagicMock(return_value=llm_client),
+            session_store=store,
+            agent_definitions=build_registry(stream=True),
+        )
+
+        events = list(use_case.execute_stream(RunAgentRequest(message="Hello")))
+
+        complete = events[-1]
+        assert isinstance(complete, StreamComplete)
+        session = store.get(complete.session_id)
+        assert session is not None
+        assert session.messages[-1] == {
+            "role": "assistant",
+            "content": "Hello, world!",
+        }
+
+    def test_execute_stream_saves_partial_text_on_error(self) -> None:
+        chunks: list[LLMStreamChunk] = [
+            {"content_delta": "Hello"},
+            {"content_delta": ", "},
+        ]
+
+        class ErrorStreamingClient:
+            def __init__(self) -> None:
+                self.chunks = chunks
+
+            def complete(self, messages: list[Message]) -> dict:
+                raise NotImplementedError
+
+            def complete_stream(self, messages: list[Message]) -> Iterator[LLMStreamChunk]:
+                yield from self.chunks
+                raise RuntimeError("Connection lost")
+
+        llm_client = ErrorStreamingClient()
+        store = InMemorySessionStore()
+        use_case = RunAgentUseCase(
+            llm_client_factory=MagicMock(return_value=llm_client),
+            session_store=store,
+            agent_definitions=build_registry(stream=True),
+        )
+
+        request = RunAgentRequest(message="Hello")
+        with pytest.raises(RuntimeError, match="Connection lost"):
+            list(use_case.execute_stream(request))
+
+        sessions = list(store._sessions.values())
+        assert len(sessions) == 1
+        session = sessions[0]
+        assert session.messages[-1] == {
+            "role": "assistant",
+            "content": "Hello, \n\n[stream interrupted]",
+        }
+
+    def test_execute_stream_saves_interrupted_marker_on_empty_error(self) -> None:
+        class ErrorStreamingClient:
+            def complete(self, messages: list[Message]) -> dict:
+                raise NotImplementedError
+
+            def complete_stream(self, messages: list[Message]) -> Iterator[LLMStreamChunk]:
+                raise RuntimeError("Connection lost")
+                yield  # unreachable
+
+        llm_client = ErrorStreamingClient()
+        store = InMemorySessionStore()
+        use_case = RunAgentUseCase(
+            llm_client_factory=MagicMock(return_value=llm_client),
+            session_store=store,
+            agent_definitions=build_registry(stream=True),
+        )
+
+        request = RunAgentRequest(message="Hello")
+        with pytest.raises(RuntimeError, match="Connection lost"):
+            list(use_case.execute_stream(request))
+
+        sessions = list(store._sessions.values())
+        assert len(sessions) == 1
+        session = sessions[0]
+        assert session.messages[-1] == {
+            "role": "assistant",
+            "content": "[stream interrupted]",
+        }
+
+    def test_execute_stream_reuses_existing_session(self) -> None:
+        first_client = StreamingStubLLMClient(
+            chunks=[{"content_delta": "First"}]
+        )
+        second_client = StreamingStubLLMClient(
+            chunks=[{"content_delta": "Second"}]
+        )
+        store = InMemorySessionStore()
+        first_use_case = RunAgentUseCase(
+            llm_client_factory=MagicMock(return_value=first_client),
+            session_store=store,
+            agent_definitions=build_registry(stream=True),
+        )
+        second_use_case = RunAgentUseCase(
+            llm_client_factory=MagicMock(return_value=second_client),
+            session_store=store,
+            agent_definitions=build_registry(stream=True),
+        )
+
+        first_events = list(
+            first_use_case.execute_stream(RunAgentRequest(message="Hello"))
+        )
+        first_complete = first_events[-1]
+        assert isinstance(first_complete, StreamComplete)
+
+        _ = list(
+            second_use_case.execute_stream(
+                RunAgentRequest(
+                    message="Again",
+                    session_id=first_complete.session_id,
+                )
+            )
+        )
+
+        assert second_client.calls[0] == [
+            {"role": "system", "content": "System prompt"},
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "First"},
+            {"role": "user", "content": "Again"},
+        ]
+
+    def test_execute_stream_uses_requested_agent_definition(self) -> None:
+        llm_client = StreamingStubLLMClient(
+            chunks=[{"content_delta": "Research reply"}]
+        )
+        llm_client_factory = MagicMock(return_value=llm_client)
+        use_case = RunAgentUseCase(
+            llm_client_factory=llm_client_factory,
+            session_store=InMemorySessionStore(),
+            agent_definitions=build_registry(stream=True),
+        )
+
+        list(
+            use_case.execute_stream(
+                RunAgentRequest(message="Hello", agent_id="researcher")
+            )
+        )
+
+        llm_client_factory.assert_called_once()
+        assert llm_client_factory.call_args.args[0].agent_id == "researcher"
+
+    def test_execute_stream_rejects_blank_message(self) -> None:
+        use_case = RunAgentUseCase(
+            llm_client_factory=MagicMock(),
+            session_store=InMemorySessionStore(),
+            agent_definitions=build_registry(stream=True),
+        )
+
+        with pytest.raises(ValidationError, match="message must not be blank"):
+            list(use_case.execute_stream(RunAgentRequest(message="   ")))
+
+    def test_execute_stream_rejects_unknown_session(self) -> None:
+        use_case = RunAgentUseCase(
+            llm_client_factory=MagicMock(),
+            session_store=InMemorySessionStore(),
+            agent_definitions=build_registry(stream=True),
+        )
+
+        with pytest.raises(SessionNotFoundError, match="Session not found"):
+            list(
+                use_case.execute_stream(
+                    RunAgentRequest(message="Hello", session_id="missing-session")
+                )
+            )
+
+    def test_execute_stream_rejects_agent_change(self) -> None:
+        llm_client = StreamingStubLLMClient(
+            chunks=[{"content_delta": "First"}]
+        )
+        store = InMemorySessionStore()
+        use_case = RunAgentUseCase(
+            llm_client_factory=MagicMock(return_value=llm_client),
+            session_store=store,
+            agent_definitions=build_registry(stream=True),
+        )
+
+        first_events = list(
+            use_case.execute_stream(RunAgentRequest(message="Hello"))
+        )
+        first_complete = first_events[-1]
+        assert isinstance(first_complete, StreamComplete)
+
+        with pytest.raises(ValidationError, match="agent_id cannot be changed"):
+            list(
+                use_case.execute_stream(
+                    RunAgentRequest(
+                        message="Again",
+                        session_id=first_complete.session_id,
+                        agent_id="researcher",
+                    )
+                )
+            )
+
+    def test_execute_stream_rejects_unknown_agent_id(self) -> None:
+        use_case = RunAgentUseCase(
+            llm_client_factory=MagicMock(),
+            session_store=InMemorySessionStore(),
+            agent_definitions=build_registry(stream=True),
+        )
+
+        with pytest.raises(ValidationError, match="Unknown agent_id: missing"):
+            list(
+                use_case.execute_stream(
+                    RunAgentRequest(message="Hello", agent_id="missing")
+                )
+            )


### PR DESCRIPTION
## Issues

- Close #896

## Why

現状 `stream=False` でハードコードされており、CLI は完全応答を待ってから一括表示、API は同期的に JSON を返すのみでした。ユーザー体験の向上と SSE による API クライアント統合を見据えて、エージェント単位でストリーミングを制御可能にします。

## Summary

レイヤー構造（Core → Application → Adapters）に従い、各層にストリーミング用の型・インターフェース・実装を追加しました。`execute()` から分岐する形で `execute_stream()` をユースケースに追加し、CLI/API 両方から利用可能にしています。設定は `agents.yaml` に `stream` フィールドを追加し、エージェント単位で制御します。

## Changes

- **Core**: `LLMStreamChunk` 型追加、`AgentDefinition` に `stream: bool` フィールド追加
- **Application**: `LLMClient` に `complete_stream()` 追加、`ContentDelta`/`StreamComplete` DTO 追加、`execute_stream()` ユースケース追加
- **Adapter (LLM)**: `LiteLLMCompletionClient` と `LiteLLMResponsesClient` に `complete_stream()` 実装
- **Adapter (CLI)**: `show_streaming_response()` リアルタイム表示関数追加、`CLIAdapter` にストリーミング分岐追加
- **Adapter (HTTP)**: `POST /api/chat/stream` SSE エンドポイント追加
- **Config**: `agents.yaml` に `stream: false` を追加（デフォルト無効）
- **Docs**: architecture SKILL の Non-goals から streaming 記述を削除

## Verification

- `ruff check` - passed
- `pytest` - 124 tests passed (新規29テスト含む)
