### PR TITLE
docs: restructure documentation for AI consumption

### DIFF
--- a/projects/simple-agent-poc/AGENTS.md
+++ b/projects/simple-agent-poc/AGENTS.md
@@ -12,9 +12,30 @@
 | **LLM Integration** | LiteLLM | LLM provider integration |
 | **Config Parsing** | PyYAML | Agent definition file loading |
 | **Environment** | python-dotenv | Environment variable management |
+| **HTTP Framework** | FastAPI + Uvicorn | HTTP API server |
+| **HTTP Testing** | httpx | HTTP client for tests |
+
+## Task → Document Mapping
+
+When working on a task, read the relevant document in `docs/` first.
+
+| Task | Primary Reference | Supplementary |
+| :--- | :--- | :--- |
+| Understand architecture / layers / dependency direction | `docs/architecture.md` | — |
+| Add or modify agent definitions (YAML) | `docs/agent-definition.md` | `agents.yaml` |
+| Modify CLI mode (adapter, renderer, interaction loop) | `docs/cli.md` | `docs/sse.md` (if streaming) |
+| Modify HTTP API (endpoints, request/response schema) | `docs/api.md` | `docs/sse.md` (if streaming) |
+| Modify SSE streaming behavior | `docs/sse.md` | `docs/api.md`, `docs/cli.md` |
+| Modify LLM integration (LiteLLM client, factory) | `docs/llm-integration.md` | `docs/types.md` |
+| Modify session management (store, lifecycle) | `docs/session.md` | `docs/bootstrap.md` |
+| Modify bootstrap / dependency injection / startup flow | `docs/bootstrap.md` | `docs/architecture.md` |
+| Add or change type definitions | `docs/types.md` | `docs/errors.md` |
+| Add or change error handling | `docs/errors.md` | `docs/types.md` |
+| Run code quality checks (format, lint, type check) | `docs/development.md` | — |
+| Write or modify tests | `docs/testing.md` | `docs/development.md` |
 
 ## References
 
-- Project overview and setup: `README.md`
-- Default agent definitions: `agents.yaml`
-- Skills index: `.claude/skills/README.md`
+- Agent definitions: `agents.yaml`
+- Skills: `.claude/skills/README.md`
+- Documentation index: `docs/`

--- a/projects/simple-agent-poc/README.md
+++ b/projects/simple-agent-poc/README.md
@@ -1,154 +1,55 @@
 # simple-agent-poc
 
-## Setup
+Lightweight AI agent PoC with CLI and HTTP API interfaces.
 
-1. Install dependencies:
+## Setup
 
 ```bash
 uv sync
-```
-
-2. Copy the environment file:
-```bash
 cp .env.example .env
+# Edit .env: set OPENAI_API_KEY, OPENAI_BASE_URL
 ```
 
-3. Edit `.env` and set your API credentials and agent definition file:
-```bash
-OPENAI_API_KEY="your-api-key"
-OPENAI_BASE_URL="your-base-url"
-AGENTS_FILE="agents.yaml"
-```
-
-## Usage
+## Quick Start
 
 ```bash
-uv run dev
-```
-
-Run the CLI with a specific agent from `agents.yaml`:
-
-```bash
+uv run dev                 # CLI (default agent)
 uv run dev --agent kansaiben
+uv run api                 # HTTP API on 127.0.0.1:8000
 ```
 
 ## API Usage
 
-Start the HTTP API:
-
 ```bash
-uv run api
-```
-
-Send a request:
-
-```bash
+# Synchronous chat
 curl -X POST http://127.0.0.1:8000/api/chat \
   -H "Content-Type: application/json" \
   -d '{"message":"Hello"}'
-```
 
-Send a request with a specific agent:
-
-```bash
-curl -X POST http://127.0.0.1:8000/api/chat \
-  -H "Content-Type: application/json" \
-  -d '{"message":"調べて","agent_id":"kansaiben"}'
-```
-
-Continue the same conversation by sending back the returned `session_id`:
-
-```bash
+# Continue a session via Session-Id header
 curl -X POST http://127.0.0.1:8000/api/chat \
   -H "Session-Id: <session-id>" \
   -H "Content-Type: application/json" \
   -d '{"message":"Continue"}'
+
+# Streaming chat (SSE)
+curl -X POST http://127.0.0.1:8000/api/chat/stream \
+  -H "Content-Type: application/json" \
+  -d '{"message":"Hello"}'
 ```
 
-`/api/chat` uses the `Session-Id` request header as the primary session transport.
-For compatibility, the JSON body still accepts an optional `session_id` for now. If both are
-sent, they must match; otherwise the API returns `400`.
+## Documentation
 
-When continuing a session, use the same `agent_id` that created it. Changing agents for an
-existing session returns `400` because the stored conversation history belongs to the original
-agent definition.
-
-## Architecture Direction
-
-`simple-agent-poc` keeps the CLI as the primary development entrypoint, but the architecture is
-now defined as a multi-entry application so the same agent flow can later be reused from HTTP and
-other adapters.
-
-- `core`: conversation session model, message types, and domain errors
-- `application`: use cases, DTOs, and ports such as `SessionStore` and `LLMClient`
-- `adapters`: CLI, HTTP, LiteLLM, and in-memory session storage
-- `entrypoints`: thin startup modules that wire dependencies
-
-The current boundary policy and migration direction are documented in
-`.claude/skills/architecture/SKILL.md`.
-
-The reusable execution contract now lives under `src/simple_agent_poc/application/`.
-The session model lives under `src/simple_agent_poc/core/`.
-The CLI and HTTP adapters live under `src/simple_agent_poc/adapters/`.
-The process entrypoints live under `src/simple_agent_poc/entrypoints/`.
-
-## Agent Definitions
-
-Agent definitions are loaded from `agents.yaml` by default. Set `AGENTS_FILE` to point at
-another YAML file when running with a different definition set.
-
-Each agent supports these fields:
-
-- `model`: required LiteLLM model name.
-- `system_prompt`: required prompt template. `{current_datetime}` is filled at session start.
-- `temperature`: optional numeric generation parameter. `null` or omission means it is not sent to the LLM API.
-- `tools`: optional list reserved for future tool-calling support.
-
-Validation happens at startup for production wiring, and per request for unknown `agent_id`
-values. Unknown fields, missing required fields, invalid field types, and missing `default`
-agent definitions are rejected.
-
-`tools` is currently parsed and validated but is not passed to LiteLLM yet.
-
-Once a session is created, later requests for that `session_id` must use the same `agent_id`.
-
-## Session Model
-
-- CLI keeps one in-process conversation and forwards the active `session_id` internally.
-- HTTP accepts `Session-Id` as the primary session transport and returns the effective `session_id` on every response.
-- HTTP request-body `session_id` remains temporarily supported for compatibility, but it must match `Session-Id` when both are present.
-- Each session stores the `agent_id` used at creation time, and subsequent calls must keep using it.
-- The initial implementation uses an in-memory `SessionStore`; durable persistence is a later step.
-
-## Development
-
-Format code:
-```bash
-uv run ruff format .
-```
-
-Check code:
-```bash
-uv run ruff check .
-```
-
-Type check:
-```bash
-uv run ty check .
-```
-
-Run tests:
-```bash
-uv run pytest
-```
-
-Run tests with coverage:
-```bash
-uv run pytest --cov=simple_agent_poc --cov-report=term-missing
-```
-
-Generate HTML coverage report:
-```bash
-uv run pytest --cov=simple_agent_poc --cov-report=html
-# Open htmlcov/index.html to view the report
-```
+Detailed specifications:
+- [Architecture](docs/architecture.md)
+- [Agent Definitions](docs/agent-definition.md)
+- [Session Model](docs/session.md)
+- [CLI Mode](docs/cli.md)
+- [HTTP API](docs/api.md)
+- [SSE Streaming](docs/sse.md)
+- [LLM Integration](docs/llm-integration.md)
+- [Bootstrap / DI](docs/bootstrap.md)
+- [Type Reference](docs/types.md)
+- [Error Handling](docs/errors.md)
+- [Development Guide](docs/development.md)
+- [Testing Guide](docs/testing.md)

--- a/projects/simple-agent-poc/docs/agent-definition.md
+++ b/projects/simple-agent-poc/docs/agent-definition.md
@@ -1,0 +1,115 @@
+# Agent Definition
+
+Agent definitions are loaded from `agents.yaml` by default. Set the `AGENTS_FILE` environment variable to point at a different YAML file.
+
+## YAML Schema
+
+```yaml
+agents:
+  <agent_id>:
+    model: <string>           # required
+    system_prompt: <string>   # required
+    temperature: <float|null> # optional, default null
+    tools: <list>            # optional, default []
+    api_type: <string>       # optional, default "completion"
+    stream: <bool>           # optional, default false
+```
+
+### Root Fields
+
+| Field | Required | Type | Description |
+|:---|:---|:---|:---|
+| `agents` | yes | `Mapping[str, Mapping]` | Map of agent IDs to their definitions |
+
+Unknown root-level fields are rejected.
+
+### Agent Fields
+
+#### `model` (required)
+
+- **Type:** `str` (non-blank)
+- **Description:** LiteLLM model name (e.g. `gpt-4.1-nano`).
+
+#### `system_prompt` (required)
+
+- **Type:** `str` (non-blank)
+- **Description:** Prompt template for the agent. The placeholder `{current_datetime}` is replaced with the current ISO datetime at session creation time.
+
+#### `temperature` (optional)
+
+- **Type:** `float | null`
+- **Default:** `null`
+- **Description:** When `null` or omitted, the temperature parameter is not sent to the LLM API. When set, it must be a number (not a boolean).
+
+#### `tools` (optional)
+
+- **Type:** `list[dict] | null`
+- **Default:** `[]`
+- **Description:** Reserved for future tool-calling support. Currently parsed and validated but not passed to LiteLLM.
+
+#### `api_type` (optional)
+
+- **Type:** `"completion" | "responses"`
+- **Default:** `"completion"`
+- **Description:** Chooses the LiteLLM client implementation:
+  - `completion` → `LiteLLMCompletionClient` (uses `litellm.completion()`)
+  - `responses` → `LiteLLMResponsesClient` (uses `litellm.responses()`)
+
+#### `stream` (optional)
+
+- **Type:** `bool`
+- **Default:** `false`
+- **Description:** When `true`, the CLI uses `execute_stream` with live text output instead of spinner+sync execution.
+
+## Validation Rules
+
+### Startup Validation
+
+On application startup, `AgentDefinitionRegistry.from_yaml_file()` validates:
+
+1. File must be readable and contain valid YAML.
+2. Root must be a mapping with string keys.
+3. Unknown root fields are rejected.
+4. `agents` must be a mapping.
+5. A `default` agent is required. Missing it raises `ValidationError`.
+6. Each agent ID must be a non-blank string.
+7. `model` and `system_prompt` are required for each agent.
+8. Unknown fields in an agent definition are rejected.
+9. `temperature` must be a number or null.
+10. `tools` must be a list of mappings or null.
+11. `api_type` must be `"completion"` or `"responses"`.
+12. `stream` must be a boolean.
+
+### Request-time Validation
+
+- `agent_id` not found in the registry → `ValidationError` (HTTP 400)
+- A request with `session_id` referencing an existing session that has a different `agent_id` → `ValidationError` (HTTP 400)
+
+## Environment Variable
+
+- `AGENTS_FILE` — path to the YAML file (default: `agents.yaml`)
+
+## Example
+
+```yaml
+agents:
+  default:
+    model: gpt-4.1-nano
+    stream: false
+    system_prompt: |
+      You are an AI assistant.
+      Current datetime: {current_datetime}
+    temperature: null
+    tools: []
+    api_type: completion
+
+  kansaiben:
+    model: gpt-5.4-nano
+    stream: true
+    system_prompt: |
+      関西弁で話してや。
+      Current datetime: {current_datetime}
+    temperature: null
+    tools: []
+    api_type: responses
+```

--- a/projects/simple-agent-poc/docs/api.md
+++ b/projects/simple-agent-poc/docs/api.md
@@ -1,0 +1,105 @@
+# HTTP API
+
+The HTTP API provides two endpoints for synchronous and streaming agent execution.
+
+## Entry Point
+
+```bash
+uv run api
+```
+
+Starts Uvicorn on `127.0.0.1:8000`. Source: `src/simple_agent_poc/entrypoints/main_api.py`
+
+## Application Factory
+
+`create_app(use_case_factory)` in `src/simple_agent_poc/adapters/http/api.py` creates the FastAPI application:
+
+- If no factory is provided, calls `bootstrap.create_run_agent_use_case_factory()` which creates a shared `InMemorySessionStore` instance with a `lambda` factory.
+- A FastAPI dependency `get_run_agent_use_case()` provides a fresh `RunAgentUseCase` per request (with the shared session store).
+
+## Endpoints
+
+### `POST /api/chat`
+
+Synchronous (non-streaming) agent execution.
+
+#### Request
+
+```json
+{
+  "message": "Hello",
+  "session_id": "abc123...",
+  "agent_id": "default"
+}
+```
+
+| Field | Type | Required | Default | Description |
+|:---|:---|:---|:---|:---|
+| `message` | `str` | yes | — | User message. Must not be blank after trimming. |
+| `session_id` | `str \| null` | no | `null` | Resume an existing conversation. |
+| `agent_id` | `str` | no | `"default"` | Agent to use. Must not be blank. |
+
+Headers:
+- `Session-Id: <session_id>` (optional) — Primary session transport. Takes priority over body `session_id`.
+
+#### Response (200)
+
+```json
+{
+  "message": "Hello! How can I help?",
+  "usage": {
+    "prompt_tokens": 50,
+    "completion_tokens": 20,
+    "total_tokens": 70
+  },
+  "model": "gpt-4.1-nano",
+  "response_time": 1.234,
+  "session_id": "abc123..."
+}
+```
+
+| Field | Type | Description |
+|:---|:---|:---|
+| `message` | `str` | Agent's full response text |
+| `usage` | `Usage` | Token usage: `prompt_tokens`, `completion_tokens`, `total_tokens` |
+| `model` | `str` | Model name as configured |
+| `response_time` | `float` | Seconds from LLM call start to response receipt |
+| `session_id` | `str` | Session ID for continuing the conversation |
+
+#### Error Responses
+
+| Status | Condition |
+|:---|:---|
+| `400` | `message` blank, `agent_id` blank, unknown `agent_id`, changing `agent_id` for existing session, conflicting session identifiers |
+| `404` | `session_id` not found in the session store |
+
+### `POST /api/chat/stream`
+
+Streaming agent execution via Server-Sent Events (SSE).
+
+#### Request
+
+Same schema as `/api/chat`. Supports `Session-Id` header with the same `resolve_session_id()` logic.
+
+#### Response
+
+Media type: `text/event-stream`
+
+See [docs/sse.md](sse.md) for the full SSE event specification.
+
+## Session Resolution
+
+`resolve_session_id(header_session_id, body_session_id)` resolves the effective session ID:
+
+```python
+def resolve_session_id(*, header_session_id, body_session_id):
+    if header_session_id is None:
+        return body_session_id          # use body only
+    if body_session_id is None or body_session_id == header_session_id:
+        return header_session_id        # use header (match)
+    raise HTTPException(400, "Conflicting session_id values...")
+```
+
+## Dependency Injection
+
+The FastAPI app uses `Depends(get_run_agent_use_case)` to inject `RunAgentUseCase` into endpoint handlers. The factory is created once at app startup via `create_run_agent_use_case_factory()`, ensuring the same `InMemorySessionStore` instance is shared across all requests.

--- a/projects/simple-agent-poc/docs/api.md
+++ b/projects/simple-agent-poc/docs/api.md
@@ -70,7 +70,8 @@ Headers:
 
 | Status | Condition |
 |:---|:---|
-| `400` | `message` blank, `agent_id` blank, unknown `agent_id`, changing `agent_id` for existing session, conflicting session identifiers |
+| `422` | `message` blank, `agent_id` blank (Pydantic validation) |
+| `400` | unknown `agent_id`, changing `agent_id` for existing session, conflicting session identifiers |
 | `404` | `session_id` not found in the session store |
 
 ### `POST /api/chat/stream`

--- a/projects/simple-agent-poc/docs/architecture.md
+++ b/projects/simple-agent-poc/docs/architecture.md
@@ -1,0 +1,121 @@
+# Architecture
+
+`simple-agent-poc` is a multi-entry AI agent application following Clean Architecture with four distinct layers. The same agent execution flow is reused by both CLI and HTTP adapters.
+
+## Layer Dependency Direction
+
+```
+entrypoints/  →  adapters/  →  application/  →  core/
+```
+
+Dependencies flow inward. Outer layers may depend on inner layers, but not the reverse.
+
+## Layers
+
+### Core
+
+Owns agent behavior independent of transport or entrypoint concerns.
+
+**Files:**
+- `src/simple_agent_poc/core/types.py` — shared message/response types, domain errors
+- `src/simple_agent_poc/core/session.py` — `ConversationSession` entity
+- `src/simple_agent_poc/core/agent_definition.py` — `AgentDefinition`, `AgentDefinitionRegistry`
+
+Core must not depend on CLI or HTTP details.
+
+### Application
+
+Owns executable use cases and explicit input/output contracts.
+
+**Files:**
+- `src/simple_agent_poc/application/use_cases.py` — `RunAgentUseCase` (orchestration)
+- `src/simple_agent_poc/application/dto.py` — request/response DTOs, stream events
+- `src/simple_agent_poc/application/ports.py` — `LLMClient`, `LLMClientFactory`, `SessionStore` protocols
+
+Application may depend on core contracts, but must not perform terminal rendering or HTTP response construction.
+
+### Adapters
+
+Own transport-specific integration details.
+
+**Files:**
+- `src/simple_agent_poc/adapters/cli/adapter.py` — `CLIAdapter` (stdin/stdout interactive loop)
+- `src/simple_agent_poc/adapters/cli/renderer.py` — spinner, streaming display, welcome banner
+- `src/simple_agent_poc/adapters/http/api.py` — FastAPI app (`/api/chat`, `/api/chat/stream`)
+- `src/simple_agent_poc/adapters/llm/litellm_client.py` — `LiteLLMCompletionClient`, `LiteLLMResponsesClient`, `LiteLLMClientFactory`
+- `src/simple_agent_poc/adapters/session_store/in_memory.py` — `InMemorySessionStore`
+
+Adapters call the application layer. They translate external inputs into DTOs and translate use case outputs into transport-specific output.
+
+### Entrypoints
+
+Own process startup and dependency wiring.
+
+**Files:**
+- `src/simple_agent_poc/entrypoints/bootstrap.py` — shared env loading, logging setup, `RunAgentUseCase` wiring
+- `src/simple_agent_poc/entrypoints/main_cli.py` — CLI startup
+- `src/simple_agent_poc/entrypoints/main_api.py` — HTTP API startup (Uvicorn)
+
+Entrypoints should stay thin. Their job is composition, not business logic.
+
+## Boundary Rules
+
+1. Keep CLI rendering outside the application and core layers.
+2. Keep HTTP request and response objects outside the application and core layers.
+3. Expose the reusable execution path as an application use case, not as a CLI or HTTP helper.
+4. Define conversation and session state policy at the application/core boundary and let adapters consume it.
+5. Keep session persistence behind `SessionStore`; adapters may choose identifiers, but they must not own message history.
+6. Inject infrastructure clients through interfaces so the same use case works for CLI and HTTP.
+
+## Current Directory Structure
+
+```text
+src/simple_agent_poc/
+  core/
+    session.py
+    types.py
+    agent_definition.py
+  application/
+    dto.py
+    ports.py
+    use_cases.py
+  adapters/
+    cli/
+      adapter.py
+      renderer.py
+    http/
+      api.py
+    llm/
+      litellm_client.py
+    session_store/
+      in_memory.py
+  entrypoints/
+    bootstrap.py
+    main_cli.py
+    main_api.py
+```
+
+## Responsibility Audit
+
+- `core/session.py` — ordered conversation history, system/user/assistant message accumulation.
+- `application/use_cases.py` — session lookup, session creation, LLM orchestration, persistence sequencing.
+- `application/ports.py` — the only boundary that application code uses for LLM and session persistence.
+- `adapters/cli/adapter.py` — interactive loop, delegates to `RunAgentUseCase`, tracks `_session_id`.
+- `adapters/http/api.py` — request parsing, translates `SessionNotFoundError` into `404`, SSE formatting.
+- `adapters/session_store/in_memory.py` — reference implementation for persistence adapters.
+- `entrypoints/bootstrap.py` — production wiring used by both CLI and HTTP.
+
+## Ongoing Guidance
+
+1. Extend session behavior in `core` and `application` before adding adapter-specific conveniences.
+2. Keep CLI-specific state limited to the active `session_id`; do not move message history back into the CLI adapter.
+3. Keep HTTP-specific concerns limited to schema validation and status-code translation.
+4. Add durable persistence by creating a new `adapters/session_store/*` implementation rather than changing use-case semantics.
+5. Keep `entrypoints/bootstrap.py` as the only place that decides production adapter composition.
+
+## Non-goals
+
+- Do not introduce every future layer immediately.
+- Do not redesign the runtime around async yet.
+- Do not change the CLI-first development workflow.
+- Do not couple future persistence work to FastAPI or terminal concerns.

--- a/projects/simple-agent-poc/docs/bootstrap.md
+++ b/projects/simple-agent-poc/docs/bootstrap.md
@@ -1,0 +1,88 @@
+# Bootstrap / Dependency Injection
+
+The bootstrap module is the single source of truth for production dependency wiring. Both CLI and HTTP entrypoints use it.
+
+Source: `src/simple_agent_poc/entrypoints/bootstrap.py`
+
+## Environment Loading
+
+```python
+load_dotenv()  # loads .env into os.environ
+```
+
+Called once at module level. Required environment variables:
+- `OPENAI_API_KEY` — LLM provider API key
+- `OPENAI_BASE_URL` — LLM provider base URL (optional, used by LiteLLM)
+
+## Agent Definition Registry
+
+```python
+def create_agent_definition_registry() -> AgentDefinitionRegistry:
+    agents_file = Path(os.environ.get("AGENTS_FILE", DEFAULT_AGENTS_FILE))
+    return AgentDefinitionRegistry.from_yaml_file(agents_file)
+```
+
+- Reads the path from `AGENTS_FILE` env var.
+- Default: `Path("agents.yaml")`.
+- Validates the YAML at construction time.
+
+## RunAgentUseCase (Production)
+
+```python
+def create_run_agent_use_case(*, session_store=None, agent_definitions=None) -> RunAgentUseCase:
+    return RunAgentUseCase(
+        llm_client_factory=LiteLLMClientFactory(),
+        session_store=session_store or InMemorySessionStore(),
+        agent_definitions=agent_definitions or create_agent_definition_registry(),
+    )
+```
+
+Creates the use case with production adapters:
+- `LiteLLMClientFactory()` for LLM calls
+- `InMemorySessionStore()` for session persistence
+- `AgentDefinitionRegistry` from YAML
+
+## RunAgentUseCase Factory (HTTP-optimized)
+
+```python
+def create_run_agent_use_case_factory() -> Callable[[], RunAgentUseCase]:
+    session_store = InMemorySessionStore()
+    agent_definitions = create_agent_definition_registry()
+    return lambda: create_run_agent_use_case(
+        session_store=session_store,
+        agent_definitions=agent_definitions,
+    )
+```
+
+Creates a factory function that:
+- Shares a single `InMemorySessionStore` instance across all invocations.
+- Shares a single `AgentDefinitionRegistry` instance.
+- Returns a `lambda` for use with FastAPI's `Depends`.
+
+This ensures that HTTP requests against the same server process share the same in-memory sessions.
+
+## Startup Sequences
+
+### CLI
+
+```
+main_cli.py
+  → build_cli_adapter(agent_id)
+    → bootstrap.create_agent_definition_registry()     # load YAML
+    → bootstrap.create_run_agent_use_case(...)          # wire use case (new session store)
+    → CLIAdapter(use_case, agent_id, agent_definitions)
+      → adapter.run()                                   # interactive loop
+```
+
+### HTTP API
+
+```
+main_api.py
+  → create_app()  (no factory arg)
+    → bootstrap.create_run_agent_use_case_factory()     # shared session store + registry
+      → FastAPI app with get_run_agent_use_case() dependency
+
+Request handling:
+  Depends(get_run_agent_use_case) → factory() → RunAgentUseCase
+    → use_case.execute(request) or execute_stream(request)
+```

--- a/projects/simple-agent-poc/docs/cli.md
+++ b/projects/simple-agent-poc/docs/cli.md
@@ -1,0 +1,122 @@
+# CLI Mode
+
+The interactive CLI provides a `stdin`/`stdout` loop for chatting with agents.
+
+## Entry Point
+
+```bash
+uv run dev                 # uses the "default" agent
+uv run dev --agent kansaiben
+```
+
+Source: `src/simple_agent_poc/entrypoints/main_cli.py`
+
+## Startup Flow
+
+1. `main_cli.py:main()` parses `--agent` argument.
+2. `build_cli_adapter(agent_id=...)` wires dependencies:
+   - `bootstrap.create_agent_definition_registry()` → loads `agents.yaml`
+   - `bootstrap.create_run_agent_use_case(agent_definitions=...)` → creates the use case
+3. `CLIAdapter(use_case, agent_id, agent_definitions)` is constructed.
+4. `adapter.run()` starts the interactive loop.
+
+## CLIAdapter
+
+Source: `src/simple_agent_poc/adapters/cli/adapter.py`
+
+The adapter uses protocol-based dependency injection for testability. All renderers and readers can be swapped via constructor arguments.
+
+### Constructor Parameters
+
+| Parameter | Type | Default | Description |
+|:---|:---|:---|:---|
+| `run_agent` | `RunAgentUseCase` | required | Shared agent execution use case |
+| `agent_id` | `str` | `"default"` | Active agent ID |
+| `agent_definitions` | `AgentDefinitionRegistry` | `None` | For checking `stream` flag |
+| `input_reader` | `Callable[[], str]` | `get_user_input` | Reads a line from stdin |
+| `response_renderer` | `Callable[[RunAgentResponse], None]` | `show_agent_response` | Displays sync response |
+| `streaming_renderer` | `StreamingRenderer` | `show_streaming_response` | Handles live text output |
+| `error_renderer` | `Callable[[Exception], None]` | `show_error` | Displays error messages |
+| `welcome_renderer` | `WelcomeRenderer` | `show_welcome` | Displays banner |
+| `exit_renderer` | `Callable[[], None]` | `show_exit_message` | Exit message |
+| `indicator_runner` | `IndicatorRunner` | `with_indicator` | Spinner wrapper |
+
+### Interactive Loop
+
+```
+while True:
+    input = get_user_input()
+    if blank → continue
+
+    if agent.stream:
+        complete = show_streaming_response(use_case.execute_stream(request))
+    else:
+        response = with_indicator("Thinking", lambda: use_case.execute(request))
+        show_agent_response(response)
+
+    self._session_id = response.session_id  # track for next iteration
+```
+
+### Exit Conditions
+
+- `KeyboardInterrupt` (Ctrl+C) → calls `show_exit_message()`, breaks loop
+- `EOFError` (Ctrl+D) → calls `show_exit_message()`, breaks loop
+- Other `Exception` → calls `show_error(error)`, loop continues
+
+## Renderer
+
+Source: `src/simple_agent_poc/adapters/cli/renderer.py`
+
+### LoadingIndicator
+
+Braille spinner animation running in a background thread.
+
+- Spinner chars: `⠋ ⠙ ⠹ ⠸ ⠼ ⠴ ⠦ ⠧ ⠇ ⠏`
+- Frame interval: 80ms
+- Output: `\r<char> <message>...`
+- On stop: clears the line with spaces
+
+### show_welcome(agent_id)
+
+```
+════════════════════════════════════════
+  ✨  Welcome to Simple Agent POC  ✨
+     (Press Ctrl+C to exit)
+     AgentId: <agent_id>
+════════════════════════════════════════
+```
+
+### show_agent_response(response)
+
+```
+Agent: <response.message>
+  └─ Model: <short_name> │ Time: <X.Xs> │ Tokens: <N> → <M> (total: <T>)
+```
+
+- Model name: displays only the part after `/` if present
+- Time: `< 1s` shown in ms, else in seconds with 2 decimal places
+- Tokens: `prompt_tokens → completion_tokens (total: total_tokens)`
+
+### show_streaming_response(stream)
+
+1. Starts `LoadingIndicator`.
+2. On first `ContentDelta`: stops indicator, prints `"Agent: "`, writes delta text in-place.
+3. Subsequent `ContentDelta`: writes delta text without prefix.
+4. On `StreamComplete`: prints newline, then stats line (same format as `show_agent_response`).
+5. Returns the `StreamComplete` event.
+
+If no `ContentDelta` was received before `StreamComplete`, the indicator is stopped and `"Agent: "` is printed before the stats.
+
+If no `StreamComplete` arrives at all, raises `RuntimeError`.
+
+### show_error(error)
+
+- `AgentError` subclasses: prints `"⚠️  Error: {error.display_message}"`
+- Other exceptions: prints `"⚠️  Error: An unexpected error occurred: {error}"`
+
+### with_indicator(message, operation)
+
+Wraps a synchronous operation with a `LoadingIndicator`:
+1. `indicator.start()` (background spinner starts)
+2. `operation()` executes
+3. `indicator.stop()` in `finally` (spinner stops, line cleared)

--- a/projects/simple-agent-poc/docs/development.md
+++ b/projects/simple-agent-poc/docs/development.md
@@ -1,0 +1,73 @@
+# Development
+
+## Tools
+
+| Tool | Purpose |
+|:---|:---|
+| `uv` | Package manager, virtual environments, script runner |
+| `ruff` | Code formatting and linting |
+| `ty` | Static type checking |
+| `pytest` | Testing framework |
+
+## Commands
+
+### Format
+
+```bash
+uv run ruff format .
+```
+
+Formats all Python files in the project.
+
+### Lint
+
+```bash
+uv run ruff check .
+```
+
+Runs the ruff linter. Fix auto-fixable issues with:
+
+```bash
+uv run ruff check --fix .
+```
+
+### Type Check
+
+```bash
+uv run ty check .
+```
+
+Runs the `ty` static type checker on the entire project.
+
+### Test
+
+```bash
+uv run pytest
+```
+
+Run all tests. See [docs/testing.md](testing.md) for details.
+
+### Test with Coverage
+
+```bash
+uv run pytest --cov=simple_agent_poc --cov-report=term-missing
+```
+
+### HTML Coverage Report
+
+```bash
+uv run pytest --cov=simple_agent_poc --cov-report=html
+# open htmlcov/index.html
+```
+
+## pyproject.toml Scripts
+
+The project defines these entry points in `pyproject.toml`:
+
+```toml
+[project.scripts]
+dev = "simple_agent_poc.entrypoints.main_cli:main"
+api = "simple_agent_poc.entrypoints.main_api:main"
+```
+
+These are invoked via `uv run dev` and `uv run api`.

--- a/projects/simple-agent-poc/docs/errors.md
+++ b/projects/simple-agent-poc/docs/errors.md
@@ -1,0 +1,126 @@
+# Error Handling
+
+## Error Hierarchy
+
+Source: `src/simple_agent_poc/core/types.py`
+
+```
+AgentError (base)
+├── AuthenticationError
+├── RateLimitError
+├── LLMError
+├── ValidationError
+└── SessionNotFoundError
+```
+
+### AgentError
+
+```python
+class AgentError(Exception):
+    def __init__(self, message: str, display_message: str | None = None):
+        ...
+        self.display_message = display_message or message
+```
+
+All domain exceptions inherit from `AgentError`. Each has:
+- `message` (technical, internal)
+- `display_message` (user-facing, safe to display)
+
+### AuthenticationError
+
+Raised when LLM API authentication fails (invalid API key, 401).
+
+**Trigger conditions in `litellm_client.py`:**
+- `litellm.exceptions.AuthenticationError` is caught
+- Generic exception message contains `"authentication"`, `"api key"`, or `"401"`
+
+**Display message:** `"Authentication failed: Invalid API key. Please check your API_KEY setting."`
+
+### RateLimitError
+
+Raised when the LLM API rate limit is exceeded.
+
+**Trigger condition:** `litellm.exceptions.RateLimitError` is caught.
+
+**Display message:** `"Rate limit exceeded. Please wait a moment before trying again."`
+
+### LLMError
+
+Raised for any LLM communication error not covered by more specific types.
+
+**Trigger condition:** Any exception from LiteLLM that is not authentication or rate-limit related.
+
+**Display message:** `"An error occurred while communicating with the LLM: {error}"`
+
+### ValidationError
+
+Raised for input validation failures.
+
+**Trigger conditions:**
+- Blank message in request
+- Blank `agent_id` in request
+- `agent_id` not found in the registry
+- Changing `agent_id` for an existing session
+- Conflicting `session_id` values (header vs body)
+- YAML file parsing errors
+- Malformed agent definitions (missing required fields, wrong types, unknown fields)
+
+**Display message:** Varies by context. Examples:
+- `"message must not be blank"`
+- `"Unknown agent_id: foo"`
+- `"agent_id cannot be changed for an existing session"`
+
+### SessionNotFoundError
+
+Raised when a requested `session_id` does not exist in the session store.
+
+**Display message:** `"Session not found."`
+
+## HTTP Status Code Mapping
+
+| Exception | HTTP Status |
+|:---|:---|
+| `ValidationError` | 400 |
+| `SessionNotFoundError` | 404 |
+| `AuthenticationError` | 500 (uncaught → FastAPI default) |
+| `RateLimitError` | 500 (uncaught → FastAPI default) |
+| `LLMError` | 500 (uncaught → FastAPI default) |
+
+The FastAPI adapter explicitly catches `SessionNotFoundError` → 404 and `ValidationError` → 400. All other exceptions propagate and FastAPI returns 500.
+
+```python
+# adapters/http/api.py
+except SessionNotFoundError as error:
+    raise HTTPException(status_code=404, detail=error.display_message)
+except ValidationError as error:
+    raise HTTPException(status_code=400, detail=error.display_message)
+```
+
+## CLI Error Display
+
+```python
+# adapters/cli/renderer.py:show_error
+def show_error(error: Exception) -> None:
+    if isinstance(error, AgentError):
+        print(f"⚠️  Error: {error.display_message}")
+    else:
+        print(f"⚠️  Error: An unexpected error occurred: {error}")
+```
+
+- `AgentError` subclasses: shows the `display_message` (user-friendly).
+- Other exceptions: shows the raw error string.
+- The CLI loop continues after displaying the error.
+
+## SSE Error Handling
+
+```python
+# adapters/http/api.py:event_stream
+except SessionNotFoundError as error:
+    yield f"event: error\ndata: {json.dumps({'detail': error.display_message})}\n\n"
+except ValidationError as error:
+    yield f"event: error\ndata: {json.dumps({'detail': error.display_message})}\n\n"
+except Exception as error:
+    yield f"event: error\ndata: {json.dumps({'detail': str(error)})}\n\n"
+```
+
+Errors during streaming are emitted as SSE `error` events rather than HTTP error responses. The stream terminates after the error event.

--- a/projects/simple-agent-poc/docs/errors.md
+++ b/projects/simple-agent-poc/docs/errors.md
@@ -78,15 +78,18 @@ Raised when a requested `session_id` does not exist in the session store.
 
 ## HTTP Status Code Mapping
 
-| Exception | HTTP Status |
+Pydantic request body validation (blank `message` / `agent_id`) happens before domain logic and returns **422** by FastAPI default. Domain errors are caught in the endpoint handler:
+
+| Error Source | HTTP Status |
 |:---|:---|
+| Pydantic validation (blank `message`, blank `agent_id`) | 422 |
 | `ValidationError` | 400 |
 | `SessionNotFoundError` | 404 |
 | `AuthenticationError` | 500 (uncaught → FastAPI default) |
 | `RateLimitError` | 500 (uncaught → FastAPI default) |
 | `LLMError` | 500 (uncaught → FastAPI default) |
 
-The FastAPI adapter explicitly catches `SessionNotFoundError` → 404 and `ValidationError` → 400. All other exceptions propagate and FastAPI returns 500.
+The FastAPI adapter explicitly catches `SessionNotFoundError` → 404 and `ValidationError` → 400. Pydantic validation errors (blank fields) return 422 before reaching the handler. All other exceptions propagate and FastAPI returns 500.
 
 ```python
 # adapters/http/api.py

--- a/projects/simple-agent-poc/docs/llm-integration.md
+++ b/projects/simple-agent-poc/docs/llm-integration.md
@@ -1,0 +1,120 @@
+# LLM Integration (LiteLLM)
+
+The LLM integration layer wraps LiteLLM behind protocol interfaces, allowing the application to work with different LLM APIs without changing use case logic.
+
+## Interfaces
+
+Source: `src/simple_agent_poc/application/ports.py`
+
+```python
+class LLMClient(Protocol):
+    def complete(self, messages: list[Message]) -> LLMResponse: ...
+    def complete_stream(self, messages: list[Message]) -> Iterator[LLMStreamChunk]: ...
+
+class LLMClientFactory(Protocol):
+    def __call__(self, agent_definition: AgentDefinition) -> LLMClient: ...
+```
+
+## LiteLLMClientFactory
+
+Source: `src/simple_agent_poc/adapters/llm/litellm_client.py:255-267`
+
+```python
+class LiteLLMClientFactory:
+    def __call__(self, agent_definition: AgentDefinition) -> LLMClient:
+        if agent_definition.api_type == "responses":
+            return LiteLLMResponsesClient(model=..., temperature=...)
+        return LiteLLMCompletionClient(model=..., temperature=...)
+```
+
+The factory selects the client based on the agent's `api_type` field in `agents.yaml`.
+
+## LiteLLMCompletionClient
+
+Uses `litellm.completion()` (OpenAI-compatible chat completions API).
+
+| API | `api_type` |
+|:---|:---|
+| `completion` | `"completion"` (default) |
+
+### synchronous (`complete`)
+
+```python
+response = completion(model=self.model, messages=messages, stream=False, **completion_params)
+# returns response.choices[0].message.content
+# returns response.usage (prompt_tokens, completion_tokens, total_tokens)
+```
+
+### streaming (`complete_stream`)
+
+```python
+response = completion(
+    model=self.model, messages=messages, stream=True,
+    stream_options={"include_usage": True}, **completion_params
+)
+for chunk in response:
+    # chunk.choices[0].delta.content  → content_delta
+    # chunk.usage                     → usage info (if present)
+```
+
+Usage info is included in the final chunk(s) via `stream_options={"include_usage": True}`.
+
+## LiteLLMResponsesClient
+
+Uses `litellm.responses()` (OpenAI Responses API).
+
+| API | `api_type` |
+|:---|:---|
+| `responses` | `"responses"` |
+
+### synchronous (`complete`)
+
+```python
+response = responses(input=messages, model=self.model, stream=False, **response_params)
+# returns response.output_text
+# returns response.usage (input_tokens, output_tokens, total_tokens)
+```
+
+Note: `litellm.responses()` takes `input=` (not `messages=`). The input format includes `role` and `content` keys.
+
+### streaming (`complete_stream`)
+
+```python
+response = responses(input=messages, model=self.model, stream=True, **response_params)
+for event in response:
+    # event.delta            → content_delta
+    # event.response.usage   → usage info (if present)
+```
+
+## Exception Translation
+
+All LiteLLM-specific exceptions are translated to domain exceptions defined in `core/types.py`:
+
+| LiteLLM Exception | Domain Exception | HTTP |
+|:---|:---|:---|
+| `AuthenticationError` (litellm) | `AuthenticationError` (domain) | 500 |
+| `RateLimitError` (litellm) | `RateLimitError` (domain) | 500 |
+| Generic with "authentication" / "api key" / "401" in message | `AuthenticationError` (domain) | 500 |
+| Other generic exceptions | `LLMError` (domain) | 500 |
+
+Each domain exception provides both a technical `message` and a user-facing `display_message`.
+
+The display messages:
+- Authentication: `"Authentication failed: Invalid API key. Please check your API_KEY setting."`
+- Rate limit: `"Rate limit exceeded. Please wait a moment before trying again."`
+- General: `"An error occurred while communicating with the LLM: {error}"`
+
+## Temperature Handling
+
+- `temperature` is `None` by default in `AgentDefinition`.
+- When `None`, the temperature parameter is **not included** in the API call.
+- When set to a float value, it is passed as `temperature=<value>`.
+
+## Logging
+
+LiteLLM's logger is silenced at module import time in `bootstrap.py`:
+
+```python
+logging.getLogger("litellm").setLevel(logging.CRITICAL)
+logging.getLogger("litellm").addHandler(logging.NullHandler())
+```

--- a/projects/simple-agent-poc/docs/session.md
+++ b/projects/simple-agent-poc/docs/session.md
@@ -1,0 +1,84 @@
+# Session Model
+
+Sessions track conversation history across multiple requests. Each session is tied to a specific `agent_id` and accumulates messages in order.
+
+## ConversationSession
+
+```python
+@dataclass(slots=True)
+class ConversationSession:
+    session_id: str          # UUID hex string
+    agent_id: str = "default"
+    messages: list[Message]   # [system, user, assistant, user, ...]
+```
+
+Source: `src/simple_agent_poc/core/session.py`
+
+### Message Order
+
+1. Session is created with the system prompt as the first message (`role: "system"`).
+2. Each user turn appends a `role: "user"` message.
+3. The LLM response appends a `role: "assistant"` message.
+4. This cycle repeats for the lifetime of the session.
+
+### Session Creation
+
+`ConversationSession.start(session_id, agent_id, system_prompt)` creates a new session with:
+- A generated `session_id` (UUID hex via `uuid4().hex`)
+- The agent's `agent_id`
+- One initial message: `{"role": "system", "content": system_prompt}`
+
+The system prompt is obtained from `AgentDefinition.format_system_prompt(current_datetime=...)`, which replaces the `{current_datetime}` placeholder.
+
+## SessionStore
+
+Protocol defined in `src/simple_agent_poc/application/ports.py`:
+
+```python
+class SessionStore(Protocol):
+    def get(self, session_id: str) -> ConversationSession | None: ...
+    def save(self, session: ConversationSession) -> None: ...
+```
+
+### InMemorySessionStore
+
+Default implementation in `src/simple_agent_poc/adapters/session_store/in_memory.py`. Stores sessions in a `dict[str, ConversationSession]` in process memory.
+
+- **CLI**: Each invocation creates a new `InMemorySessionStore` instance.
+- **HTTP**: A single shared instance is created by `create_run_agent_use_case_factory()` and reused across requests via `lambda`.
+
+## Session Transport
+
+### CLI
+
+The `CLIAdapter` tracks the current `session_id` in its `_session_id` field. After each call to `execute()` or `execute_stream()`, it updates `_session_id` from the response's `session_id` field.
+
+### HTTP
+
+Sessions are transported via two mechanisms, with the header taking priority:
+
+1. **`Session-Id` header** (primary) — the recommended way to resume a session.
+2. **`session_id` in JSON body** (compatibility) — retained for backward compatibility.
+
+`resolve_session_id(header_session_id, body_session_id)` resolves the effective session ID:
+- If only header is present → use header
+- If only body is present → use body
+- If both are present and match → use header
+- If both are present and differ → HTTP 400
+
+## Agent ID Immutability
+
+Once a session is created with a given `agent_id`, all subsequent requests for that `session_id` must use the same `agent_id`. Changing it returns `ValidationError` (HTTP 400).
+
+This is enforced in `RunAgentUseCase._load_session()`:
+```python
+if session.agent_id != agent_definition.agent_id:
+    raise ValidationError("agent_id cannot be changed for an existing session")
+```
+
+## Future Persistence
+
+To add durable persistence:
+1. Create a new class implementing `SessionStore` in `adapters/session_store/`.
+2. Wire it in `entrypoints/bootstrap.py` instead of `InMemorySessionStore`.
+3. Do not change `RunAgentUseCase` semantics.

--- a/projects/simple-agent-poc/docs/sse.md
+++ b/projects/simple-agent-poc/docs/sse.md
@@ -1,0 +1,117 @@
+# SSE Streaming
+
+Server-Sent Events (SSE) provide real-time streaming of agent responses via the `/api/chat/stream` endpoint. Both CLI and HTTP use the same underlying `RunAgentUseCase.execute_stream()` generator — only the formatting differs.
+
+## SSE Format
+
+Media type: `text/event-stream`
+
+Each event is a pair of lines:
+```
+event: <event_type>
+data: <json_payload>
+```
+
+Events are separated by an empty line (`\n\n`).
+
+## Event Types
+
+### `delta` — Partial Text
+
+```text
+event: delta
+data: {"content": "Hello"}
+```
+
+Emitted for each chunk of text received from the LLM. The `content` field contains the incremental text.
+
+### `complete` — Stream Finished
+
+```text
+event: complete
+data: {"session_id": "abc123...", "usage": {"prompt_tokens": 50, "completion_tokens": 20, "total_tokens": 70}, "model": "gpt-4.1-nano", "response_time": 1.5}
+```
+
+Emitted when the stream finishes successfully. Contains:
+
+| Field | Type | Description |
+|:---|:---|:---|
+| `session_id` | `str` | Session ID for continuing the conversation |
+| `usage` | `Usage \| null` | Token usage. May be `null` if the LLM did not provide it. |
+| `model` | `str` | Model name |
+| `response_time` | `float` | Seconds from stream start to completion |
+
+### `done` — End of Stream
+
+```text
+event: done
+data: {}
+```
+
+Emitted after `complete` to signal the end of the SSE stream. Contains an empty JSON object.
+
+### `error` — Error
+
+```text
+event: error
+data: {"detail": "Session not found."}
+```
+
+Emitted when an error occurs during streaming. Contains:
+
+| Field | Type | Description |
+|:---|:---|:---|
+| `detail` | `str` | Human-readable error message |
+
+## HTTP to SSE Mapping
+
+In `adapters/http/api.py`, the `chat_stream` endpoint wraps `execute_stream()` in a `StreamingResponse` generator:
+
+```python
+def event_stream():
+    for event in run_agent.execute_stream(request):
+        if isinstance(event, ContentDelta):
+            yield f"event: delta\ndata: {json.dumps({'content': event.delta})}\n\n"
+        elif isinstance(event, StreamComplete):
+            yield f"event: complete\ndata: {json.dumps(asdict(event))}\n\n"
+    yield "event: done\ndata: {}\n\n"
+```
+
+Errors caught:
+- `SessionNotFoundError` → `event: error` with 404 detail
+- `ValidationError` → `event: error` with 400 detail
+- Generic `Exception` → `event: error` with the error string
+
+## execute_stream() Generator Behavior
+
+Source: `src/simple_agent_poc/application/use_cases.py:60-108`
+
+1. Validates the message.
+2. Loads or creates a session (same as `execute()`).
+3. Validates `agent_id` immutability.
+4. Appends the user message to the session.
+5. Opens the LLM stream via `llm_client.complete_stream(messages)`.
+6. For each chunk:
+   - If `content_delta` is present → accumulates text, yields `ContentDelta(delta=...)`.
+   - If `usage` is present → stores it in `usage_from_stream`.
+7. After the stream ends:
+   - Appends the accumulated text to the session as an assistant message.
+   - Yields `StreamComplete(...)` with the session metadata.
+8. In `finally`: saves the session to the session store.
+
+### Error Handling During Streaming
+
+If the stream raises an exception:
+
+- **Text was accumulated**: Appends `"{accumulated_text}\n\n[stream interrupted]"` to the session.
+- **No text was accumulated**: Appends `"[stream interrupted]"` to the session.
+- The exception is re-raised after saving.
+
+The `finally` block ensures the session is always persisted, even on failure.
+
+## CLI Streaming
+
+In CLI mode, `show_streaming_response()` consumes the same `execute_stream()` generator:
+- Displays `ContentDelta` as live text on stdout.
+- On `StreamComplete`, prints a stats line (model, time, tokens).
+- See [docs/cli.md](cli.md) for details.

--- a/projects/simple-agent-poc/docs/testing.md
+++ b/projects/simple-agent-poc/docs/testing.md
@@ -1,0 +1,72 @@
+# Testing
+
+## Framework
+
+- **pytest** — testing framework
+- **pytest-cov** — coverage reporting
+- **httpx** — HTTP client for API integration tests
+
+## Test Directory
+
+All tests live under `tests/`:
+
+| File | Tests | Lines |
+|:---|:---|:---|
+| `test_agent_definition.py` | Agent definition YAML loading and validation | 261 |
+| `test_api.py` | HTTP API endpoint integration tests | 262 |
+| `test_application.py` | Use case tests | 272 |
+| `test_cli.py` | CLI adapter tests | 216 |
+| `test_http_stream_api.py` | HTTP SSE streaming tests | 151 |
+| `test_interfaces.py` | Protocol interface tests | 35 |
+| `test_llm_client.py` | LiteLLM client tests (largest) | 648 |
+| `test_main.py` | Entry point tests | 77 |
+| `test_main_api.py` | API entry point tests | 22 |
+| `test_renderer.py` | CLI renderer tests | 151 |
+| `test_session.py` | Session entity tests | 62 |
+| `test_types.py` | Type definition tests | 87 |
+| `test_use_cases_stream.py` | Streaming use case tests | 335 |
+
+## Running Tests
+
+```bash
+# All tests
+uv run pytest
+
+# Specific test file
+uv run pytest tests/test_session.py
+
+# With verbose output
+uv run pytest -v
+
+# Match test name pattern
+uv run pytest -k "stream"
+```
+
+## Coverage
+
+```bash
+# Terminal summary with missing lines
+uv run pytest --cov=simple_agent_poc --cov-report=term-missing
+
+# HTML report
+uv run pytest --cov=simple_agent_poc --cov-report=html
+```
+
+HTML output goes to `htmlcov/`.
+
+## Mocking Strategy
+
+Tests mock external dependencies rather than making real LLM calls:
+- `LLMClient` is mocked in use case and adapter tests.
+- LiteLLM functions (`completion`, `responses`) are patched in `test_llm_client.py`.
+- `stdin`/`stdout` are mocked in CLI tests.
+
+## E2E / Manual Testing
+
+For end-to-end verification against a live LLM:
+
+```bash
+uv run dev
+```
+
+Interact with the agent via the CLI. Verify response quality and streaming behavior.

--- a/projects/simple-agent-poc/docs/types.md
+++ b/projects/simple-agent-poc/docs/types.md
@@ -1,0 +1,205 @@
+# Type Definitions
+
+All core types and DTOs used across the application.
+
+## Core Types
+
+Source: `src/simple_agent_poc/core/types.py`
+
+### MessageRole
+
+```python
+MessageRole = Literal["system", "user", "assistant"]
+```
+
+### Message
+
+```python
+class Message(TypedDict):
+    role: MessageRole
+    content: str
+```
+
+### Usage
+
+```python
+class Usage(TypedDict):
+    prompt_tokens: int
+    completion_tokens: int
+    total_tokens: int
+```
+
+### LLMResponse
+
+```python
+class LLMResponse(TypedDict):
+    content: str
+    usage: Usage
+    model: str
+    response_time: float
+```
+
+### LLMStreamChunk
+
+```python
+class LLMStreamChunk(TypedDict):
+    content_delta: str | None
+    usage: NotRequired[Usage]
+```
+
+- `content_delta`: The incremental text. `None` when the chunk contains only usage info.
+- `usage`: Token usage. Only present in final chunks that include usage metadata.
+
+## Application DTOs
+
+Source: `src/simple_agent_poc/application/dto.py`
+
+### RunAgentRequest
+
+```python
+@dataclass(frozen=True, slots=True)
+class RunAgentRequest:
+    message: str
+    session_id: str | None = None
+    agent_id: str = "default"
+```
+
+### RunAgentResponse
+
+```python
+@dataclass(frozen=True, slots=True)
+class RunAgentResponse:
+    message: str
+    usage: Usage
+    model: str
+    response_time: float
+    session_id: str
+```
+
+Factory method:
+```python
+@classmethod
+def from_llm_response(cls, response: LLMResponse, *, session_id: str) -> "RunAgentResponse"
+```
+
+### ContentDelta
+
+```python
+@dataclass(frozen=True, slots=True)
+class ContentDelta:
+    delta: str
+```
+
+Emitted during streaming for each text chunk.
+
+### StreamComplete
+
+```python
+@dataclass(frozen=True, slots=True)
+class StreamComplete:
+    session_id: str
+    usage: Usage | None
+    model: str
+    response_time: float
+```
+
+Emitted when a stream finishes successfully. `usage` may be `None` if the LLM did not provide token counts.
+
+## HTTP Schemas
+
+Source: `src/simple_agent_poc/adapters/http/api.py`
+
+### ChatRequest
+
+```python
+class ChatRequest(BaseModel):
+    model_config = ConfigDict(str_strip_whitespace=True)
+    message: str
+    session_id: str | None = None
+    agent_id: str = "default"
+```
+
+Validators:
+- `message`: rejected if blank after stripping
+- `agent_id`: rejected if blank after stripping
+
+### ChatResponse
+
+```python
+class ChatResponse(BaseModel):
+    message: str
+    usage: Usage
+    model: str
+    response_time: float
+    session_id: str
+```
+
+Factory method:
+```python
+@classmethod
+def from_use_case_response(cls, response: RunAgentResponse) -> "ChatResponse"
+```
+
+## Entity
+
+Source: `src/simple_agent_poc/core/session.py`
+
+### ConversationSession
+
+```python
+@dataclass(slots=True)
+class ConversationSession:
+    session_id: str
+    agent_id: str = "default"
+    messages: list[Message] = field(default_factory=list)
+```
+
+Factory method:
+```python
+@classmethod
+def start(cls, *, session_id: str, agent_id: str, system_prompt: str) -> "ConversationSession"
+```
+
+Methods:
+- `append_user_message(content: str) -> None`
+- `append_assistant_message(content: str) -> None`
+
+### AgentDefinition
+
+```python
+@dataclass(frozen=True, slots=True)
+class AgentDefinition:
+    agent_id: str
+    model: str
+    system_prompt: str
+    temperature: float | None = None
+    tools: list[dict[str, Any]] = field(default_factory=list)
+    api_type: Literal["completion", "responses"] = "completion"
+    stream: bool = False
+```
+
+Method:
+```python
+def format_system_prompt(self, *, current_datetime: str) -> str
+```
+
+### AgentDefinitionRegistry
+
+```python
+@dataclass(frozen=True, slots=True)
+class AgentDefinitionRegistry:
+    _definitions: Mapping[str, AgentDefinition]
+```
+
+Factory methods:
+```python
+@classmethod
+def from_yaml_file(cls, path: str | Path) -> "AgentDefinitionRegistry"
+@classmethod
+def from_mapping(cls, data: object) -> "AgentDefinitionRegistry"
+```
+
+Query method:
+```python
+def get(self, agent_id: str) -> AgentDefinition
+```


### PR DESCRIPTION
## Summary

Restructure documentation into 12 AI-consumable reference docs under `docs/`, thin README to human-facing quick start only, and add task-to-document mapping in AGENTS.md.

## Why

Previously all detailed specifications lived in README.md (154 lines) and `.claude/skills/`. This made it hard for AI agents to find the right reference document for a given task. The `docs/` directory was empty.

## Changes

- **12 new docs files** under `docs/`:
  - `architecture.md` — Clean Architecture layers, boundaries, directory structure
  - `agent-definition.md` — YAML schema, field specs, validation rules
  - `session.md` — ConversationSession, SessionStore, transport
  - `cli.md` — CLI adapter, renderer, spinner, interactive loop
  - `api.md` — HTTP endpoints, request/response schemas, headers
  - `sse.md` — SSE event types, format, error handling, partial text saving
  - `llm-integration.md` — LiteLLM clients, factory, exception translation
  - `bootstrap.md` — Dependency injection wire-up, startup sequences
  - `types.md` — All type definitions (core types, DTOs, entities, HTTP schemas)
  - `errors.md` — Error hierarchy, HTTP status mapping, CLI/SSE display
  - `development.md` — Code quality commands
  - `testing.md` — Test structure, coverage, mocking strategy

- **README.md** — Thinned from 154 lines to ~45 lines. Setup + quick start only, links to docs/.

- **AGENTS.md** — Added 12-row Task-to-Document mapping table. AI agents can now look up the relevant doc for any task.

## Verification

- `uv run ruff check .` — passed
- `uv run ruff format --check .` — passed
- `uv run ty check .` — passed
