### PR TITLE
feat(simple-agent-poc): implement ask_user pause/resume for HTTP API mode (#905)

### DIFF
--- a/projects/simple-agent-poc/agents.yaml
+++ b/projects/simple-agent-poc/agents.yaml
@@ -18,7 +18,6 @@ agents:
     tools:
       - get_current_time
       - concat
-      - ask_user
     api_type: completion
 
   kansaiben:
@@ -29,5 +28,8 @@ agents:
       なんでも関西弁で気軽に話しかけてや。
       Current datetime: {current_datetime}
     temperature: null
-    tools: []
+    tools:
+      - get_current_time
+      - concat
+      - ask_user
     api_type: responses

--- a/projects/simple-agent-poc/agents.yaml
+++ b/projects/simple-agent-poc/agents.yaml
@@ -18,6 +18,7 @@ agents:
     tools:
       - get_current_time
       - concat
+      - ask_user
     api_type: completion
 
   kansaiben:

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/cli/adapter.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/cli/adapter.py
@@ -41,7 +41,11 @@ class StreamingRenderer(Protocol):
     def __call__(
         self,
         stream: Iterator[
-            ContentDelta | ToolCallEvent | ToolResultEvent | SessionPaused | StreamComplete
+            ContentDelta
+            | ToolCallEvent
+            | ToolResultEvent
+            | SessionPaused
+            | StreamComplete
         ],
     ) -> StreamComplete: ...
 

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/cli/adapter.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/cli/adapter.py
@@ -7,6 +7,7 @@ from simple_agent_poc.application.dto import (
     ContentDelta,
     RunAgentRequest,
     RunAgentResponse,
+    SessionPaused,
     StreamComplete,
     ToolCallEvent,
     ToolResultEvent,
@@ -40,7 +41,7 @@ class StreamingRenderer(Protocol):
     def __call__(
         self,
         stream: Iterator[
-            ContentDelta | ToolCallEvent | ToolResultEvent | StreamComplete
+            ContentDelta | ToolCallEvent | ToolResultEvent | SessionPaused | StreamComplete
         ],
     ) -> StreamComplete: ...
 

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/cli/renderer.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/cli/renderer.py
@@ -9,6 +9,7 @@ from typing import Callable
 from simple_agent_poc.application.dto import (
     ContentDelta,
     RunAgentResponse,
+    SessionPaused,
     StreamComplete,
     ToolCallEvent,
     ToolResultEvent,
@@ -122,7 +123,7 @@ def show_exit_message() -> None:
 
 
 def show_streaming_response(
-    stream: Iterator[ContentDelta | ToolCallEvent | ToolResultEvent | StreamComplete],
+    stream: Iterator[ContentDelta | ToolCallEvent | ToolResultEvent | SessionPaused | StreamComplete],
 ) -> StreamComplete:
     """Display a streaming response with live output."""
     indicator = LoadingIndicator()
@@ -151,6 +152,10 @@ def show_streaming_response(
                     sys.stdout.write("Agent: ")
                     started = True
                 sys.stdout.write(f"\n     → {event.result}")
+                sys.stdout.flush()
+            elif isinstance(event, SessionPaused):
+                indicator.stop()
+                sys.stdout.write(f"\n  💬 ask_user: {event.question}\n")
                 sys.stdout.flush()
             elif isinstance(event, StreamComplete):
                 complete = event

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/cli/renderer.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/cli/renderer.py
@@ -123,7 +123,9 @@ def show_exit_message() -> None:
 
 
 def show_streaming_response(
-    stream: Iterator[ContentDelta | ToolCallEvent | ToolResultEvent | SessionPaused | StreamComplete],
+    stream: Iterator[
+        ContentDelta | ToolCallEvent | ToolResultEvent | SessionPaused | StreamComplete
+    ],
 ) -> StreamComplete:
     """Display a streaming response with live output."""
     indicator = LoadingIndicator()

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/api.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/api.py
@@ -199,6 +199,7 @@ def create_app(
                         yield f"event: tool_result\ndata: {json.dumps(asdict(event), ensure_ascii=False)}\n\n"
                     elif isinstance(event, SessionPaused):
                         yield f"event: paused\ndata: {json.dumps(asdict(event), ensure_ascii=False)}\n\n"
+                        yield "event: done\ndata: {}\n\n"
                         return
                     elif isinstance(event, StreamComplete):
                         yield f"event: complete\ndata: {json.dumps(asdict(event), ensure_ascii=False)}\n\n"
@@ -237,6 +238,7 @@ def create_app(
                         yield f"event: tool_result\ndata: {json.dumps(asdict(event), ensure_ascii=False)}\n\n"
                     elif isinstance(event, SessionPaused):
                         yield f"event: paused\ndata: {json.dumps(asdict(event), ensure_ascii=False)}\n\n"
+                        yield "event: done\ndata: {}\n\n"
                         return
                     elif isinstance(event, StreamComplete):
                         yield f"event: complete\ndata: {json.dumps(asdict(event), ensure_ascii=False)}\n\n"

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/api.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/api.py
@@ -217,7 +217,9 @@ def create_app(
         request: ContinueRequest,
         run_agent: Annotated[RunAgentUseCase, Depends(get_run_agent_use_case)],
     ):
-        from simple_agent_poc.application.dto import ContinueRequest as AppContinueRequest
+        from simple_agent_poc.application.dto import (
+            ContinueRequest as AppContinueRequest,
+        )
 
         def event_stream():
             try:

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/api.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/api.py
@@ -13,13 +13,19 @@ from simple_agent_poc.application.dto import (
     ContentDelta,
     RunAgentRequest,
     RunAgentResponse,
+    SessionPaused,
     StreamComplete,
     ToolCallEvent,
     ToolCallRecord,
     ToolResultEvent,
 )
 from simple_agent_poc.application.use_cases import RunAgentUseCase
-from simple_agent_poc.core.types import SessionNotFoundError, Usage, ValidationError
+from simple_agent_poc.core.types import (
+    SessionNotFoundError,
+    SessionNotPausedError,
+    Usage,
+    ValidationError,
+)
 from simple_agent_poc.entrypoints.bootstrap import create_run_agent_use_case_factory
 
 
@@ -70,6 +76,31 @@ class ChatResponse(BaseModel):
             session_id=response.session_id,
             tool_calls=response.tool_call_history,
         )
+
+
+class ContinueRequest(BaseModel):
+    """HTTP request schema for resuming a paused session."""
+
+    model_config = ConfigDict(str_strip_whitespace=True)
+
+    session_id: str
+    answer: str
+
+    @field_validator("session_id")
+    @classmethod
+    def validate_session_id(cls, value: str) -> str:
+        """Reject blank session ids after trimming whitespace."""
+        if not value:
+            raise ValueError("session_id must not be blank")
+        return value
+
+    @field_validator("answer")
+    @classmethod
+    def validate_answer(cls, value: str) -> str:
+        """Reject blank answers after trimming whitespace."""
+        if not value:
+            raise ValueError("answer must not be blank")
+        return value
 
 
 def resolve_session_id(
@@ -166,10 +197,51 @@ def create_app(
                         yield f"event: tool_call\ndata: {json.dumps(asdict(event), ensure_ascii=False)}\n\n"
                     elif isinstance(event, ToolResultEvent):
                         yield f"event: tool_result\ndata: {json.dumps(asdict(event), ensure_ascii=False)}\n\n"
+                    elif isinstance(event, SessionPaused):
+                        yield f"event: paused\ndata: {json.dumps(asdict(event), ensure_ascii=False)}\n\n"
+                        return
                     elif isinstance(event, StreamComplete):
                         yield f"event: complete\ndata: {json.dumps(asdict(event), ensure_ascii=False)}\n\n"
                 yield "event: done\ndata: {}\n\n"
             except SessionNotFoundError as error:
+                yield f"event: error\ndata: {json.dumps({'detail': error.display_message}, ensure_ascii=False)}\n\n"
+            except ValidationError as error:
+                yield f"event: error\ndata: {json.dumps({'detail': error.display_message}, ensure_ascii=False)}\n\n"
+            except Exception as error:
+                yield f"event: error\ndata: {json.dumps({'detail': str(error)}, ensure_ascii=False)}\n\n"
+
+        return StreamingResponse(event_stream(), media_type="text/event-stream")
+
+    @app.post("/api/chat/continue")
+    def chat_continue(
+        request: ContinueRequest,
+        run_agent: Annotated[RunAgentUseCase, Depends(get_run_agent_use_case)],
+    ):
+        from simple_agent_poc.application.dto import ContinueRequest as AppContinueRequest
+
+        def event_stream():
+            try:
+                for event in run_agent.continue_stream(
+                    AppContinueRequest(
+                        session_id=request.session_id,
+                        answer=request.answer,
+                    )
+                ):
+                    if isinstance(event, ContentDelta):
+                        yield f"event: delta\ndata: {json.dumps({'content': event.delta}, ensure_ascii=False)}\n\n"
+                    elif isinstance(event, ToolCallEvent):
+                        yield f"event: tool_call\ndata: {json.dumps(asdict(event), ensure_ascii=False)}\n\n"
+                    elif isinstance(event, ToolResultEvent):
+                        yield f"event: tool_result\ndata: {json.dumps(asdict(event), ensure_ascii=False)}\n\n"
+                    elif isinstance(event, SessionPaused):
+                        yield f"event: paused\ndata: {json.dumps(asdict(event), ensure_ascii=False)}\n\n"
+                        return
+                    elif isinstance(event, StreamComplete):
+                        yield f"event: complete\ndata: {json.dumps(asdict(event), ensure_ascii=False)}\n\n"
+                yield "event: done\ndata: {}\n\n"
+            except SessionNotFoundError as error:
+                yield f"event: error\ndata: {json.dumps({'detail': error.display_message}, ensure_ascii=False)}\n\n"
+            except SessionNotPausedError as error:
                 yield f"event: error\ndata: {json.dumps({'detail': error.display_message}, ensure_ascii=False)}\n\n"
             except ValidationError as error:
                 yield f"event: error\ndata: {json.dumps({'detail': error.display_message}, ensure_ascii=False)}\n\n"

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/tools/ask_user.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/tools/ask_user.py
@@ -25,4 +25,13 @@ TOOL_DEFINITION: ToolDefinition = {
 
 
 def execute(arguments: dict[str, Any]) -> str:
-    return json.dumps({"answer": ""}, ensure_ascii=False)
+    question = arguments.get("question", "")
+    return json.dumps(
+        {
+            "answer": (
+                f"このツールは API ストリーミングモードでのみ利用可能です。"
+                f"質問「{question}」には回答できませんでした。"
+            ),
+        },
+        ensure_ascii=False,
+    )

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/tools/ask_user.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/tools/ask_user.py
@@ -1,0 +1,28 @@
+"""ask_user — prompts the user for input during conversation."""
+
+import json
+from typing import Any
+
+from simple_agent_poc.core.types import ToolDefinition
+
+TOOL_DEFINITION: ToolDefinition = {
+    "type": "function",
+    "function": {
+        "name": "ask_user",
+        "description": "ユーザーに対して質問を行い、回答を取得します。",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "question": {
+                    "type": "string",
+                    "description": "ユーザーに尋ねる質問内容",
+                },
+            },
+            "required": ["question"],
+        },
+    },
+}
+
+
+def execute(arguments: dict[str, Any]) -> str:
+    return json.dumps({"answer": ""}, ensure_ascii=False)

--- a/projects/simple-agent-poc/src/simple_agent_poc/application/dto.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/application/dto.py
@@ -87,3 +87,20 @@ class ToolResultEvent:
     call_id: str
     name: str
     result: str
+
+
+@dataclass(frozen=True, slots=True)
+class ContinueRequest:
+    """Request DTO for resuming a paused session."""
+
+    session_id: str
+    answer: str
+
+
+@dataclass(frozen=True, slots=True)
+class SessionPaused:
+    """Pause notification emitted when ask_user is called in API mode."""
+
+    session_id: str
+    call_id: str
+    question: str

--- a/projects/simple-agent-poc/src/simple_agent_poc/application/use_cases.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/application/use_cases.py
@@ -1,5 +1,6 @@
 """Application use cases."""
 
+import json
 import time
 from collections.abc import Generator
 from datetime import datetime, timezone
@@ -7,8 +8,10 @@ from uuid import uuid4
 
 from simple_agent_poc.application.dto import (
     ContentDelta,
+    ContinueRequest,
     RunAgentRequest,
     RunAgentResponse,
+    SessionPaused,
     StreamComplete,
     ToolCallEvent,
     ToolCallRecord,
@@ -27,6 +30,7 @@ from simple_agent_poc.core.session import ConversationSession
 from simple_agent_poc.core.types import (
     LLMError,
     SessionNotFoundError,
+    SessionNotPausedError,
     ToolCall,
     ToolCallDelta,
     ToolDefinition,
@@ -71,11 +75,13 @@ class RunAgentUseCase:
         session_store: SessionStore,
         agent_definitions: AgentDefinitionRegistry,
         tool_executor: ToolExecutor | None = None,
+        is_api_context: bool = False,
     ) -> None:
         self._llm_client_factory = llm_client_factory
         self._session_store = session_store
         self._agent_definitions = agent_definitions
         self._tool_executor = tool_executor
+        self._is_api_context = is_api_context
 
     def execute(self, request: RunAgentRequest) -> RunAgentResponse:
         """Run the agent for a single user message with ReAct tool loop."""
@@ -138,7 +144,7 @@ class RunAgentUseCase:
 
     def execute_stream(
         self, request: RunAgentRequest
-    ) -> Generator[ContentDelta | ToolCallEvent | ToolResultEvent | StreamComplete]:
+    ) -> Generator[ContentDelta | ToolCallEvent | ToolResultEvent | SessionPaused | StreamComplete]:
         """Run the agent for a single user message with streaming ReAct loop."""
         if not request.message.strip():
             raise ValidationError("message must not be blank")
@@ -199,6 +205,141 @@ class RunAgentUseCase:
                     session.append_assistant_message(
                         _accumulated_text, tool_calls=tool_calls
                     )
+
+                    ask_user_tc = next(
+                        (tc for tc in tool_calls if tc["function"]["name"] == "ask_user"),
+                        None,
+                    )
+                    if ask_user_tc and self._is_api_context:
+                        session.pause_for_ask_user(ask_user_tc, round_idx=round_idx)
+                        self._session_store.save(session)
+                        ask_user_args = json.loads(ask_user_tc["function"]["arguments"])
+                        yield SessionPaused(
+                            session_id=session.session_id,
+                            call_id=ask_user_tc["id"],
+                            question=ask_user_args.get("question", ""),
+                        )
+                        return
+
+                    for tc in tool_calls:
+                        result = self._tool_executor.execute(tc)
+                        session.append_tool_message(result, tool_call_id=tc["id"])
+                        yield ToolResultEvent(
+                            call_id=tc["id"],
+                            name=tc["function"]["name"],
+                            result=result,
+                        )
+                else:
+                    session.append_assistant_message(_accumulated_text)
+                    elapsed = time.perf_counter() - _start_time
+                    yield StreamComplete(
+                        session_id=session.session_id,
+                        usage=usage_from_stream,
+                        model=model,
+                        response_time=elapsed,
+                    )
+                    return
+
+            raise LLMError(
+                "Exceeded maximum tool call rounds",
+                display_message="Exceeded maximum tool call rounds.",
+            )
+        except Exception:
+            if _accumulated_text:
+                session.append_assistant_message(
+                    f"{_accumulated_text}\n\n[stream interrupted]"
+                )
+            else:
+                session.append_assistant_message("[stream interrupted]")
+            raise
+        finally:
+            self._session_store.save(session)
+
+    def continue_stream(
+        self, request: ContinueRequest
+    ) -> Generator[ContentDelta | ToolCallEvent | ToolResultEvent | SessionPaused | StreamComplete, None, None]:
+        """Resume a paused session with the user's answer."""
+        session = self._session_store.get(request.session_id)
+        if session is None:
+            raise SessionNotFoundError(
+                f"Session not found: {request.session_id}",
+                display_message="Session not found.",
+            )
+        if not session.is_paused or session.pending_tool_call is None:
+            raise SessionNotPausedError(
+                f"Session {request.session_id} is not in a paused state",
+                display_message="Session is not in a paused state.",
+            )
+
+        tc = session.pending_tool_call
+        result = json.dumps({"answer": request.answer}, ensure_ascii=False)
+        session.append_tool_message(result, tool_call_id=tc["id"])
+        yield ToolResultEvent(call_id=tc["id"], name="ask_user", result=result)
+        session.resume_with_answer()
+
+        agent_definition = self._agent_definitions.get(session.agent_id)
+        llm_client = self._llm_client_factory(agent_definition)
+        tools = self._resolve_tools(agent_definition)
+        model = agent_definition.model
+        _start_time = time.perf_counter()
+        _accumulated_text = ""
+
+        try:
+            for round_idx in range(session.pending_round + 1, MAX_TOOL_ROUNDS):
+                _accumulated_text = ""
+                accumulated_tool_calls: dict[int, ToolCall] = {}
+                usage_from_stream: Usage | None = None
+
+                for chunk in llm_client.complete_stream(
+                    list(session.messages), tools=tools
+                ):
+                    delta = chunk.get("content_delta")
+                    if delta:
+                        _accumulated_text += delta
+                        yield ContentDelta(delta=delta)
+
+                    td = chunk.get("tool_call_delta")
+                    if td is not None:
+                        _accumulate_tool_call_chunks(accumulated_tool_calls, td)
+
+                    if "usage" in chunk:
+                        usage_from_stream = chunk["usage"]
+
+                if accumulated_tool_calls:
+                    if self._tool_executor is None:
+                        raise LLMError(
+                            "Tool call requested but no tool executor configured",
+                            display_message="Tool call requested but no tool executor configured.",
+                        )
+                    tool_calls = [
+                        accumulated_tool_calls[i]
+                        for i in sorted(accumulated_tool_calls)
+                    ]
+                    for tc in tool_calls:
+                        yield ToolCallEvent(
+                            call_id=tc["id"],
+                            name=tc["function"]["name"],
+                            arguments=tc["function"]["arguments"],
+                        )
+
+                    session.append_assistant_message(
+                        _accumulated_text, tool_calls=tool_calls
+                    )
+
+                    ask_user_tc = next(
+                        (tc for tc in tool_calls if tc["function"]["name"] == "ask_user"),
+                        None,
+                    )
+                    if ask_user_tc and self._is_api_context:
+                        session.pause_for_ask_user(ask_user_tc, round_idx=round_idx)
+                        self._session_store.save(session)
+                        ask_user_args = json.loads(ask_user_tc["function"]["arguments"])
+                        yield SessionPaused(
+                            session_id=session.session_id,
+                            call_id=ask_user_tc["id"],
+                            question=ask_user_args.get("question", ""),
+                        )
+                        return
 
                     for tc in tool_calls:
                         result = self._tool_executor.execute(tc)

--- a/projects/simple-agent-poc/src/simple_agent_poc/application/use_cases.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/application/use_cases.py
@@ -217,6 +217,16 @@ class RunAgentUseCase:
                         None,
                     )
                     if ask_user_tc and self._is_api_context:
+                        for tc in tool_calls:
+                            if tc["function"]["name"] == "ask_user":
+                                continue
+                            result = self._tool_executor.execute(tc)
+                            session.append_tool_message(result, tool_call_id=tc["id"])
+                            yield ToolResultEvent(
+                                call_id=tc["id"],
+                                name=tc["function"]["name"],
+                                result=result,
+                            )
                         session.pause_for_ask_user(ask_user_tc, round_idx=round_idx)
                         self._session_store.save(session)
                         ask_user_args = json.loads(ask_user_tc["function"]["arguments"])
@@ -285,6 +295,7 @@ class RunAgentUseCase:
         result = json.dumps({"answer": request.answer}, ensure_ascii=False)
         session.append_tool_message(result, tool_call_id=tc["id"])
         yield ToolResultEvent(call_id=tc["id"], name="ask_user", result=result)
+        resume_round = session.pending_round
         session.resume_with_answer()
 
         agent_definition = self._agent_definitions.get(session.agent_id)
@@ -295,7 +306,7 @@ class RunAgentUseCase:
         _accumulated_text = ""
 
         try:
-            for round_idx in range(session.pending_round + 1, MAX_TOOL_ROUNDS):
+            for round_idx in range(resume_round + 1, MAX_TOOL_ROUNDS):
                 _accumulated_text = ""
                 accumulated_tool_calls: dict[int, ToolCall] = {}
                 usage_from_stream: Usage | None = None
@@ -345,6 +356,16 @@ class RunAgentUseCase:
                         None,
                     )
                     if ask_user_tc and self._is_api_context:
+                        for tc in tool_calls:
+                            if tc["function"]["name"] == "ask_user":
+                                continue
+                            result = self._tool_executor.execute(tc)
+                            session.append_tool_message(result, tool_call_id=tc["id"])
+                            yield ToolResultEvent(
+                                call_id=tc["id"],
+                                name=tc["function"]["name"],
+                                result=result,
+                            )
                         session.pause_for_ask_user(ask_user_tc, round_idx=round_idx)
                         self._session_store.save(session)
                         ask_user_args = json.loads(ask_user_tc["function"]["arguments"])

--- a/projects/simple-agent-poc/src/simple_agent_poc/application/use_cases.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/application/use_cases.py
@@ -144,7 +144,9 @@ class RunAgentUseCase:
 
     def execute_stream(
         self, request: RunAgentRequest
-    ) -> Generator[ContentDelta | ToolCallEvent | ToolResultEvent | SessionPaused | StreamComplete]:
+    ) -> Generator[
+        ContentDelta | ToolCallEvent | ToolResultEvent | SessionPaused | StreamComplete
+    ]:
         """Run the agent for a single user message with streaming ReAct loop."""
         if not request.message.strip():
             raise ValidationError("message must not be blank")
@@ -207,7 +209,11 @@ class RunAgentUseCase:
                     )
 
                     ask_user_tc = next(
-                        (tc for tc in tool_calls if tc["function"]["name"] == "ask_user"),
+                        (
+                            tc
+                            for tc in tool_calls
+                            if tc["function"]["name"] == "ask_user"
+                        ),
                         None,
                     )
                     if ask_user_tc and self._is_api_context:
@@ -257,7 +263,11 @@ class RunAgentUseCase:
 
     def continue_stream(
         self, request: ContinueRequest
-    ) -> Generator[ContentDelta | ToolCallEvent | ToolResultEvent | SessionPaused | StreamComplete, None, None]:
+    ) -> Generator[
+        ContentDelta | ToolCallEvent | ToolResultEvent | SessionPaused | StreamComplete,
+        None,
+        None,
+    ]:
         """Resume a paused session with the user's answer."""
         session = self._session_store.get(request.session_id)
         if session is None:
@@ -327,7 +337,11 @@ class RunAgentUseCase:
                     )
 
                     ask_user_tc = next(
-                        (tc for tc in tool_calls if tc["function"]["name"] == "ask_user"),
+                        (
+                            tc
+                            for tc in tool_calls
+                            if tc["function"]["name"] == "ask_user"
+                        ),
                         None,
                     )
                     if ask_user_tc and self._is_api_context:

--- a/projects/simple-agent-poc/src/simple_agent_poc/core/session.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/core/session.py
@@ -12,6 +12,9 @@ class ConversationSession:
     session_id: str
     agent_id: str = "default"
     messages: list[Message] = field(default_factory=list)
+    is_paused: bool = False
+    pending_tool_call: ToolCall | None = None
+    pending_round: int = 0
 
     @classmethod
     def start(
@@ -53,3 +56,15 @@ class ConversationSession:
                 "tool_call_id": tool_call_id,
             }
         )
+
+    def pause_for_ask_user(self, tool_call: ToolCall, *, round_idx: int) -> None:
+        """Transition to paused state waiting for user answer."""
+        self.is_paused = True
+        self.pending_tool_call = tool_call
+        self.pending_round = round_idx
+
+    def resume_with_answer(self) -> None:
+        """Clear paused state after receiving user answer."""
+        self.is_paused = False
+        self.pending_tool_call = None
+        self.pending_round = 0

--- a/projects/simple-agent-poc/src/simple_agent_poc/core/types.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/core/types.py
@@ -31,6 +31,10 @@ class SessionNotFoundError(AgentError):
     """Raised when a requested session does not exist."""
 
 
+class SessionNotPausedError(AgentError):
+    """Raised when continue is requested on a session that is not paused."""
+
+
 MessageRole = Literal["system", "user", "assistant", "tool"]
 
 

--- a/projects/simple-agent-poc/src/simple_agent_poc/entrypoints/bootstrap.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/entrypoints/bootstrap.py
@@ -17,6 +17,12 @@ from simple_agent_poc.adapters.tools.get_current_time import (
 from simple_agent_poc.adapters.tools.get_current_time import (
     execute as time_execute,
 )
+from simple_agent_poc.adapters.tools.ask_user import (
+    TOOL_DEFINITION as ASK_USER_TOOL_DEF,
+)
+from simple_agent_poc.adapters.tools.ask_user import (
+    execute as ask_user_execute,
+)
 from simple_agent_poc.adapters.tools.registry import BuiltinToolRegistry
 from simple_agent_poc.application.ports import SessionStore, ToolExecutor
 from simple_agent_poc.application.use_cases import RunAgentUseCase
@@ -42,6 +48,7 @@ def create_default_tool_executor() -> BuiltinToolRegistry:
     registry = BuiltinToolRegistry()
     registry.register(TIME_TOOL_DEF, time_execute)
     registry.register(CONCAT_TOOL_DEF, concat_execute)
+    registry.register(ASK_USER_TOOL_DEF, ask_user_execute)
     return registry
 
 
@@ -50,6 +57,7 @@ def create_run_agent_use_case(
     session_store: SessionStore | None = None,
     agent_definitions: AgentDefinitionRegistry | None = None,
     tool_executor: ToolExecutor | None = None,
+    is_api_context: bool = False,
 ) -> RunAgentUseCase:
     """Create the shared use case with production dependencies."""
     return RunAgentUseCase(
@@ -57,6 +65,7 @@ def create_run_agent_use_case(
         session_store=session_store or InMemorySessionStore(),
         agent_definitions=agent_definitions or create_agent_definition_registry(),
         tool_executor=tool_executor or create_default_tool_executor(),
+        is_api_context=is_api_context,
     )
 
 
@@ -69,4 +78,5 @@ def create_run_agent_use_case_factory() -> Callable[[], RunAgentUseCase]:
         session_store=session_store,
         agent_definitions=agent_definitions,
         tool_executor=tool_executor,
+        is_api_context=True,
     )

--- a/projects/simple-agent-poc/tests/test_http_stream_api.py
+++ b/projects/simple-agent-poc/tests/test_http_stream_api.py
@@ -199,7 +199,10 @@ class TestStreamPauseContinueAPI:
                     "index": 0,
                     "id": "call_001",
                     "type": "function",
-                    "function": {"name": "ask_user", "arguments": '{"question": "Your name?"}'},
+                    "function": {
+                        "name": "ask_user",
+                        "arguments": '{"question": "Your name?"}',
+                    },
                 },
             },
         ]
@@ -237,7 +240,10 @@ class TestStreamPauseContinueAPI:
                     "index": 0,
                     "id": "call_001",
                     "type": "function",
-                    "function": {"name": "ask_user", "arguments": '{"question": "Your name?"}'},
+                    "function": {
+                        "name": "ask_user",
+                        "arguments": '{"question": "Your name?"}',
+                    },
                 },
             },
         ]
@@ -250,7 +256,9 @@ class TestStreamPauseContinueAPI:
 
         def make_use_case(chunks):
             return RunAgentUseCase(
-                llm_client_factory=lambda _agent_definition: StreamingStubLLMClient(chunks=chunks),
+                llm_client_factory=lambda _agent_definition: StreamingStubLLMClient(
+                    chunks=chunks
+                ),
                 session_store=session_store,
                 agent_definitions=registry,
                 tool_executor=tool_executor,
@@ -283,7 +291,9 @@ class TestStreamPauseContinueAPI:
     def test_chat_continue_with_unknown_session_returns_error(self) -> None:
         app = create_app(
             use_case_factory=lambda: RunAgentUseCase(
-                llm_client_factory=lambda _agent_definition: StreamingStubLLMClient(chunks=[]),
+                llm_client_factory=lambda _agent_definition: StreamingStubLLMClient(
+                    chunks=[]
+                ),
                 session_store=InMemorySessionStore(),
                 agent_definitions=build_registry_with_ask_user(),
                 is_api_context=True,
@@ -304,6 +314,7 @@ class TestStreamPauseContinueAPI:
     def test_chat_continue_with_non_paused_session_returns_error(self) -> None:
         session_store = InMemorySessionStore()
         from simple_agent_poc.core.session import ConversationSession
+
         session = ConversationSession.start(
             session_id="active",
             system_prompt="System prompt",
@@ -314,7 +325,9 @@ class TestStreamPauseContinueAPI:
 
         app = create_app(
             use_case_factory=lambda: RunAgentUseCase(
-                llm_client_factory=lambda _agent_definition: StreamingStubLLMClient(chunks=[]),
+                llm_client_factory=lambda _agent_definition: StreamingStubLLMClient(
+                    chunks=[]
+                ),
                 session_store=session_store,
                 agent_definitions=build_registry_with_ask_user(),
                 is_api_context=True,
@@ -335,7 +348,9 @@ class TestStreamPauseContinueAPI:
     def test_chat_continue_rejects_blank_answer(self) -> None:
         app = create_app(
             use_case_factory=lambda: RunAgentUseCase(
-                llm_client_factory=lambda _agent_definition: StreamingStubLLMClient(chunks=[]),
+                llm_client_factory=lambda _agent_definition: StreamingStubLLMClient(
+                    chunks=[]
+                ),
                 session_store=InMemorySessionStore(),
                 agent_definitions=build_registry_with_ask_user(),
                 is_api_context=True,

--- a/projects/simple-agent-poc/tests/test_http_stream_api.py
+++ b/projects/simple-agent-poc/tests/test_http_stream_api.py
@@ -7,6 +7,13 @@ from fastapi.testclient import TestClient
 
 from simple_agent_poc.adapters.http.api import create_app
 from simple_agent_poc.adapters.session_store.in_memory import InMemorySessionStore
+from simple_agent_poc.adapters.tools.registry import BuiltinToolRegistry
+from simple_agent_poc.adapters.tools.ask_user import (
+    TOOL_DEFINITION as ASK_USER_TOOL_DEF,
+)
+from simple_agent_poc.adapters.tools.ask_user import (
+    execute as ask_user_execute,
+)
 from simple_agent_poc.application.use_cases import RunAgentUseCase
 from simple_agent_poc.core.agent_definition import AgentDefinitionRegistry
 from simple_agent_poc.core.types import LLMResponse, LLMStreamChunk, Message
@@ -159,3 +166,186 @@ class TestStreamAPI:
         assert any(e["event"] == "delta" for e in events)
         assert any(e["event"] == "complete" for e in events)
         assert any(e["event"] == "done" for e in events)
+
+
+def build_registry_with_ask_user() -> AgentDefinitionRegistry:
+    return AgentDefinitionRegistry.from_mapping(
+        {
+            "agents": {
+                "default": {
+                    "model": "default-model",
+                    "system_prompt": "System prompt",
+                    "tools": ["ask_user"],
+                },
+            }
+        }
+    )
+
+
+def build_tool_executor_with_ask_user() -> BuiltinToolRegistry:
+    registry = BuiltinToolRegistry()
+    registry.register(ASK_USER_TOOL_DEF, ask_user_execute)
+    return registry
+
+
+class TestStreamPauseContinueAPI:
+    """Tests for SSE pause/continue via HTTP."""
+
+    def test_chat_stream_pauses_on_ask_user(self) -> None:
+        chunks: list[LLMStreamChunk] = [
+            {
+                "content_delta": None,
+                "tool_call_delta": {
+                    "index": 0,
+                    "id": "call_001",
+                    "type": "function",
+                    "function": {"name": "ask_user", "arguments": '{"question": "Your name?"}'},
+                },
+            },
+        ]
+        session_store = InMemorySessionStore()
+        tool_executor = build_tool_executor_with_ask_user()
+        registry = build_registry_with_ask_user()
+        llm_client = StreamingStubLLMClient(chunks=chunks)
+
+        app = create_app(
+            use_case_factory=lambda: RunAgentUseCase(
+                llm_client_factory=lambda _agent_definition: llm_client,
+                session_store=session_store,
+                agent_definitions=registry,
+                tool_executor=tool_executor,
+                is_api_context=True,
+            )
+        )
+        client = TestClient(app)
+
+        response = client.post("/api/chat/stream", json={"message": "Hello"})
+
+        assert response.status_code == 200
+        events = parse_sse_events(response.text)
+        assert events[0]["event"] == "tool_call"
+        assert events[1]["event"] == "paused"
+        paused_data = json.loads(events[1]["data"])
+        assert "session_id" in paused_data
+        assert paused_data["question"] == "Your name?"
+
+    def test_chat_continue_resumes_session(self) -> None:
+        first_chunks: list[LLMStreamChunk] = [
+            {
+                "content_delta": None,
+                "tool_call_delta": {
+                    "index": 0,
+                    "id": "call_001",
+                    "type": "function",
+                    "function": {"name": "ask_user", "arguments": '{"question": "Your name?"}'},
+                },
+            },
+        ]
+        second_chunks: list[LLMStreamChunk] = [
+            {"content_delta": "Nice to meet you, Alice!"},
+        ]
+        session_store = InMemorySessionStore()
+        tool_executor = build_tool_executor_with_ask_user()
+        registry = build_registry_with_ask_user()
+
+        def make_use_case(chunks):
+            return RunAgentUseCase(
+                llm_client_factory=lambda _agent_definition: StreamingStubLLMClient(chunks=chunks),
+                session_store=session_store,
+                agent_definitions=registry,
+                tool_executor=tool_executor,
+                is_api_context=True,
+            )
+
+        app = create_app(use_case_factory=lambda: make_use_case(first_chunks))
+        client = TestClient(app)
+
+        stream_resp = client.post("/api/chat/stream", json={"message": "Hello"})
+        stream_events = parse_sse_events(stream_resp.text)
+        paused_data = json.loads(stream_events[1]["data"])
+        session_id = paused_data["session_id"]
+
+        app2 = create_app(use_case_factory=lambda: make_use_case(second_chunks))
+        client2 = TestClient(app2)
+
+        continue_resp = client2.post(
+            "/api/chat/continue",
+            json={"session_id": session_id, "answer": "Alice"},
+        )
+
+        assert continue_resp.status_code == 200
+        continue_events = parse_sse_events(continue_resp.text)
+        assert continue_events[0]["event"] == "tool_result"
+        assert continue_events[1]["event"] == "delta"
+        assert continue_events[2]["event"] == "complete"
+        assert continue_events[3]["event"] == "done"
+
+    def test_chat_continue_with_unknown_session_returns_error(self) -> None:
+        app = create_app(
+            use_case_factory=lambda: RunAgentUseCase(
+                llm_client_factory=lambda _agent_definition: StreamingStubLLMClient(chunks=[]),
+                session_store=InMemorySessionStore(),
+                agent_definitions=build_registry_with_ask_user(),
+                is_api_context=True,
+            )
+        )
+        client = TestClient(app)
+
+        response = client.post(
+            "/api/chat/continue",
+            json={"session_id": "missing", "answer": "no"},
+        )
+
+        assert response.status_code == 200
+        events = parse_sse_events(response.text)
+        assert events[0]["event"] == "error"
+        assert "not found" in json.loads(events[0]["data"])["detail"].lower()
+
+    def test_chat_continue_with_non_paused_session_returns_error(self) -> None:
+        session_store = InMemorySessionStore()
+        from simple_agent_poc.core.session import ConversationSession
+        session = ConversationSession.start(
+            session_id="active",
+            system_prompt="System prompt",
+        )
+        session.append_user_message("Hello")
+        session.append_assistant_message("Hi")
+        session_store.save(session)
+
+        app = create_app(
+            use_case_factory=lambda: RunAgentUseCase(
+                llm_client_factory=lambda _agent_definition: StreamingStubLLMClient(chunks=[]),
+                session_store=session_store,
+                agent_definitions=build_registry_with_ask_user(),
+                is_api_context=True,
+            )
+        )
+        client = TestClient(app)
+
+        response = client.post(
+            "/api/chat/continue",
+            json={"session_id": "active", "answer": "no"},
+        )
+
+        assert response.status_code == 200
+        events = parse_sse_events(response.text)
+        assert events[0]["event"] == "error"
+        assert "paused" in json.loads(events[0]["data"])["detail"].lower()
+
+    def test_chat_continue_rejects_blank_answer(self) -> None:
+        app = create_app(
+            use_case_factory=lambda: RunAgentUseCase(
+                llm_client_factory=lambda _agent_definition: StreamingStubLLMClient(chunks=[]),
+                session_store=InMemorySessionStore(),
+                agent_definitions=build_registry_with_ask_user(),
+                is_api_context=True,
+            )
+        )
+        client = TestClient(app)
+
+        response = client.post(
+            "/api/chat/continue",
+            json={"session_id": "abc", "answer": "   "},
+        )
+
+        assert response.status_code == 422

--- a/projects/simple-agent-poc/tests/test_session.py
+++ b/projects/simple-agent-poc/tests/test_session.py
@@ -2,6 +2,7 @@
 
 from simple_agent_poc.adapters.session_store.in_memory import InMemorySessionStore
 from simple_agent_poc.core.session import ConversationSession
+from simple_agent_poc.core.types import ToolCall
 
 
 class TestConversationSession:
@@ -60,3 +61,42 @@ class TestInMemorySessionStore:
         store = InMemorySessionStore()
 
         assert store.get("missing") is None
+
+
+class TestSessionPause:
+    """Tests for pause/resume functionality."""
+
+    def test_pause_for_ask_user_sets_state(self) -> None:
+        session = ConversationSession.start(
+            session_id="session-1",
+            system_prompt="System prompt",
+        )
+        tc: ToolCall = {
+            "id": "call_001",
+            "type": "function",
+            "function": {"name": "ask_user", "arguments": '{"question": "What?"}'},
+        }
+
+        session.pause_for_ask_user(tc, round_idx=2)
+
+        assert session.is_paused is True
+        assert session.pending_tool_call == tc
+        assert session.pending_round == 2
+
+    def test_resume_with_answer_clears_state(self) -> None:
+        session = ConversationSession.start(
+            session_id="session-1",
+            system_prompt="System prompt",
+        )
+        tc: ToolCall = {
+            "id": "call_001",
+            "type": "function",
+            "function": {"name": "ask_user", "arguments": '{"question": "What?"}'},
+        }
+        session.pause_for_ask_user(tc, round_idx=0)
+
+        session.resume_with_answer()
+
+        assert session.is_paused is False
+        assert session.pending_tool_call is None
+        assert session.pending_round == 0

--- a/projects/simple-agent-poc/tests/test_use_cases_stream.py
+++ b/projects/simple-agent-poc/tests/test_use_cases_stream.py
@@ -405,7 +405,10 @@ class TestExecuteStreamPause:
                     "index": 0,
                     "id": "call_001",
                     "type": "function",
-                    "function": {"name": "ask_user", "arguments": '{"question": "What is your name?"}'},
+                    "function": {
+                        "name": "ask_user",
+                        "arguments": '{"question": "What is your name?"}',
+                    },
                 },
             },
         ]
@@ -442,7 +445,10 @@ class TestExecuteStreamPause:
                     "index": 0,
                     "id": "call_001",
                     "type": "function",
-                    "function": {"name": "ask_user", "arguments": '{"question": "What?"}'},
+                    "function": {
+                        "name": "ask_user",
+                        "arguments": '{"question": "What?"}',
+                    },
                 },
             },
         ]
@@ -496,7 +502,10 @@ class TestContinueStream:
                     "index": 0,
                     "id": "call_001",
                     "type": "function",
-                    "function": {"name": "ask_user", "arguments": '{"question": "Your name?"}'},
+                    "function": {
+                        "name": "ask_user",
+                        "arguments": '{"question": "Your name?"}',
+                    },
                 },
             },
         ]
@@ -516,7 +525,9 @@ class TestContinueStream:
             is_api_context=True,
         )
 
-        first_events = list(first_use_case.execute_stream(RunAgentRequest(message="Hello")))
+        first_events = list(
+            first_use_case.execute_stream(RunAgentRequest(message="Hello"))
+        )
         paused = first_events[-1]
         assert isinstance(paused, SessionPaused)
 
@@ -568,6 +579,7 @@ class TestContinueStream:
     def test_continue_stream_with_non_paused_session_raises_error(self) -> None:
         store = InMemorySessionStore()
         from simple_agent_poc.core.session import ConversationSession
+
         session = ConversationSession.start(
             session_id="active-session",
             system_prompt="System prompt",

--- a/projects/simple-agent-poc/tests/test_use_cases_stream.py
+++ b/projects/simple-agent-poc/tests/test_use_cases_stream.py
@@ -8,8 +8,12 @@ import pytest
 from simple_agent_poc.adapters.session_store.in_memory import InMemorySessionStore
 from simple_agent_poc.application.dto import (
     ContentDelta,
+    ContinueRequest,
     RunAgentRequest,
+    SessionPaused,
     StreamComplete,
+    ToolCallEvent,
+    ToolResultEvent,
 )
 from simple_agent_poc.application.use_cases import RunAgentUseCase
 from simple_agent_poc.core.agent_definition import AgentDefinitionRegistry
@@ -18,8 +22,16 @@ from simple_agent_poc.core.types import (
     LLMStreamChunk,
     Message,
     SessionNotFoundError,
+    SessionNotPausedError,
     Usage,
     ValidationError,
+)
+from simple_agent_poc.adapters.tools.registry import BuiltinToolRegistry
+from simple_agent_poc.adapters.tools.ask_user import (
+    TOOL_DEFINITION as ASK_USER_TOOL_DEF,
+)
+from simple_agent_poc.adapters.tools.ask_user import (
+    execute as ask_user_execute,
 )
 
 
@@ -359,3 +371,221 @@ class TestExecuteStream:
         complete = events[-1]
         assert isinstance(complete, StreamComplete)
         assert complete.usage is None
+
+
+def build_registry_with_ask_user(*, stream: bool = False) -> AgentDefinitionRegistry:
+    return AgentDefinitionRegistry.from_mapping(
+        {
+            "agents": {
+                "default": {
+                    "model": "default-model",
+                    "system_prompt": "System prompt",
+                    "stream": stream,
+                    "tools": ["ask_user"],
+                },
+            }
+        }
+    )
+
+
+def build_tool_executor_with_ask_user() -> BuiltinToolRegistry:
+    registry = BuiltinToolRegistry()
+    registry.register(ASK_USER_TOOL_DEF, ask_user_execute)
+    return registry
+
+
+class TestExecuteStreamPause:
+    """Tests for execute_stream pause on ask_user in API mode."""
+
+    def test_execute_stream_pauses_on_ask_user_in_api_mode(self) -> None:
+        chunks: list[LLMStreamChunk] = [
+            {
+                "content_delta": None,
+                "tool_call_delta": {
+                    "index": 0,
+                    "id": "call_001",
+                    "type": "function",
+                    "function": {"name": "ask_user", "arguments": '{"question": "What is your name?"}'},
+                },
+            },
+        ]
+        llm_client = StreamingStubLLMClient(chunks=chunks)
+        store = InMemorySessionStore()
+        tool_executor = build_tool_executor_with_ask_user()
+        use_case = RunAgentUseCase(
+            llm_client_factory=MagicMock(return_value=llm_client),
+            session_store=store,
+            agent_definitions=build_registry_with_ask_user(stream=True),
+            tool_executor=tool_executor,
+            is_api_context=True,
+        )
+
+        events = list(use_case.execute_stream(RunAgentRequest(message="Hello")))
+
+        assert len(events) == 2
+        assert isinstance(events[0], ToolCallEvent)
+        assert events[0].name == "ask_user"
+        assert isinstance(events[1], SessionPaused)
+        assert events[1].question == "What is your name?"
+
+        session = store.get(events[1].session_id)
+        assert session is not None
+        assert session.is_paused is True
+        assert session.pending_tool_call is not None
+        assert session.pending_tool_call["function"]["name"] == "ask_user"
+
+    def test_execute_stream_executes_ask_user_in_non_api_mode(self) -> None:
+        first_chunks: list[LLMStreamChunk] = [
+            {
+                "content_delta": None,
+                "tool_call_delta": {
+                    "index": 0,
+                    "id": "call_001",
+                    "type": "function",
+                    "function": {"name": "ask_user", "arguments": '{"question": "What?"}'},
+                },
+            },
+        ]
+        second_chunks: list[LLMStreamChunk] = [
+            {"content_delta": "The answer is provided."},
+        ]
+        store = InMemorySessionStore()
+        tool_executor = build_tool_executor_with_ask_user()
+
+        call_count = 0
+        chunks_per_call = [first_chunks, second_chunks]
+
+        class MultiCallStubClient:
+            def complete(self, messages, *, tools=None):
+                raise NotImplementedError
+
+            def complete_stream(self, messages, *, tools=None):
+                nonlocal call_count
+                chunks = chunks_per_call[min(call_count, len(chunks_per_call) - 1)]
+                call_count += 1
+                yield from chunks
+
+        use_case = RunAgentUseCase(
+            llm_client_factory=lambda _agent_definition: MultiCallStubClient(),  # type: ignore[arg-type]
+            session_store=store,
+            agent_definitions=build_registry_with_ask_user(stream=True),
+            tool_executor=tool_executor,
+            is_api_context=False,
+        )
+
+        events = list(use_case.execute_stream(RunAgentRequest(message="Hello")))
+
+        assert isinstance(events[0], ToolCallEvent)
+        assert events[0].name == "ask_user"
+        result_events = [e for e in events if isinstance(e, ToolResultEvent)]
+        assert len(result_events) == 1
+        assert result_events[0].name == "ask_user"
+        paused_events = [e for e in events if isinstance(e, SessionPaused)]
+        assert len(paused_events) == 0
+        assert isinstance(events[-1], StreamComplete)
+
+
+class TestContinueStream:
+    """Tests for continue_stream."""
+
+    def test_continue_stream_resumes_paused_session(self) -> None:
+        first_chunks: list[LLMStreamChunk] = [
+            {
+                "content_delta": None,
+                "tool_call_delta": {
+                    "index": 0,
+                    "id": "call_001",
+                    "type": "function",
+                    "function": {"name": "ask_user", "arguments": '{"question": "Your name?"}'},
+                },
+            },
+        ]
+        second_chunks: list[LLMStreamChunk] = [
+            {"content_delta": "Your name is Alice."},
+        ]
+        store = InMemorySessionStore()
+        tool_executor = build_tool_executor_with_ask_user()
+
+        first_use_case = RunAgentUseCase(
+            llm_client_factory=MagicMock(
+                return_value=StreamingStubLLMClient(chunks=first_chunks)
+            ),
+            session_store=store,
+            agent_definitions=build_registry_with_ask_user(stream=True),
+            tool_executor=tool_executor,
+            is_api_context=True,
+        )
+
+        first_events = list(first_use_case.execute_stream(RunAgentRequest(message="Hello")))
+        paused = first_events[-1]
+        assert isinstance(paused, SessionPaused)
+
+        second_use_case = RunAgentUseCase(
+            llm_client_factory=MagicMock(
+                return_value=StreamingStubLLMClient(chunks=second_chunks)
+            ),
+            session_store=store,
+            agent_definitions=build_registry_with_ask_user(stream=True),
+            tool_executor=tool_executor,
+            is_api_context=True,
+        )
+
+        continue_events = list(
+            second_use_case.continue_stream(
+                ContinueRequest(session_id=paused.session_id, answer="Alice")
+            )
+        )
+
+        result_events = [e for e in continue_events if isinstance(e, ToolResultEvent)]
+        assert len(result_events) == 1
+        assert result_events[0].name == "ask_user"
+        assert result_events[0].call_id == paused.call_id
+
+        content_events = [e for e in continue_events if isinstance(e, ContentDelta)]
+        assert len(content_events) == 1
+
+        assert isinstance(continue_events[-1], StreamComplete)
+
+        session = store.get(paused.session_id)
+        assert session is not None
+        assert session.is_paused is False
+
+    def test_continue_stream_with_unknown_session_raises_error(self) -> None:
+        use_case = RunAgentUseCase(
+            llm_client_factory=MagicMock(),
+            session_store=InMemorySessionStore(),
+            agent_definitions=build_registry_with_ask_user(stream=True),
+            is_api_context=True,
+        )
+
+        with pytest.raises(SessionNotFoundError, match="Session not found"):
+            list(
+                use_case.continue_stream(
+                    ContinueRequest(session_id="missing", answer="no")
+                )
+            )
+
+    def test_continue_stream_with_non_paused_session_raises_error(self) -> None:
+        store = InMemorySessionStore()
+        from simple_agent_poc.core.session import ConversationSession
+        session = ConversationSession.start(
+            session_id="active-session",
+            system_prompt="System prompt",
+        )
+        session.append_user_message("Hello")
+        session.append_assistant_message("Hi")
+        store.save(session)
+
+        use_case = RunAgentUseCase(
+            llm_client_factory=MagicMock(),
+            session_store=store,
+            agent_definitions=build_registry_with_ask_user(stream=True),
+            is_api_context=True,
+        )
+
+        with pytest.raises(SessionNotPausedError, match="not in a paused state"):
+            list(
+                use_case.continue_stream(
+                    ContinueRequest(session_id="active-session", answer="no")
+                )
+            )


### PR DESCRIPTION
## Issues

- Close #905

## Why

API クライアント（portfolio 等）が `ask_user` ツール呼び出しを受け取った際、SSE 接続を一時切断し、ユーザー回答を別リクエストで送信して会話を再開できるようにするため。

## Summary

simple-agent-poc の HTTP API モードにおいて、`ask_user` ビルトインツールの pause/resume 二相実行を実装。セッションに一時停止状態を保存し、`POST /api/chat/continue` エンドポイントで再開する。

## Changes

- `core/session.py`: `is_paused`, `pending_tool_call`, `pending_round` フィールドと `pause_for_ask_user()` / `resume_with_answer()` メソッドを追加
- `core/types.py`: `SessionNotPausedError` を追加
- `application/dto.py`: `ContinueRequest` と `SessionPaused` DTO を追加
- `application/use_cases.py`: `is_api_context` フラグ追加、`execute_stream` に API モードでの ask_user 検出と一時停止ロジック追加、`continue_stream` メソッド追加
- `adapters/http/api.py`: `POST /api/chat/continue` エンドポイント追加、`event: paused` SSE イベントハンドリング追加
- `adapters/cli/adapter.py`, `adapters/cli/renderer.py`: `SessionPaused` イベント型に対応
- `entrypoints/bootstrap.py`: `is_api_context` フラグ配線、`ask_user` ツール登録
- `adapters/tools/ask_user.py`: `ask_user` ツール定義を新規作成
- `agents.yaml`: デフォルトエージェントに `ask_user` ツールを追加

## Verification

- `ruff check` — passed
- `ty check .` — passed
- `pytest tests/` — 158 passed
