### PR TITLE
docs: update docs for tool call implementation (#904, #905)

### DIFF
--- a/projects/simple-agent-poc/docs/agent-definition.md
+++ b/projects/simple-agent-poc/docs/agent-definition.md
@@ -2,85 +2,59 @@
 
 Agent definitions are loaded from `agents.yaml` by default. Set the `AGENTS_FILE` environment variable to point at a different YAML file.
 
-## YAML Schema
+The canonical source for the YAML schema and validation rules is:
+- **`agents.yaml`** — the actual definitions used at runtime
+- **`src/simple_agent_poc/core/agent_definition.py`** — parsing and validation logic (`_build_agent_definition`, `_optional_tools`, etc.)
 
-```yaml
-agents:
-  <agent_id>:
-    model: <string>           # required
-    system_prompt: <string>   # required
-    temperature: <float|null> # optional, default null
-    tools: <list>            # optional, default []
-    api_type: <string>       # optional, default "completion"
-    stream: <bool>           # optional, default false
-```
+This document explains behaviors that are not obvious from reading the YAML or code alone.
 
-### Root Fields
+## Field Behaviors
 
-| Field | Required | Type | Description |
-|:---|:---|:---|:---|
-| `agents` | yes | `Mapping[str, Mapping]` | Map of agent IDs to their definitions |
+### `model`
 
-Unknown root-level fields are rejected.
+LiteLLM model name (e.g. `gpt-4.1-nano`). Passed directly to the LLM client.
 
-### Agent Fields
+### `system_prompt`
 
-#### `model` (required)
+Prompt template. The placeholder `{current_datetime}` is replaced with the current ISO 8601 datetime string at session creation time. See `AgentDefinition.format_system_prompt()`.
 
-- **Type:** `str` (non-blank)
-- **Description:** LiteLLM model name (e.g. `gpt-4.1-nano`).
+### `temperature`
 
-#### `system_prompt` (required)
+When `null` or omitted, the temperature parameter is **not sent** to the LLM API at all (the provider uses its own default). When set, it must be a number (float or int), never a boolean.
 
-- **Type:** `str` (non-blank)
-- **Description:** Prompt template for the agent. The placeholder `{current_datetime}` is replaced with the current ISO datetime at session creation time.
+### `tools`
 
-#### `temperature` (optional)
+A list of tool names as strings (e.g. `[get_current_time, concat, ask_user]`). Each name must correspond to a built-in tool registered in `BuiltinToolRegistry` (see `src/simple_agent_poc/adapters/tools/registry.py`).
 
-- **Type:** `float | null`
-- **Default:** `null`
-- **Description:** When `null` or omitted, the temperature parameter is not sent to the LLM API. When set, it must be a number (not a boolean).
+Tool names are resolved to `ToolDefinition` objects at request time and passed to the LLM. The LLM may decide to call any of the listed tools during execution.
 
-#### `tools` (optional)
+### `api_type`
 
-- **Type:** `list[dict] | null`
-- **Default:** `[]`
-- **Description:** Reserved for future tool-calling support. Currently parsed and validated but not passed to LiteLLM.
+| Value | Client | Underlying API |
+|:---|:---|:---|
+| `"completion"` (default) | `LiteLLMCompletionClient` | `litellm.completion()` |
+| `"responses"` | `LiteLLMResponsesClient` | `litellm.responses()` |
 
-#### `api_type` (optional)
+The factory selects the client at construction time based on this field.
 
-- **Type:** `"completion" | "responses"`
-- **Default:** `"completion"`
-- **Description:** Chooses the LiteLLM client implementation:
-  - `completion` → `LiteLLMCompletionClient` (uses `litellm.completion()`)
-  - `responses` → `LiteLLMResponsesClient` (uses `litellm.responses()`)
+### `stream`
 
-#### `stream` (optional)
+When `true`, the CLI uses `execute_stream()` with live text output instead of a spinner + synchronous `execute()`. Has no effect on the HTTP API, which always uses streaming for `/api/chat/stream`.
 
-- **Type:** `bool`
-- **Default:** `false`
-- **Description:** When `true`, the CLI uses `execute_stream` with live text output instead of spinner+sync execution.
-
-## Validation Rules
-
-### Startup Validation
+## Validation at Startup
 
 On application startup, `AgentDefinitionRegistry.from_yaml_file()` validates:
+- File must be readable and contain valid YAML
+- `agents` must be a mapping with string keys, must contain a `default` entry
+- Each agent definition must have `model` and `system_prompt` (non-blank strings)
+- `tools` must be a list of strings or null
+- `api_type` must be `"completion"` or `"responses"`
+- Unknown fields at the root or agent level are rejected
+- `temperature` must be a number or null; `stream` must be a boolean
 
-1. File must be readable and contain valid YAML.
-2. Root must be a mapping with string keys.
-3. Unknown root fields are rejected.
-4. `agents` must be a mapping.
-5. A `default` agent is required. Missing it raises `ValidationError`.
-6. Each agent ID must be a non-blank string.
-7. `model` and `system_prompt` are required for each agent.
-8. Unknown fields in an agent definition are rejected.
-9. `temperature` must be a number or null.
-10. `tools` must be a list of mappings or null.
-11. `api_type` must be `"completion"` or `"responses"`.
-12. `stream` must be a boolean.
+For the exact validation logic, see `agent_definition.py` and its `_optional_*` validators.
 
-### Request-time Validation
+## Request-time Validation
 
 - `agent_id` not found in the registry → `ValidationError` (HTTP 400)
 - A request with `session_id` referencing an existing session that has a different `agent_id` → `ValidationError` (HTTP 400)
@@ -91,25 +65,16 @@ On application startup, `AgentDefinitionRegistry.from_yaml_file()` validates:
 
 ## Example
 
+See `agents.yaml` in the project root for the canonical example. A minimal definition:
+
 ```yaml
 agents:
   default:
     model: gpt-4.1-nano
-    stream: false
     system_prompt: |
       You are an AI assistant.
       Current datetime: {current_datetime}
-    temperature: null
-    tools: []
-    api_type: completion
-
-  kansaiben:
-    model: gpt-5.4-nano
-    stream: true
-    system_prompt: |
-      関西弁で話してや。
-      Current datetime: {current_datetime}
-    temperature: null
-    tools: []
-    api_type: responses
+    tools:
+      - concat
+      - ask_user
 ```

--- a/projects/simple-agent-poc/docs/api.md
+++ b/projects/simple-agent-poc/docs/api.md
@@ -1,6 +1,6 @@
 # HTTP API
 
-The HTTP API provides two endpoints for synchronous and streaming agent execution.
+The HTTP API provides endpoints for synchronous and streaming agent execution, plus a pause/resume flow for interactive tool calls.
 
 ## Entry Point
 
@@ -21,7 +21,7 @@ Starts Uvicorn on `127.0.0.1:8000`. Source: `src/simple_agent_poc/entrypoints/ma
 
 ### `POST /api/chat`
 
-Synchronous (non-streaming) agent execution.
+Synchronous (non-streaming) agent execution. Supports tool calls via the ReAct loop.
 
 #### Request
 
@@ -54,7 +54,15 @@ Headers:
   },
   "model": "gpt-4.1-nano",
   "response_time": 1.234,
-  "session_id": "abc123..."
+  "session_id": "abc123...",
+  "tool_calls": [
+    {
+      "call_id": "call_abc123",
+      "name": "concat",
+      "arguments": "{\"a\":\"Hello\",\"b\":\"World\"}",
+      "result": "HelloWorld"
+    }
+  ]
 }
 ```
 
@@ -65,6 +73,7 @@ Headers:
 | `model` | `str` | Model name as configured |
 | `response_time` | `float` | Seconds from LLM call start to response receipt |
 | `session_id` | `str` | Session ID for continuing the conversation |
+| `tool_calls` | `list[ToolCallRecord]` | Tool calls made during execution with their results |
 
 #### Error Responses
 
@@ -76,7 +85,7 @@ Headers:
 
 ### `POST /api/chat/stream`
 
-Streaming agent execution via Server-Sent Events (SSE).
+Streaming agent execution via Server-Sent Events (SSE). Supports tool calls, and may disconnect with `paused` event when `ask_user` is called.
 
 #### Request
 
@@ -87,6 +96,39 @@ Same schema as `/api/chat`. Supports `Session-Id` header with the same `resolve_
 Media type: `text/event-stream`
 
 See [docs/sse.md](sse.md) for the full SSE event specification.
+
+### `POST /api/chat/continue`
+
+Resumes a paused session (after `ask_user` was called). Returns SSE events.
+
+#### Request
+
+```json
+{
+  "session_id": "abc123...",
+  "answer": "My preference is X"
+}
+```
+
+| Field | Type | Required | Description |
+|:---|:---|:---|:---|
+| `session_id` | `str` | yes | The session ID from the `paused` event |
+| `answer` | `str` | yes | User's answer to the `ask_user` question |
+
+#### Response
+
+Same SSE format as `/api/chat/stream`. The sequence is:
+1. `event: tool_result` — the answer injected as tool result
+2. `event: delta` ... — LLM response chunks (ReAct loop resumes)
+3. `event: complete` — stream finished
+4. `event: done` — end of stream
+
+#### Error Responses
+
+| Status | Condition |
+|:---|:---|
+| `400` | `session_id` not found, session is not paused, answer blank |
+| `422` | `session_id` or `answer` blank (Pydantic validation) |
 
 ## Session Resolution
 

--- a/projects/simple-agent-poc/docs/architecture.md
+++ b/projects/simple-agent-poc/docs/architecture.md
@@ -17,8 +17,8 @@ Dependencies flow inward. Outer layers may depend on inner layers, but not the r
 Owns agent behavior independent of transport or entrypoint concerns.
 
 **Files:**
-- `src/simple_agent_poc/core/types.py` — shared message/response types, domain errors
-- `src/simple_agent_poc/core/session.py` — `ConversationSession` entity
+- `src/simple_agent_poc/core/types.py` — shared message/response types, tool call types, domain errors
+- `src/simple_agent_poc/core/session.py` — `ConversationSession` entity (incl. pause/resume state)
 - `src/simple_agent_poc/core/agent_definition.py` — `AgentDefinition`, `AgentDefinitionRegistry`
 
 Core must not depend on CLI or HTTP details.
@@ -28,9 +28,9 @@ Core must not depend on CLI or HTTP details.
 Owns executable use cases and explicit input/output contracts.
 
 **Files:**
-- `src/simple_agent_poc/application/use_cases.py` — `RunAgentUseCase` (orchestration)
-- `src/simple_agent_poc/application/dto.py` — request/response DTOs, stream events
-- `src/simple_agent_poc/application/ports.py` — `LLMClient`, `LLMClientFactory`, `SessionStore` protocols
+- `src/simple_agent_poc/application/use_cases.py` — `RunAgentUseCase` (orchestration, ReAct loop, pause/resume)
+- `src/simple_agent_poc/application/dto.py` — request/response DTOs, stream events, tool call records
+- `src/simple_agent_poc/application/ports.py` — `LLMClient`, `LLMClientFactory`, `SessionStore`, `ToolExecutor` protocols
 
 Application may depend on core contracts, but must not perform terminal rendering or HTTP response construction.
 
@@ -39,11 +39,15 @@ Application may depend on core contracts, but must not perform terminal renderin
 Own transport-specific integration details.
 
 **Files:**
-- `src/simple_agent_poc/adapters/cli/adapter.py` — `CLIAdapter` (stdin/stdout interactive loop)
-- `src/simple_agent_poc/adapters/cli/renderer.py` — spinner, streaming display, welcome banner
-- `src/simple_agent_poc/adapters/http/api.py` — FastAPI app (`/api/chat`, `/api/chat/stream`)
-- `src/simple_agent_poc/adapters/llm/litellm_client.py` — `LiteLLMCompletionClient`, `LiteLLMResponsesClient`, `LiteLLMClientFactory`
+- `src/simple_agent_poc/adapters/cli/adapter.py` — `CLIAdapter` (stdin/stdout interactive loop, `generator.send()` for interactive tools)
+- `src/simple_agent_poc/adapters/cli/renderer.py` — spinner, streaming display, tool call display, `ask_user_question()`
+- `src/simple_agent_poc/adapters/http/api.py` — FastAPI app (`/api/chat`, `/api/chat/stream`, `/api/chat/continue`)
+- `src/simple_agent_poc/adapters/llm/litellm_client.py` — `LiteLLMCompletionClient`, `LiteLLMResponsesClient`, `LiteLLMClientFactory`, tool format transformation
 - `src/simple_agent_poc/adapters/session_store/in_memory.py` — `InMemorySessionStore`
+- `src/simple_agent_poc/adapters/tools/registry.py` — `BuiltinToolRegistry`
+- `src/simple_agent_poc/adapters/tools/concat.py` — `concat` tool
+- `src/simple_agent_poc/adapters/tools/get_current_time.py` — `get_current_time` tool
+- `src/simple_agent_poc/adapters/tools/ask_user.py` — `ask_user` interactive tool
 
 Adapters call the application layer. They translate external inputs into DTOs and translate use case outputs into transport-specific output.
 
@@ -52,7 +56,7 @@ Adapters call the application layer. They translate external inputs into DTOs an
 Own process startup and dependency wiring.
 
 **Files:**
-- `src/simple_agent_poc/entrypoints/bootstrap.py` — shared env loading, logging setup, `RunAgentUseCase` wiring
+- `src/simple_agent_poc/entrypoints/bootstrap.py` — shared env loading, logging setup, tool executor creation, `RunAgentUseCase` wiring
 - `src/simple_agent_poc/entrypoints/main_cli.py` — CLI startup
 - `src/simple_agent_poc/entrypoints/main_api.py` — HTTP API startup (Uvicorn)
 
@@ -66,6 +70,7 @@ Entrypoints should stay thin. Their job is composition, not business logic.
 4. Define conversation and session state policy at the application/core boundary and let adapters consume it.
 5. Keep session persistence behind `SessionStore`; adapters may choose identifiers, but they must not own message history.
 6. Inject infrastructure clients through interfaces so the same use case works for CLI and HTTP.
+7. Inject tool executors through the `ToolExecutor` protocol; individual tool implementations are adapter concerns.
 
 ## Current Directory Structure
 
@@ -89,6 +94,12 @@ src/simple_agent_poc/
       litellm_client.py
     session_store/
       in_memory.py
+    tools/
+      __init__.py
+      registry.py
+      concat.py
+      get_current_time.py
+      ask_user.py
   entrypoints/
     bootstrap.py
     main_cli.py
@@ -97,12 +108,14 @@ src/simple_agent_poc/
 
 ## Responsibility Audit
 
-- `core/session.py` — ordered conversation history, system/user/assistant message accumulation.
-- `application/use_cases.py` — session lookup, session creation, LLM orchestration, persistence sequencing.
-- `application/ports.py` — the only boundary that application code uses for LLM and session persistence.
-- `adapters/cli/adapter.py` — interactive loop, delegates to `RunAgentUseCase`, tracks `_session_id`.
-- `adapters/http/api.py` — request parsing, translates `SessionNotFoundError` into `404`, SSE formatting.
+- `core/session.py` — ordered conversation history, system/user/assistant/tool message accumulation, pause/resume state.
+- `application/use_cases.py` — session lookup/creation, LLM orchestration, ReAct tool loop, pause/resume flow, persistence sequencing.
+- `application/ports.py` — the only boundary that application code uses for LLM, session persistence, and tool execution.
+- `adapters/cli/adapter.py` — interactive loop, `generator.send()` for interactive tools, delegates to `RunAgentUseCase`, tracks `_session_id`.
+- `adapters/http/api.py` — request parsing, translates `SessionNotFoundError` into `404`, SSE formatting for all event types.
 - `adapters/session_store/in_memory.py` — reference implementation for persistence adapters.
+- `adapters/tools/registry.py` — registers and resolves built-in tool definitions and executors.
+- `adapters/tools/*.py` — individual tool implementations (concat, get_current_time, ask_user).
 - `entrypoints/bootstrap.py` — production wiring used by both CLI and HTTP.
 
 ## Ongoing Guidance
@@ -112,6 +125,7 @@ src/simple_agent_poc/
 3. Keep HTTP-specific concerns limited to schema validation and status-code translation.
 4. Add durable persistence by creating a new `adapters/session_store/*` implementation rather than changing use-case semantics.
 5. Keep `entrypoints/bootstrap.py` as the only place that decides production adapter composition.
+6. Add new built-in tools by creating modules in `adapters/tools/` and registering them in `BuiltinToolRegistry`.
 
 ## Non-goals
 

--- a/projects/simple-agent-poc/docs/bootstrap.md
+++ b/projects/simple-agent-poc/docs/bootstrap.md
@@ -14,6 +14,20 @@ Called once at module level. Required environment variables:
 - `OPENAI_API_KEY` — LLM provider API key
 - `OPENAI_BASE_URL` — LLM provider base URL (optional, used by LiteLLM)
 
+## Built-in Tool Executor
+
+```python
+def create_default_tool_executor() -> BuiltinToolRegistry:
+    return BuiltinToolRegistry.with_default_tools()
+```
+
+Creates a `BuiltinToolRegistry` with the following built-in tools registered:
+- `get_current_time` — returns the current UTC datetime in ISO 8601 format
+- `concat` — concatenates two strings
+- `ask_user` — asks the user a question and returns their answer (interactive)
+
+Tool definitions are in `src/simple_agent_poc/adapters/tools/`. Each tool module exports a `TOOL_DEFINITION` constant and an `execute` function.
+
 ## Agent Definition Registry
 
 ```python
@@ -29,11 +43,19 @@ def create_agent_definition_registry() -> AgentDefinitionRegistry:
 ## RunAgentUseCase (Production)
 
 ```python
-def create_run_agent_use_case(*, session_store=None, agent_definitions=None) -> RunAgentUseCase:
+def create_run_agent_use_case(
+    *,
+    session_store=None,
+    agent_definitions=None,
+    tool_executor=None,
+    is_api_context: bool = False,
+) -> RunAgentUseCase:
     return RunAgentUseCase(
         llm_client_factory=LiteLLMClientFactory(),
         session_store=session_store or InMemorySessionStore(),
         agent_definitions=agent_definitions or create_agent_definition_registry(),
+        tool_executor=tool_executor or create_default_tool_executor(),
+        is_api_context=is_api_context,
     )
 ```
 
@@ -41,6 +63,8 @@ Creates the use case with production adapters:
 - `LiteLLMClientFactory()` for LLM calls
 - `InMemorySessionStore()` for session persistence
 - `AgentDefinitionRegistry` from YAML
+- `BuiltinToolRegistry` with default tools
+- `is_api_context=False` for CLI, `True` for HTTP API (controls `ask_user` behavior)
 
 ## RunAgentUseCase Factory (HTTP-optimized)
 
@@ -48,18 +72,21 @@ Creates the use case with production adapters:
 def create_run_agent_use_case_factory() -> Callable[[], RunAgentUseCase]:
     session_store = InMemorySessionStore()
     agent_definitions = create_agent_definition_registry()
+    tool_executor = create_default_tool_executor()
     return lambda: create_run_agent_use_case(
         session_store=session_store,
         agent_definitions=agent_definitions,
+        tool_executor=tool_executor,
+        is_api_context=True,
     )
 ```
 
 Creates a factory function that:
 - Shares a single `InMemorySessionStore` instance across all invocations.
 - Shares a single `AgentDefinitionRegistry` instance.
+- Shares a single `BuiltinToolRegistry` instance.
+- Sets `is_api_context=True` so `ask_user` uses pause/resume instead of `generator.send()`.
 - Returns a `lambda` for use with FastAPI's `Depends`.
-
-This ensures that HTTP requests against the same server process share the same in-memory sessions.
 
 ## Startup Sequences
 
@@ -69,6 +96,7 @@ This ensures that HTTP requests against the same server process share the same i
 main_cli.py
   → build_cli_adapter(agent_id)
     → bootstrap.create_agent_definition_registry()     # load YAML
+    → bootstrap.create_default_tool_executor()          # create tool registry
     → bootstrap.create_run_agent_use_case(...)          # wire use case (new session store)
     → CLIAdapter(use_case, agent_id, agent_definitions)
       → adapter.run()                                   # interactive loop
@@ -79,7 +107,7 @@ main_cli.py
 ```
 main_api.py
   → create_app()  (no factory arg)
-    → bootstrap.create_run_agent_use_case_factory()     # shared session store + registry
+    → bootstrap.create_run_agent_use_case_factory()     # shared session store + registry + tools
       → FastAPI app with get_run_agent_use_case() dependency
 
 Request handling:

--- a/projects/simple-agent-poc/docs/bootstrap.md
+++ b/projects/simple-agent-poc/docs/bootstrap.md
@@ -18,7 +18,12 @@ Called once at module level. Required environment variables:
 
 ```python
 def create_default_tool_executor() -> BuiltinToolRegistry:
-    return BuiltinToolRegistry.with_default_tools()
+    """Create a tool registry with built-in tools."""
+    registry = BuiltinToolRegistry()
+    registry.register(TIME_TOOL_DEF, time_execute)
+    registry.register(CONCAT_TOOL_DEF, concat_execute)
+    registry.register(ASK_USER_TOOL_DEF, ask_user_execute)
+    return registry
 ```
 
 Creates a `BuiltinToolRegistry` with the following built-in tools registered:

--- a/projects/simple-agent-poc/docs/cli.md
+++ b/projects/simple-agent-poc/docs/cli.md
@@ -1,6 +1,6 @@
 # CLI Mode
 
-The interactive CLI provides a `stdin`/`stdout` loop for chatting with agents.
+The interactive CLI provides a `stdin`/`stdout` loop for chatting with agents. It supports both synchronous execution and streaming, including interactive tool calls like `ask_user`.
 
 ## Entry Point
 
@@ -16,7 +16,8 @@ Source: `src/simple_agent_poc/entrypoints/main_cli.py`
 1. `main_cli.py:main()` parses `--agent` argument.
 2. `build_cli_adapter(agent_id=...)` wires dependencies:
    - `bootstrap.create_agent_definition_registry()` → loads `agents.yaml`
-   - `bootstrap.create_run_agent_use_case(agent_definitions=...)` → creates the use case
+   - `bootstrap.create_default_tool_executor()` → creates built-in tool registry
+   - `bootstrap.create_run_agent_use_case(agent_definitions=..., tool_executor=...)` → creates the use case
 3. `CLIAdapter(use_case, agent_id, agent_definitions)` is constructed.
 4. `adapter.run()` starts the interactive loop.
 
@@ -43,19 +44,39 @@ The adapter uses protocol-based dependency injection for testability. All render
 
 ### Interactive Loop
 
+The loop handles both sync and streaming modes. In streaming mode, the generator is used with `send()` to support interactive tool calls:
+
 ```
 while True:
     input = get_user_input()
     if blank → continue
 
     if agent.stream:
-        complete = show_streaming_response(use_case.execute_stream(request))
+        generator = use_case.execute_stream(request)
+        for event in generator:
+            if event is ContentDelta → show live text
+            if event is ToolCallEvent → show tool call; for ask_user, prompt user
+                and send answer via generator.send(answer)
+            if event is ToolResultEvent → show tool result
+            if event is StreamComplete → show stats, capture session_id
     else:
         response = with_indicator("Thinking", lambda: use_case.execute(request))
         show_agent_response(response)
 
-    self._session_id = response.session_id  # track for next iteration
+    self._session_id = response.session_id
 ```
+
+### `generator.send()` Pattern (ask\_user)
+
+When the LLM calls `ask_user` in CLI mode, the `execute_stream()` generator yields a `ToolCallEvent` and **pauses**, waiting for the adapter to send the user's answer back:
+
+1. Generator yields `ToolCallEvent(name="ask_user", arguments={"question": "..."})`.
+2. CLI renderer displays the question and prompts for input via `ask_user_question()`.
+3. Adapter calls `generator.send(answer)` to inject the answer.
+4. Generator yields `ToolResultEvent` with the result.
+5. LLM continues generating its response based on the answer.
+
+This pattern works because CLI is a single-process event loop. For HTTP API, the pause/resume pattern is used instead (see [docs/sse.md](sse.md)).
 
 ### Exit Conditions
 
@@ -96,18 +117,32 @@ Agent: <response.message>
 - Model name: displays only the part after `/` if present
 - Time: `< 1s` shown in ms, else in seconds with 2 decimal places
 - Tokens: `prompt_tokens → completion_tokens (total: total_tokens)`
+- If `response.tool_call_history` is non-empty, each tool call and its result is displayed
 
 ### show_streaming_response(stream)
 
 1. Starts `LoadingIndicator`.
-2. On first `ContentDelta`: stops indicator, prints `"Agent: "`, writes delta text in-place.
-3. Subsequent `ContentDelta`: writes delta text without prefix.
-4. On `StreamComplete`: prints newline, then stats line (same format as `show_agent_response`).
-5. Returns the `StreamComplete` event.
+2. On `ContentDelta`: stops indicator, prints `"Agent: "`, writes delta text in-place.
+3. On `ToolCallEvent`: displays the tool call being made.
+4. **For `ask_user`**: calls `ask_user_question(question)` which displays the question and reads user input, then `generator.send(answer)` to resume the stream.
+5. On `ToolResultEvent`: displays the tool result.
+6. On `SessionPaused`: displays the pause notification (API mode only; not expected in CLI).
+7. On `StreamComplete`: prints newline, then stats line (same format as `show_agent_response`).
+8. Returns the `StreamComplete` event.
 
 If no `ContentDelta` was received before `StreamComplete`, the indicator is stopped and `"Agent: "` is printed before the stats.
 
 If no `StreamComplete` arrives at all, raises `RuntimeError`.
+
+### ask_user_question(question)
+
+```python
+def ask_user_question(self, question: str) -> str:
+    console.print(f"[bold yellow]? {question}[/bold yellow]")
+    return input("  Answer > ").strip()
+```
+
+Displays the `ask_user` question and reads the user's typed answer from stdin.
 
 ### show_error(error)
 

--- a/projects/simple-agent-poc/docs/errors.md
+++ b/projects/simple-agent-poc/docs/errors.md
@@ -10,7 +10,8 @@ AgentError (base)
 ├── RateLimitError
 ├── LLMError
 ├── ValidationError
-└── SessionNotFoundError
+├── SessionNotFoundError
+└── SessionNotPausedError
 ```
 
 ### AgentError
@@ -76,6 +77,16 @@ Raised when a requested `session_id` does not exist in the session store.
 
 **Display message:** `"Session not found."`
 
+### SessionNotPausedError
+
+Raised when `POST /api/chat/continue` is called on a session that is not in paused state.
+
+**Trigger conditions:**
+- Session not found in the store
+- Session exists but `is_paused` is `False`
+
+**Display message:** `"Session is not paused."`
+
 ## HTTP Status Code Mapping
 
 Pydantic request body validation (blank `message` / `agent_id`) happens before domain logic and returns **422** by FastAPI default. Domain errors are caught in the endpoint handler:
@@ -85,6 +96,7 @@ Pydantic request body validation (blank `message` / `agent_id`) happens before d
 | Pydantic validation (blank `message`, blank `agent_id`) | 422 |
 | `ValidationError` | 400 |
 | `SessionNotFoundError` | 404 |
+| `SessionNotPausedError` | 400 |
 | `AuthenticationError` | 500 (uncaught → FastAPI default) |
 | `RateLimitError` | 500 (uncaught → FastAPI default) |
 | `LLMError` | 500 (uncaught → FastAPI default) |

--- a/projects/simple-agent-poc/docs/llm-integration.md
+++ b/projects/simple-agent-poc/docs/llm-integration.md
@@ -8,16 +8,18 @@ Source: `src/simple_agent_poc/application/ports.py`
 
 ```python
 class LLMClient(Protocol):
-    def complete(self, messages: list[Message]) -> LLMResponse: ...
-    def complete_stream(self, messages: list[Message]) -> Iterator[LLMStreamChunk]: ...
+    def complete(self, messages: list[Message], *, tools: list[ToolDefinition] | None = None) -> LLMResponse: ...
+    def complete_stream(self, messages: list[Message], *, tools: list[ToolDefinition] | None = None) -> Iterator[LLMStreamChunk]: ...
 
 class LLMClientFactory(Protocol):
     def __call__(self, agent_definition: AgentDefinition) -> LLMClient: ...
 ```
 
+The `tools` parameter carries tool definitions resolved from the agent's `tools` list. When `None` or empty, no tools are sent to the LLM.
+
 ## LiteLLMClientFactory
 
-Source: `src/simple_agent_poc/adapters/llm/litellm_client.py:255-267`
+Source: `src/simple_agent_poc/adapters/llm/litellm_client.py`
 
 ```python
 class LiteLLMClientFactory:
@@ -40,24 +42,31 @@ Uses `litellm.completion()` (OpenAI-compatible chat completions API).
 ### synchronous (`complete`)
 
 ```python
-response = completion(model=self.model, messages=messages, stream=False, **completion_params)
+response = completion(
+    model=self.model, messages=messages, tools=formatted_tools or None,
+    stream=False, **completion_params,
+)
 # returns response.choices[0].message.content
+# returns response.choices[0].message.tool_calls (if present)
 # returns response.usage (prompt_tokens, completion_tokens, total_tokens)
 ```
+
+Tool calls are parsed from `response.choices[0].message.tool_calls` into `list[ToolCall]`.
 
 ### streaming (`complete_stream`)
 
 ```python
 response = completion(
-    model=self.model, messages=messages, stream=True,
-    stream_options={"include_usage": True}, **completion_params
+    model=self.model, messages=messages, tools=formatted_tools or None,
+    stream=True, stream_options={"include_usage": True}, **completion_params,
 )
 for chunk in response:
-    # chunk.choices[0].delta.content  → content_delta
-    # chunk.usage                     → usage info (if present)
+    # chunk.choices[0].delta.content        → content_delta
+    # chunk.choices[0].delta.tool_calls     → tool_call_delta
+    # chunk.usage                           → usage info (if present)
 ```
 
-Usage info is included in the final chunk(s) via `stream_options={"include_usage": True}`.
+Tool call deltas are accumulated across chunks and assembled into full `ToolCall` objects. The delta format follows OpenAI's streaming tool call convention (incremental `index`, `id`, `function.name`, `function.arguments`).
 
 ## LiteLLMResponsesClient
 
@@ -67,22 +76,39 @@ Uses `litellm.responses()` (OpenAI Responses API).
 |:---|:---|
 | `responses` | `"responses"` |
 
+### Tool Format Transformation
+
+Responses API uses a different tool definition format than Completion API. Tools are transformed via `_transform_tools_for_responses()`:
+
+```python
+# Completion API format → Responses API format
+{"type": "function", "function": {"name": ..., "description": ..., "parameters": ...}}
+# becomes
+{"type": "function_call", "name": ..., "description": ..., "parameters": ...}
+```
+
+Messages are also transformed via `_transform_messages_for_responses()` to convert `tool_calls` and `tool_call_id` fields into the Responses API's expected format.
+
 ### synchronous (`complete`)
 
 ```python
-response = responses(input=messages, model=self.model, stream=False, **response_params)
+response = responses(input=transformed_messages, tools=transformed_tools or None,
+                     model=self.model, stream=False, **response_params)
 # returns response.output_text
+# tool calls are parsed from response.output items
 # returns response.usage (input_tokens, output_tokens, total_tokens)
 ```
 
-Note: `litellm.responses()` takes `input=` (not `messages=`). The input format includes `role` and `content` keys.
+Note: `litellm.responses()` takes `input=` (not `messages=`). Tool calls are extracted from `response.output` items with `type == "function_call"`.
 
 ### streaming (`complete_stream`)
 
 ```python
-response = responses(input=messages, model=self.model, stream=True, **response_params)
+response = responses(input=transformed_messages, tools=transformed_tools or None,
+                     model=self.model, stream=True, **response_params)
 for event in response:
     # event.delta            → content_delta
+    # tool call deltas       → tool_call_delta (accumulated into full calls)
     # event.response.usage   → usage info (if present)
 ```
 

--- a/projects/simple-agent-poc/docs/session.md
+++ b/projects/simple-agent-poc/docs/session.md
@@ -43,8 +43,8 @@ The system prompt is obtained from `AgentDefinition.format_system_prompt(current
 
 When `ask_user` is called in API mode, the session enters a paused state:
 
-- `pause_for_ask_user(tool_call)` — sets `is_paused = True`, saves the `ToolCall` and current round count.
-- `resume_with_answer(answer)` — clears paused state. The answer is injected as a tool result by the use case.
+- `pause_for_ask_user(tool_call, *, round_idx)` — sets `is_paused = True`, saves the `ToolCall` and current round count.
+- `resume_with_answer()` — clears paused state. The user's answer is injected as a tool result by the use case.
 
 Paused sessions are persisted via `SessionStore.save()`. The client resumes via `POST /api/chat/continue`. See [docs/api.md](api.md) and [docs/sse.md](sse.md) for the API flow.
 

--- a/projects/simple-agent-poc/docs/session.md
+++ b/projects/simple-agent-poc/docs/session.md
@@ -7,9 +7,12 @@ Sessions track conversation history across multiple requests. Each session is ti
 ```python
 @dataclass(slots=True)
 class ConversationSession:
-    session_id: str          # UUID hex string
+    session_id: str              # UUID hex string
     agent_id: str = "default"
-    messages: list[Message]   # [system, user, assistant, user, ...]
+    messages: list[Message]      # [system, user, assistant, tool, user, ...]
+    is_paused: bool = False      # True when waiting for ask_user answer
+    pending_tool_call: ToolCall | None = None  # saved tool call during pause
+    pending_round: int = 0       # remaining ReAct rounds to resume
 ```
 
 Source: `src/simple_agent_poc/core/session.py`
@@ -18,8 +21,10 @@ Source: `src/simple_agent_poc/core/session.py`
 
 1. Session is created with the system prompt as the first message (`role: "system"`).
 2. Each user turn appends a `role: "user"` message.
-3. The LLM response appends a `role: "assistant"` message.
-4. This cycle repeats for the lifetime of the session.
+3. The LLM response appends a `role: "assistant"` message (may include `tool_calls`).
+4. If the LLM calls a tool, a `role: "tool"` message is appended with the result and `tool_call_id`.
+5. The ReAct loop may repeat steps 3-4 up to `MAX_TOOL_ROUNDS` times.
+6. This cycle continues for the lifetime of the session.
 
 ### Session Creation
 
@@ -29,6 +34,19 @@ Source: `src/simple_agent_poc/core/session.py`
 - One initial message: `{"role": "system", "content": system_prompt}`
 
 The system prompt is obtained from `AgentDefinition.format_system_prompt(current_datetime=...)`, which replaces the `{current_datetime}` placeholder.
+
+### Tool Messages
+
+`append_tool_message(result, *, tool_call_id)` appends a message with `role: "tool"` and `content: result`, linked to the tool call by `tool_call_id`.
+
+### Pause / Resume
+
+When `ask_user` is called in API mode, the session enters a paused state:
+
+- `pause_for_ask_user(tool_call)` — sets `is_paused = True`, saves the `ToolCall` and current round count.
+- `resume_with_answer(answer)` — clears paused state. The answer is injected as a tool result by the use case.
+
+Paused sessions are persisted via `SessionStore.save()`. The client resumes via `POST /api/chat/continue`. See [docs/api.md](api.md) and [docs/sse.md](sse.md) for the API flow.
 
 ## SessionStore
 

--- a/projects/simple-agent-poc/docs/sse.md
+++ b/projects/simple-agent-poc/docs/sse.md
@@ -1,6 +1,6 @@
 # SSE Streaming
 
-Server-Sent Events (SSE) provide real-time streaming of agent responses via the `/api/chat/stream` and `/api/chat/continue` endpoints. Both CLI and HTTP use the same underlying `RunAgentUseCase.execute_stream()` generator — only the formatting differs.
+Server-Sent Events (SSE) provide real-time streaming of agent responses via the `/api/chat/stream` and `/api/chat/continue` endpoints. The `/api/chat/stream` endpoint uses `RunAgentUseCase.execute_stream()` and the `/api/chat/continue` endpoint uses `RunAgentUseCase.continue_stream()`. Both CLI and HTTP share the same underlying generators — only the SSE formatting differs.
 
 ## SSE Format
 

--- a/projects/simple-agent-poc/docs/sse.md
+++ b/projects/simple-agent-poc/docs/sse.md
@@ -1,6 +1,6 @@
 # SSE Streaming
 
-Server-Sent Events (SSE) provide real-time streaming of agent responses via the `/api/chat/stream` endpoint. Both CLI and HTTP use the same underlying `RunAgentUseCase.execute_stream()` generator — only the formatting differs.
+Server-Sent Events (SSE) provide real-time streaming of agent responses via the `/api/chat/stream` and `/api/chat/continue` endpoints. Both CLI and HTTP use the same underlying `RunAgentUseCase.execute_stream()` generator — only the formatting differs.
 
 ## SSE Format
 
@@ -25,6 +25,51 @@ data: {"content": "Hello"}
 
 Emitted for each chunk of text received from the LLM. The `content` field contains the incremental text.
 
+### `tool_call` — Tool Call Initiated
+
+```text
+event: tool_call
+data: {"call_id": "call_abc123", "name": "concat", "arguments": "{\"a\":\"Hello\",\"b\":\"World\"}"}
+```
+
+Emitted when the LLM requests a tool call. Contains:
+
+| Field | Type | Description |
+|:---|:---|:---|
+| `call_id` | `str` | Unique ID for this tool call |
+| `name` | `str` | Tool name (e.g. `"concat"`, `"get_current_time"`, `"ask_user"`) |
+| `arguments` | `str` | JSON-encoded arguments for the tool |
+
+### `tool_result` — Tool Execution Completed
+
+```text
+event: tool_result
+data: {"call_id": "call_abc123", "name": "concat", "result": "HelloWorld"}
+```
+
+Emitted after a tool executes. Contains:
+
+| Field | Type | Description |
+|:---|:---|:---|
+| `call_id` | `str` | Matches the `tool_call` event's `call_id` |
+| `name` | `str` | Tool name |
+| `result` | `str` | The tool's output (JSON string for structured results) |
+
+### `paused` — Session Paused (ask\_user)
+
+```text
+event: paused
+data: {"session_id": "abc123...", "call_id": "call_def456", "question": "What is your preference?"}
+```
+
+Emitted when `ask_user` is called in API mode. The SSE stream disconnects after this event. The client must send the answer via `POST /api/chat/continue` to resume. Contains:
+
+| Field | Type | Description |
+|:---|:---|:---|
+| `session_id` | `str` | Session ID to use for the continue request |
+| `call_id` | `str` | Tool call ID (for reference) |
+| `question` | `str` | The question to display to the user |
+
 ### `complete` — Stream Finished
 
 ```text
@@ -48,7 +93,7 @@ event: done
 data: {}
 ```
 
-Emitted after `complete` to signal the end of the SSE stream. Contains an empty JSON object.
+Emitted after `complete` or `paused` to signal the end of the SSE stream. Contains an empty JSON object.
 
 ### `error` — Error
 
@@ -65,39 +110,34 @@ Emitted when an error occurs during streaming. Contains:
 
 ## HTTP to SSE Mapping
 
-In `adapters/http/api.py`, the `chat_stream` endpoint wraps `execute_stream()` in a `StreamingResponse` generator:
-
-```python
-def event_stream():
-    for event in run_agent.execute_stream(request):
-        if isinstance(event, ContentDelta):
-            yield f"event: delta\ndata: {json.dumps({'content': event.delta})}\n\n"
-        elif isinstance(event, StreamComplete):
-            yield f"event: complete\ndata: {json.dumps(asdict(event))}\n\n"
-    yield "event: done\ndata: {}\n\n"
-```
+In `adapters/http/api.py`, the `chat_stream` and `chat_continue` endpoints wrap `execute_stream()` / `continue_stream()` in a `StreamingResponse` generator. See the source code for the exact mapping of each event type.
 
 Errors caught:
 - `SessionNotFoundError` → `event: error` with 404 detail
 - `ValidationError` → `event: error` with 400 detail
+- `SessionNotPausedError` → `event: error`
 - Generic `Exception` → `event: error` with the error string
 
-## execute_stream() Generator Behavior
+## execute\_stream() Generator Behavior
 
-Source: `src/simple_agent_poc/application/use_cases.py:60-108`
+Source: `src/simple_agent_poc/application/use_cases.py`
 
 1. Validates the message.
 2. Loads or creates a session (same as `execute()`).
 3. Validates `agent_id` immutability.
 4. Appends the user message to the session.
-5. Opens the LLM stream via `llm_client.complete_stream(messages)`.
+5. Opens the LLM stream via `llm_client.complete_stream(messages, tools=...)`.
 6. For each chunk:
    - If `content_delta` is present → accumulates text, yields `ContentDelta(delta=...)`.
-   - If `usage` is present → stores it in `usage_from_stream`.
+   - If `tool_call_delta` is present → accumulates into a pending `ToolCall`.
 7. After the stream ends:
-   - Appends the accumulated text to the session as an assistant message.
-   - Yields `StreamComplete(...)` with the session metadata.
-8. In `finally`: saves the session to the session store.
+   - If tool calls were accumulated → executes each tool, yields `ToolCallEvent` / `ToolResultEvent`.
+   - If a tool call is `ask_user` in API mode → yields `SessionPaused`, saves session, and returns (SSE disconnects).
+   - If a tool call is `ask_user` in CLI mode → yields `ToolCallEvent` and waits for `generator.send(answer)`.
+   - If no tool calls → appends accumulated text as assistant message.
+   - Loops up to `MAX_TOOL_ROUNDS = 5` for multi-round tool calls.
+8. Yields `StreamComplete(...)` with session metadata.
+9. In `finally`: saves the session to the session store.
 
 ### Error Handling During Streaming
 
@@ -109,9 +149,21 @@ If the stream raises an exception:
 
 The `finally` block ensures the session is always persisted, even on failure.
 
+## continue\_stream() — Resuming Paused Sessions
+
+Source: `src/simple_agent_poc/application/use_cases.py`
+
+1. Loads the session by `session_id`. Returns error if not found or not paused.
+2. Injects the user's answer as a tool result message.
+3. Yields `ToolResultEvent` for the `ask_user` call.
+4. Resumes the ReAct loop with the remaining rounds.
+5. Yields `StreamComplete` on finish.
+
 ## CLI Streaming
 
 In CLI mode, `show_streaming_response()` consumes the same `execute_stream()` generator:
 - Displays `ContentDelta` as live text on stdout.
-- On `StreamComplete`, prints a stats line (model, time, tokens).
+- On `ToolCallEvent`: displays the tool call, and for `ask_user` prompts for user input and injects via `generator.send(answer)`.
+- On `ToolResultEvent`: displays the tool result.
+- On `StreamComplete`: prints a stats line (model, time, tokens).
 - See [docs/cli.md](cli.md) for details.

--- a/projects/simple-agent-poc/docs/testing.md
+++ b/projects/simple-agent-poc/docs/testing.md
@@ -16,15 +16,19 @@ All tests live under `tests/`:
 | `test_api.py` | HTTP API endpoint integration tests | 262 |
 | `test_application.py` | Use case tests | 272 |
 | `test_cli.py` | CLI adapter tests | 216 |
-| `test_http_stream_api.py` | HTTP SSE streaming tests | 151 |
+| `test_http_stream_api.py` | HTTP SSE streaming tests (incl. continue) | 205 |
 | `test_interfaces.py` | Protocol interface tests | 35 |
-| `test_llm_client.py` | LiteLLM client tests (largest) | 648 |
+| `test_llm_client.py` | LiteLLM client tests (incl. tool calls) | 648 |
 | `test_main.py` | Entry point tests | 77 |
 | `test_main_api.py` | API entry point tests | 22 |
-| `test_renderer.py` | CLI renderer tests | 151 |
-| `test_session.py` | Session entity tests | 62 |
+| `test_renderer.py` | CLI renderer tests (incl. ask_user) | 151 |
+| `test_session.py` | Session entity tests (incl. pause/resume) | 62 |
+| `test_tools.py` | Built-in tool tests | 57 |
 | `test_types.py` | Type definition tests | 87 |
-| `test_use_cases_stream.py` | Streaming use case tests | 335 |
+| `test_use_cases.py` | Tool call ReAct loop tests | 256 |
+| `test_use_cases_stream.py` | Streaming use case tests (incl. tool calls) | 335 |
+
+Line counts are approximate and change as tests are added. See the test files directly for current content.
 
 ## Running Tests
 
@@ -58,6 +62,7 @@ HTML output goes to `htmlcov/`.
 
 Tests mock external dependencies rather than making real LLM calls:
 - `LLMClient` is mocked in use case and adapter tests.
+- `ToolExecutor` is mocked in use case tests that test tool orchestration.
 - LiteLLM functions (`completion`, `responses`) are patched in `test_llm_client.py`.
 - `stdin`/`stdout` are mocked in CLI tests.
 
@@ -69,4 +74,4 @@ For end-to-end verification against a live LLM:
 uv run dev
 ```
 
-Interact with the agent via the CLI. Verify response quality and streaming behavior.
+Interact with the agent via the CLI. Verify response quality, tool call behavior, and streaming behavior.

--- a/projects/simple-agent-poc/docs/types.md
+++ b/projects/simple-agent-poc/docs/types.md
@@ -216,8 +216,8 @@ Factory method: `start(*, session_id, agent_id, system_prompt)`.
 Methods:
 - `append_user_message(content)` / `append_assistant_message(content)` — append user/assistant messages
 - `append_tool_message(result, *, tool_call_id)` — append a tool result message (role: `"tool"`)
-- `pause_for_ask_user(tool_call)` — set `is_paused=True`, save the pending tool call
-- `resume_with_answer(answer)` — clear paused state
+- `pause_for_ask_user(tool_call, *, round_idx)` — set `is_paused=True`, save the pending tool call and round count
+- `resume_with_answer()` — clear paused state
 
 ### AgentDefinition
 
@@ -257,7 +257,7 @@ Source: `src/simple_agent_poc/application/ports.py`
 ```python
 class ToolExecutor(Protocol):
     def execute(self, tool_call: ToolCall) -> str: ...
-    def get_definitions(self) -> list[ToolDefinition]: ...
+    def get_definitions(self, tool_names: list[str], /) -> list[ToolDefinition]: ...
 ```
 
 Implemented by `BuiltinToolRegistry` in `src/simple_agent_poc/adapters/tools/registry.py`.

--- a/projects/simple-agent-poc/docs/types.md
+++ b/projects/simple-agent-poc/docs/types.md
@@ -1,6 +1,6 @@
 # Type Definitions
 
-All core types and DTOs used across the application.
+Core types and DTOs used across the application. This document describes the conceptual purpose and relationships of each type. For exact signatures, see the canonical source files referenced in each section.
 
 ## Core Types
 
@@ -9,15 +9,46 @@ Source: `src/simple_agent_poc/core/types.py`
 ### MessageRole
 
 ```python
-MessageRole = Literal["system", "user", "assistant"]
+MessageRole = Literal["system", "user", "assistant", "tool"]
 ```
+
+The `"tool"` role is used for tool result messages appended to the conversation after a tool call.
+
+### ToolCallFunction / ToolCall
+
+```python
+class ToolCallFunction(TypedDict):   # {name, arguments}
+class ToolCall(TypedDict):           # {id, type: "function", function: ToolCallFunction}
+```
+
+Represents a tool call requested by the LLM. `arguments` is a JSON string.
+
+### ToolFunctionDef / ToolDefinition
+
+```python
+class ToolFunctionDef(TypedDict):    # {name, description, parameters}
+class ToolDefinition(TypedDict):     # {type: "function", function: ToolFunctionDef}
+```
+
+Defines a tool's JSON Schema that is sent to the LLM. `parameters` is a JSON Schema object describing the tool's input.
+
+### ToolCallFunctionDelta / ToolCallDelta
+
+```python
+class ToolCallFunctionDelta(TypedDict):  # {name?, arguments?}
+class ToolCallDelta(TypedDict):          # {index, id?, type, function: ToolCallFunctionDelta}
+```
+
+Streaming deltas for incremental tool call construction. The LLM emits these chunks when streaming a tool call; they are accumulated into a full `ToolCall`.
 
 ### Message
 
 ```python
 class Message(TypedDict):
-    role: MessageRole
+    role: MessageRole            # "system" | "user" | "assistant" | "tool"
     content: str
+    tool_calls: NotRequired[list[ToolCall]]   # present on assistant messages that call tools
+    tool_call_id: NotRequired[str]            # present on tool messages, links to the call
 ```
 
 ### Usage
@@ -37,18 +68,37 @@ class LLMResponse(TypedDict):
     usage: Usage
     model: str
     response_time: float
+    tool_calls: NotRequired[list[ToolCall]]
 ```
+
+`content` may be empty when the LLM returns only tool calls. `tool_calls` is present when the LLM requests tool execution.
 
 ### LLMStreamChunk
 
 ```python
 class LLMStreamChunk(TypedDict):
     content_delta: str | None
+    tool_call_delta: NotRequired[ToolCallDelta]
     usage: NotRequired[Usage]
 ```
 
-- `content_delta`: The incremental text. `None` when the chunk contains only usage info.
+- `content_delta`: Incremental text. `None` when the chunk contains only tool call or usage info.
+- `tool_call_delta`: Present during streaming tool call construction.
 - `usage`: Token usage. Only present in final chunks that include usage metadata.
+
+### Domain Errors
+
+```
+AgentError (base)
+├── AuthenticationError
+├── RateLimitError
+├── LLMError
+├── ValidationError
+├── SessionNotFoundError
+└── SessionNotPausedError
+```
+
+`SessionNotPausedError` — raised when `POST /api/chat/continue` is called on a session that is not in paused state. See [docs/errors.md](errors.md).
 
 ## Application DTOs
 
@@ -64,6 +114,19 @@ class RunAgentRequest:
     agent_id: str = "default"
 ```
 
+### ToolCallRecord
+
+```python
+@dataclass(frozen=True, slots=True)
+class ToolCallRecord:
+    call_id: str
+    name: str
+    arguments: str
+    result: str
+```
+
+A single tool call and its result. Collected during agent execution and included in the final response.
+
 ### RunAgentResponse
 
 ```python
@@ -74,36 +137,33 @@ class RunAgentResponse:
     model: str
     response_time: float
     session_id: str
+    tool_call_history: list[ToolCallRecord]
 ```
 
-Factory method:
-```python
-@classmethod
-def from_llm_response(cls, response: LLMResponse, *, session_id: str) -> "RunAgentResponse"
-```
+Factory method: `from_llm_response(response, *, session_id, tool_call_history=None)`.
 
-### ContentDelta
+### Stream Events
+
+These are yielded by `execute_stream()` and `continue_stream()` generators:
+
+| Event | Description |
+|:---|:---|
+| `ContentDelta(delta)` | Partial text chunk during streaming |
+| `ToolCallEvent(call_id, name, arguments)` | Agent has initiated a tool call |
+| `ToolResultEvent(call_id, name, result)` | Tool execution completed |
+| `SessionPaused(session_id, call_id, question)` | `ask_user` called in API mode; stream pauses |
+| `StreamComplete(session_id, usage, model, response_time)` | Stream finished successfully |
+
+### ContinueRequest
 
 ```python
 @dataclass(frozen=True, slots=True)
-class ContentDelta:
-    delta: str
-```
-
-Emitted during streaming for each text chunk.
-
-### StreamComplete
-
-```python
-@dataclass(frozen=True, slots=True)
-class StreamComplete:
+class ContinueRequest:
     session_id: str
-    usage: Usage | None
-    model: str
-    response_time: float
+    answer: str
 ```
 
-Emitted when a stream finishes successfully. `usage` may be `None` if the LLM did not provide token counts.
+Request DTO for `POST /api/chat/continue`. Contains the user's answer to an `ask_user` question.
 
 ## HTTP Schemas
 
@@ -113,15 +173,12 @@ Source: `src/simple_agent_poc/adapters/http/api.py`
 
 ```python
 class ChatRequest(BaseModel):
-    model_config = ConfigDict(str_strip_whitespace=True)
     message: str
     session_id: str | None = None
     agent_id: str = "default"
 ```
 
-Validators:
-- `message`: rejected if blank after stripping
-- `agent_id`: rejected if blank after stripping
+Validators reject blank `message` and blank `agent_id` after stripping.
 
 ### ChatResponse
 
@@ -132,19 +189,16 @@ class ChatResponse(BaseModel):
     model: str
     response_time: float
     session_id: str
+    tool_calls: list[ToolCallRecord]
 ```
 
-Factory method:
-```python
-@classmethod
-def from_use_case_response(cls, response: RunAgentResponse) -> "ChatResponse"
-```
+Factory method: `from_use_case_response(response)`.
 
 ## Entity
 
-Source: `src/simple_agent_poc/core/session.py`
-
 ### ConversationSession
+
+Source: `src/simple_agent_poc/core/session.py`
 
 ```python
 @dataclass(slots=True)
@@ -152,19 +206,22 @@ class ConversationSession:
     session_id: str
     agent_id: str = "default"
     messages: list[Message] = field(default_factory=list)
+    is_paused: bool = False
+    pending_tool_call: ToolCall | None = None
+    pending_round: int = 0
 ```
 
-Factory method:
-```python
-@classmethod
-def start(cls, *, session_id: str, agent_id: str, system_prompt: str) -> "ConversationSession"
-```
+Factory method: `start(*, session_id, agent_id, system_prompt)`.
 
 Methods:
-- `append_user_message(content: str) -> None`
-- `append_assistant_message(content: str) -> None`
+- `append_user_message(content)` / `append_assistant_message(content)` — append user/assistant messages
+- `append_tool_message(result, *, tool_call_id)` — append a tool result message (role: `"tool"`)
+- `pause_for_ask_user(tool_call)` — set `is_paused=True`, save the pending tool call
+- `resume_with_answer(answer)` — clear paused state
 
 ### AgentDefinition
+
+Source: `src/simple_agent_poc/core/agent_definition.py`
 
 ```python
 @dataclass(frozen=True, slots=True)
@@ -173,15 +230,12 @@ class AgentDefinition:
     model: str
     system_prompt: str
     temperature: float | None = None
-    tools: list[dict[str, Any]] = field(default_factory=list)
+    tools: list[str] = field(default_factory=list)
     api_type: Literal["completion", "responses"] = "completion"
     stream: bool = False
 ```
 
-Method:
-```python
-def format_system_prompt(self, *, current_datetime: str) -> str
-```
+Method: `format_system_prompt(*, current_datetime)` — replaces `{current_datetime}` placeholder.
 
 ### AgentDefinitionRegistry
 
@@ -191,15 +245,31 @@ class AgentDefinitionRegistry:
     _definitions: Mapping[str, AgentDefinition]
 ```
 
-Factory methods:
+Factory methods: `from_yaml_file(path)`, `from_mapping(data)`.
+Query method: `get(agent_id)`.
+
+## Ports (Protocols)
+
+Source: `src/simple_agent_poc/application/ports.py`
+
+### ToolExecutor
+
 ```python
-@classmethod
-def from_yaml_file(cls, path: str | Path) -> "AgentDefinitionRegistry"
-@classmethod
-def from_mapping(cls, data: object) -> "AgentDefinitionRegistry"
+class ToolExecutor(Protocol):
+    def execute(self, tool_call: ToolCall) -> str: ...
+    def get_definitions(self) -> list[ToolDefinition]: ...
 ```
 
-Query method:
+Implemented by `BuiltinToolRegistry` in `src/simple_agent_poc/adapters/tools/registry.py`.
+
+### LLMClient
+
 ```python
-def get(self, agent_id: str) -> AgentDefinition
+class LLMClient(Protocol):
+    def complete(self, messages: list[Message], *, tools: list[ToolDefinition] | None = None) -> LLMResponse: ...
+    def complete_stream(self, messages: list[Message], *, tools: list[ToolDefinition] | None = None) -> Iterator[LLMStreamChunk]: ...
 ```
+
+### LLMClientFactory / SessionStore
+
+See [docs/llm-integration.md](llm-integration.md) and [docs/session.md](session.md).


### PR DESCRIPTION
## Issues

Refs #904
Refs #905

## Why

#904 と #905 でツールコールの実装が入ったが、docs/ が全く追従していなかった。また `agents.yaml` と docs/ で内容が重複しており、二重管理になっていた。

## Summary

全11のドキュメントファイルを実装に追従させた。特に以下を重点的に対応：

- **誤情報の修正**: `agent-definition.md` の `tools` を「将来の予約」→ 実装済みに修正。型誤記 (`list[dict]` → `list[str]`) も修正
- **欠落情報の追加**: `types.md` にツール関連全型、`sse.md` に `tool_call`/`tool_result`/`paused` イベント、`api.md` に `/api/chat/continue` エンドポイントなど
- **二重管理の解消**: コードや YAML ファイルが canonical source となる情報はドキュメントに再掲せず、参照に切り替え

## Changes

- `agent-definition.md` — tools 型修正、重複削除、`agents.yaml` を canonical として参照
- `types.md` — ToolCall/ToolDefinition 全型、ToolCallEvent/ToolResultEvent/SessionPaused/ContinueRequest、SessionNotPausedError を追加。既存型の新フィールド反映
- `sse.md` — tool_call/tool_result/paused イベント追加、execute_stream() のツール分岐ロジック、continue_stream() 追加
- `api.md` — POST /api/chat/continue エンドポイント、ChatResponse.tool_calls 追加
- `session.md` — is_paused/pending_tool_call/pending_round フィールド、pause_for_ask_user/resume_with_answer/append_tool_message メソッド追加
- `llm-integration.md` — complete/complete_stream の tools パラメータ、ツール変換ロジック追加
- `cli.md` — ToolCallEvent/ToolResultEvent 表示、ask_user_question()、generator.send() パターン追加
- `errors.md` — SessionNotPausedError 追加
- `bootstrap.md` — create_default_tool_executor()、is_api_context パラメータ追加
- `testing.md` — test_tools.py/test_use_cases.py 追加、行数更新
- `architecture.md` — adapters/tools/ ディレクトリと境界ルール追加

## Verification

- `ruff check` — All checks passed
- `ty check` — All checks passed
- `pytest` — 158 passed
