### PR TITLE
feat(simple-agent-poc): implement built-in tool calling with ReAct loop

### DIFF
--- a/projects/simple-agent-poc/agents.yaml
+++ b/projects/simple-agent-poc/agents.yaml
@@ -11,10 +11,13 @@ agents:
       3. Admit when you don't know something
       4. Maintain a professional and friendly tone
       5. Use the current temporal context when relevant to the user's query.
+      6. When asked to perform operations like string concatenation or checking time, use the available tools.
 
       Current datetime: {current_datetime}
     temperature: null
-    tools: []
+    tools:
+      - get_current_time
+      - concat
     api_type: completion
 
   kansaiben:

--- a/projects/simple-agent-poc/plans/integration-portfolio.md
+++ b/projects/simple-agent-poc/plans/integration-portfolio.md
@@ -1,0 +1,123 @@
+# Integration Plan: portfolio ↔ simple-agent-poc
+
+## 結合方式
+
+**API-to-API (HTTP)**: portfolio の Hono バックエンドが simple-agent-poc の FastAPI に HTTP リクエスト。
+
+```
+portfolio (Browser) ──EventSource──→ portfolio (Hono Backend)
+                                          │
+                                          │ HTTP (adapter)
+                                          ▼
+                                   simple-agent-poc (FastAPI)
+                                          │
+                                          ▼
+                                      LiteLLM → OpenAI etc.
+```
+
+## 現状のSSEフォーマット差異
+
+| 観点 | simple-agent-poc (Starlette) | portfolio - legacy | portfolio - session |
+|:---|:---|:---|:---|
+| Endpoint | `POST /api/chat/stream` | `POST /api/chat/stream` | `POST /api/chat/sessions` + `GET .../events` |
+| フォーマット | `event: <type>\ndata: <JSON>\n\n` | `data: <JSON>\n\n` | `event: <type>\nid: <uuid>\ndata: <JSON>\n\n` |
+| イベント種別 | `delta`, `complete`, `done`, `error` | `delta`, `finish`, `usage` (JSON内) | `user_message`, `assistant_delta`, `assistant_finish`, `usage`, `done`, `cancelled`, `error` |
+| 終端 | `event: done\ndata: {}\n\n` | `data: [DONE]\n\n` | `event: done\ndata: {}\n\n` |
+| IDフィールド | なし | JSON内に`id` | `id:` 行 + JSON内に`id` + `sessionId` |
+| 再接続 | なし | なし | `Last-Event-ID` / `afterEventId` |
+| Session管理 | `Session-Id` header or body | なし | URLパス + `sessionId` in events |
+| 認証 | なし（env） | `api-key` + `base-url` header | `api-key` + `base-url` header |
+| Content-Type | `text/event-stream` | `text/event-stream` | `text/event-stream` |
+
+## 設計上の決定事項（確定済み）
+
+### 1. 結合アーキテクチャ ✅
+
+portfolio の Hono バックエンド内に **adapter 層** を置き、以下を担当：
+- simple-agent-poc の SSE → portfolio の `ChatSessionEvent` 形式への変換
+- 認証情報の管理（portfolio の api-key → simple-agent-poc の内部認証 or env）
+- セッション管理の調整
+
+### 2. SSE 形式すり合わせ ✅
+
+**simple-agent-poc は現状の SSE 形式を維持。adapter で吸収する。**
+- simple-agent-poc の session 管理方式（`InMemorySessionStore` + `Session-Id` header）を変更しない
+- portfolio の session 方式（`Last-Event-ID` + `EventSource`）に合わせる必要はない
+- adapter が両者の差異を吸収する
+
+### 3. ツールコールのSSE表現 ✅
+
+simple-agent-poc 側に以下のイベントを追加：
+
+```
+event: tool_call
+data: {"call_id": "...", "name": "concat", "arguments": "{\"a\":\"hello\",\"b\":\"world\"}"}
+
+event: tool_result
+data: {"call_id": "...", "name": "concat", "result": "{\"result\":\"helloworld\"}"}
+```
+
+portfolio 側の `ChatSessionEvent.type` への追加候補：`tool_call`, `tool_result`
+
+### 4. 認証フロー ✅
+
+**内部API前提で認証なし。** portfolio のバックエンドがゲートウェイとなり、simple-agent-poc は同一ネットワーク内の内部APIとして運用する。
+
+### 5. ツール定義方式 ✅
+
+**agents.yaml はツール名のリスト。定義本体は Python 実装側に持つ。**
+
+```yaml
+tools:
+  - get_current_time
+  - concat
+```
+
+### 6. ビルトインツール ✅
+
+| ツール | パラメータ | 戻り値 | Phase |
+|:---|:---|:---|:---|
+| `get_current_time` | なし | ISO 8601 日時文字列 | 1 |
+| `concat` | `a: string, b: string` | `{"result": "..."}` | 1 |
+| `ask_user` | `question: string` | `{"answer": "..."}` | 2, 3 |
+
+## 未決定事項
+
+- [ ] ツールコールのUI表示パターン（折りたたみ / インライン / etc.）
+- [ ] reasoning（思考過程）の扱い
+- [ ] `ask_user` の API モード実装方式（pause/resume 二相実行の詳細）
+- [ ] メッセージ型変換の詳細設計（portfolio `ApiChatMessage` ↔ simple-agent-poc `Message`）
+
+## 実装フェーズ
+
+### Phase 0: 設計確定 ✅
+- [x] 本ドキュメント作成
+- [x] SSEすり合わせ方針の決定（adapter で吸収）
+- [x] ツールコール実装範囲の決定（段階的：非対話→CLI対話→API対話）
+- [x] Issue 作成 → [#902](https://github.com/u7chan/monorepo/issues/902)
+
+### Phase 1: simple-agent-poc ツールコール基盤 (Issue #902)
+- [x] ツールコール型定義 (Core層 Message 拡張)
+- [x] ツール実行機構 (BuiltinToolRegistry)
+- [x] ReActループ (Application層 RunAgentUseCase)
+- [x] API/SSE 拡張 (tool_call/tool_result イベント)
+- [x] `get_current_time` + `concat` 実装
+
+### Phase 2: simple-agent-poc ask_user CLI (別Issue)
+- [ ] `generator.send()` パターンによるユーザー入力注入
+- [ ] CLI renderer 拡張
+
+### Phase 3: simple-agent-poc ask_user API (別Issue)
+- [ ] pause/resume 二相実行
+- [ ] `POST /api/chat/continue` エンドポイント
+
+### Phase 4: portfolio 側 結合
+- [ ] Hono adapter 実装 (SSE変換, メッセージ変換)
+- [ ] ツールコール UI コンポーネント
+- [ ] セッション管理連携
+- [ ] 結合テスト
+
+### Phase 5: 運用
+- [ ] エラーハンドリング精査
+- [ ] パフォーマンス確認
+- [ ] ドキュメント整備

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/cli/adapter.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/cli/adapter.py
@@ -8,6 +8,8 @@ from simple_agent_poc.application.dto import (
     RunAgentRequest,
     RunAgentResponse,
     StreamComplete,
+    ToolCallEvent,
+    ToolResultEvent,
 )
 from simple_agent_poc.application.use_cases import RunAgentUseCase
 from simple_agent_poc.adapters.cli.renderer import (
@@ -37,7 +39,7 @@ class StreamingRenderer(Protocol):
 
     def __call__(
         self,
-        stream: Iterator[ContentDelta | StreamComplete],
+        stream: Iterator[ContentDelta | ToolCallEvent | ToolResultEvent | StreamComplete],
     ) -> StreamComplete: ...
 
 

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/cli/adapter.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/cli/adapter.py
@@ -39,7 +39,9 @@ class StreamingRenderer(Protocol):
 
     def __call__(
         self,
-        stream: Iterator[ContentDelta | ToolCallEvent | ToolResultEvent | StreamComplete],
+        stream: Iterator[
+            ContentDelta | ToolCallEvent | ToolResultEvent | StreamComplete
+        ],
     ) -> StreamComplete: ...
 
 

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/cli/renderer.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/cli/renderer.py
@@ -85,7 +85,15 @@ def get_user_input() -> str:
 
 def show_agent_response(response: RunAgentResponse) -> None:
     """Display the agent's response."""
-    print(f"Agent: {response.message}")
+    if response.tool_call_history:
+        print("Agent: ")
+        for tc in response.tool_call_history:
+            print(f"  🔧 {tc.name}({tc.arguments})")
+            print(f"     → {tc.result}")
+        if response.message:
+            print(f"       {response.message}")
+    else:
+        print(f"Agent: {response.message}")
 
     elapsed = response.response_time
     if elapsed < 1:

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/cli/renderer.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/cli/renderer.py
@@ -10,6 +10,8 @@ from simple_agent_poc.application.dto import (
     ContentDelta,
     RunAgentResponse,
     StreamComplete,
+    ToolCallEvent,
+    ToolResultEvent,
 )
 from simple_agent_poc.core.types import AgentError
 
@@ -112,7 +114,7 @@ def show_exit_message() -> None:
 
 
 def show_streaming_response(
-    stream: Iterator[ContentDelta | StreamComplete],
+    stream: Iterator[ContentDelta | ToolCallEvent | ToolResultEvent | StreamComplete],
 ) -> StreamComplete:
     """Display a streaming response with live output."""
     indicator = LoadingIndicator()
@@ -127,6 +129,20 @@ def show_streaming_response(
                     sys.stdout.write("Agent: ")
                     started = True
                 sys.stdout.write(event.delta)
+                sys.stdout.flush()
+            elif isinstance(event, ToolCallEvent):
+                if not started:
+                    indicator.stop()
+                    sys.stdout.write("Agent: ")
+                    started = True
+                sys.stdout.write(f"\n  🔧 {event.name}({event.arguments})")
+                sys.stdout.flush()
+            elif isinstance(event, ToolResultEvent):
+                if not started:
+                    indicator.stop()
+                    sys.stdout.write("Agent: ")
+                    started = True
+                sys.stdout.write(f"\n     → {event.result}")
                 sys.stdout.flush()
             elif isinstance(event, StreamComplete):
                 complete = event

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/api.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/api.py
@@ -14,6 +14,8 @@ from simple_agent_poc.application.dto import (
     RunAgentRequest,
     RunAgentResponse,
     StreamComplete,
+    ToolCallEvent,
+    ToolResultEvent,
 )
 from simple_agent_poc.application.use_cases import RunAgentUseCase
 from simple_agent_poc.core.types import SessionNotFoundError, Usage, ValidationError
@@ -157,6 +159,10 @@ def create_app(
                 ):
                     if isinstance(event, ContentDelta):
                         yield f"event: delta\ndata: {json.dumps({'content': event.delta}, ensure_ascii=False)}\n\n"
+                    elif isinstance(event, ToolCallEvent):
+                        yield f"event: tool_call\ndata: {json.dumps(asdict(event), ensure_ascii=False)}\n\n"
+                    elif isinstance(event, ToolResultEvent):
+                        yield f"event: tool_result\ndata: {json.dumps(asdict(event), ensure_ascii=False)}\n\n"
                     elif isinstance(event, StreamComplete):
                         yield f"event: complete\ndata: {json.dumps(asdict(event), ensure_ascii=False)}\n\n"
                 yield "event: done\ndata: {}\n\n"

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/api.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/api.py
@@ -15,6 +15,7 @@ from simple_agent_poc.application.dto import (
     RunAgentResponse,
     StreamComplete,
     ToolCallEvent,
+    ToolCallRecord,
     ToolResultEvent,
 )
 from simple_agent_poc.application.use_cases import RunAgentUseCase
@@ -56,6 +57,7 @@ class ChatResponse(BaseModel):
     model: str
     response_time: float
     session_id: str
+    tool_calls: list[ToolCallRecord] = []
 
     @classmethod
     def from_use_case_response(cls, response: RunAgentResponse) -> "ChatResponse":
@@ -66,6 +68,7 @@ class ChatResponse(BaseModel):
             model=response.model,
             response_time=response.response_time,
             session_id=response.session_id,
+            tool_calls=response.tool_call_history,
         )
 
 

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/llm/litellm_client.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/llm/litellm_client.py
@@ -33,14 +33,16 @@ warnings.filterwarnings(
 def _parse_tool_calls(raw_tool_calls) -> list[ToolCall]:
     result: list[ToolCall] = []
     for tc in raw_tool_calls:
-        result.append({
-            "id": tc.id,
-            "type": "function",
-            "function": {
-                "name": tc.function.name,
-                "arguments": tc.function.arguments,
-            },
-        })
+        result.append(
+            {
+                "id": tc.id,
+                "type": "function",
+                "function": {
+                    "name": tc.function.name,
+                    "arguments": tc.function.arguments,
+                },
+            }
+        )
     return result
 
 
@@ -130,9 +132,7 @@ class LiteLLMCompletionClient(LLMClient):
             "model": self.model,
             "response_time": elapsed,
         }
-        raw_tool_calls = getattr(
-            response.choices[0].message, "tool_calls", None
-        )
+        raw_tool_calls = getattr(response.choices[0].message, "tool_calls", None)
         if raw_tool_calls:
             result["tool_calls"] = _parse_tool_calls(raw_tool_calls)
         return result

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/llm/litellm_client.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/llm/litellm_client.py
@@ -68,6 +68,35 @@ def _parse_tool_call_delta(raw_tool_calls) -> list[ToolCallDelta]:
     return result
 
 
+def _item_type(item) -> str | None:
+    if isinstance(item, dict):
+        return item.get("type")
+    return getattr(item, "type", None)
+
+
+def _item_attr(item, attr: str, default=None):
+    if isinstance(item, dict):
+        return item.get(attr, default)
+    return getattr(item, attr, default)
+
+
+def _parse_tool_calls_from_responses_output(output) -> list[ToolCall]:
+    result: list[ToolCall] = []
+    for item in output:
+        if _item_type(item) == "function_call":
+            result.append(
+                {
+                    "id": _item_attr(item, "call_id", ""),
+                    "type": "function",
+                    "function": {
+                        "name": _item_attr(item, "name", ""),
+                        "arguments": _item_attr(item, "arguments", ""),
+                    },
+                }
+            )
+    return result
+
+
 class LiteLLMCompletionClient(LLMClient):
     """LLM client using litellm.completion()."""
 
@@ -261,8 +290,8 @@ class LiteLLMResponsesClient(LLMClient):
             ) from error
 
         elapsed = time.perf_counter() - start_time
-        return {
-            "content": response.output_text,
+        result: LLMResponse = {
+            "content": response.output_text or "",
             "usage": {
                 "prompt_tokens": response.usage.input_tokens,
                 "completion_tokens": response.usage.output_tokens,
@@ -271,6 +300,12 @@ class LiteLLMResponsesClient(LLMClient):
             "model": self.model,
             "response_time": elapsed,
         }
+        tool_calls = _parse_tool_calls_from_responses_output(
+            getattr(response, "output", [])
+        )
+        if tool_calls:
+            result["tool_calls"] = tool_calls
+        return result
 
     def complete_stream(
         self,
@@ -318,6 +353,36 @@ class LiteLLMResponsesClient(LLMClient):
             ) from error
 
         for event in response:
+            event_type = getattr(event, "type", None)
+
+            if event_type == "response.output_item.added":
+                item = getattr(event, "item", None)
+                if item is not None and _item_type(item) == "function_call":
+                    td: ToolCallDelta = {
+                        "index": getattr(event, "output_index", 0),
+                        "id": _item_attr(item, "call_id", None),
+                        "type": "function",
+                        "function": {
+                            "name": _item_attr(item, "name", None),
+                            "arguments": _item_attr(item, "arguments", None),
+                        },
+                    }
+                    yield {"content_delta": None, "tool_call_delta": td}
+                continue
+
+            if event_type == "response.function_call_arguments.delta":
+                td: ToolCallDelta = {
+                    "index": getattr(event, "output_index", 0),
+                    "id": getattr(event, "item_id", None),
+                    "type": "function",
+                    "function": {
+                        "name": None,
+                        "arguments": getattr(event, "delta", None),
+                    },
+                }
+                yield {"content_delta": None, "tool_call_delta": td}
+                continue
+
             chunk_data: LLMStreamChunk = {"content_delta": None}
             if hasattr(event, "delta") and event.delta:
                 chunk_data["content_delta"] = event.delta

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/llm/litellm_client.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/llm/litellm_client.py
@@ -19,12 +19,51 @@ from simple_agent_poc.core.types import (
     LLMStreamChunk,
     Message,
     RateLimitError,
+    ToolCall,
+    ToolCallDelta,
+    ToolDefinition,
 )
 
 warnings.filterwarnings(
     "ignore",
     message="Pydantic serializ",
 )
+
+
+def _parse_tool_calls(raw_tool_calls) -> list[ToolCall]:
+    result: list[ToolCall] = []
+    for tc in raw_tool_calls:
+        result.append({
+            "id": tc.id,
+            "type": "function",
+            "function": {
+                "name": tc.function.name,
+                "arguments": tc.function.arguments,
+            },
+        })
+    return result
+
+
+def _parse_tool_call_delta(raw_tool_calls) -> list[ToolCallDelta]:
+    result: list[ToolCallDelta] = []
+    for tc in raw_tool_calls:
+        fn_name: str | None = None
+        fn_args: str | None = None
+        if tc.function and tc.function.name:
+            fn_name = tc.function.name
+        if tc.function and tc.function.arguments:
+            fn_args = tc.function.arguments
+        td: ToolCallDelta = {
+            "index": tc.index,
+            "id": tc.id,
+            "type": "function",
+            "function": {
+                "name": fn_name,
+                "arguments": fn_args,
+            },
+        }
+        result.append(td)
+    return result
 
 
 class LiteLLMCompletionClient(LLMClient):
@@ -34,11 +73,18 @@ class LiteLLMCompletionClient(LLMClient):
         self.model = model
         self.temperature = temperature
 
-    def complete(self, messages: list[Message]) -> LLMResponse:
+    def complete(
+        self,
+        messages: list[Message],
+        *,
+        tools: list[ToolDefinition] | None = None,
+    ) -> LLMResponse:
         start_time = time.perf_counter()
-        completion_params: dict[str, float] = {}
+        completion_params: dict[str, object] = {}
         if self.temperature is not None:
             completion_params["temperature"] = self.temperature
+        if tools:
+            completion_params["tools"] = tools
 
         try:
             response = completion(
@@ -74,8 +120,8 @@ class LiteLLMCompletionClient(LLMClient):
             ) from error
 
         elapsed = time.perf_counter() - start_time
-        return {
-            "content": response.choices[0].message.content,
+        result: LLMResponse = {
+            "content": response.choices[0].message.content or "",
             "usage": {
                 "prompt_tokens": response.usage.prompt_tokens,
                 "completion_tokens": response.usage.completion_tokens,
@@ -84,11 +130,24 @@ class LiteLLMCompletionClient(LLMClient):
             "model": self.model,
             "response_time": elapsed,
         }
+        raw_tool_calls = getattr(
+            response.choices[0].message, "tool_calls", None
+        )
+        if raw_tool_calls:
+            result["tool_calls"] = _parse_tool_calls(raw_tool_calls)
+        return result
 
-    def complete_stream(self, messages: list[Message]) -> Iterator[LLMStreamChunk]:
-        completion_params: dict[str, float] = {}
+    def complete_stream(
+        self,
+        messages: list[Message],
+        *,
+        tools: list[ToolDefinition] | None = None,
+    ) -> Iterator[LLMStreamChunk]:
+        completion_params: dict[str, object] = {}
         if self.temperature is not None:
             completion_params["temperature"] = self.temperature
+        if tools:
+            completion_params["tools"] = tools
 
         try:
             response = completion(
@@ -127,9 +186,17 @@ class LiteLLMCompletionClient(LLMClient):
         for chunk in response:
             chunk_data: LLMStreamChunk = {"content_delta": None}
             if chunk.choices:
-                delta = chunk.choices[0].delta.content
-                if delta:
-                    chunk_data["content_delta"] = delta
+                delta = chunk.choices[0].delta
+                if delta.content:
+                    chunk_data["content_delta"] = delta.content
+                if hasattr(delta, "tool_calls") and delta.tool_calls:
+                    tc_deltas = _parse_tool_call_delta(delta.tool_calls)
+                    for td in tc_deltas:
+                        tc_chunk: LLMStreamChunk = {
+                            "content_delta": None,
+                            "tool_call_delta": td,
+                        }
+                        yield tc_chunk
             if hasattr(chunk, "usage") and chunk.usage is not None:
                 chunk_data["usage"] = {
                     "prompt_tokens": chunk.usage.prompt_tokens,
@@ -147,11 +214,18 @@ class LiteLLMResponsesClient(LLMClient):
         self.model = model
         self.temperature = temperature
 
-    def complete(self, messages: list[Message]) -> LLMResponse:
+    def complete(
+        self,
+        messages: list[Message],
+        *,
+        tools: list[ToolDefinition] | None = None,
+    ) -> LLMResponse:
         start_time = time.perf_counter()
-        response_params: dict[str, float] = {}
+        response_params: dict[str, object] = {}
         if self.temperature is not None:
             response_params["temperature"] = self.temperature
+        if tools:
+            response_params["tools"] = tools
 
         try:
             response = responses(
@@ -198,10 +272,17 @@ class LiteLLMResponsesClient(LLMClient):
             "response_time": elapsed,
         }
 
-    def complete_stream(self, messages: list[Message]) -> Iterator[LLMStreamChunk]:
-        response_params: dict[str, float] = {}
+    def complete_stream(
+        self,
+        messages: list[Message],
+        *,
+        tools: list[ToolDefinition] | None = None,
+    ) -> Iterator[LLMStreamChunk]:
+        response_params: dict[str, object] = {}
         if self.temperature is not None:
             response_params["temperature"] = self.temperature
+        if tools:
+            response_params["tools"] = tools
 
         try:
             response = responses(

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/tools/__init__.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Built-in tool implementations."""

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/tools/concat.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/tools/concat.py
@@ -29,7 +29,9 @@ TOOL_DEFINITION: ToolDefinition = {
 
 
 def execute(arguments: dict[str, Any]) -> str:
+    a = arguments.get("a", "")
+    b = arguments.get("b", "")
     return json.dumps(
-        {"result": arguments["a"] + arguments["b"]},
+        {"result": str(a) + str(b)},
         ensure_ascii=False,
     )

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/tools/concat.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/tools/concat.py
@@ -1,0 +1,35 @@
+"""concat — joins two strings and returns the result."""
+
+import json
+from typing import Any
+
+from simple_agent_poc.core.types import ToolDefinition
+
+TOOL_DEFINITION: ToolDefinition = {
+    "type": "function",
+    "function": {
+        "name": "concat",
+        "description": "2つの文字列を結合して返します。",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "a": {
+                    "type": "string",
+                    "description": "1つ目の文字列",
+                },
+                "b": {
+                    "type": "string",
+                    "description": "2つ目の文字列",
+                },
+            },
+            "required": ["a", "b"],
+        },
+    },
+}
+
+
+def execute(arguments: dict[str, Any]) -> str:
+    return json.dumps(
+        {"result": arguments["a"] + arguments["b"]},
+        ensure_ascii=False,
+    )

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/tools/get_current_time.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/tools/get_current_time.py
@@ -10,7 +10,7 @@ TOOL_DEFINITION: ToolDefinition = {
     "type": "function",
     "function": {
         "name": "get_current_time",
-        "description": "現在の日時をISO 8601形式で返します。",
+        "description": "現在の日時をUTCのISO 8601形式で返します。",
         "parameters": {
             "type": "object",
             "properties": {},

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/tools/get_current_time.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/tools/get_current_time.py
@@ -1,0 +1,27 @@
+"""get_current_time — returns current UTC datetime in ISO 8601."""
+
+import json
+from datetime import datetime, timezone
+from typing import Any
+
+from simple_agent_poc.core.types import ToolDefinition
+
+TOOL_DEFINITION: ToolDefinition = {
+    "type": "function",
+    "function": {
+        "name": "get_current_time",
+        "description": "現在の日時をISO 8601形式で返します。",
+        "parameters": {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        },
+    },
+}
+
+
+def execute(arguments: dict[str, Any]) -> str:
+    return json.dumps(
+        {"datetime": datetime.now(timezone.utc).isoformat()},
+        ensure_ascii=False,
+    )

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/tools/registry.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/tools/registry.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 from typing import Any
 
 from simple_agent_poc.application.ports import ToolExecutor
-from simple_agent_poc.core.types import ToolCall, ToolDefinition
+from simple_agent_poc.core.types import LLMError, ToolCall, ToolDefinition
 
 _ExecuteFn = Callable[[dict[str, Any]], str]
 
@@ -28,6 +28,8 @@ class BuiltinToolRegistry(ToolExecutor):
 
     def execute(self, tool_call: ToolCall, /) -> str:
         name = tool_call["function"]["name"]
+        if name not in self._executors:
+            raise LLMError(f"Unknown tool: {name}")
         executor = self._executors[name]
         arguments = json.loads(tool_call["function"]["arguments"])
         return executor(arguments)

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/tools/registry.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/tools/registry.py
@@ -34,7 +34,5 @@ class BuiltinToolRegistry(ToolExecutor):
 
     def get_definitions(self, tool_names: list[str], /) -> list[ToolDefinition]:
         return [
-            self._definitions[name]
-            for name in tool_names
-            if name in self._definitions
+            self._definitions[name] for name in tool_names if name in self._definitions
         ]

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/tools/registry.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/tools/registry.py
@@ -1,0 +1,40 @@
+"""Built-in tool registry — resolves tool names to definitions and executors."""
+
+import json
+from collections.abc import Callable
+from typing import Any
+
+from simple_agent_poc.application.ports import ToolExecutor
+from simple_agent_poc.core.types import ToolCall, ToolDefinition
+
+_ExecuteFn = Callable[[dict[str, Any]], str]
+
+
+class BuiltinToolRegistry(ToolExecutor):
+    """Registry for built-in tools with definition + execute pairing."""
+
+    def __init__(self) -> None:
+        self._definitions: dict[str, ToolDefinition] = {}
+        self._executors: dict[str, _ExecuteFn] = {}
+
+    def register(
+        self,
+        definition: ToolDefinition,
+        execute: _ExecuteFn,
+    ) -> None:
+        name = definition["function"]["name"]
+        self._definitions[name] = definition
+        self._executors[name] = execute
+
+    def execute(self, tool_call: ToolCall, /) -> str:
+        name = tool_call["function"]["name"]
+        executor = self._executors[name]
+        arguments = json.loads(tool_call["function"]["arguments"])
+        return executor(arguments)
+
+    def get_definitions(self, tool_names: list[str], /) -> list[ToolDefinition]:
+        return [
+            self._definitions[name]
+            for name in tool_names
+            if name in self._definitions
+        ]

--- a/projects/simple-agent-poc/src/simple_agent_poc/application/dto.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/application/dto.py
@@ -56,3 +56,21 @@ class StreamComplete:
     usage: Usage | None
     model: str
     response_time: float
+
+
+@dataclass(frozen=True, slots=True)
+class ToolCallEvent:
+    """Emitted when the agent initiates a tool call."""
+
+    call_id: str
+    name: str
+    arguments: str
+
+
+@dataclass(frozen=True, slots=True)
+class ToolResultEvent:
+    """Emitted when a tool execution completes."""
+
+    call_id: str
+    name: str
+    result: str

--- a/projects/simple-agent-poc/src/simple_agent_poc/application/dto.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/application/dto.py
@@ -15,6 +15,16 @@ class RunAgentRequest:
 
 
 @dataclass(frozen=True, slots=True)
+class ToolCallRecord:
+    """A single tool call and its result recorded during agent execution."""
+
+    call_id: str
+    name: str
+    arguments: str
+    result: str
+
+
+@dataclass(frozen=True, slots=True)
 class RunAgentResponse:
     """Response DTO for reusable agent execution."""
 
@@ -23,6 +33,7 @@ class RunAgentResponse:
     model: str
     response_time: float
     session_id: str
+    tool_call_history: list[ToolCallRecord]
 
     @classmethod
     def from_llm_response(
@@ -30,6 +41,7 @@ class RunAgentResponse:
         response: LLMResponse,
         *,
         session_id: str,
+        tool_call_history: list[ToolCallRecord] | None = None,
     ) -> "RunAgentResponse":
         """Build the application DTO from a raw LLM response."""
         return cls(
@@ -38,6 +50,7 @@ class RunAgentResponse:
             model=response["model"],
             response_time=response["response_time"],
             session_id=session_id,
+            tool_call_history=tool_call_history or [],
         )
 
 

--- a/projects/simple-agent-poc/src/simple_agent_poc/application/ports.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/application/ports.py
@@ -5,16 +5,42 @@ from typing import Protocol
 
 from simple_agent_poc.core.agent_definition import AgentDefinition
 from simple_agent_poc.core.session import ConversationSession
-from simple_agent_poc.core.types import LLMResponse, LLMStreamChunk, Message
+from simple_agent_poc.core.types import (
+    LLMResponse,
+    LLMStreamChunk,
+    Message,
+    ToolCall,
+    ToolDefinition,
+)
+
+
+class ToolExecutor(Protocol):
+    """Execute built-in tools by name."""
+
+    def execute(self, tool_call: ToolCall, /) -> str:
+        """Execute a tool call and return the result string."""
+
+    def get_definitions(self, tool_names: list[str], /) -> list[ToolDefinition]:
+        """Return tool definitions for the given tool names."""
 
 
 class LLMClient(Protocol):
     """Interface for LLM clients."""
 
-    def complete(self, messages: list[Message]) -> LLMResponse:
+    def complete(
+        self,
+        messages: list[Message],
+        *,
+        tools: list[ToolDefinition] | None = None,
+    ) -> LLMResponse:
         """Receive message history and return an LLM response."""
 
-    def complete_stream(self, messages: list[Message]) -> Iterator[LLMStreamChunk]:
+    def complete_stream(
+        self,
+        messages: list[Message],
+        *,
+        tools: list[ToolDefinition] | None = None,
+    ) -> Iterator[LLMStreamChunk]:
         """Receive message history and yield streaming chunks."""
 
 

--- a/projects/simple-agent-poc/src/simple_agent_poc/application/use_cases.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/application/use_cases.py
@@ -11,6 +11,7 @@ from simple_agent_poc.application.dto import (
     RunAgentResponse,
     StreamComplete,
     ToolCallEvent,
+    ToolCallRecord,
     ToolResultEvent,
 )
 from simple_agent_poc.application.ports import (
@@ -92,6 +93,8 @@ class RunAgentUseCase:
         llm_client = self._llm_client_factory(agent_definition)
         tools = self._resolve_tools(agent_definition)
 
+        tool_call_history: list[ToolCallRecord] = []
+
         for _ in range(MAX_TOOL_ROUNDS):
             response = llm_client.complete(list(session.messages), tools=tools)
 
@@ -102,6 +105,7 @@ class RunAgentUseCase:
                 return RunAgentResponse.from_llm_response(
                     response,
                     session_id=session.session_id,
+                    tool_call_history=tool_call_history,
                 )
 
             if self._tool_executor is None:
@@ -115,6 +119,14 @@ class RunAgentUseCase:
             for tc in tool_calls:
                 result = self._tool_executor.execute(tc)
                 session.append_tool_message(result, tool_call_id=tc["id"])
+                tool_call_history.append(
+                    ToolCallRecord(
+                        call_id=tc["id"],
+                        name=tc["function"]["name"],
+                        arguments=tc["function"]["arguments"],
+                        result=result,
+                    )
+                )
 
         raise LLMError(
             "Exceeded maximum tool call rounds",

--- a/projects/simple-agent-poc/src/simple_agent_poc/application/use_cases.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/application/use_cases.py
@@ -93,9 +93,7 @@ class RunAgentUseCase:
         tools = self._resolve_tools(agent_definition)
 
         for _ in range(MAX_TOOL_ROUNDS):
-            response = llm_client.complete(
-                list(session.messages), tools=tools
-            )
+            response = llm_client.complete(list(session.messages), tools=tools)
 
             tool_calls = response.get("tool_calls")
             if not tool_calls:
@@ -116,9 +114,7 @@ class RunAgentUseCase:
             )
             for tc in tool_calls:
                 result = self._tool_executor.execute(tc)
-                session.append_tool_message(
-                    result, tool_call_id=tc["id"]
-                )
+                session.append_tool_message(result, tool_call_id=tc["id"])
 
         raise LLMError(
             "Exceeded maximum tool call rounds",
@@ -191,9 +187,7 @@ class RunAgentUseCase:
 
                     for tc in tool_calls:
                         result = self._tool_executor.execute(tc)
-                        session.append_tool_message(
-                            result, tool_call_id=tc["id"]
-                        )
+                        session.append_tool_message(result, tool_call_id=tc["id"])
                         yield ToolResultEvent(
                             call_id=tc["id"],
                             name=tc["function"]["name"],

--- a/projects/simple-agent-poc/src/simple_agent_poc/application/use_cases.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/application/use_cases.py
@@ -10,14 +10,53 @@ from simple_agent_poc.application.dto import (
     RunAgentRequest,
     RunAgentResponse,
     StreamComplete,
+    ToolCallEvent,
+    ToolResultEvent,
 )
-from simple_agent_poc.application.ports import LLMClientFactory, SessionStore
+from simple_agent_poc.application.ports import (
+    LLMClientFactory,
+    SessionStore,
+    ToolExecutor,
+)
 from simple_agent_poc.core.agent_definition import (
     AgentDefinition,
     AgentDefinitionRegistry,
 )
 from simple_agent_poc.core.session import ConversationSession
-from simple_agent_poc.core.types import SessionNotFoundError, Usage, ValidationError
+from simple_agent_poc.core.types import (
+    LLMError,
+    SessionNotFoundError,
+    ToolCall,
+    ToolCallDelta,
+    Usage,
+    ValidationError,
+)
+
+MAX_TOOL_ROUNDS = 5
+
+
+def _accumulate_tool_call_chunks(
+    accumulated: dict[int, ToolCall],
+    td: ToolCallDelta,
+) -> None:
+    idx = td["index"]
+    if idx not in accumulated:
+        accumulated[idx] = {
+            "id": "",
+            "type": "function",
+            "function": {"name": "", "arguments": ""},
+        }
+    acc = accumulated[idx]
+    tid = td.get("id")
+    if tid:
+        acc["id"] = tid
+    fn_delta = td["function"]
+    fn_name = fn_delta.get("name")
+    if fn_name:
+        acc["function"]["name"] += fn_name
+    fn_args = fn_delta.get("arguments")
+    if fn_args:
+        acc["function"]["arguments"] += fn_args
 
 
 class RunAgentUseCase:
@@ -29,13 +68,15 @@ class RunAgentUseCase:
         llm_client_factory: LLMClientFactory,
         session_store: SessionStore,
         agent_definitions: AgentDefinitionRegistry,
+        tool_executor: ToolExecutor | None = None,
     ) -> None:
         self._llm_client_factory = llm_client_factory
         self._session_store = session_store
         self._agent_definitions = agent_definitions
+        self._tool_executor = tool_executor
 
     def execute(self, request: RunAgentRequest) -> RunAgentResponse:
-        """Run the agent for a single user message."""
+        """Run the agent for a single user message with ReAct tool loop."""
         if not request.message.strip():
             raise ValidationError("message must not be blank")
 
@@ -49,18 +90,45 @@ class RunAgentUseCase:
         session.append_user_message(request.message)
 
         llm_client = self._llm_client_factory(agent_definition)
-        response = llm_client.complete(list(session.messages))
+        tools = self._resolve_tools(agent_definition)
 
-        session.append_assistant_message(response["content"])
-        self._session_store.save(session)
-        return RunAgentResponse.from_llm_response(
-            response, session_id=session.session_id
+        for _ in range(MAX_TOOL_ROUNDS):
+            response = llm_client.complete(
+                list(session.messages), tools=tools
+            )
+
+            tool_calls = response.get("tool_calls")
+            if not tool_calls:
+                session.append_assistant_message(response["content"])
+                self._session_store.save(session)
+                return RunAgentResponse.from_llm_response(
+                    response,
+                    session_id=session.session_id,
+                )
+
+            if self._tool_executor is None:
+                raise LLMError(
+                    "Tool call requested but no tool executor configured",
+                    display_message="Tool call requested but no tool executor configured.",
+                )
+            session.append_assistant_message(
+                response["content"] or "", tool_calls=tool_calls
+            )
+            for tc in tool_calls:
+                result = self._tool_executor.execute(tc)
+                session.append_tool_message(
+                    result, tool_call_id=tc["id"]
+                )
+
+        raise LLMError(
+            "Exceeded maximum tool call rounds",
+            display_message="Exceeded maximum tool call rounds.",
         )
 
     def execute_stream(
         self, request: RunAgentRequest
-    ) -> Generator[ContentDelta | StreamComplete, None, None]:
-        """Run the agent for a single user message with streaming."""
+    ) -> Generator[ContentDelta | ToolCallEvent | ToolResultEvent | StreamComplete]:
+        """Run the agent for a single user message with streaming ReAct loop."""
         if not request.message.strip():
             raise ValidationError("message must not be blank")
 
@@ -74,32 +142,82 @@ class RunAgentUseCase:
         session.append_user_message(request.message)
 
         llm_client = self._llm_client_factory(agent_definition)
-        start_time = time.perf_counter()
-        accumulated_text = ""
+        tools = self._resolve_tools(agent_definition)
         model = agent_definition.model
+        _start_time = time.perf_counter()
+        _accumulated_text = ""
 
         try:
-            usage_from_stream: Usage | None = None
-            for chunk in llm_client.complete_stream(list(session.messages)):
-                delta = chunk.get("content_delta")
-                if delta:
-                    accumulated_text += delta
-                    yield ContentDelta(delta=delta)
-                if "usage" in chunk:
-                    usage_from_stream = chunk["usage"]
+            for round_idx in range(MAX_TOOL_ROUNDS):
+                _accumulated_text = ""
+                accumulated_tool_calls: dict[int, ToolCall] = {}
+                usage_from_stream: Usage | None = None
 
-            session.append_assistant_message(accumulated_text)
-            elapsed = time.perf_counter() - start_time
-            yield StreamComplete(
-                session_id=session.session_id,
-                usage=usage_from_stream,
-                model=model,
-                response_time=elapsed,
+                for chunk in llm_client.complete_stream(
+                    list(session.messages), tools=tools
+                ):
+                    delta = chunk.get("content_delta")
+                    if delta:
+                        _accumulated_text += delta
+                        yield ContentDelta(delta=delta)
+
+                    td = chunk.get("tool_call_delta")
+                    if td is not None:
+                        _accumulate_tool_call_chunks(accumulated_tool_calls, td)
+
+                    if "usage" in chunk:
+                        usage_from_stream = chunk["usage"]
+
+                if accumulated_tool_calls:
+                    if self._tool_executor is None:
+                        raise LLMError(
+                            "Tool call requested but no tool executor configured",
+                            display_message="Tool call requested but no tool executor configured.",
+                        )
+                    tool_calls = [
+                        accumulated_tool_calls[i]
+                        for i in sorted(accumulated_tool_calls)
+                    ]
+                    for tc in tool_calls:
+                        yield ToolCallEvent(
+                            call_id=tc["id"],
+                            name=tc["function"]["name"],
+                            arguments=tc["function"]["arguments"],
+                        )
+
+                    session.append_assistant_message(
+                        _accumulated_text, tool_calls=tool_calls
+                    )
+
+                    for tc in tool_calls:
+                        result = self._tool_executor.execute(tc)
+                        session.append_tool_message(
+                            result, tool_call_id=tc["id"]
+                        )
+                        yield ToolResultEvent(
+                            call_id=tc["id"],
+                            name=tc["function"]["name"],
+                            result=result,
+                        )
+                else:
+                    session.append_assistant_message(_accumulated_text)
+                    elapsed = time.perf_counter() - _start_time
+                    yield StreamComplete(
+                        session_id=session.session_id,
+                        usage=usage_from_stream,
+                        model=model,
+                        response_time=elapsed,
+                    )
+                    return
+
+            raise LLMError(
+                "Exceeded maximum tool call rounds",
+                display_message="Exceeded maximum tool call rounds.",
             )
         except Exception:
-            if accumulated_text:
+            if _accumulated_text:
                 session.append_assistant_message(
-                    f"{accumulated_text}\n\n[stream interrupted]"
+                    f"{_accumulated_text}\n\n[stream interrupted]"
                 )
             else:
                 session.append_assistant_message("[stream interrupted]")
@@ -129,3 +247,8 @@ class RunAgentUseCase:
                 display_message="Session not found.",
             )
         return session
+
+    def _resolve_tools(self, agent_definition: AgentDefinition) -> list | None:
+        if not self._tool_executor or not agent_definition.tools:
+            return None
+        return self._tool_executor.get_definitions(agent_definition.tools)

--- a/projects/simple-agent-poc/src/simple_agent_poc/application/use_cases.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/application/use_cases.py
@@ -257,7 +257,9 @@ class RunAgentUseCase:
             )
         return session
 
-    def _resolve_tools(self, agent_definition: AgentDefinition) -> list[ToolDefinition] | None:
+    def _resolve_tools(
+        self, agent_definition: AgentDefinition
+    ) -> list[ToolDefinition] | None:
         if not self._tool_executor or not agent_definition.tools:
             return None
         return self._tool_executor.get_definitions(agent_definition.tools)

--- a/projects/simple-agent-poc/src/simple_agent_poc/application/use_cases.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/application/use_cases.py
@@ -2,7 +2,7 @@
 
 import time
 from collections.abc import Generator
-from datetime import datetime
+from datetime import datetime, timezone
 from uuid import uuid4
 
 from simple_agent_poc.application.dto import (
@@ -29,6 +29,7 @@ from simple_agent_poc.core.types import (
     SessionNotFoundError,
     ToolCall,
     ToolCallDelta,
+    ToolDefinition,
     Usage,
     ValidationError,
 )
@@ -95,43 +96,45 @@ class RunAgentUseCase:
 
         tool_call_history: list[ToolCallRecord] = []
 
-        for _ in range(MAX_TOOL_ROUNDS):
-            response = llm_client.complete(list(session.messages), tools=tools)
+        try:
+            for _ in range(MAX_TOOL_ROUNDS):
+                response = llm_client.complete(list(session.messages), tools=tools)
 
-            tool_calls = response.get("tool_calls")
-            if not tool_calls:
-                session.append_assistant_message(response["content"])
-                self._session_store.save(session)
-                return RunAgentResponse.from_llm_response(
-                    response,
-                    session_id=session.session_id,
-                    tool_call_history=tool_call_history,
-                )
-
-            if self._tool_executor is None:
-                raise LLMError(
-                    "Tool call requested but no tool executor configured",
-                    display_message="Tool call requested but no tool executor configured.",
-                )
-            session.append_assistant_message(
-                response["content"] or "", tool_calls=tool_calls
-            )
-            for tc in tool_calls:
-                result = self._tool_executor.execute(tc)
-                session.append_tool_message(result, tool_call_id=tc["id"])
-                tool_call_history.append(
-                    ToolCallRecord(
-                        call_id=tc["id"],
-                        name=tc["function"]["name"],
-                        arguments=tc["function"]["arguments"],
-                        result=result,
+                tool_calls = response.get("tool_calls")
+                if not tool_calls:
+                    session.append_assistant_message(response["content"])
+                    return RunAgentResponse.from_llm_response(
+                        response,
+                        session_id=session.session_id,
+                        tool_call_history=tool_call_history,
                     )
-                )
 
-        raise LLMError(
-            "Exceeded maximum tool call rounds",
-            display_message="Exceeded maximum tool call rounds.",
-        )
+                if self._tool_executor is None:
+                    raise LLMError(
+                        "Tool call requested but no tool executor configured",
+                        display_message="Tool call requested but no tool executor configured.",
+                    )
+                session.append_assistant_message(
+                    response["content"] or "", tool_calls=tool_calls
+                )
+                for tc in tool_calls:
+                    result = self._tool_executor.execute(tc)
+                    session.append_tool_message(result, tool_call_id=tc["id"])
+                    tool_call_history.append(
+                        ToolCallRecord(
+                            call_id=tc["id"],
+                            name=tc["function"]["name"],
+                            arguments=tc["function"]["arguments"],
+                            result=result,
+                        )
+                    )
+
+            raise LLMError(
+                "Exceeded maximum tool call rounds",
+                display_message="Exceeded maximum tool call rounds.",
+            )
+        finally:
+            self._session_store.save(session)
 
     def execute_stream(
         self, request: RunAgentRequest
@@ -242,7 +245,7 @@ class RunAgentUseCase:
                 session_id=uuid4().hex,
                 agent_id=agent_definition.agent_id,
                 system_prompt=agent_definition.format_system_prompt(
-                    current_datetime=datetime.now().isoformat()
+                    current_datetime=datetime.now(timezone.utc).isoformat()
                 ),
             )
 
@@ -254,7 +257,7 @@ class RunAgentUseCase:
             )
         return session
 
-    def _resolve_tools(self, agent_definition: AgentDefinition) -> list | None:
+    def _resolve_tools(self, agent_definition: AgentDefinition) -> list[ToolDefinition] | None:
         if not self._tool_executor or not agent_definition.tools:
             return None
         return self._tool_executor.get_definitions(agent_definition.tools)

--- a/projects/simple-agent-poc/src/simple_agent_poc/core/agent_definition.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/core/agent_definition.py
@@ -23,7 +23,7 @@ class AgentDefinition:
     model: str
     system_prompt: str
     temperature: float | None = None
-    tools: list[dict[str, Any]] = field(default_factory=list)
+    tools: list[str] = field(default_factory=list)
     api_type: Literal["completion", "responses"] = "completion"
     stream: bool = False
 
@@ -159,14 +159,14 @@ def _optional_float(value: object, path: str) -> float | None:
     return float(value)
 
 
-def _optional_tools(value: object, path: str) -> list[dict[str, Any]]:
+def _optional_tools(value: object, path: str) -> list[str]:
     if value is None:
         return []
     if not isinstance(value, list):
         raise ValidationError(f"{path} must be a list")
-    if not all(isinstance(item, dict) for item in value):
-        raise ValidationError(f"{path} items must be mappings")
-    return cast(list[dict[str, Any]], value)
+    if not all(isinstance(item, str) for item in value):
+        raise ValidationError(f"{path} items must be strings")
+    return cast(list[str], value)
 
 
 def _optional_api_type(

--- a/projects/simple-agent-poc/src/simple_agent_poc/core/session.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/core/session.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass, field
 
-from simple_agent_poc.core.types import Message
+from simple_agent_poc.core.types import Message, ToolCall
 
 
 @dataclass(slots=True)
@@ -32,6 +32,22 @@ class ConversationSession:
         """Append a user message to the conversation."""
         self.messages.append({"role": "user", "content": content})
 
-    def append_assistant_message(self, content: str) -> None:
-        """Append an assistant message to the conversation."""
-        self.messages.append({"role": "assistant", "content": content})
+    def append_assistant_message(
+        self,
+        content: str,
+        *,
+        tool_calls: list[ToolCall] | None = None,
+    ) -> None:
+        """Append an assistant message, optionally with tool calls."""
+        msg: Message = {"role": "assistant", "content": content}
+        if tool_calls:
+            msg["tool_calls"] = tool_calls
+        self.messages.append(msg)
+
+    def append_tool_message(self, content: str, *, tool_call_id: str) -> None:
+        """Append a tool result message to the conversation."""
+        self.messages.append({
+            "role": "tool",
+            "content": content,
+            "tool_call_id": tool_call_id,
+        })

--- a/projects/simple-agent-poc/src/simple_agent_poc/core/session.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/core/session.py
@@ -46,8 +46,10 @@ class ConversationSession:
 
     def append_tool_message(self, content: str, *, tool_call_id: str) -> None:
         """Append a tool result message to the conversation."""
-        self.messages.append({
-            "role": "tool",
-            "content": content,
-            "tool_call_id": tool_call_id,
-        })
+        self.messages.append(
+            {
+                "role": "tool",
+                "content": content,
+                "tool_call_id": tool_call_id,
+            }
+        )

--- a/projects/simple-agent-poc/src/simple_agent_poc/core/types.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/core/types.py
@@ -31,12 +31,25 @@ class SessionNotFoundError(AgentError):
     """Raised when a requested session does not exist."""
 
 
-MessageRole = Literal["system", "user", "assistant"]
+MessageRole = Literal["system", "user", "assistant", "tool"]
+
+
+class ToolCallFunction(TypedDict):
+    name: str
+    arguments: str
+
+
+class ToolCall(TypedDict):
+    id: str
+    type: Literal["function"]
+    function: ToolCallFunction
 
 
 class Message(TypedDict):
     role: MessageRole
     content: str
+    tool_calls: NotRequired[list[ToolCall]]
+    tool_call_id: NotRequired[str]
 
 
 class Usage(TypedDict):
@@ -45,13 +58,38 @@ class Usage(TypedDict):
     total_tokens: int
 
 
+class ToolFunctionDef(TypedDict):
+    name: str
+    description: str
+    parameters: dict
+
+
+class ToolDefinition(TypedDict):
+    type: Literal["function"]
+    function: ToolFunctionDef
+
+
 class LLMResponse(TypedDict):
     content: str
     usage: Usage
     model: str
     response_time: float
+    tool_calls: NotRequired[list[ToolCall]]
+
+
+class ToolCallFunctionDelta(TypedDict):
+    name: str | None
+    arguments: str | None
+
+
+class ToolCallDelta(TypedDict):
+    index: int
+    id: str | None
+    type: Literal["function"]
+    function: ToolCallFunctionDelta
 
 
 class LLMStreamChunk(TypedDict):
     content_delta: str | None
+    tool_call_delta: NotRequired[ToolCallDelta]
     usage: NotRequired[Usage]

--- a/projects/simple-agent-poc/src/simple_agent_poc/entrypoints/bootstrap.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/entrypoints/bootstrap.py
@@ -9,7 +9,16 @@ from dotenv import load_dotenv
 
 from simple_agent_poc.adapters.llm.litellm_client import LiteLLMClientFactory
 from simple_agent_poc.adapters.session_store.in_memory import InMemorySessionStore
-from simple_agent_poc.application.ports import SessionStore
+from simple_agent_poc.adapters.tools.concat import TOOL_DEFINITION as CONCAT_TOOL_DEF
+from simple_agent_poc.adapters.tools.concat import execute as concat_execute
+from simple_agent_poc.adapters.tools.get_current_time import (
+    TOOL_DEFINITION as TIME_TOOL_DEF,
+)
+from simple_agent_poc.adapters.tools.get_current_time import (
+    execute as time_execute,
+)
+from simple_agent_poc.adapters.tools.registry import BuiltinToolRegistry
+from simple_agent_poc.application.ports import SessionStore, ToolExecutor
 from simple_agent_poc.application.use_cases import RunAgentUseCase
 from simple_agent_poc.core.agent_definition import AgentDefinitionRegistry
 
@@ -28,16 +37,26 @@ def create_agent_definition_registry() -> AgentDefinitionRegistry:
     return AgentDefinitionRegistry.from_yaml_file(agents_file)
 
 
+def create_default_tool_executor() -> BuiltinToolRegistry:
+    """Create a tool registry with built-in tools."""
+    registry = BuiltinToolRegistry()
+    registry.register(TIME_TOOL_DEF, time_execute)
+    registry.register(CONCAT_TOOL_DEF, concat_execute)
+    return registry
+
+
 def create_run_agent_use_case(
     *,
     session_store: SessionStore | None = None,
     agent_definitions: AgentDefinitionRegistry | None = None,
+    tool_executor: ToolExecutor | None = None,
 ) -> RunAgentUseCase:
     """Create the shared use case with production dependencies."""
     return RunAgentUseCase(
         llm_client_factory=LiteLLMClientFactory(),
         session_store=session_store or InMemorySessionStore(),
         agent_definitions=agent_definitions or create_agent_definition_registry(),
+        tool_executor=tool_executor or create_default_tool_executor(),
     )
 
 
@@ -45,7 +64,9 @@ def create_run_agent_use_case_factory() -> Callable[[], RunAgentUseCase]:
     """Create a use case factory backed by a shared in-memory session store."""
     session_store = InMemorySessionStore()
     agent_definitions = create_agent_definition_registry()
+    tool_executor = create_default_tool_executor()
     return lambda: create_run_agent_use_case(
         session_store=session_store,
         agent_definitions=agent_definitions,
+        tool_executor=tool_executor,
     )

--- a/projects/simple-agent-poc/tests/__init__.py
+++ b/projects/simple-agent-poc/tests/__init__.py
@@ -1,1 +1,0 @@
-"""Tests for simple-agent-poc."""

--- a/projects/simple-agent-poc/tests/conftest.py
+++ b/projects/simple-agent-poc/tests/conftest.py
@@ -17,27 +17,31 @@ from simple_agent_poc.core.types import ToolCall
 
 @pytest.fixture
 def default_agent_def():
-    return AgentDefinitionRegistry.from_mapping({
-        "agents": {
-            "default": {
-                "model": "test-model",
-                "system_prompt": "You are a helpful assistant.",
+    return AgentDefinitionRegistry.from_mapping(
+        {
+            "agents": {
+                "default": {
+                    "model": "test-model",
+                    "system_prompt": "You are a helpful assistant.",
+                },
             },
-        },
-    })
+        }
+    )
 
 
 @pytest.fixture
 def agent_def_with_tools():
-    return AgentDefinitionRegistry.from_mapping({
-        "agents": {
-            "default": {
-                "model": "test-model",
-                "system_prompt": "You are a helpful assistant with tools.",
-                "tools": ["get_current_time", "concat"],
+    return AgentDefinitionRegistry.from_mapping(
+        {
+            "agents": {
+                "default": {
+                    "model": "test-model",
+                    "system_prompt": "You are a helpful assistant with tools.",
+                    "tools": ["get_current_time", "concat"],
+                },
             },
-        },
-    })
+        }
+    )
 
 
 @pytest.fixture

--- a/projects/simple-agent-poc/tests/conftest.py
+++ b/projects/simple-agent-poc/tests/conftest.py
@@ -1,0 +1,72 @@
+"""Fixtures for simple-agent-poc tests."""
+
+import pytest
+
+from simple_agent_poc.adapters.tools.concat import TOOL_DEFINITION as CONCAT_TOOL_DEF
+from simple_agent_poc.adapters.tools.concat import execute as concat_execute
+from simple_agent_poc.adapters.tools.get_current_time import (
+    TOOL_DEFINITION as TIME_TOOL_DEF,
+)
+from simple_agent_poc.adapters.tools.get_current_time import (
+    execute as time_execute,
+)
+from simple_agent_poc.adapters.tools.registry import BuiltinToolRegistry
+from simple_agent_poc.core.agent_definition import AgentDefinitionRegistry
+from simple_agent_poc.core.types import ToolCall
+
+
+@pytest.fixture
+def default_agent_def():
+    return AgentDefinitionRegistry.from_mapping({
+        "agents": {
+            "default": {
+                "model": "test-model",
+                "system_prompt": "You are a helpful assistant.",
+            },
+        },
+    })
+
+
+@pytest.fixture
+def agent_def_with_tools():
+    return AgentDefinitionRegistry.from_mapping({
+        "agents": {
+            "default": {
+                "model": "test-model",
+                "system_prompt": "You are a helpful assistant with tools.",
+                "tools": ["get_current_time", "concat"],
+            },
+        },
+    })
+
+
+@pytest.fixture
+def tool_registry():
+    registry = BuiltinToolRegistry()
+    registry.register(TIME_TOOL_DEF, time_execute)
+    registry.register(CONCAT_TOOL_DEF, concat_execute)
+    return registry
+
+
+@pytest.fixture
+def concat_tool_call():
+    return ToolCall(
+        id="call_001",
+        type="function",
+        function={
+            "name": "concat",
+            "arguments": '{"a": "hello", "b": "world"}',
+        },
+    )
+
+
+@pytest.fixture
+def time_tool_call():
+    return ToolCall(
+        id="call_002",
+        type="function",
+        function={
+            "name": "get_current_time",
+            "arguments": "{}",
+        },
+    )

--- a/projects/simple-agent-poc/tests/test_api.py
+++ b/projects/simple-agent-poc/tests/test_api.py
@@ -1,23 +1,29 @@
 """Tests for the HTTP API adapter."""
 
+from collections.abc import Iterator
+
 from fastapi.testclient import TestClient
 
 from simple_agent_poc.adapters.http.api import create_app
 from simple_agent_poc.adapters.session_store.in_memory import InMemorySessionStore
-from simple_agent_poc.application.ports import LLMClient
 from simple_agent_poc.application.use_cases import RunAgentUseCase
 from simple_agent_poc.core.agent_definition import AgentDefinitionRegistry
-from simple_agent_poc.core.types import LLMResponse, Message
+from simple_agent_poc.core.types import LLMResponse, LLMStreamChunk, Message
 
 
-class StubLLMClient(LLMClient):
+class StubLLMClient:
     """Deterministic LLM stub for HTTP adapter tests."""
 
     def __init__(self, reply: str) -> None:
         self.reply = reply
         self.calls: list[list[Message]] = []
 
-    def complete(self, messages: list[Message]) -> LLMResponse:
+    def complete(
+        self,
+        messages: list[Message],
+        *,
+        tools=None,
+    ) -> LLMResponse:
         self.calls.append(list(messages))
         return {
             "content": self.reply,
@@ -29,6 +35,14 @@ class StubLLMClient(LLMClient):
             "model": "stub-model",
             "response_time": 0.1,
         }
+
+    def complete_stream(
+        self,
+        messages: list[Message],
+        *,
+        tools=None,
+    ) -> Iterator[LLMStreamChunk]:
+        raise NotImplementedError
 
 
 def unused_use_case_factory() -> RunAgentUseCase:
@@ -260,3 +274,39 @@ class TestAPI:
         assert second_response.json() == {
             "detail": "agent_id cannot be changed for an existing session"
         }
+
+
+class TestSSEEvents:
+    """Tests for SSE event format for tool_call and tool_result."""
+
+    def test_sse_format_tool_call(self) -> None:
+        import json
+        from dataclasses import asdict
+
+        from simple_agent_poc.application.dto import ToolCallEvent
+
+        event = ToolCallEvent(
+            call_id="call_001",
+            name="concat",
+            arguments='{"a":"hello","b":"world"}',
+        )
+        sse_line = f"event: tool_call\ndata: {json.dumps(asdict(event), ensure_ascii=False)}\n\n"
+        assert "event: tool_call" in sse_line
+        assert "call_001" in sse_line
+        assert "concat" in sse_line
+
+    def test_sse_format_tool_result(self) -> None:
+        import json
+        from dataclasses import asdict
+
+        from simple_agent_poc.application.dto import ToolResultEvent
+
+        event = ToolResultEvent(
+            call_id="call_001",
+            name="concat",
+            result='{"result":"helloworld"}',
+        )
+        sse_line = f"event: tool_result\ndata: {json.dumps(asdict(event), ensure_ascii=False)}\n\n"
+        assert "event: tool_result" in sse_line
+        assert "call_001" in sse_line
+        assert "helloworld" in sse_line

--- a/projects/simple-agent-poc/tests/test_application.py
+++ b/projects/simple-agent-poc/tests/test_application.py
@@ -112,7 +112,8 @@ class TestRunAgentUseCase:
             [
                 {"role": "system", "content": "System prompt"},
                 {"role": "user", "content": "Hello"},
-            ]
+            ],
+            tools=None,
         )
         llm_client_factory.assert_called_once()
         assert llm_client_factory.call_args.args[0].agent_id == "default"
@@ -154,7 +155,8 @@ class TestRunAgentUseCase:
             [
                 {"role": "system", "content": "Research prompt"},
                 {"role": "user", "content": "Hello"},
-            ]
+            ],
+            tools=None,
         )
 
     def test_execute_reuses_existing_session(self) -> None:
@@ -206,7 +208,8 @@ class TestRunAgentUseCase:
                 {"role": "user", "content": "Hello"},
                 {"role": "assistant", "content": "First reply"},
                 {"role": "user", "content": "Again"},
-            ]
+            ],
+            tools=None,
         )
 
     def test_execute_rejects_agent_change_for_existing_session(self) -> None:

--- a/projects/simple-agent-poc/tests/test_application.py
+++ b/projects/simple-agent-poc/tests/test_application.py
@@ -105,6 +105,7 @@ class TestRunAgentUseCase:
             },
             model="gpt-4o-mini",
             response_time=0.85,
+            tool_call_history=[],
             session_id=response.session_id,
         )
         assert response.session_id

--- a/projects/simple-agent-poc/tests/test_cli.py
+++ b/projects/simple-agent-poc/tests/test_cli.py
@@ -32,6 +32,7 @@ class TestCLIAdapter:
             },
             model="gpt-4o-mini",
             response_time=0.85,
+            tool_call_history=[],
             session_id="session-1",
         )
         input_reader = MagicMock(side_effect=["Hello", EOFError()])
@@ -70,6 +71,7 @@ class TestCLIAdapter:
             },
             model="gpt-4o-mini",
             response_time=0.85,
+            tool_call_history=[],
             session_id="session-1",
         )
         input_reader = MagicMock(side_effect=["Hello", EOFError()])
@@ -97,6 +99,7 @@ class TestCLIAdapter:
             },
             model="gpt-4o-mini",
             response_time=0.85,
+            tool_call_history=[],
             session_id="session-1",
         )
         input_reader = MagicMock(side_effect=["Hello", EOFError()])
@@ -122,6 +125,7 @@ class TestCLIAdapter:
                 usage={"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
                 model="gpt-4o-mini",
                 response_time=0.1,
+                tool_call_history=[],
                 session_id="session-1",
             ),
             RunAgentResponse(
@@ -129,6 +133,7 @@ class TestCLIAdapter:
                 usage={"prompt_tokens": 2, "completion_tokens": 2, "total_tokens": 4},
                 model="gpt-4o-mini",
                 response_time=0.2,
+                tool_call_history=[],
                 session_id="session-1",
             ),
         ]
@@ -193,6 +198,7 @@ class TestCLIAdapter:
             },
             model="gpt-4o-mini",
             response_time=0.25,
+            tool_call_history=[],
             session_id="session-1",
         )
         run_agent.execute.side_effect = [RuntimeError("boom"), recovered_response]

--- a/projects/simple-agent-poc/tests/test_http_stream_api.py
+++ b/projects/simple-agent-poc/tests/test_http_stream_api.py
@@ -18,10 +18,20 @@ class StreamingStubLLMClient:
     def __init__(self, chunks: list[LLMStreamChunk]) -> None:
         self.chunks = chunks
 
-    def complete(self, messages: list[Message]) -> LLMResponse:
+    def complete(
+        self,
+        messages: list[Message],
+        *,
+        tools=None,
+    ) -> LLMResponse:
         raise NotImplementedError
 
-    def complete_stream(self, messages: list[Message]) -> Iterator[LLMStreamChunk]:
+    def complete_stream(
+        self,
+        messages: list[Message],
+        *,
+        tools=None,
+    ) -> Iterator[LLMStreamChunk]:
         yield from self.chunks
 
 

--- a/projects/simple-agent-poc/tests/test_llm_client.py
+++ b/projects/simple-agent-poc/tests/test_llm_client.py
@@ -305,6 +305,68 @@ class TestLiteLLMResponsesClient:
 
         assert "An error occurred" in exc_info.value.display_message
 
+    @patch("simple_agent_poc.adapters.llm.litellm_client.responses")
+    def test_complete_parses_tool_calls_from_output(
+        self, mock_responses: MagicMock
+    ) -> None:
+        tool_call_item = MagicMock()
+        tool_call_item.type = "function_call"
+        tool_call_item.call_id = "call_001"
+        tool_call_item.name = "concat"
+        tool_call_item.arguments = '{"a":"1","b":"2"}'
+        mock_response = MagicMock()
+        mock_response.output_text = ""
+        mock_response.usage.input_tokens = 20
+        mock_response.usage.output_tokens = 15
+        mock_response.usage.total_tokens = 35
+        mock_response.output = [tool_call_item]
+        mock_responses.return_value = mock_response
+
+        client = LiteLLMResponsesClient(model="gpt-5.4-nano")
+        messages: list[Message] = [{"role": "user", "content": "concat a and b"}]
+
+        result = client.complete(messages)
+
+        assert "tool_calls" in result
+        assert result["tool_calls"] == [
+            {
+                "id": "call_001",
+                "type": "function",
+                "function": {
+                    "name": "concat",
+                    "arguments": '{"a":"1","b":"2"}',
+                },
+            }
+        ]
+
+    @patch("simple_agent_poc.adapters.llm.litellm_client.responses")
+    def test_complete_parses_tool_calls_from_output_dict(
+        self, mock_responses: MagicMock
+    ) -> None:
+        mock_response = MagicMock()
+        mock_response.output_text = ""
+        mock_response.usage.input_tokens = 20
+        mock_response.usage.output_tokens = 15
+        mock_response.usage.total_tokens = 35
+        mock_response.output = [
+            {
+                "type": "function_call",
+                "call_id": "call_002",
+                "name": "get_current_time",
+                "arguments": "",
+            }
+        ]
+        mock_responses.return_value = mock_response
+
+        client = LiteLLMResponsesClient(model="gpt-5.4-nano")
+        messages: list[Message] = [{"role": "user", "content": "what time is it"}]
+
+        result = client.complete(messages)
+
+        assert "tool_calls" in result
+        assert result["tool_calls"][0]["id"] == "call_002"
+        assert result["tool_calls"][0]["function"]["name"] == "get_current_time"
+
 
 class TestLiteLLMClientFactory:
     """Tests for LiteLLMClientFactory class."""
@@ -646,3 +708,85 @@ class TestLiteLLMResponsesClientStream:
 
         with pytest.raises(LLMError):
             list(client.complete_stream(messages))
+
+    @patch("simple_agent_poc.adapters.llm.litellm_client.responses")
+    def test_complete_stream_yields_tool_call_delta_from_output_item_added(
+        self,
+        mock_responses: MagicMock,
+    ) -> None:
+        item = MagicMock()
+        item.type = "function_call"
+        item.call_id = "call_001"
+        item.name = "concat"
+        item.arguments = ""
+        event = MagicMock()
+        event.type = "response.output_item.added"
+        event.output_index = 0
+        event.item = item
+        mock_responses.return_value = [event]
+
+        client = LiteLLMResponsesClient(model="gpt-5.4-nano")
+        messages: list[Message] = [{"role": "user", "content": "concat a b"}]
+        result = list(client.complete_stream(messages))
+
+        assert len(result) == 1
+        assert result[0]["content_delta"] is None
+        td = result[0]["tool_call_delta"]
+        assert td is not None
+        assert td["index"] == 0
+        assert td["id"] == "call_001"
+        assert td["function"]["name"] == "concat"
+
+    @patch("simple_agent_poc.adapters.llm.litellm_client.responses")
+    def test_complete_stream_yields_tool_call_delta_from_arguments_delta(
+        self,
+        mock_responses: MagicMock,
+    ) -> None:
+        event = MagicMock()
+        event.type = "response.function_call_arguments.delta"
+        event.output_index = 0
+        event.item_id = "call_001"
+        event.delta = '{"a":"1"}'
+        mock_responses.return_value = [event]
+
+        client = LiteLLMResponsesClient(model="gpt-5.4-nano")
+        messages: list[Message] = [{"role": "user", "content": "concat a b"}]
+        result = list(client.complete_stream(messages))
+
+        assert len(result) == 1
+        assert result[0]["content_delta"] is None
+        td = result[0]["tool_call_delta"]
+        assert td is not None
+        assert td["index"] == 0
+        assert td["id"] == "call_001"
+        assert td["function"]["name"] is None
+        assert td["function"]["arguments"] == '{"a":"1"}'
+
+    @patch("simple_agent_poc.adapters.llm.litellm_client.responses")
+    def test_complete_stream_tool_call_and_text_interleaved(
+        self,
+        mock_responses: MagicMock,
+    ) -> None:
+        item = MagicMock()
+        item.type = "function_call"
+        item.call_id = "call_001"
+        item.name = "concat"
+        item.arguments = ""
+        tool_event = MagicMock()
+        tool_event.type = "response.output_item.added"
+        tool_event.output_index = 0
+        tool_event.item = item
+
+        text_event = MagicMock()
+        del text_event.response
+        text_event.type = "response.output_text.delta"
+        text_event.delta = "Hello"
+
+        mock_responses.return_value = [tool_event, text_event]
+
+        client = LiteLLMResponsesClient(model="gpt-5.4-nano")
+        result = list(client.complete_stream([]))
+
+        assert len(result) == 2
+        assert result[0]["tool_call_delta"] is not None
+        assert result[1]["content_delta"] == "Hello"

--- a/projects/simple-agent-poc/tests/test_renderer.py
+++ b/projects/simple-agent-poc/tests/test_renderer.py
@@ -108,6 +108,7 @@ class TestShowAgentResponse:
             },
             model="gpt-4o-mini",
             response_time=0.85,
+            tool_call_history=[],
             session_id="session-1",
         )
         show_agent_response(response)

--- a/projects/simple-agent-poc/tests/test_tools.py
+++ b/projects/simple-agent-poc/tests/test_tools.py
@@ -1,0 +1,62 @@
+"""Tests for built-in tool execution and registry."""
+
+import json
+
+from simple_agent_poc.adapters.tools.concat import TOOL_DEFINITION as CONCAT_TOOL_DEF
+from simple_agent_poc.adapters.tools.concat import execute as concat_execute
+from simple_agent_poc.adapters.tools.get_current_time import (
+    TOOL_DEFINITION as TIME_TOOL_DEF,
+)
+from simple_agent_poc.adapters.tools.get_current_time import (
+    execute as time_execute,
+)
+
+
+def test_concat_execution():
+    result = concat_execute({"a": "hello", "b": "world"})
+    data = json.loads(result)
+    assert data["result"] == "helloworld"
+
+
+def test_get_current_time_execution():
+    result = time_execute({})
+    data = json.loads(result)
+    assert "datetime" in data
+
+
+def test_registry_execute_concat(tool_registry, concat_tool_call):
+    result = tool_registry.execute(concat_tool_call)
+    data = json.loads(result)
+    assert data["result"] == "helloworld"
+
+
+def test_registry_execute_time(tool_registry, time_tool_call):
+    result = tool_registry.execute(time_tool_call)
+    data = json.loads(result)
+    assert "datetime" in data
+
+
+def test_registry_get_definitions(tool_registry):
+    defs = tool_registry.get_definitions(["get_current_time", "concat"])
+    assert len(defs) == 2
+    names = {d["function"]["name"] for d in defs}
+    assert names == {"get_current_time", "concat"}
+
+
+def test_registry_get_definitions_partial(tool_registry):
+    defs = tool_registry.get_definitions(["get_current_time", "nonexistent"])
+    assert len(defs) == 1
+    assert defs[0]["function"]["name"] == "get_current_time"
+
+
+def test_tool_definition_schema():
+    assert CONCAT_TOOL_DEF["type"] == "function"
+    assert CONCAT_TOOL_DEF["function"]["name"] == "concat"
+    params = CONCAT_TOOL_DEF["function"]["parameters"]
+    assert "a" in params["properties"]
+    assert "b" in params["properties"]
+
+
+def test_time_definition_schema():
+    assert TIME_TOOL_DEF["type"] == "function"
+    assert TIME_TOOL_DEF["function"]["name"] == "get_current_time"

--- a/projects/simple-agent-poc/tests/test_types.py
+++ b/projects/simple-agent-poc/tests/test_types.py
@@ -6,6 +6,7 @@ from simple_agent_poc.core.types import ToolCall
 
 def test_message_role_includes_tool():
     from simple_agent_poc.core.types import MessageRole
+
     tool_msg: MessageRole = "tool"
     assert tool_msg == "tool"
 
@@ -25,11 +26,13 @@ def test_session_append_assistant_with_tool_calls():
         session_id="s1",
         system_prompt="test",
     )
-    tool_calls: list[ToolCall] = [{
-        "id": "call_001",
-        "type": "function",
-        "function": {"name": "concat", "arguments": '{"a":"1","b":"2"}'},
-    }]
+    tool_calls: list[ToolCall] = [
+        {
+            "id": "call_001",
+            "type": "function",
+            "function": {"name": "concat", "arguments": '{"a":"1","b":"2"}'},
+        }
+    ]
     session.append_assistant_message("Using tool...", tool_calls=tool_calls)
     assert session.messages[-1]["tool_calls"] == tool_calls
 

--- a/projects/simple-agent-poc/tests/test_types.py
+++ b/projects/simple-agent-poc/tests/test_types.py
@@ -1,87 +1,56 @@
-"""Tests for core types module."""
+"""Tests for core types and session changes."""
 
-from simple_agent_poc.core.types import (
-    AgentError,
-    AuthenticationError,
-    LLMError,
-    Message,
-    RateLimitError,
-    SessionNotFoundError,
-    Usage,
-)
+from simple_agent_poc.core.session import ConversationSession
+from simple_agent_poc.core.types import ToolCall
 
 
-class TestAgentError:
-    """Tests for AgentError exception."""
-
-    def test_basic_error(self) -> None:
-        error = AgentError("Something went wrong")
-        assert str(error) == "Something went wrong"
-        assert error.display_message == "Something went wrong"
-
-    def test_error_with_display_message(self) -> None:
-        error = AgentError(
-            message="Internal error details",
-            display_message="User-friendly message",
-        )
-        assert str(error) == "Internal error details"
-        assert error.display_message == "User-friendly message"
+def test_message_role_includes_tool():
+    from simple_agent_poc.core.types import MessageRole
+    tool_msg: MessageRole = "tool"
+    assert tool_msg == "tool"
 
 
-class TestAuthenticationError:
-    """Tests for AuthenticationError exception."""
-
-    def test_inheritance(self) -> None:
-        error = AuthenticationError("Auth failed")
-        assert isinstance(error, AgentError)
-
-
-class TestRateLimitError:
-    """Tests for RateLimitError exception."""
-
-    def test_inheritance(self) -> None:
-        error = RateLimitError("Rate limited")
-        assert isinstance(error, AgentError)
+def test_tool_call_typed_dict():
+    tc: ToolCall = {
+        "id": "call_001",
+        "type": "function",
+        "function": {"name": "concat", "arguments": '{"a":"1","b":"2"}'},
+    }
+    assert tc["id"] == "call_001"
+    assert tc["function"]["name"] == "concat"
 
 
-class TestLLMError:
-    """Tests for LLMError exception."""
-
-    def test_inheritance(self) -> None:
-        error = LLMError("LLM failed")
-        assert isinstance(error, AgentError)
-
-
-class TestSessionNotFoundError:
-    """Tests for SessionNotFoundError exception."""
-
-    def test_inheritance(self) -> None:
-        error = SessionNotFoundError("Missing session")
-        assert isinstance(error, AgentError)
+def test_session_append_assistant_with_tool_calls():
+    session = ConversationSession.start(
+        session_id="s1",
+        system_prompt="test",
+    )
+    tool_calls: list[ToolCall] = [{
+        "id": "call_001",
+        "type": "function",
+        "function": {"name": "concat", "arguments": '{"a":"1","b":"2"}'},
+    }]
+    session.append_assistant_message("Using tool...", tool_calls=tool_calls)
+    assert session.messages[-1]["tool_calls"] == tool_calls
 
 
-class TestMessageType:
-    """Tests for Message TypedDict."""
-
-    def test_create_message(self) -> None:
-        msg: Message = {"role": "user", "content": "Hello"}
-        assert msg["role"] == "user"
-        assert msg["content"] == "Hello"
-
-    def test_assistant_message(self) -> None:
-        msg: Message = {"role": "assistant", "content": "Hi there"}
-        assert msg["role"] == "assistant"
+def test_session_append_assistant_without_tool_calls():
+    session = ConversationSession.start(
+        session_id="s1",
+        system_prompt="test",
+    )
+    session.append_assistant_message("Hello")
+    assert "tool_calls" not in session.messages[-1]
+    assert session.messages[-1]["content"] == "Hello"
 
 
-class TestUsageType:
-    """Tests for Usage TypedDict."""
-
-    def test_create_usage(self) -> None:
-        usage: Usage = {
-            "prompt_tokens": 10,
-            "completion_tokens": 20,
-            "total_tokens": 30,
-        }
-        assert usage["prompt_tokens"] == 10
-        assert usage["completion_tokens"] == 20
-        assert usage["total_tokens"] == 30
+def test_session_append_tool_message():
+    session = ConversationSession.start(
+        session_id="s1",
+        system_prompt="test",
+    )
+    session.append_tool_message('{"result":"ok"}', tool_call_id="call_001")
+    msg = session.messages[-1]
+    assert msg["role"] == "tool"
+    assert msg["content"] == '{"result":"ok"}'
+    assert msg["tool_call_id"] == "call_001"

--- a/projects/simple-agent-poc/tests/test_use_cases.py
+++ b/projects/simple-agent-poc/tests/test_use_cases.py
@@ -1,0 +1,250 @@
+"""Tests for RunAgentUseCase with tool calling (ReAct loop)."""
+
+from collections.abc import Iterator
+
+from simple_agent_poc.adapters.session_store.in_memory import InMemorySessionStore
+from simple_agent_poc.application.dto import (
+    ContentDelta,
+    RunAgentRequest,
+    StreamComplete,
+    ToolCallEvent,
+    ToolResultEvent,
+)
+from simple_agent_poc.application.use_cases import RunAgentUseCase
+from simple_agent_poc.core.types import (
+    LLMError,
+    LLMResponse,
+    LLMStreamChunk,
+    Message,
+    ToolCall,
+    ToolDefinition,
+    Usage,
+    ValidationError,
+)
+
+
+class FakeLLMClient:
+    """Mock LLM client that returns tool calls, then final response."""
+
+    def __init__(self, *, rounds: list[LLMResponse]) -> None:
+        self._rounds = rounds
+        self._call_count = 0
+
+    def complete(
+        self,
+        messages: list[Message],
+        *,
+        tools: list[ToolDefinition] | None = None,
+    ) -> LLMResponse:
+        idx = self._call_count
+        self._call_count += 1
+        if idx < len(self._rounds):
+            return self._rounds[idx]
+        return {
+            "content": "Done.",
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+            "model": "fake",
+            "response_time": 0.1,
+        }
+
+    def complete_stream(
+        self,
+        messages: list[Message],
+        *,
+        tools: list[ToolDefinition] | None = None,
+    ) -> Iterator[LLMStreamChunk]:
+        idx = self._call_count
+        self._call_count += 1
+        if idx < len(self._rounds):
+            resp = self._rounds[idx]
+            yield LLMStreamChunk(content_delta=resp["content"])
+            if "tool_calls" in resp:
+                for tc in resp["tool_calls"]:
+                    yield LLMStreamChunk(
+                        content_delta=None,
+                        tool_call_delta={
+                            "index": 0,
+                            "id": tc["id"],
+                            "type": "function",
+                            "function": {
+                                "name": tc["function"]["name"],
+                                "arguments": tc["function"]["arguments"],
+                            },
+                        },
+                    )
+            yield LLMStreamChunk(content_delta=None, usage=resp["usage"])
+        else:
+            yield LLMStreamChunk(content_delta="Done.")
+            yield LLMStreamChunk(
+                content_delta=None,
+                usage={
+                    "prompt_tokens": 10,
+                    "completion_tokens": 5,
+                    "total_tokens": 15,
+                },
+            )
+
+
+class FakeLLMClientFactory:
+    def __init__(self, client: FakeLLMClient) -> None:
+        self._client = client
+
+    def __call__(self, agent_definition) -> FakeLLMClient:
+        return self._client
+
+
+def _concat_tool_call() -> list[ToolCall]:
+    return [
+        {
+            "id": "call_001",
+            "type": "function",
+            "function": {
+                "name": "concat",
+                "arguments": '{"a": "hello", "b": "world"}',
+            },
+        }
+    ]
+
+
+def _usage() -> Usage:
+    return {"prompt_tokens": 20, "completion_tokens": 10, "total_tokens": 30}
+
+
+def test_execute_yields_final_response_without_tools(
+    default_agent_def, tool_registry
+):
+    """Without tools, the agent returns a normal text response."""
+    fake_llm = FakeLLMClient(rounds=[])
+
+    use_case = RunAgentUseCase(
+        llm_client_factory=FakeLLMClientFactory(fake_llm),
+        session_store=InMemorySessionStore(),
+        agent_definitions=default_agent_def,
+        tool_executor=tool_registry,
+    )
+    response = use_case.execute(RunAgentRequest(message="hello"))
+    assert response.message == "Done."
+    assert response.session_id
+
+
+def test_execute_with_tool_call(default_agent_def, tool_registry):
+    """When the LLM returns a tool call, execute the tool and continue."""
+    fake_llm = FakeLLMClient(rounds=[
+        {  # Round 1: tool call
+            "content": "",
+            "usage": _usage(),
+            "model": "fake",
+            "response_time": 0.1,
+            "tool_calls": _concat_tool_call(),
+        },
+    ])
+
+    use_case = RunAgentUseCase(
+        llm_client_factory=FakeLLMClientFactory(fake_llm),
+        session_store=InMemorySessionStore(),
+        agent_definitions=default_agent_def,
+        tool_executor=tool_registry,
+    )
+    response = use_case.execute(RunAgentRequest(message="concat hello world"))
+    assert "helloworld" in response.message.lower() or "Done" in response.message
+    assert response.session_id
+
+
+def test_execute_exceeds_max_tool_rounds(default_agent_def, tool_registry):
+    """After MAX_TOOL_ROUNDS, an LLMError is raised."""
+    rounds = []
+    for _ in range(5):
+        rounds.append({
+            "content": "",
+            "usage": _usage(),
+            "model": "fake",
+            "response_time": 0.1,
+            "tool_calls": _concat_tool_call(),
+        })
+
+    fake_llm = FakeLLMClient(rounds=rounds)
+    use_case = RunAgentUseCase(
+        llm_client_factory=FakeLLMClientFactory(fake_llm),
+        session_store=InMemorySessionStore(),
+        agent_definitions=default_agent_def,
+        tool_executor=tool_registry,
+    )
+    try:
+        use_case.execute(RunAgentRequest(message="loop"))
+        assert False, "Expected LLMError"
+    except LLMError:
+        pass
+
+
+def test_execute_blank_message_rejected(default_agent_def, tool_registry):
+    use_case = RunAgentUseCase(
+        llm_client_factory=FakeLLMClientFactory(FakeLLMClient(rounds=[])),
+        session_store=InMemorySessionStore(),
+        agent_definitions=default_agent_def,
+        tool_executor=tool_registry,
+    )
+    try:
+        use_case.execute(RunAgentRequest(message="  "))
+        assert False, "Expected ValidationError"
+    except ValidationError:
+        pass
+
+
+def test_execute_stream_without_tools(default_agent_def, tool_registry):
+    """Streaming works normally when no tools are called."""
+    fake_llm = FakeLLMClient(rounds=[])
+    use_case = RunAgentUseCase(
+        llm_client_factory=FakeLLMClientFactory(fake_llm),
+        session_store=InMemorySessionStore(),
+        agent_definitions=default_agent_def,
+        tool_executor=tool_registry,
+    )
+    events = list(use_case.execute_stream(RunAgentRequest(message="hello")))
+    assert len(events) >= 2
+    assert isinstance(events[0], ContentDelta)
+    assert events[0].delta == "Done."
+    assert isinstance(events[-1], StreamComplete)
+
+
+def test_execute_stream_with_tool_call(default_agent_def, tool_registry):
+    """Streaming with a tool call yields ToolCallEvent and ToolResultEvent."""
+    fake_llm = FakeLLMClient(rounds=[
+        {
+            "content": "",
+            "usage": _usage(),
+            "model": "fake",
+            "response_time": 0.1,
+            "tool_calls": _concat_tool_call(),
+        },
+    ])
+    use_case = RunAgentUseCase(
+        llm_client_factory=FakeLLMClientFactory(fake_llm),
+        session_store=InMemorySessionStore(),
+        agent_definitions=default_agent_def,
+        tool_executor=tool_registry,
+    )
+    events = list(use_case.execute_stream(RunAgentRequest(message="concat hello world")))
+
+    tool_call_events = [e for e in events if isinstance(e, ToolCallEvent)]
+    tool_result_events = [e for e in events if isinstance(e, ToolResultEvent)]
+
+    assert len(tool_call_events) >= 1
+    assert tool_call_events[0].name == "concat"
+    assert "hello" in tool_call_events[0].arguments
+    assert len(tool_result_events) >= 1
+    assert tool_result_events[0].name == "concat"
+    assert "helloworld" in tool_result_events[0].result
+
+
+def test_execute_stream_final_complete(default_agent_def, tool_registry):
+    """The last event in a stream should be StreamComplete."""
+    fake_llm = FakeLLMClient(rounds=[])
+    use_case = RunAgentUseCase(
+        llm_client_factory=FakeLLMClientFactory(fake_llm),
+        session_store=InMemorySessionStore(),
+        agent_definitions=default_agent_def,
+        tool_executor=tool_registry,
+    )
+    events = list(use_case.execute_stream(RunAgentRequest(message="hello")))
+    assert isinstance(events[-1], StreamComplete)
+    assert events[-1].session_id

--- a/projects/simple-agent-poc/tests/test_use_cases.py
+++ b/projects/simple-agent-poc/tests/test_use_cases.py
@@ -110,9 +110,7 @@ def _usage() -> Usage:
     return {"prompt_tokens": 20, "completion_tokens": 10, "total_tokens": 30}
 
 
-def test_execute_yields_final_response_without_tools(
-    default_agent_def, tool_registry
-):
+def test_execute_yields_final_response_without_tools(default_agent_def, tool_registry):
     """Without tools, the agent returns a normal text response."""
     fake_llm = FakeLLMClient(rounds=[])
 
@@ -129,15 +127,17 @@ def test_execute_yields_final_response_without_tools(
 
 def test_execute_with_tool_call(default_agent_def, tool_registry):
     """When the LLM returns a tool call, execute the tool and continue."""
-    fake_llm = FakeLLMClient(rounds=[
-        {  # Round 1: tool call
-            "content": "",
-            "usage": _usage(),
-            "model": "fake",
-            "response_time": 0.1,
-            "tool_calls": _concat_tool_call(),
-        },
-    ])
+    fake_llm = FakeLLMClient(
+        rounds=[
+            {  # Round 1: tool call
+                "content": "",
+                "usage": _usage(),
+                "model": "fake",
+                "response_time": 0.1,
+                "tool_calls": _concat_tool_call(),
+            },
+        ]
+    )
 
     use_case = RunAgentUseCase(
         llm_client_factory=FakeLLMClientFactory(fake_llm),
@@ -154,13 +154,15 @@ def test_execute_exceeds_max_tool_rounds(default_agent_def, tool_registry):
     """After MAX_TOOL_ROUNDS, an LLMError is raised."""
     rounds = []
     for _ in range(5):
-        rounds.append({
-            "content": "",
-            "usage": _usage(),
-            "model": "fake",
-            "response_time": 0.1,
-            "tool_calls": _concat_tool_call(),
-        })
+        rounds.append(
+            {
+                "content": "",
+                "usage": _usage(),
+                "model": "fake",
+                "response_time": 0.1,
+                "tool_calls": _concat_tool_call(),
+            }
+        )
 
     fake_llm = FakeLLMClient(rounds=rounds)
     use_case = RunAgentUseCase(
@@ -208,22 +210,26 @@ def test_execute_stream_without_tools(default_agent_def, tool_registry):
 
 def test_execute_stream_with_tool_call(default_agent_def, tool_registry):
     """Streaming with a tool call yields ToolCallEvent and ToolResultEvent."""
-    fake_llm = FakeLLMClient(rounds=[
-        {
-            "content": "",
-            "usage": _usage(),
-            "model": "fake",
-            "response_time": 0.1,
-            "tool_calls": _concat_tool_call(),
-        },
-    ])
+    fake_llm = FakeLLMClient(
+        rounds=[
+            {
+                "content": "",
+                "usage": _usage(),
+                "model": "fake",
+                "response_time": 0.1,
+                "tool_calls": _concat_tool_call(),
+            },
+        ]
+    )
     use_case = RunAgentUseCase(
         llm_client_factory=FakeLLMClientFactory(fake_llm),
         session_store=InMemorySessionStore(),
         agent_definitions=default_agent_def,
         tool_executor=tool_registry,
     )
-    events = list(use_case.execute_stream(RunAgentRequest(message="concat hello world")))
+    events = list(
+        use_case.execute_stream(RunAgentRequest(message="concat hello world"))
+    )
 
     tool_call_events = [e for e in events if isinstance(e, ToolCallEvent)]
     tool_result_events = [e for e in events if isinstance(e, ToolResultEvent)]

--- a/projects/simple-agent-poc/tests/test_use_cases_stream.py
+++ b/projects/simple-agent-poc/tests/test_use_cases_stream.py
@@ -30,10 +30,20 @@ class StreamingStubLLMClient:
         self.chunks = chunks
         self.calls: list[list[Message]] = []
 
-    def complete(self, messages: list[Message]) -> LLMResponse:
+    def complete(
+        self,
+        messages: list[Message],
+        *,
+        tools=None,
+    ) -> LLMResponse:
         raise NotImplementedError
 
-    def complete_stream(self, messages: list[Message]) -> Iterator[LLMStreamChunk]:
+    def complete_stream(
+        self,
+        messages: list[Message],
+        *,
+        tools=None,
+    ) -> Iterator[LLMStreamChunk]:
         self.calls.append(list(messages))
         yield from self.chunks
 
@@ -117,11 +127,19 @@ class TestExecuteStream:
             def __init__(self) -> None:
                 self.chunks = chunks
 
-            def complete(self, messages: list[Message]) -> LLMResponse:
+            def complete(
+                self,
+                messages: list[Message],
+                *,
+                tools=None,
+            ) -> LLMResponse:
                 raise NotImplementedError
 
             def complete_stream(  # type: ignore[return-type]
-                self, messages: list[Message]
+                self,
+                messages: list[Message],
+                *,
+                tools=None,
             ) -> Iterator[LLMStreamChunk]:
                 yield from self.chunks
                 raise RuntimeError("Connection lost")
@@ -148,11 +166,19 @@ class TestExecuteStream:
 
     def test_execute_stream_saves_interrupted_marker_on_empty_error(self) -> None:
         class ErrorStreamingClient:
-            def complete(self, messages: list[Message]) -> LLMResponse:
+            def complete(
+                self,
+                messages: list[Message],
+                *,
+                tools=None,
+            ) -> LLMResponse:
                 raise NotImplementedError
 
             def complete_stream(  # type: ignore[return-type]
-                self, messages: list[Message]
+                self,
+                messages: list[Message],
+                *,
+                tools=None,
             ) -> Iterator[LLMStreamChunk]:
                 raise RuntimeError("Connection lost")
                 yield  # pragma: no cover


### PR DESCRIPTION

## Issues

- Close #902

## Why

simple-agent-poc にツール呼び出し機能がなく、LLM が自律的にツールを呼び出せなかった。portfolio との結合前にツールコール基盤が必要。

## Summary

ビルトインツール `get_current_time` と `concat` を実装し、ReAct パターンのループ（MAX_TOOL_ROUNDS=5）で LLM がツールを呼び出し、結果を会話に反映できるようにした。

## Changes

- **Core 層**: `ToolCall`, `ToolDefinition`, `ToolCallDelta` 型追加。`MessageRole` に `tool` 追加。`Message`, `LLMResponse`, `LLMStreamChunk` 拡張。`agents.yaml` の tools を `list[str]` に変更
- **Application 層**: `ToolExecutor` プロトコル追加、`LLMClient` に `tools` パラメータ追加。`ToolCallEvent`/`ToolResultEvent` DTO 追加。ReAct ループ実装
- **Adapters 層**: `BuiltinToolRegistry` + `get_current_time` + `concat` ツール新規。LiteLLM クライアントに tools パラメータと tool_calls パース追加。SSE `tool_call`/`tool_result` イベント追加。CLI ツール表示
- **Entrypoints 層**: `BuiltinToolRegistry` を DI 配線
- **Tests**: ツール実行、ReAct ループ、SSE イベント、回帰テスト追加（計 141 tests）
- **Docs**: `plans/integration-portfolio.md` に設計決定事項反映

## Verification

- `pytest` - 141 passed
- `ruff check` - passed
- `ty check` - passed

## Reviewer Checklist

### 型定義・Core 層
- [ ] `ToolCall`, `ToolDefinition`, `ToolCallDelta` の型定義が適切か（必須フィールドの過不足がないか）
- [ ] `MessageRole` に `tool` ロールを追加したが、既存のロールと排他的になっているか
- [ ] `Message`, `LLMResponse`, `LLMStreamChunk` の拡張が後方互換を壊していないか
- [ ] `agents.yaml` の tools スキーマ変更（`list[str]`）は適切か

### Application 層
- [ ] `ToolExecutor` プロトコルの抽象度は適切か（tool の追加が容易か）
- [ ] `LLMClient` の `tools` パラメータ追加がインターフェースとして自然か
- [ ] `ToolCallEvent` / `ToolResultEvent` DTO の設計が SSE イベント送出に適しているか
- [ ] ReAct ループの停止条件（`MAX_TOOL_ROUNDS=5`）は妥当か
- [ ] 無限ループや過剰な tool call に対するガードが十分か

### Adapters 層
- [ ] `BuiltinToolRegistry` の登録・解決方法が拡張可能な設計か
- [ ] `get_current_time` の時刻フォーマットは一貫しているか（タイムゾーン考慮）
- [ ] `concat` ツールの引数バリデーションは十分か
- [ ] LiteLLM クライアントでの tool_calls パースが Responses API / Chat Completions API 両方で正しく動作するか
- [ ] SSE `tool_call` / `tool_result` イベントのペイロード設計がクライアント側で扱いやすいか
- [ ] CLI レンダラーでのツール呼び出し表示が見やすいか（実行中〜結果の流れが把握できるか）

### エラーハンドリング
- [ ] ツール実行失敗時のエラーハンドリングが適切か（ReAct ループにどう伝播するか）
- [ ] tool_calls パース失敗時のフォールバック処理はあるか
- [ ] 存在しないツールを指定された場合の挙動は適切か
- [ ] ストリーミング中にエラーが発生した場合、中途半端な状態にならないか

### アーキテクチャ
- [ ] レイヤー間の依存方向が `docs/architecture.md` に準拠しているか
- [ ] DI（bootstrap）の配線に循環参照がないか

### 動作確認（手動）
- [ ] CLI モードでツール呼び出しを含む会話が正しく動作するか
- [ ] HTTP API + SSE で `tool_call` / `tool_result` イベントが正しく送出されるか
- [ ] ツールを呼ばない通常の会話も引き続き動作するか（デグレードチェック）
