### PR TITLE
feat(simple-agent-poc): add generator.send() pattern for ask_user CLI tool (#904)

### DIFF
--- a/projects/simple-agent-poc/agents.yaml
+++ b/projects/simple-agent-poc/agents.yaml
@@ -18,6 +18,7 @@ agents:
     tools:
       - get_current_time
       - concat
+      - ask_user
     api_type: completion
 
   kansaiben:

--- a/projects/simple-agent-poc/plans/integration-portfolio.md
+++ b/projects/simple-agent-poc/plans/integration-portfolio.md
@@ -85,7 +85,7 @@ tools:
 
 - [ ] ツールコールのUI表示パターン（折りたたみ / インライン / etc.）
 - [ ] reasoning（思考過程）の扱い
-- [ ] `ask_user` の API モード実装方式（pause/resume 二相実行の詳細）
+- [x] `ask_user` の API モード実装方式（pause/resume 二相実行の詳細）
 - [ ] メッセージ型変換の詳細設計（portfolio `ApiChatMessage` ↔ simple-agent-poc `Message`）
 
 ## 実装フェーズ
@@ -103,13 +103,13 @@ tools:
 - [x] API/SSE 拡張 (tool_call/tool_result イベント)
 - [x] `get_current_time` + `concat` 実装
 
-### Phase 2: simple-agent-poc ask_user CLI (別Issue)
-- [ ] `generator.send()` パターンによるユーザー入力注入
-- [ ] CLI renderer 拡張
+### Phase 2: simple-agent-poc ask_user CLI (Issue #904) ✅
+- [x] `generator.send()` パターンによるユーザー入力注入
+- [x] CLI renderer 拡張
 
-### Phase 3: simple-agent-poc ask_user API (別Issue)
-- [ ] pause/resume 二相実行
-- [ ] `POST /api/chat/continue` エンドポイント
+### Phase 3: simple-agent-poc ask_user API (別Issue) ✅
+- [x] pause/resume 二相実行
+- [x] `POST /api/chat/continue` エンドポイント
 
 ### Phase 4: portfolio 側 結合
 - [ ] Hono adapter 実装 (SSE変換, メッセージ変換)

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/cli/adapter.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/cli/adapter.py
@@ -1,6 +1,6 @@
 """CLI adapter for the application flow."""
 
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Generator
 from typing import Protocol
 
 from simple_agent_poc.application.dto import (
@@ -40,12 +40,14 @@ class StreamingRenderer(Protocol):
 
     def __call__(
         self,
-        stream: Iterator[
+        stream: Generator[
             ContentDelta
             | ToolCallEvent
             | ToolResultEvent
             | SessionPaused
-            | StreamComplete
+            | StreamComplete,
+            str | None,
+            None,
         ],
     ) -> StreamComplete: ...
 

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/cli/renderer.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/cli/renderer.py
@@ -181,7 +181,6 @@ def show_streaming_response(
                 if event.name == "ask_user":
                     args = json.loads(event.arguments)
                     answer = ask_user_question(args.get("question", ""))
-                    indicator.start()
                     try:
                         next_event = stream.send(answer)
                     except StopIteration:

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/cli/renderer.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/cli/renderer.py
@@ -1,9 +1,10 @@
 """UI rendering functions for CLI output."""
 
+import json
 import sys
 import threading
 import time
-from collections.abc import Iterator
+from collections.abc import Generator
 from typing import Callable
 
 from simple_agent_poc.application.dto import (
@@ -84,6 +85,12 @@ def get_user_input() -> str:
     return input("> ")
 
 
+def ask_user_question(question: str) -> str:
+    """Display an ask_user question and return the user's answer."""
+    print(f"\n  💬 ask_user: {question}")
+    return input("  Answer > ").strip()
+
+
 def show_agent_response(response: RunAgentResponse) -> None:
     """Display the agent's response."""
     if response.tool_call_history:
@@ -123,17 +130,39 @@ def show_exit_message() -> None:
 
 
 def show_streaming_response(
-    stream: Iterator[
-        ContentDelta | ToolCallEvent | ToolResultEvent | SessionPaused | StreamComplete
+    stream: Generator[
+        ContentDelta | ToolCallEvent | ToolResultEvent | SessionPaused | StreamComplete,
+        str | None,
+        None,
     ],
 ) -> StreamComplete:
-    """Display a streaming response with live output."""
+    """Display a streaming response with live output.
+
+    When an ask_user ToolCallEvent arrives, the generator pauses.
+    The user is prompted for input and ``generator.send(answer)``
+    resumes the generator with the answer.
+    """
     indicator = LoadingIndicator()
     indicator.start()
     try:
         complete: StreamComplete | None = None
         started = False
-        for event in stream:
+
+        event: (
+            ContentDelta
+            | ToolCallEvent
+            | ToolResultEvent
+            | SessionPaused
+            | StreamComplete
+            | None
+        ) = None
+
+        while complete is None:
+            try:
+                event = next(stream)
+            except StopIteration:
+                break
+
             if isinstance(event, ContentDelta):
                 if not started:
                     indicator.stop()
@@ -148,6 +177,19 @@ def show_streaming_response(
                     started = True
                 sys.stdout.write(f"\n  🔧 {event.name}({event.arguments})")
                 sys.stdout.flush()
+
+                if event.name == "ask_user":
+                    args = json.loads(event.arguments)
+                    answer = ask_user_question(args.get("question", ""))
+                    indicator.start()
+                    try:
+                        next_event = stream.send(answer)
+                    except StopIteration:
+                        break
+                    if isinstance(next_event, ToolResultEvent):
+                        sys.stdout.write(f"\n     → {next_event.result}")
+                        sys.stdout.flush()
+                    continue
             elif isinstance(event, ToolResultEvent):
                 if not started:
                     indicator.stop()

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/llm/litellm_client.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/llm/litellm_client.py
@@ -80,6 +80,56 @@ def _item_attr(item, attr: str, default=None):
     return getattr(item, attr, default)
 
 
+def _transform_messages_for_responses(
+    messages: list[Message],
+) -> list[dict]:
+    result: list[dict] = []
+    for msg in messages:
+        role = msg.get("role")
+        if role == "tool":
+            result.append(
+                {
+                    "type": "function_call_output",
+                    "call_id": msg.get("tool_call_id", ""),
+                    "output": msg.get("content", ""),
+                }
+            )
+            continue
+
+        item: dict = {"role": role, "content": msg.get("content", "")}
+        result.append(item)
+
+        tool_calls = msg.get("tool_calls")
+        if tool_calls:
+            for tc in tool_calls:
+                result.append(
+                    {
+                        "type": "function_call",
+                        "call_id": tc.get("id", ""),
+                        "name": tc["function"]["name"],
+                        "arguments": tc["function"]["arguments"],
+                    }
+                )
+    return result
+
+
+def _transform_tools_for_responses(
+    tools: list[ToolDefinition],
+) -> list[dict]:
+    result: list[dict] = []
+    for tool in tools:
+        func = tool["function"]
+        result.append(
+            {
+                "type": tool["type"],
+                "name": func["name"],
+                "description": func["description"],
+                "parameters": func["parameters"],
+            }
+        )
+    return result
+
+
 def _parse_tool_calls_from_responses_output(output) -> list[ToolCall]:
     result: list[ToolCall] = []
     for item in output:
@@ -254,11 +304,11 @@ class LiteLLMResponsesClient(LLMClient):
         if self.temperature is not None:
             response_params["temperature"] = self.temperature
         if tools:
-            response_params["tools"] = tools
+            response_params["tools"] = _transform_tools_for_responses(tools)
 
         try:
             response = responses(
-                input=messages,
+                input=_transform_messages_for_responses(messages),
                 model=self.model,
                 stream=False,
                 **response_params,
@@ -317,11 +367,11 @@ class LiteLLMResponsesClient(LLMClient):
         if self.temperature is not None:
             response_params["temperature"] = self.temperature
         if tools:
-            response_params["tools"] = tools
+            response_params["tools"] = _transform_tools_for_responses(tools)
 
         try:
             response = responses(
-                input=messages,
+                input=_transform_messages_for_responses(messages),
                 model=self.model,
                 stream=True,
                 **response_params,

--- a/projects/simple-agent-poc/src/simple_agent_poc/application/use_cases.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/application/use_cases.py
@@ -124,6 +124,11 @@ class RunAgentUseCase:
                     response["content"] or "", tool_calls=tool_calls
                 )
                 for tc in tool_calls:
+                    if tc["function"]["name"] == "ask_user":
+                        raise LLMError(
+                            "Tool call 'ask_user' is not supported in non-streaming mode.",
+                            display_message="ask_user はストリーミングモードでのみご利用いただけます。",
+                        )
                     result = self._tool_executor.execute(tc)
                     session.append_tool_message(result, tool_call_id=tc["id"])
                     tool_call_history.append(
@@ -145,9 +150,16 @@ class RunAgentUseCase:
     def execute_stream(
         self, request: RunAgentRequest
     ) -> Generator[
-        ContentDelta | ToolCallEvent | ToolResultEvent | SessionPaused | StreamComplete
+        ContentDelta | ToolCallEvent | ToolResultEvent | SessionPaused | StreamComplete,
+        str | None,
+        None,
     ]:
-        """Run the agent for a single user message with streaming ReAct loop."""
+        """Run the agent for a single user message with streaming ReAct loop.
+
+        When the LLM calls the ask_user tool and is_api_context is False,
+        the generator pauses via ``yield ToolCallEvent(...)``. The caller
+        must inject the user's answer by calling ``generator.send(answer)``.
+        """
         if not request.message.strip():
             raise ValidationError("message must not be blank")
 
@@ -197,16 +209,6 @@ class RunAgentUseCase:
                         accumulated_tool_calls[i]
                         for i in sorted(accumulated_tool_calls)
                     ]
-                    for tc in tool_calls:
-                        yield ToolCallEvent(
-                            call_id=tc["id"],
-                            name=tc["function"]["name"],
-                            arguments=tc["function"]["arguments"],
-                        )
-
-                    session.append_assistant_message(
-                        _accumulated_text, tool_calls=tool_calls
-                    )
 
                     ask_user_tc = next(
                         (
@@ -216,7 +218,17 @@ class RunAgentUseCase:
                         ),
                         None,
                     )
+                    session.append_assistant_message(
+                        _accumulated_text, tool_calls=tool_calls
+                    )
+
                     if ask_user_tc and self._is_api_context:
+                        for tc in tool_calls:
+                            yield ToolCallEvent(
+                                call_id=tc["id"],
+                                name=tc["function"]["name"],
+                                arguments=tc["function"]["arguments"],
+                            )
                         for tc in tool_calls:
                             if tc["function"]["name"] == "ask_user":
                                 continue
@@ -238,7 +250,23 @@ class RunAgentUseCase:
                         return
 
                     for tc in tool_calls:
-                        result = self._tool_executor.execute(tc)
+                        if tc["function"]["name"] == "ask_user":
+                            event = ToolCallEvent(
+                                call_id=tc["id"],
+                                name=tc["function"]["name"],
+                                arguments=tc["function"]["arguments"],
+                            )
+                            user_answer = yield event
+                            result = json.dumps(
+                                {"answer": user_answer or ""}, ensure_ascii=False
+                            )
+                        else:
+                            yield ToolCallEvent(
+                                call_id=tc["id"],
+                                name=tc["function"]["name"],
+                                arguments=tc["function"]["arguments"],
+                            )
+                            result = self._tool_executor.execute(tc)
                         session.append_tool_message(result, tool_call_id=tc["id"])
                         yield ToolResultEvent(
                             call_id=tc["id"],


### PR DESCRIPTION
## Issues

- Close #904

## Why

Phase 1 で実装された `concat` / `get_current_time` は同期的ツールだが、`ask_user` は CLI 上でユーザー入力を待ち受ける対話型ツールであるため、`ToolExecutor.execute() -> str` のパターンに当てはまらない。`generator.send()` パターンを用いて、ツール実行中にユーザー入力を注入する仕組みが必要。

## Summary

`execute_stream()` を `.send(str)` を受け取れるジェネレータに変更し、`ask_user` ツールコール時に `yield ToolCallEvent(...)` で一時停止、CLI が `generator.send(answer)` で回答を注入する仕組みを実装した。

## Changes

- `application/use_cases.py`:
  - `execute_stream()` の返り値型を `Generator[..., str | None, None]` に変更
  - 非APIコンテキストの `ask_user` 検出時に `user_answer = yield ToolCallEvent(...)` で一時停止し、回答を注入
  - APIコンテキストは既存の pause/resume パターンを維持
  - `execute()` で `ask_user` が呼ばれた場合に `LLMError` を送出（非ストリーミングでの `ask_user` 非サポートを明示）
- `adapters/cli/renderer.py`:
  - `ask_user_question()` 関数を追加（質問表示 + ユーザー入力）
  - `show_streaming_response()` を `for` ループから `while` + `next()` / `.send()` 対応に変更
- `adapters/cli/adapter.py`: `StreamingRenderer` プロトコルを `Generator` 型に対応
- `agents.yaml`: デフォルトエージェントにも `ask_user` を追加
- `plans/integration-portfolio.md`: Phase 2/3 のステータスを完了に更新

## Verification

- `uv run ruff check` - passed
- `uv run ty check` - passed
- `uv run pytest` - 158 passed (全テストパス、回帰なし)
