### PR TITLE
feat: add /chat-compare parallel model comparison page

### DIFF
--- a/projects/portfolio/src/client/components/chat-compare/compare-column.tsx
+++ b/projects/portfolio/src/client/components/chat-compare/compare-column.tsx
@@ -27,9 +27,6 @@ export function CompareColumn({ state }: CompareColumnProps) {
             {error}
           </div>
         )}
-        {status === 'idle' && !error && (
-          <p className='text-center text-gray-400 text-sm dark:text-gray-500'>応答を待っています...</p>
-        )}
         {(status === 'streaming' || status === 'done' || status === 'idle') && (
           <>
             {reasoningContent && (

--- a/projects/portfolio/src/client/components/chat-compare/compare-column.tsx
+++ b/projects/portfolio/src/client/components/chat-compare/compare-column.tsx
@@ -1,0 +1,76 @@
+import type { ModelStreamState } from './hooks/use-compare-state'
+
+interface CompareColumnProps {
+  state: ModelStreamState
+}
+
+function formatResponseTime(ms: number): string {
+  if (ms < 1000) return `${ms}ms`
+  return `${(ms / 1000).toFixed(1)}s`
+}
+
+export function CompareColumn({ state }: CompareColumnProps) {
+  const { model, status, content, reasoningContent, usage, finishReason, responseTimeMs, error } = state
+  const showMeta = status === 'done' && (finishReason || usage || responseTimeMs !== null)
+
+  return (
+    <div className='flex min-w-0 flex-1 flex-col overflow-hidden border-r border-gray-200 last:border-r-0 dark:border-gray-700'>
+      <div className='shrink-0 overflow-hidden text-ellipsis whitespace-nowrap border-b border-gray-200 px-3 py-2 text-center font-medium text-sm dark:border-gray-700 dark:text-gray-200'>
+        {model}
+        {status === 'streaming' && (
+          <span className='ml-1 inline-block h-2 w-2 animate-pulse rounded-full bg-primary-600 align-middle' />
+        )}
+      </div>
+      <div className='min-h-0 flex-1 overflow-y-auto px-3 py-2'>
+        {error && (
+          <div className='rounded-md bg-red-50 p-2 text-red-600 text-sm dark:bg-red-900/30 dark:text-red-400'>
+            {error}
+          </div>
+        )}
+        {status === 'idle' && !error && (
+          <p className='text-center text-gray-400 text-sm dark:text-gray-500'>応答を待っています...</p>
+        )}
+        {(status === 'streaming' || status === 'done' || status === 'idle') && (
+          <>
+            {reasoningContent && (
+              <details className='mb-2'>
+                <summary className='cursor-pointer text-xs text-gray-400 dark:text-gray-500'>
+                  Reasoning ({reasoningContent.length} chars)
+                </summary>
+                <pre className='mt-1 whitespace-pre-wrap break-all text-xs text-gray-500 dark:text-gray-400'>
+                  {reasoningContent}
+                </pre>
+              </details>
+            )}
+            {content ? (
+              <p className='whitespace-pre-wrap break-all text-sm text-gray-900 dark:text-gray-100'>{content}</p>
+            ) : status === 'streaming' ? (
+              <p className='animate-pulse text-gray-400 text-sm dark:text-gray-500'>...</p>
+            ) : null}
+          </>
+        )}
+        {showMeta && (
+          <div className='mt-3 border-t border-gray-100 pt-2 dark:border-gray-700'>
+            <div className='flex flex-wrap gap-1 text-xs text-gray-400 dark:text-gray-500'>
+              {finishReason && (
+                <span className='rounded bg-gray-100 px-1.5 py-0.5 dark:bg-gray-700'>finish: {finishReason}</span>
+              )}
+              {responseTimeMs !== null && (
+                <span className='rounded bg-gray-100 px-1.5 py-0.5 dark:bg-gray-700'>
+                  {formatResponseTime(responseTimeMs)}
+                </span>
+              )}
+              {usage && (
+                <span className='rounded bg-gray-100 px-1.5 py-0.5 dark:bg-gray-700'>
+                  in:{usage.promptTokens ?? '-'} / out:{usage.completionTokens ?? '-'} / total:
+                  {usage.totalTokens ?? '-'}
+                  {usage.reasoningTokens !== undefined && <> / reas:{usage.reasoningTokens}</>}
+                </span>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/projects/portfolio/src/client/components/chat-compare/compare-column.tsx
+++ b/projects/portfolio/src/client/components/chat-compare/compare-column.tsx
@@ -1,4 +1,5 @@
 import type { ModelStreamState } from './hooks/use-compare-state'
+import type { ApiChatMessage, ImageContent, TextContent } from '#/types'
 
 interface CompareColumnProps {
   state: ModelStreamState
@@ -9,8 +10,51 @@ function formatResponseTime(ms: number): string {
   return `${(ms / 1000).toFixed(1)}s`
 }
 
+function renderMessageContent(content: ApiChatMessage['content']) {
+  if (typeof content === 'string') {
+    return content
+  }
+
+  return content.map((value: TextContent | ImageContent, index) => {
+    if (value.type === 'text') {
+      return <div key={index}>{value.text}</div>
+    }
+
+    return (
+      <img
+        key={index}
+        src={value.image_url.url}
+        alt='upload-img'
+        className='my-1 max-w-3xs rounded-md border border-gray-200 dark:border-gray-600'
+      />
+    )
+  })
+}
+
+function CompareMessage({ message }: { message: ApiChatMessage }) {
+  if (message.role === 'system') {
+    return null
+  }
+
+  if (message.role === 'user') {
+    return (
+      <div className='message mt-2 text-right'>
+        <div className='inline-block max-w-full whitespace-pre-wrap break-all rounded-t-3xl rounded-l-3xl bg-gray-100 px-4 py-2 text-left text-sm text-gray-900 dark:bg-gray-600 dark:text-white'>
+          {renderMessageContent(message.content)}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className='message mt-2 text-left'>
+      <p className='whitespace-pre-wrap break-all text-sm text-gray-900 dark:text-gray-100'>{message.content}</p>
+    </div>
+  )
+}
+
 export function CompareColumn({ state }: CompareColumnProps) {
-  const { model, status, content, reasoningContent, usage, finishReason, responseTimeMs, error } = state
+  const { model, status, messages, content, reasoningContent, usage, finishReason, responseTimeMs, error } = state
   const showMeta = status === 'done' && (finishReason || usage || responseTimeMs !== null)
 
   return (
@@ -22,15 +66,18 @@ export function CompareColumn({ state }: CompareColumnProps) {
         )}
       </div>
       <div className='min-h-0 flex-1 overflow-y-auto px-3 py-2'>
+        {messages.map((message, index) => (
+          <CompareMessage key={`${message.role}-${index}`} message={message} />
+        ))}
         {error && (
-          <div className='rounded-md bg-red-50 p-2 text-red-600 text-sm dark:bg-red-900/30 dark:text-red-400'>
+          <div className='mt-2 rounded-md bg-red-50 p-2 text-red-600 text-sm dark:bg-red-900/30 dark:text-red-400'>
             {error}
           </div>
         )}
-        {(status === 'streaming' || status === 'done' || status === 'idle') && (
+        {status === 'streaming' && (
           <>
             {reasoningContent && (
-              <details className='mb-2'>
+              <details className='mt-2 mb-2'>
                 <summary className='cursor-pointer text-xs text-gray-400 dark:text-gray-500'>
                   Reasoning ({reasoningContent.length} chars)
                 </summary>
@@ -40,10 +87,10 @@ export function CompareColumn({ state }: CompareColumnProps) {
               </details>
             )}
             {content ? (
-              <p className='whitespace-pre-wrap break-all text-sm text-gray-900 dark:text-gray-100'>{content}</p>
-            ) : status === 'streaming' ? (
+              <p className='mt-2 whitespace-pre-wrap break-all text-sm text-gray-900 dark:text-gray-100'>{content}</p>
+            ) : (
               <p className='animate-pulse text-gray-400 text-sm dark:text-gray-500'>...</p>
-            ) : null}
+            )}
           </>
         )}
         {showMeta && (

--- a/projects/portfolio/src/client/components/chat-compare/compare-column.tsx
+++ b/projects/portfolio/src/client/components/chat-compare/compare-column.tsx
@@ -73,15 +73,7 @@ function CopyMessageButton({ copied, onClick }: CopyMessageButtonProps) {
   )
 }
 
-function CompareMessage({
-  copied,
-  message,
-  onCopy,
-}: {
-  copied: boolean
-  message: ApiChatMessage
-  onCopy: () => void
-}) {
+function CompareMessage({ copied, message, onCopy }: { copied: boolean; message: ApiChatMessage; onCopy: () => void }) {
   if (message.role === 'system') {
     return null
   }

--- a/projects/portfolio/src/client/components/chat-compare/compare-column.tsx
+++ b/projects/portfolio/src/client/components/chat-compare/compare-column.tsx
@@ -1,5 +1,9 @@
-import type { ModelStreamState } from './hooks/use-compare-state'
+import { useCallback, useState } from 'react'
+import { copyToClipboard } from '#/client/components/chat/copy-to-clipboard'
+import { CheckIcon } from '#/client/components/svg/check-icon'
+import { CopyIcon } from '#/client/components/svg/copy-icon'
 import type { ApiChatMessage, ImageContent, TextContent } from '#/types'
+import type { ModelStreamState } from './hooks/use-compare-state'
 
 interface CompareColumnProps {
   state: ModelStreamState
@@ -31,7 +35,53 @@ function renderMessageContent(content: ApiChatMessage['content']) {
   })
 }
 
-function CompareMessage({ message }: { message: ApiChatMessage }) {
+interface CopyMessageButtonProps {
+  copied: boolean
+  onClick: () => void
+}
+
+function CopyMessageButton({ copied, onClick }: CopyMessageButtonProps) {
+  return (
+    <button
+      type='button'
+      className={`relative flex h-8 w-8 cursor-pointer items-center justify-center rounded-full text-gray-500 transition-[background-color,color,transform] duration-200 ease-out focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 dark:text-gray-300 dark:focus-visible:ring-gray-500 disabled:cursor-default ${
+        copied
+          ? 'text-emerald-600 dark:text-emerald-400'
+          : 'hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-700 dark:hover:text-white'
+      }`}
+      onClick={onClick}
+      disabled={copied}
+      aria-label={copied ? 'Copied' : 'Copy message'}
+    >
+      <span
+        aria-hidden='true'
+        className={`absolute transition-[opacity,transform] duration-200 ease-out motion-reduce:transition-none ${
+          copied ? '-translate-y-0.5 scale-90 opacity-0' : 'translate-y-0 scale-100 opacity-100'
+        }`}
+      >
+        <CopyIcon size={20} className='stroke-current' />
+      </span>
+      <span
+        aria-hidden='true'
+        className={`absolute transition-[opacity,transform] duration-200 ease-out motion-reduce:transition-none ${
+          copied ? 'translate-y-0 scale-100 opacity-100' : 'translate-y-0.5 scale-90 opacity-0'
+        }`}
+      >
+        <CheckIcon size={20} className='stroke-current' />
+      </span>
+    </button>
+  )
+}
+
+function CompareMessage({
+  copied,
+  message,
+  onCopy,
+}: {
+  copied: boolean
+  message: ApiChatMessage
+  onCopy: () => void
+}) {
   if (message.role === 'system') {
     return null
   }
@@ -47,8 +97,15 @@ function CompareMessage({ message }: { message: ApiChatMessage }) {
   }
 
   return (
-    <div className='message mt-2 text-left'>
+    <div className='message group mt-2 text-left'>
       <p className='whitespace-pre-wrap break-all text-sm text-gray-900 dark:text-gray-100'>{message.content}</p>
+      <div
+        className={`mt-1 ml-1 flex items-center gap-1 transition-opacity duration-200 ease-out motion-reduce:transition-none md:opacity-0 md:group-hover:opacity-100 ${
+          copied ? 'opacity-100' : ''
+        }`}
+      >
+        <CopyMessageButton copied={copied} onClick={onCopy} />
+      </div>
     </div>
   )
 }
@@ -56,6 +113,18 @@ function CompareMessage({ message }: { message: ApiChatMessage }) {
 export function CompareColumn({ state }: CompareColumnProps) {
   const { model, status, messages, content, reasoningContent, usage, finishReason, responseTimeMs, error } = state
   const showMeta = status === 'done' && (finishReason || usage || responseTimeMs !== null)
+  const [copiedId, setCopiedId] = useState('')
+  const copyMessage = useCallback(async (message: string, index: number) => {
+    const id = `compare_${index}`
+    setCopiedId(id)
+    try {
+      await copyToClipboard(message)
+      await new Promise((resolve) => setTimeout(resolve, 3000))
+    } catch (error) {
+      alert(error)
+    }
+    setCopiedId('')
+  }, [])
 
   return (
     <div className='flex min-w-0 flex-1 flex-col overflow-hidden border-r border-gray-200 last:border-r-0 dark:border-gray-700'>
@@ -67,7 +136,16 @@ export function CompareColumn({ state }: CompareColumnProps) {
       </div>
       <div className='min-h-0 flex-1 overflow-y-auto px-3 py-2'>
         {messages.map((message, index) => (
-          <CompareMessage key={`${message.role}-${index}`} message={message} />
+          <CompareMessage
+            key={`${message.role}-${index}`}
+            copied={copiedId === `compare_${index}`}
+            message={message}
+            onCopy={() => {
+              if (message.role === 'assistant') {
+                void copyMessage(message.content, index)
+              }
+            }}
+          />
         ))}
         {error && (
           <div className='mt-2 rounded-md bg-red-50 p-2 text-red-600 text-sm dark:bg-red-900/30 dark:text-red-400'>

--- a/projects/portfolio/src/client/components/chat-compare/compare-composer.tsx
+++ b/projects/portfolio/src/client/components/chat-compare/compare-composer.tsx
@@ -4,7 +4,8 @@ import { StopIcon } from '#/client/components/svg/stop-icon'
 
 interface CompareComposerProps {
   value: string
-  disabled: boolean
+  inputDisabled: boolean
+  submitDisabled: boolean
   loading: boolean
   onChangeInput: (event: ChangeEvent<HTMLTextAreaElement>) => void
   onKeyDown: (event: KeyboardEvent<HTMLTextAreaElement>) => void
@@ -15,7 +16,8 @@ interface CompareComposerProps {
 
 export function CompareComposer({
   value,
-  disabled,
+  inputDisabled,
+  submitDisabled,
   loading,
   onChangeInput,
   onKeyDown,
@@ -37,14 +39,14 @@ export function CompareComposer({
 
   const handleKeyDown = useCallback(
     (event: KeyboardEvent<HTMLTextAreaElement>) => {
-      if (event.key === 'Enter' && !event.shiftKey && !isComposing && !loading && value.trim().length > 0) {
+      if (event.key === 'Enter' && !event.shiftKey && !isComposing && !submitDisabled && value.trim().length > 0) {
         event.preventDefault()
         onSubmit()
         return
       }
       onKeyDown(event)
     },
-    [isComposing, loading, onSubmit, onKeyDown, value]
+    [isComposing, onSubmit, onKeyDown, submitDisabled, value]
   )
 
   return (
@@ -57,8 +59,8 @@ export function CompareComposer({
           onCompositionStart={handleCompositionStart}
           onCompositionEnd={handleCompositionEnd}
           rows={2}
-          placeholder={loading ? '応答を待っています...' : 'プロンプトを入力'}
-          disabled={disabled}
+          placeholder={loading ? '' : 'プロンプトを入力'}
+          disabled={inputDisabled}
           className='min-h-0 flex-1 resize-none overflow-y-auto rounded-xl border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:border-primary-700 focus:outline-none focus:ring-0.5 disabled:opacity-40 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-500'
         />
         {loading ? (
@@ -73,7 +75,7 @@ export function CompareComposer({
           <button
             type='button'
             onClick={onSubmit}
-            disabled={disabled || value.trim().length === 0}
+            disabled={submitDisabled || value.trim().length === 0}
             className='flex h-10 w-10 shrink-0 cursor-pointer items-center justify-center rounded-full bg-primary-800 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-gray-400 disabled:cursor-default disabled:opacity-40 dark:bg-primary-700 dark:hover:bg-primary-600 dark:disabled:hover:bg-primary-700'
           >
             <ArrowUpIcon className='fill-white' size={22} />

--- a/projects/portfolio/src/client/components/chat-compare/compare-composer.tsx
+++ b/projects/portfolio/src/client/components/chat-compare/compare-composer.tsx
@@ -1,0 +1,85 @@
+import { type ChangeEvent, type KeyboardEvent, useCallback, useState } from 'react'
+import { ArrowUpIcon } from '#/client/components/svg/arrow-up-icon'
+import { StopIcon } from '#/client/components/svg/stop-icon'
+
+interface CompareComposerProps {
+  value: string
+  disabled: boolean
+  loading: boolean
+  onChangeInput: (event: ChangeEvent<HTMLTextAreaElement>) => void
+  onKeyDown: (event: KeyboardEvent<HTMLTextAreaElement>) => void
+  onChangeComposition: (composition: boolean) => void
+  onCancel: () => void
+  onSubmit: () => void
+}
+
+export function CompareComposer({
+  value,
+  disabled,
+  loading,
+  onChangeInput,
+  onKeyDown,
+  onChangeComposition,
+  onCancel,
+  onSubmit,
+}: CompareComposerProps) {
+  const [isComposing, setIsComposing] = useState(false)
+
+  const handleCompositionStart = useCallback(() => {
+    setIsComposing(true)
+    onChangeComposition(true)
+  }, [onChangeComposition])
+
+  const handleCompositionEnd = useCallback(() => {
+    setIsComposing(false)
+    onChangeComposition(false)
+  }, [onChangeComposition])
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLTextAreaElement>) => {
+      if (event.key === 'Enter' && !event.shiftKey && !isComposing && !loading && value.trim().length > 0) {
+        event.preventDefault()
+        onSubmit()
+        return
+      }
+      onKeyDown(event)
+    },
+    [isComposing, loading, onSubmit, onKeyDown, value]
+  )
+
+  return (
+    <div className='shrink-0 border-t border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800'>
+      <div className='mx-auto flex max-w-(--breakpoint-lg) items-end gap-2'>
+        <textarea
+          value={value}
+          onChange={onChangeInput}
+          onKeyDown={handleKeyDown}
+          onCompositionStart={handleCompositionStart}
+          onCompositionEnd={handleCompositionEnd}
+          rows={2}
+          placeholder={loading ? '応答を待っています...' : 'プロンプトを入力'}
+          disabled={disabled}
+          className='min-h-0 flex-1 resize-none overflow-y-auto rounded-xl border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:border-primary-700 focus:outline-none focus:ring-0.5 disabled:opacity-40 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-500'
+        />
+        {loading ? (
+          <button
+            type='button'
+            onClick={onCancel}
+            className='flex h-10 w-10 shrink-0 cursor-pointer items-center justify-center rounded-full bg-primary-800 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-gray-400 dark:bg-primary-700 dark:hover:bg-primary-600'
+          >
+            <StopIcon className='fill-white' size={18} />
+          </button>
+        ) : (
+          <button
+            type='button'
+            onClick={onSubmit}
+            disabled={disabled || value.trim().length === 0}
+            className='flex h-10 w-10 shrink-0 cursor-pointer items-center justify-center rounded-full bg-primary-800 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-gray-400 disabled:cursor-default disabled:opacity-40 dark:bg-primary-700 dark:hover:bg-primary-600 dark:disabled:hover:bg-primary-700'
+          >
+            <ArrowUpIcon className='fill-white' size={22} />
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/projects/portfolio/src/client/components/chat-compare/compare-layout.tsx
+++ b/projects/portfolio/src/client/components/chat-compare/compare-layout.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from 'react'
+
+interface CompareLayoutProps {
+  header: ReactNode
+  modelSelector: ReactNode
+  columns: ReactNode
+  composer: ReactNode
+  children?: ReactNode
+}
+
+export function CompareLayout({ header, modelSelector, columns, composer, children }: CompareLayoutProps) {
+  return (
+    <div className='flex h-[calc(100dvh-3.5rem)] flex-col bg-white md:h-dvh dark:bg-gray-900'>
+      {header}
+      {modelSelector}
+      <div className='flex min-h-0 flex-1 overflow-x-auto'>{columns}</div>
+      {composer}
+      {children}
+    </div>
+  )
+}

--- a/projects/portfolio/src/client/components/chat-compare/compare-settings.tsx
+++ b/projects/portfolio/src/client/components/chat-compare/compare-settings.tsx
@@ -28,8 +28,11 @@ export function CompareSettings({ settings, open, onUpdate, onClose }: CompareSe
   if (!open) return null
 
   return (
-    <div className='border-y border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800'>
-      <div className='mx-auto flex max-w-(--breakpoint-lg) flex-wrap items-end gap-4'>
+    <div
+      className='border-y border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800'
+      onClick={onClose}
+    >
+      <div className='mx-auto flex max-w-(--breakpoint-lg) flex-wrap items-end gap-4' onClick={(e) => e.stopPropagation()}>
         <div className='flex min-w-0 flex-1 flex-col gap-1'>
           <label htmlFor='compare-base-url' className='text-xs text-gray-500 dark:text-gray-400'>
             Base URL

--- a/projects/portfolio/src/client/components/chat-compare/compare-settings.tsx
+++ b/projects/portfolio/src/client/components/chat-compare/compare-settings.tsx
@@ -76,13 +76,6 @@ export function CompareSettings({ settings, open, onUpdate, onClose }: CompareSe
             <option value='responses'>Responses</option>
           </select>
         </div>
-        <button
-          type='button'
-          onClick={onClose}
-          className='flex shrink-0 cursor-pointer items-center rounded-md bg-gray-200 px-3 py-1.5 text-sm text-gray-700 transition-colors hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-gray-400 dark:bg-gray-600 dark:text-gray-200 dark:hover:bg-gray-500'
-        >
-          Close
-        </button>
       </div>
     </div>
   )

--- a/projects/portfolio/src/client/components/chat-compare/compare-settings.tsx
+++ b/projects/portfolio/src/client/components/chat-compare/compare-settings.tsx
@@ -28,10 +28,7 @@ export function CompareSettings({ settings, open, onUpdate, onClose }: CompareSe
   if (!open) return null
 
   return (
-    <div
-      className='border-y border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800'
-      onClick={onClose}
-    >
+    <div className='border-y border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800' onClick={onClose}>
       <div
         className='mx-auto flex max-w-(--breakpoint-lg) flex-wrap items-end gap-4'
         onClick={(e) => e.stopPropagation()}

--- a/projects/portfolio/src/client/components/chat-compare/compare-settings.tsx
+++ b/projects/portfolio/src/client/components/chat-compare/compare-settings.tsx
@@ -1,0 +1,83 @@
+import { type ChangeEvent, useCallback } from 'react'
+import type { ApiMode } from '#/types'
+import type { CompareSettings } from './hooks/use-compare-settings'
+
+interface CompareSettingsProps {
+  settings: CompareSettings
+  open: boolean
+  onUpdate: (settings: CompareSettings) => void
+  onClose: () => void
+}
+
+export function CompareSettings({ settings, open, onUpdate, onClose }: CompareSettingsProps) {
+  const handleChange = useCallback(
+    (field: keyof CompareSettings, value: string) => {
+      onUpdate({ ...settings, [field]: value })
+    },
+    [onUpdate, settings]
+  )
+
+  const handleApiModeChange = useCallback(
+    (e: ChangeEvent<HTMLSelectElement>) => {
+      const value = e.target.value as ApiMode
+      onUpdate({ ...settings, apiMode: value })
+    },
+    [onUpdate, settings]
+  )
+
+  if (!open) return null
+
+  return (
+    <div className='border-y border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800'>
+      <div className='mx-auto flex max-w-(--breakpoint-lg) flex-wrap items-end gap-4'>
+        <div className='flex min-w-0 flex-1 flex-col gap-1'>
+          <label htmlFor='compare-base-url' className='text-xs text-gray-500 dark:text-gray-400'>
+            Base URL
+          </label>
+          <input
+            id='compare-base-url'
+            type='text'
+            value={settings.baseURL}
+            onChange={(e) => handleChange('baseURL', e.target.value)}
+            placeholder='https://api.openai.com/v1'
+            className='w-full rounded-md border border-gray-300 bg-white px-2 py-1 text-sm text-gray-900 placeholder-gray-400 focus:border-primary-700 focus:outline-none focus:ring-0.5 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-500'
+          />
+        </div>
+        <div className='flex min-w-0 flex-1 flex-col gap-1'>
+          <label htmlFor='compare-api-key' className='text-xs text-gray-500 dark:text-gray-400'>
+            API Key
+          </label>
+          <input
+            id='compare-api-key'
+            type='password'
+            value={settings.apiKey}
+            onChange={(e) => handleChange('apiKey', e.target.value)}
+            placeholder='sk-...'
+            className='w-full rounded-md border border-gray-300 bg-white px-2 py-1 text-sm text-gray-900 placeholder-gray-400 focus:border-primary-700 focus:outline-none focus:ring-0.5 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-500'
+          />
+        </div>
+        <div className='flex flex-col gap-1'>
+          <label htmlFor='compare-api-mode' className='text-xs text-gray-500 dark:text-gray-400'>
+            API Mode
+          </label>
+          <select
+            id='compare-api-mode'
+            value={settings.apiMode}
+            onChange={handleApiModeChange}
+            className='rounded-md border border-gray-300 bg-white px-2 py-1 text-sm text-gray-900 focus:border-primary-700 focus:outline-none focus:ring-0.5 dark:border-gray-600 dark:bg-gray-700 dark:text-white'
+          >
+            <option value='chat_completions'>Chat Completions</option>
+            <option value='responses'>Responses</option>
+          </select>
+        </div>
+        <button
+          type='button'
+          onClick={onClose}
+          className='flex shrink-0 cursor-pointer items-center rounded-md bg-gray-200 px-3 py-1.5 text-sm text-gray-700 transition-colors hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-gray-400 dark:bg-gray-600 dark:text-gray-200 dark:hover:bg-gray-500'
+        >
+          Close
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/projects/portfolio/src/client/components/chat-compare/compare-settings.tsx
+++ b/projects/portfolio/src/client/components/chat-compare/compare-settings.tsx
@@ -46,7 +46,10 @@ export function CompareSettings({ settings, open, onUpdate, onClose }: CompareSe
       className='border-y border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800'
       onClick={onClose}
     >
-      <div className='mx-auto flex max-w-(--breakpoint-lg) flex-wrap items-end gap-4' onClick={(e) => e.stopPropagation()}>
+      <div
+        className='mx-auto flex max-w-(--breakpoint-lg) flex-wrap items-end gap-4'
+        onClick={(e) => e.stopPropagation()}
+      >
         <div className='flex min-w-0 flex-1 flex-col gap-1'>
           <label htmlFor='compare-base-url' className='text-xs text-gray-500 dark:text-gray-400'>
             Base URL

--- a/projects/portfolio/src/client/components/chat-compare/compare-settings.tsx
+++ b/projects/portfolio/src/client/components/chat-compare/compare-settings.tsx
@@ -1,4 +1,4 @@
-import { type ChangeEvent, useCallback, useEffect, useRef } from 'react'
+import { type ChangeEvent, useCallback } from 'react'
 import type { ApiMode } from '#/types'
 import type { CompareSettings } from './hooks/use-compare-settings'
 
@@ -10,8 +10,6 @@ interface CompareSettingsProps {
 }
 
 export function CompareSettings({ settings, open, onUpdate, onClose }: CompareSettingsProps) {
-  const panelRef = useRef<HTMLDivElement>(null)
-
   const handleChange = useCallback(
     (field: keyof CompareSettings, value: string) => {
       onUpdate({ ...settings, [field]: value })
@@ -27,22 +25,10 @@ export function CompareSettings({ settings, open, onUpdate, onClose }: CompareSe
     [onUpdate, settings]
   )
 
-  useEffect(() => {
-    if (!open) return
-    const handleClickOutside = (e: MouseEvent) => {
-      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
-        onClose()
-      }
-    }
-    document.addEventListener('mousedown', handleClickOutside)
-    return () => document.removeEventListener('mousedown', handleClickOutside)
-  }, [open, onClose])
-
   if (!open) return null
 
   return (
     <div
-      ref={panelRef}
       className='border-y border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800'
       onClick={onClose}
     >

--- a/projects/portfolio/src/client/components/chat-compare/compare-settings.tsx
+++ b/projects/portfolio/src/client/components/chat-compare/compare-settings.tsx
@@ -1,4 +1,4 @@
-import { type ChangeEvent, useCallback } from 'react'
+import { type ChangeEvent, useCallback, useEffect, useRef } from 'react'
 import type { ApiMode } from '#/types'
 import type { CompareSettings } from './hooks/use-compare-settings'
 
@@ -10,6 +10,8 @@ interface CompareSettingsProps {
 }
 
 export function CompareSettings({ settings, open, onUpdate, onClose }: CompareSettingsProps) {
+  const panelRef = useRef<HTMLDivElement>(null)
+
   const handleChange = useCallback(
     (field: keyof CompareSettings, value: string) => {
       onUpdate({ ...settings, [field]: value })
@@ -25,10 +27,22 @@ export function CompareSettings({ settings, open, onUpdate, onClose }: CompareSe
     [onUpdate, settings]
   )
 
+  useEffect(() => {
+    if (!open) return
+    const handleClickOutside = (e: MouseEvent) => {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        onClose()
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [open, onClose])
+
   if (!open) return null
 
   return (
     <div
+      ref={panelRef}
       className='border-y border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800'
       onClick={onClose}
     >

--- a/projects/portfolio/src/client/components/chat-compare/hooks/use-compare-settings.ts
+++ b/projects/portfolio/src/client/components/chat-compare/hooks/use-compare-settings.ts
@@ -1,0 +1,55 @@
+import { useCallback, useState } from 'react'
+import type { ApiMode } from '#/types'
+
+const STORAGE_KEY = 'portfolio.compare-settings'
+const SCHEMA_VERSION = '1.0.0'
+
+export interface CompareSettings {
+  schemaVersion: string
+  baseURL: string
+  apiKey: string
+  apiMode: ApiMode
+}
+
+const defaultSettings: CompareSettings = {
+  schemaVersion: SCHEMA_VERSION,
+  baseURL: '',
+  apiKey: '',
+  apiMode: 'chat_completions',
+}
+
+function readFromLocalStorage(): CompareSettings {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (!stored) return defaultSettings
+    const parsed = JSON.parse(stored)
+    if (!parsed || typeof parsed !== 'object') return defaultSettings
+    return {
+      schemaVersion: typeof parsed.schemaVersion === 'string' ? parsed.schemaVersion : SCHEMA_VERSION,
+      baseURL: typeof parsed.baseURL === 'string' ? parsed.baseURL : defaultSettings.baseURL,
+      apiKey: typeof parsed.apiKey === 'string' ? parsed.apiKey : defaultSettings.apiKey,
+      apiMode:
+        parsed.apiMode === 'chat_completions' || parsed.apiMode === 'responses'
+          ? parsed.apiMode
+          : defaultSettings.apiMode,
+    }
+  } catch {
+    return defaultSettings
+  }
+}
+
+function writeToLocalStorage(settings: CompareSettings): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify({ ...settings, schemaVersion: SCHEMA_VERSION }))
+}
+
+export function useCompareSettings() {
+  const [settings, setSettings] = useState<CompareSettings>(() => readFromLocalStorage())
+
+  const updateSettings = useCallback((next: CompareSettings) => {
+    const normalized = { ...next, schemaVersion: SCHEMA_VERSION }
+    writeToLocalStorage(normalized)
+    setSettings(normalized)
+  }, [])
+
+  return { settings, updateSettings }
+}

--- a/projects/portfolio/src/client/components/chat-compare/hooks/use-compare-state.ts
+++ b/projects/portfolio/src/client/components/chat-compare/hooks/use-compare-state.ts
@@ -1,0 +1,181 @@
+import { useCallback, useState } from 'react'
+import type { ApiChatMessage, ChatUsage } from '#/types'
+
+export interface ModelStreamState {
+  model: string
+  status: 'idle' | 'streaming' | 'done' | 'error'
+  messages: ApiChatMessage[]
+  content: string
+  reasoningContent: string
+  usage: ChatUsage | null
+  finishReason: string | null
+  responseTimeMs: number | null
+  error: string | null
+}
+
+function createModelStreamState(model: string): ModelStreamState {
+  return {
+    model,
+    status: 'idle',
+    messages: [],
+    content: '',
+    reasoningContent: '',
+    usage: null,
+    finishReason: null,
+    responseTimeMs: null,
+    error: null,
+  }
+}
+
+export function useCompareState() {
+  const [selectedModels, setSelectedModels] = useState<string[]>([])
+  const [modelStates, setModelStates] = useState<Record<string, ModelStreamState>>({})
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const hasConversation = selectedModels.some((model) => (modelStates[model]?.messages.length ?? 0) > 0)
+
+  const initModelStates = useCallback((models: string[]) => {
+    setModelStates((prev) => {
+      const next = { ...prev }
+      for (const model of models) {
+        if (!next[model]) {
+          next[model] = createModelStreamState(model)
+        }
+      }
+      return next
+    })
+  }, [])
+
+  const updateStreamingContent = useCallback((model: string, content: string, reasoningContent: string) => {
+    setModelStates((prev) => ({
+      ...prev,
+      [model]: {
+        ...prev[model],
+        status: 'streaming' as const,
+        content,
+        reasoningContent,
+      },
+    }))
+  }, [])
+
+  const setModelDone = useCallback(
+    (
+      model: string,
+      result: {
+        finishReason: string
+        usage: ChatUsage | null
+        responseTimeMs: number
+      }
+    ) => {
+      setModelStates((prev) => ({
+        ...prev,
+        [model]: {
+          ...prev[model],
+          status: 'done' as const,
+          finishReason: result.finishReason,
+          usage: result.usage,
+          responseTimeMs: result.responseTimeMs,
+        },
+      }))
+    },
+    []
+  )
+
+  const setModelError = useCallback((model: string, error: string) => {
+    setModelStates((prev) => ({
+      ...prev,
+      [model]: {
+        ...prev[model],
+        status: 'error' as const,
+        error,
+      },
+    }))
+  }, [])
+
+  const resetModelStream = useCallback((model: string) => {
+    setModelStates((prev) => {
+      const current = prev[model]
+      if (!current) return prev
+      return {
+        ...prev,
+        [model]: {
+          ...current,
+          status: 'idle' as const,
+          content: '',
+          reasoningContent: '',
+          usage: null,
+          finishReason: null,
+          responseTimeMs: null,
+          error: null,
+        },
+      }
+    })
+  }, [])
+
+  const appendAssistantMessage = useCallback((model: string, assistantMessage: ApiChatMessage) => {
+    setModelStates((prev) => ({
+      ...prev,
+      [model]: {
+        ...prev[model],
+        messages: [...prev[model].messages, assistantMessage],
+      },
+    }))
+  }, [])
+
+  const setModelStreaming = useCallback((model: string) => {
+    setModelStates((prev) => ({
+      ...prev,
+      [model]: {
+        ...prev[model],
+        status: 'streaming' as const,
+        content: '',
+        reasoningContent: '',
+        usage: null,
+        finishReason: null,
+        responseTimeMs: null,
+        error: null,
+      },
+    }))
+  }, [])
+
+  const appendUserMessageToAll = useCallback((userMessage: ApiChatMessage) => {
+    setModelStates((prev) => {
+      const next = { ...prev }
+      for (const model of Object.keys(next)) {
+        next[model] = {
+          ...next[model],
+          messages: [...next[model].messages, userMessage],
+        }
+      }
+      return next
+    })
+  }, [])
+
+  const resetAllConversations = useCallback((models: string[]) => {
+    setModelStates((prev) => {
+      const next = { ...prev }
+      for (const model of models) {
+        next[model] = createModelStreamState(model)
+      }
+      return next
+    })
+  }, [])
+
+  return {
+    selectedModels,
+    setSelectedModels,
+    modelStates,
+    isSubmitting,
+    setIsSubmitting,
+    hasConversation,
+    initModelStates,
+    updateStreamingContent,
+    setModelDone,
+    setModelError,
+    resetModelStream,
+    appendAssistantMessage,
+    setModelStreaming,
+    appendUserMessageToAll,
+    resetAllConversations,
+  }
+}

--- a/projects/portfolio/src/client/components/chat-compare/hooks/use-compare-state.ts
+++ b/projects/portfolio/src/client/components/chat-compare/hooks/use-compare-state.ts
@@ -138,10 +138,11 @@ export function useCompareState() {
     }))
   }, [])
 
-  const appendUserMessageToAll = useCallback((userMessage: ApiChatMessage) => {
+  const appendUserMessageToAll = useCallback((selectedModels: string[], userMessage: ApiChatMessage) => {
     setModelStates((prev) => {
       const next = { ...prev }
-      for (const model of Object.keys(next)) {
+      for (const model of selectedModels) {
+        if (!next[model]) continue
         next[model] = {
           ...next[model],
           messages: [...next[model].messages, userMessage],

--- a/projects/portfolio/src/client/components/chat-compare/hooks/use-compare-stream.ts
+++ b/projects/portfolio/src/client/components/chat-compare/hooks/use-compare-stream.ts
@@ -34,11 +34,13 @@ export function useCompareStream() {
     async (
       settings: CompareSettings,
       modelStates: Record<string, ModelStreamState>,
+      selectedModels: string[],
       userMessage: ApiChatMessage,
       callbacks: StreamCallbacks
     ) => {
-      const models = Object.keys(modelStates)
-      if (models.length === 0) return
+      if (selectedModels.length === 0) return
+
+      const models = selectedModels
 
       const controller = new AbortController()
       abortControllerRef.current = controller

--- a/projects/portfolio/src/client/components/chat-compare/hooks/use-compare-stream.ts
+++ b/projects/portfolio/src/client/components/chat-compare/hooks/use-compare-stream.ts
@@ -1,0 +1,171 @@
+import { hc } from 'hono/client'
+import { useCallback, useRef } from 'react'
+import { parseChatStreamEvent, updateChatStream } from '#/client/components/chat/hooks/chat-response'
+import type { AppType } from '#/server/app.d'
+import type { ApiChatMessage, ChatUsage } from '#/types'
+import type { CompareSettings } from './use-compare-settings'
+import type { ModelStreamState } from './use-compare-state'
+
+const client = hc<AppType>('/')
+
+interface StreamCallbacks {
+  onStreamContent: (model: string, content: string, reasoningContent: string) => void
+  onStreamDone: (
+    model: string,
+    result: {
+      finishReason: string
+      usage: ChatUsage | null
+      responseTimeMs: number
+      content: string
+    }
+  ) => void
+  onStreamError: (model: string, error: string) => void
+}
+
+export function useCompareStream() {
+  const abortControllerRef = useRef<AbortController | null>(null)
+
+  const cancelAll = useCallback(() => {
+    abortControllerRef.current?.abort()
+    abortControllerRef.current = null
+  }, [])
+
+  const submitCompare = useCallback(
+    async (
+      settings: CompareSettings,
+      modelStates: Record<string, ModelStreamState>,
+      userMessage: ApiChatMessage,
+      callbacks: StreamCallbacks
+    ) => {
+      const models = Object.keys(modelStates)
+      if (models.length === 0) return
+
+      const controller = new AbortController()
+      abortControllerRef.current = controller
+
+      const header = {
+        'api-key': settings.apiKey,
+        'base-url': settings.baseURL,
+      }
+
+      const promises = models.map((model) =>
+        runModelStream(
+          model,
+          header,
+          {
+            apiMode: settings.apiMode,
+            model,
+            messages: [...modelStates[model].messages, userMessage],
+          },
+          controller.signal,
+          (content, reasoningContent) => callbacks.onStreamContent(model, content, reasoningContent),
+          (result) => callbacks.onStreamDone(model, result),
+          (error) => callbacks.onStreamError(model, error)
+        )
+      )
+
+      await Promise.allSettled(promises)
+    },
+    []
+  )
+
+  return { submitCompare, cancelAll }
+}
+
+async function runModelStream(
+  model: string,
+  header: { 'api-key': string; 'base-url': string },
+  body: {
+    apiMode: string
+    model: string
+    messages: ApiChatMessage[]
+  },
+  signal: AbortSignal,
+  onContent: (content: string, reasoningContent: string) => void,
+  onDone: (result: { finishReason: string; usage: ChatUsage | null; responseTimeMs: number; content: string }) => void,
+  onError: (error: string) => void
+): Promise<void> {
+  const startTime = Date.now()
+
+  try {
+    const res = await client.api.chat.stream.$post(
+      {
+        header,
+        json: body,
+      } as never,
+      { init: { signal } }
+    )
+
+    if (!res.ok) {
+      const errorData = (await res.json()) as { error?: string }
+      onError(errorData?.error || `HTTP ${res.status}`)
+      return
+    }
+
+    const reader = res.body?.getReader()
+    if (!reader) {
+      onError('Failed to get response reader')
+      return
+    }
+
+    const decoder = new TextDecoder('utf-8')
+    let buffer = ''
+    let accumulated = { content: '', reasoningContent: '' }
+    let finishReason = ''
+    let usage: ChatUsage | null = null
+    let receivedFinish = false
+    let running = true
+
+    while (running) {
+      const { done, value } = await reader.read()
+      if (done) break
+
+      buffer += decoder.decode(value, { stream: true })
+      while (running) {
+        const idx = buffer.indexOf('\n')
+        if (idx === -1) break
+
+        const line = buffer.slice(0, idx).trim()
+        buffer = buffer.slice(idx + 1)
+        if (!line.startsWith('data: ')) continue
+
+        const jsonStr = line.replace(/^data:\s*/, '')
+        if (jsonStr === '[DONE]') {
+          running = false
+          break
+        }
+
+        try {
+          const event = parseChatStreamEvent(jsonStr)
+          accumulated = updateChatStream(accumulated, event)
+
+          if (event.event === 'delta') {
+            onContent(accumulated.content, accumulated.reasoningContent)
+          }
+          if (event.event === 'finish') {
+            finishReason = event.finishReason
+            receivedFinish = true
+          }
+          if (event.event === 'usage') {
+            usage = event.usage
+          }
+        } catch {
+          // パース失敗は無視
+        }
+      }
+    }
+
+    if (receivedFinish) {
+      const responseTimeMs = Date.now() - startTime
+      onDone({
+        finishReason,
+        usage,
+        responseTimeMs,
+        content: accumulated.content,
+      })
+    }
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') return
+    onError(error instanceof Error ? error.message : 'Unknown error')
+  }
+}

--- a/projects/portfolio/src/client/components/chat-compare/model-change-confirm-dialog.tsx
+++ b/projects/portfolio/src/client/components/chat-compare/model-change-confirm-dialog.tsx
@@ -1,0 +1,37 @@
+interface ModelChangeConfirmDialogProps {
+  open: boolean
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export function ModelChangeConfirmDialog({ open, onConfirm, onCancel }: ModelChangeConfirmDialogProps) {
+  if (!open) return null
+
+  return (
+    <div className='fixed inset-0 z-50 flex items-center justify-center'>
+      <div className='fixed inset-0 bg-black/50' onClick={onCancel} />
+      <div className='relative z-10 mx-4 w-full max-w-md rounded-lg border border-gray-200 bg-white p-6 shadow-lg dark:border-gray-700 dark:bg-gray-800'>
+        <h3 className='font-semibold text-gray-900 text-lg dark:text-gray-100'>モデル選択の変更</h3>
+        <p className='mt-2 text-sm text-gray-600 dark:text-gray-400'>
+          モデル選択を変更すると現在の比較会話は破棄されます。続行しますか？
+        </p>
+        <div className='mt-4 flex justify-end gap-2'>
+          <button
+            type='button'
+            onClick={onCancel}
+            className='cursor-pointer rounded-md border border-gray-300 bg-white px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-400 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600'
+          >
+            キャンセル
+          </button>
+          <button
+            type='button'
+            onClick={onConfirm}
+            className='cursor-pointer rounded-md bg-red-600 px-4 py-2 text-sm text-white hover:bg-red-500 focus:outline-none focus:ring-2 focus:ring-red-400'
+          >
+            破棄して続行
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/projects/portfolio/src/client/components/chat-compare/model-checkbox-list.tsx
+++ b/projects/portfolio/src/client/components/chat-compare/model-checkbox-list.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 import { SpinnerIcon } from '#/client/components/svg/spinner-icon'
 
 interface ModelCheckboxListProps {
@@ -8,6 +8,35 @@ interface ModelCheckboxListProps {
   error: string | null
   disabled: boolean
   onChange: (selected: string[]) => void
+}
+
+interface GroupedModel {
+  id: string
+  label: string
+}
+
+interface ModelGroup {
+  provider: string
+  models: GroupedModel[]
+}
+
+const OTHER_PROVIDER = 'その他'
+
+export function groupModelsByProvider(models: string[]): ModelGroup[] {
+  const groups = new Map<string, GroupedModel[]>()
+
+  for (const model of models) {
+    const separatorIndex = model.indexOf('/')
+    const hasProviderAndModel = separatorIndex > 0 && separatorIndex < model.length - 1
+    const provider = hasProviderAndModel ? model.slice(0, separatorIndex) : OTHER_PROVIDER
+    const label = hasProviderAndModel ? model.slice(separatorIndex + 1) : model
+    const groupModels = groups.get(provider) ?? []
+
+    groupModels.push({ id: model, label })
+    groups.set(provider, groupModels)
+  }
+
+  return Array.from(groups, ([provider, groupedModels]) => ({ provider, models: groupedModels }))
 }
 
 export function ModelCheckboxList({
@@ -27,6 +56,7 @@ export function ModelCheckboxList({
     },
     [onChange, selectedModels]
   )
+  const modelGroups = useMemo(() => groupModelsByProvider(models), [models])
 
   if (loading) {
     return (
@@ -55,25 +85,36 @@ export function ModelCheckboxList({
   }
 
   return (
-    <div className='flex flex-wrap gap-2 px-2'>
-      {models.map((model) => (
-        <label
-          key={model}
-          className={`flex cursor-pointer items-center gap-1.5 rounded-full border px-2.5 py-1 text-sm transition-colors ${
-            selectedModels.includes(model)
-              ? 'border-primary-300 bg-primary-50 text-primary-800 dark:border-primary-600 dark:bg-primary-900/30 dark:text-primary-300'
-              : 'border-gray-200 text-gray-600 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800'
-          } ${disabled ? 'cursor-not-allowed opacity-50' : ''}`}
-        >
-          <input
-            type='checkbox'
-            checked={selectedModels.includes(model)}
-            onChange={() => handleToggle(model)}
-            disabled={disabled}
-            className='h-3.5 w-3.5 rounded border-gray-300 text-primary-700 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-700 dark:focus:ring-primary-400'
-          />
-          <span className='truncate max-w-[200px]'>{model}</span>
-        </label>
+    <div className='flex flex-col gap-3 px-2'>
+      {modelGroups.map((group) => (
+        <section key={group.provider} className='grid gap-1.5'>
+          <div className='flex items-center gap-2'>
+            <h2 className='font-semibold text-gray-600 text-xs dark:text-gray-300'>{group.provider}</h2>
+            <span className='text-gray-400 text-xs dark:text-gray-500'>{group.models.length}</span>
+          </div>
+          <div className='flex flex-wrap gap-2'>
+            {group.models.map((model) => (
+              <label
+                key={model.id}
+                title={model.id}
+                className={`flex max-w-full cursor-pointer items-center gap-1.5 rounded-md border px-2.5 py-1 text-sm transition-colors ${
+                  selectedModels.includes(model.id)
+                    ? 'border-primary-300 bg-primary-50 text-primary-800 dark:border-primary-600 dark:bg-primary-900/30 dark:text-primary-300'
+                    : 'border-gray-200 text-gray-600 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800'
+                } ${disabled ? 'cursor-not-allowed opacity-50' : ''}`}
+              >
+                <input
+                  type='checkbox'
+                  checked={selectedModels.includes(model.id)}
+                  onChange={() => handleToggle(model.id)}
+                  disabled={disabled}
+                  className='h-3.5 w-3.5 rounded border-gray-300 text-primary-700 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-700 dark:focus:ring-primary-400'
+                />
+                <span className='max-w-[220px] truncate'>{model.label}</span>
+              </label>
+            ))}
+          </div>
+        </section>
       ))}
     </div>
   )

--- a/projects/portfolio/src/client/components/chat-compare/model-checkbox-list.tsx
+++ b/projects/portfolio/src/client/components/chat-compare/model-checkbox-list.tsx
@@ -1,0 +1,80 @@
+import { useCallback } from 'react'
+import { SpinnerIcon } from '#/client/components/svg/spinner-icon'
+
+interface ModelCheckboxListProps {
+  models: string[]
+  selectedModels: string[]
+  loading: boolean
+  error: string | null
+  disabled: boolean
+  onChange: (selected: string[]) => void
+}
+
+export function ModelCheckboxList({
+  models,
+  selectedModels,
+  loading,
+  error,
+  disabled,
+  onChange,
+}: ModelCheckboxListProps) {
+  const handleToggle = useCallback(
+    (model: string) => {
+      const next = selectedModels.includes(model)
+        ? selectedModels.filter((m) => m !== model)
+        : [...selectedModels, model]
+      onChange(next)
+    },
+    [onChange, selectedModels]
+  )
+
+  if (loading) {
+    return (
+      <div className='flex items-center justify-center gap-2 py-4'>
+        <SpinnerIcon />
+        <span className='text-sm text-gray-500 dark:text-gray-400'>モデル一覧を取得中...</span>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className='py-2 text-center text-red-500 text-sm dark:text-red-400'>
+        {error}
+        <p className='mt-1 text-xs text-gray-400'>設定を確認してください</p>
+      </div>
+    )
+  }
+
+  if (models.length === 0) {
+    return (
+      <div className='py-2 text-center text-gray-400 text-sm dark:text-gray-500'>
+        モデルが見つかりません。設定でBase URLとAPI Keyを構成してください
+      </div>
+    )
+  }
+
+  return (
+    <div className='flex flex-wrap gap-2 px-2'>
+      {models.map((model) => (
+        <label
+          key={model}
+          className={`flex cursor-pointer items-center gap-1.5 rounded-full border px-2.5 py-1 text-sm transition-colors ${
+            selectedModels.includes(model)
+              ? 'border-primary-300 bg-primary-50 text-primary-800 dark:border-primary-600 dark:bg-primary-900/30 dark:text-primary-300'
+              : 'border-gray-200 text-gray-600 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800'
+          } ${disabled ? 'cursor-not-allowed opacity-50' : ''}`}
+        >
+          <input
+            type='checkbox'
+            checked={selectedModels.includes(model)}
+            onChange={() => handleToggle(model)}
+            disabled={disabled}
+            className='h-3.5 w-3.5 rounded border-gray-300 text-primary-700 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-700 dark:focus:ring-primary-400'
+          />
+          <span className='truncate max-w-[200px]'>{model}</span>
+        </label>
+      ))}
+    </div>
+  )
+}

--- a/projects/portfolio/src/client/components/svg/compare-icon.tsx
+++ b/projects/portfolio/src/client/components/svg/compare-icon.tsx
@@ -1,0 +1,12 @@
+import { type IconProps, SvgIcon } from './icon-base'
+
+export function CompareIcon({ size = 24, className = 'fill-black dark:fill-white' }: IconProps) {
+  return (
+    <SvgIcon size={size} viewBox='0 0 16 16' title='compare-icon'>
+      <g className={className}>
+        <rect x='1' y='2' width='6' height='12' rx='1' />
+        <rect x='9' y='2' width='6' height='12' rx='1' />
+      </g>
+    </SvgIcon>
+  )
+}

--- a/projects/portfolio/src/client/pages/chat-compare/index.tsx
+++ b/projects/portfolio/src/client/pages/chat-compare/index.tsx
@@ -11,6 +11,7 @@ import { useCompareStream } from '#/client/components/chat-compare/hooks/use-com
 import { ModelChangeConfirmDialog } from '#/client/components/chat-compare/model-change-confirm-dialog'
 import { ModelCheckboxList } from '#/client/components/chat-compare/model-checkbox-list'
 import { GearIcon } from '#/client/components/svg/gear-icon'
+import { CloseIcon } from '#/client/components/svg/close-icon'
 import type { AppType } from '#/server/app.d'
 
 const client = hc<AppType>('/')
@@ -185,8 +186,17 @@ export function ChatCompare() {
               onClick={() => setSettingsOpen((prev) => !prev)}
               className='flex cursor-pointer items-center gap-1 rounded-md px-2 py-1 text-gray-500 text-xs transition-colors hover:bg-gray-200 dark:text-gray-400 dark:hover:bg-gray-700'
             >
-              <GearIcon size={14} />
-              Settings
+              {settingsOpen ? (
+                <>
+                  <CloseIcon size={14} />
+                  Close
+                </>
+              ) : (
+                <>
+                  <GearIcon size={14} />
+                  Settings
+                </>
+              )}
             </button>
           </div>
         }
@@ -243,7 +253,8 @@ export function ChatCompare() {
         composer={
           <CompareComposer
             value={input}
-            disabled={selectedModels.length === 0 || loading}
+            inputDisabled={loading}
+            submitDisabled={selectedModels.length === 0 || loading}
             loading={loading}
             onChangeInput={handleChangeInput}
             onKeyDown={handleKeyDown}

--- a/projects/portfolio/src/client/pages/chat-compare/index.tsx
+++ b/projects/portfolio/src/client/pages/chat-compare/index.tsx
@@ -49,8 +49,8 @@ export function ChatCompare() {
         setSettingsOpen(false)
       }
     }
-    document.addEventListener('click', handleClickOutside)
-    return () => document.removeEventListener('click', handleClickOutside)
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
   }, [settingsOpen])
 
   const canFetchModels = settings.baseURL.length > 0 && settings.apiKey.length > 0
@@ -183,6 +183,9 @@ export function ChatCompare() {
             <h1 className='font-semibold text-gray-800 text-sm dark:text-gray-200'>Chat Compare</h1>
             <button
               type='button'
+              onMouseDown={(e) => {
+                if (settingsOpen) e.stopPropagation()
+              }}
               onClick={() => setSettingsOpen((prev) => !prev)}
               className='flex cursor-pointer items-center gap-1 rounded-md px-2 py-1 text-gray-500 text-xs transition-colors hover:bg-gray-200 dark:text-gray-400 dark:hover:bg-gray-700'
             >

--- a/projects/portfolio/src/client/pages/chat-compare/index.tsx
+++ b/projects/portfolio/src/client/pages/chat-compare/index.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { hc } from 'hono/client'
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { CompareColumn } from '#/client/components/chat-compare/compare-column'
 import { CompareComposer } from '#/client/components/chat-compare/compare-composer'
 import { CompareLayout } from '#/client/components/chat-compare/compare-layout'
@@ -39,6 +39,18 @@ export function ChatCompare() {
   const [input, setInput] = useState('')
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [pendingModelChange, setPendingModelChange] = useState<string[] | null>(null)
+  const modelSelectorRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!settingsOpen) return
+    const handleClickOutside = (e: MouseEvent) => {
+      if (modelSelectorRef.current && !modelSelectorRef.current.contains(e.target as Node)) {
+        setSettingsOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [settingsOpen])
 
   const canFetchModels = settings.baseURL.length > 0 && settings.apiKey.length > 0
 
@@ -179,7 +191,7 @@ export function ChatCompare() {
           </div>
         }
         modelSelector={
-          <>
+          <div ref={modelSelectorRef}>
             <CompareSettings
               settings={settings}
               open={settingsOpen}
@@ -198,7 +210,7 @@ export function ChatCompare() {
                 />
               </div>
             )}
-          </>
+          </div>
         }
         columns={
           selectedModels.length === 0 ? (

--- a/projects/portfolio/src/client/pages/chat-compare/index.tsx
+++ b/projects/portfolio/src/client/pages/chat-compare/index.tsx
@@ -179,22 +179,26 @@ export function ChatCompare() {
           </div>
         }
         modelSelector={
-          <div className='shrink-0 border-b border-gray-200 bg-white px-4 py-2 dark:border-gray-700 dark:bg-gray-800'>
+          <>
             <CompareSettings
               settings={settings}
               open={settingsOpen}
               onUpdate={updateSettings}
               onClose={() => setSettingsOpen(false)}
             />
-            <ModelCheckboxList
-              models={models}
-              selectedModels={selectedModels}
-              loading={canFetchModels && modelsQuery.isLoading}
-              error={modelsQuery.isError ? 'モデル一覧の取得に失敗しました' : null}
-              disabled={isSubmitting}
-              onChange={handleModelChange}
-            />
-          </div>
+            {settingsOpen && (
+              <div className='shrink-0 border-b border-gray-200 bg-white px-4 py-2 dark:border-gray-700 dark:bg-gray-800'>
+                <ModelCheckboxList
+                  models={models}
+                  selectedModels={selectedModels}
+                  loading={canFetchModels && modelsQuery.isLoading}
+                  error={modelsQuery.isError ? 'モデル一覧の取得に失敗しました' : null}
+                  disabled={isSubmitting}
+                  onChange={handleModelChange}
+                />
+              </div>
+            )}
+          </>
         }
         columns={
           selectedModels.length === 0 ? (

--- a/projects/portfolio/src/client/pages/chat-compare/index.tsx
+++ b/projects/portfolio/src/client/pages/chat-compare/index.tsx
@@ -180,7 +180,7 @@ export function ChatCompare() {
       <CompareLayout
         header={
           <div className='flex shrink-0 items-center justify-between border-b border-gray-200 bg-gray-50 px-4 py-2 dark:border-gray-700 dark:bg-gray-800'>
-            <h1 className='font-semibold text-gray-800 text-sm dark:text-gray-200'>Model Compare</h1>
+            <h1 className='font-semibold text-gray-800 text-sm dark:text-gray-200'>Chat Compare</h1>
             <button
               type='button'
               onClick={() => setSettingsOpen((prev) => !prev)}

--- a/projects/portfolio/src/client/pages/chat-compare/index.tsx
+++ b/projects/portfolio/src/client/pages/chat-compare/index.tsx
@@ -99,12 +99,12 @@ export function ChatCompare() {
     setInput('')
     setIsSubmitting(true)
 
-    appendUserMessageToAll(userMessage)
+    appendUserMessageToAll(models, userMessage)
     for (const model of models) {
       setModelStreaming(model)
     }
 
-    await submitCompare(settings, modelStates, userMessage, {
+    await submitCompare(settings, modelStates, models, userMessage, {
       onStreamContent: (model, content, reasoningContent) => {
         updateStreamingContent(model, content, reasoningContent)
       },

--- a/projects/portfolio/src/client/pages/chat-compare/index.tsx
+++ b/projects/portfolio/src/client/pages/chat-compare/index.tsx
@@ -10,8 +10,8 @@ import { useCompareState } from '#/client/components/chat-compare/hooks/use-comp
 import { useCompareStream } from '#/client/components/chat-compare/hooks/use-compare-stream'
 import { ModelChangeConfirmDialog } from '#/client/components/chat-compare/model-change-confirm-dialog'
 import { ModelCheckboxList } from '#/client/components/chat-compare/model-checkbox-list'
-import { GearIcon } from '#/client/components/svg/gear-icon'
 import { CloseIcon } from '#/client/components/svg/close-icon'
+import { GearIcon } from '#/client/components/svg/gear-icon'
 import type { AppType } from '#/server/app.d'
 
 const client = hc<AppType>('/')
@@ -49,8 +49,8 @@ export function ChatCompare() {
         setSettingsOpen(false)
       }
     }
-    document.addEventListener('mousedown', handleClickOutside)
-    return () => document.removeEventListener('mousedown', handleClickOutside)
+    document.addEventListener('click', handleClickOutside)
+    return () => document.removeEventListener('click', handleClickOutside)
   }, [settingsOpen])
 
   const canFetchModels = settings.baseURL.length > 0 && settings.apiKey.length > 0

--- a/projects/portfolio/src/client/pages/chat-compare/index.tsx
+++ b/projects/portfolio/src/client/pages/chat-compare/index.tsx
@@ -12,6 +12,7 @@ import { ModelChangeConfirmDialog } from '#/client/components/chat-compare/model
 import { ModelCheckboxList } from '#/client/components/chat-compare/model-checkbox-list'
 import { CloseIcon } from '#/client/components/svg/close-icon'
 import { GearIcon } from '#/client/components/svg/gear-icon'
+import { NewChatIcon } from '#/client/components/svg/new-chat-icon'
 import type { AppType } from '#/server/app.d'
 
 const client = hc<AppType>('/')
@@ -173,6 +174,12 @@ export function ChatCompare() {
     // IME 編集中は Enter 送信しないよう Composer が管理
   }, [])
 
+  const handleNewChat = useCallback(() => {
+    if (isSubmitting) return
+    setInput('')
+    resetAllConversations(selectedModels)
+  }, [isSubmitting, resetAllConversations, selectedModels])
+
   const loading = isSubmitting
 
   return (
@@ -180,27 +187,40 @@ export function ChatCompare() {
       <CompareLayout
         header={
           <div className='flex shrink-0 items-center justify-between border-b border-gray-200 bg-gray-50 px-4 py-2 dark:border-gray-700 dark:bg-gray-800'>
-            <h1 className='font-semibold text-gray-800 text-sm dark:text-gray-200'>Chat Compare</h1>
-            <button
-              type='button'
-              onMouseDown={(e) => {
-                if (settingsOpen) e.stopPropagation()
-              }}
-              onClick={() => setSettingsOpen((prev) => !prev)}
-              className='flex cursor-pointer items-center gap-1 rounded-md px-2 py-1 text-gray-500 text-xs transition-colors hover:bg-gray-200 dark:text-gray-400 dark:hover:bg-gray-700'
-            >
-              {settingsOpen ? (
-                <>
-                  <CloseIcon size={14} />
-                  Close
-                </>
-              ) : (
-                <>
-                  <GearIcon size={14} />
-                  Settings
-                </>
-              )}
-            </button>
+            <div className='flex items-center gap-2'>
+              <h1 className='font-semibold text-gray-800 text-sm dark:text-gray-200'>Chat Compare</h1>
+              <button
+                type='button'
+                onClick={handleNewChat}
+                disabled={!hasConversation || isSubmitting}
+                aria-label='New chat'
+                className='flex h-8 w-8 items-center justify-center rounded-md text-gray-500 transition-colors enabled:cursor-pointer enabled:hover:bg-gray-200 disabled:cursor-not-allowed disabled:opacity-40 dark:text-gray-400 dark:enabled:hover:bg-gray-700'
+              >
+                <NewChatIcon size={18} className='fill-current' />
+              </button>
+            </div>
+            <div className='flex items-center gap-2'>
+              <button
+                type='button'
+                onMouseDown={(e) => {
+                  if (settingsOpen) e.stopPropagation()
+                }}
+                onClick={() => setSettingsOpen((prev) => !prev)}
+                className='flex cursor-pointer items-center gap-1 rounded-md px-2 py-1 text-gray-500 text-xs transition-colors hover:bg-gray-200 dark:text-gray-400 dark:hover:bg-gray-700'
+              >
+                {settingsOpen ? (
+                  <>
+                    <CloseIcon size={14} />
+                    Close
+                  </>
+                ) : (
+                  <>
+                    <GearIcon size={14} />
+                    Settings
+                  </>
+                )}
+              </button>
+            </div>
           </div>
         }
         modelSelector={

--- a/projects/portfolio/src/client/pages/chat-compare/index.tsx
+++ b/projects/portfolio/src/client/pages/chat-compare/index.tsx
@@ -1,0 +1,247 @@
+import { useQuery } from '@tanstack/react-query'
+import { hc } from 'hono/client'
+import { useCallback, useState } from 'react'
+import { CompareColumn } from '#/client/components/chat-compare/compare-column'
+import { CompareComposer } from '#/client/components/chat-compare/compare-composer'
+import { CompareLayout } from '#/client/components/chat-compare/compare-layout'
+import { CompareSettings } from '#/client/components/chat-compare/compare-settings'
+import { useCompareSettings } from '#/client/components/chat-compare/hooks/use-compare-settings'
+import { useCompareState } from '#/client/components/chat-compare/hooks/use-compare-state'
+import { useCompareStream } from '#/client/components/chat-compare/hooks/use-compare-stream'
+import { ModelChangeConfirmDialog } from '#/client/components/chat-compare/model-change-confirm-dialog'
+import { ModelCheckboxList } from '#/client/components/chat-compare/model-checkbox-list'
+import { GearIcon } from '#/client/components/svg/gear-icon'
+import type { AppType } from '#/server/app.d'
+
+const client = hc<AppType>('/')
+
+export function ChatCompare() {
+  const { settings, updateSettings } = useCompareSettings()
+  const {
+    selectedModels,
+    setSelectedModels,
+    modelStates,
+    isSubmitting,
+    setIsSubmitting,
+    hasConversation,
+    initModelStates,
+    updateStreamingContent,
+    setModelDone,
+    setModelError,
+    resetModelStream,
+    appendAssistantMessage,
+    setModelStreaming,
+    appendUserMessageToAll,
+    resetAllConversations,
+  } = useCompareState()
+  const { submitCompare, cancelAll } = useCompareStream()
+
+  const [input, setInput] = useState('')
+  const [settingsOpen, setSettingsOpen] = useState(false)
+  const [pendingModelChange, setPendingModelChange] = useState<string[] | null>(null)
+
+  const canFetchModels = settings.baseURL.length > 0 && settings.apiKey.length > 0
+
+  const modelsQuery = useQuery({
+    queryKey: ['compare-models', settings.baseURL, settings.apiKey],
+    queryFn: async () => {
+      const res = await client.api['fetch-models'].$get({
+        header: {
+          'api-key': settings.apiKey,
+          'base-url': settings.baseURL,
+        },
+      } as never)
+      return (await res.json()) as string[]
+    },
+    enabled: canFetchModels,
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const models = modelsQuery.data ?? []
+
+  const handleModelChange = useCallback(
+    (nextModels: string[]) => {
+      if (hasConversation && nextModels.some((m) => !selectedModels.includes(m))) {
+        setPendingModelChange(nextModels)
+        return
+      }
+      applyModelChange(nextModels)
+    },
+    [hasConversation, selectedModels]
+  )
+
+  const applyModelChange = useCallback(
+    (nextModels: string[]) => {
+      initModelStates(nextModels)
+      setSelectedModels(nextModels)
+      setPendingModelChange(null)
+    },
+    [initModelStates, setSelectedModels]
+  )
+
+  const confirmModelChange = useCallback(() => {
+    if (!pendingModelChange) return
+    resetAllConversations(selectedModels)
+    applyModelChange(pendingModelChange)
+  }, [applyModelChange, pendingModelChange, resetAllConversations, selectedModels])
+
+  const cancelModelChange = useCallback(() => {
+    setPendingModelChange(null)
+  }, [])
+
+  const handleSubmit = useCallback(async () => {
+    const trimmed = input.trim()
+    if (trimmed.length === 0 || selectedModels.length === 0 || isSubmitting) return
+
+    const models = selectedModels
+    const userMessage = { role: 'user' as const, content: trimmed }
+
+    setInput('')
+    setIsSubmitting(true)
+
+    appendUserMessageToAll(userMessage)
+    for (const model of models) {
+      setModelStreaming(model)
+    }
+
+    await submitCompare(settings, modelStates, userMessage, {
+      onStreamContent: (model, content, reasoningContent) => {
+        updateStreamingContent(model, content, reasoningContent)
+      },
+      onStreamDone: (model, result) => {
+        setModelDone(model, {
+          finishReason: result.finishReason,
+          usage: result.usage,
+          responseTimeMs: result.responseTimeMs,
+        })
+        if (result.content) {
+          appendAssistantMessage(model, { role: 'assistant', content: result.content })
+        }
+      },
+      onStreamError: (model, error) => {
+        setModelError(model, error)
+      },
+    })
+
+    setIsSubmitting(false)
+  }, [
+    appendAssistantMessage,
+    appendUserMessageToAll,
+    input,
+    isSubmitting,
+    modelStates,
+    selectedModels,
+    setModelDone,
+    setModelError,
+    setModelStreaming,
+    setIsSubmitting,
+    settings,
+    submitCompare,
+    updateStreamingContent,
+  ])
+
+  const handleCancel = useCallback(() => {
+    cancelAll()
+    setIsSubmitting(false)
+    for (const model of selectedModels) {
+      resetModelStream(model)
+    }
+  }, [cancelAll, resetModelStream, selectedModels, setIsSubmitting])
+
+  const handleChangeInput = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setInput(e.target.value)
+  }, [])
+
+  const handleKeyDown = useCallback((_e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    // キーダウン処理は不要（Composer 側で Enter ハンドリング）
+  }, [])
+
+  const handleChangeComposition = useCallback((_composition: boolean) => {
+    // IME 編集中は Enter 送信しないよう Composer が管理
+  }, [])
+
+  const loading = isSubmitting
+
+  return (
+    <>
+      <CompareLayout
+        header={
+          <div className='flex shrink-0 items-center justify-between border-b border-gray-200 bg-gray-50 px-4 py-2 dark:border-gray-700 dark:bg-gray-800'>
+            <h1 className='font-semibold text-gray-800 text-sm dark:text-gray-200'>Model Compare</h1>
+            <button
+              type='button'
+              onClick={() => setSettingsOpen((prev) => !prev)}
+              className='flex cursor-pointer items-center gap-1 rounded-md px-2 py-1 text-gray-500 text-xs transition-colors hover:bg-gray-200 dark:text-gray-400 dark:hover:bg-gray-700'
+            >
+              <GearIcon size={14} />
+              Settings
+            </button>
+          </div>
+        }
+        modelSelector={
+          <div className='shrink-0 border-b border-gray-200 bg-white px-4 py-2 dark:border-gray-700 dark:bg-gray-800'>
+            <CompareSettings
+              settings={settings}
+              open={settingsOpen}
+              onUpdate={updateSettings}
+              onClose={() => setSettingsOpen(false)}
+            />
+            <ModelCheckboxList
+              models={models}
+              selectedModels={selectedModels}
+              loading={canFetchModels && modelsQuery.isLoading}
+              error={modelsQuery.isError ? 'モデル一覧の取得に失敗しました' : null}
+              disabled={isSubmitting}
+              onChange={handleModelChange}
+            />
+          </div>
+        }
+        columns={
+          selectedModels.length === 0 ? (
+            <div className='flex flex-1 items-center justify-center'>
+              <p className='text-gray-400 text-sm dark:text-gray-500'>
+                {canFetchModels ? '比較するモデルを選択してください' : '設定でBase URLとAPI Keyを構成してください'}
+              </p>
+            </div>
+          ) : (
+            selectedModels.map((model) => (
+              <CompareColumn
+                key={model}
+                state={
+                  modelStates[model] ?? {
+                    model,
+                    status: 'idle' as const,
+                    messages: [],
+                    content: '',
+                    reasoningContent: '',
+                    usage: null,
+                    finishReason: null,
+                    responseTimeMs: null,
+                    error: null,
+                  }
+                }
+              />
+            ))
+          )
+        }
+        composer={
+          <CompareComposer
+            value={input}
+            disabled={selectedModels.length === 0 || loading}
+            loading={loading}
+            onChangeInput={handleChangeInput}
+            onKeyDown={handleKeyDown}
+            onChangeComposition={handleChangeComposition}
+            onCancel={handleCancel}
+            onSubmit={handleSubmit}
+          />
+        }
+      />
+      <ModelChangeConfirmDialog
+        open={pendingModelChange !== null}
+        onConfirm={confirmModelChange}
+        onCancel={cancelModelChange}
+      />
+    </>
+  )
+}

--- a/projects/portfolio/src/client/routeTree.gen.ts
+++ b/projects/portfolio/src/client/routeTree.gen.ts
@@ -10,8 +10,8 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as DiffRouteImport } from './routes/diff'
-import { Route as ChatRouteImport } from './routes/chat'
 import { Route as ChatCompareRouteImport } from './routes/chat-compare'
+import { Route as ChatRouteImport } from './routes/chat'
 import { Route as AboutRouteImport } from './routes/about'
 import { Route as IndexRouteImport } from './routes/index'
 
@@ -20,14 +20,14 @@ const DiffRoute = DiffRouteImport.update({
   path: '/diff',
   getParentRoute: () => rootRouteImport,
 } as any)
-const ChatRoute = ChatRouteImport.update({
-  id: '/chat',
-  path: '/chat',
-  getParentRoute: () => rootRouteImport,
-} as any)
 const ChatCompareRoute = ChatCompareRouteImport.update({
   id: '/chat-compare',
   path: '/chat-compare',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ChatRoute = ChatRouteImport.update({
+  id: '/chat',
+  path: '/chat',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AboutRoute = AboutRouteImport.update({
@@ -88,18 +88,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DiffRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/chat': {
-      id: '/chat'
-      path: '/chat'
-      fullPath: '/chat'
-      preLoaderRoute: typeof ChatRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/chat-compare': {
       id: '/chat-compare'
       path: '/chat-compare'
       fullPath: '/chat-compare'
       preLoaderRoute: typeof ChatCompareRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/chat': {
+      id: '/chat'
+      path: '/chat'
+      fullPath: '/chat'
+      preLoaderRoute: typeof ChatRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/about': {

--- a/projects/portfolio/src/client/routeTree.gen.ts
+++ b/projects/portfolio/src/client/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as DiffRouteImport } from './routes/diff'
 import { Route as ChatRouteImport } from './routes/chat'
+import { Route as ChatCompareRouteImport } from './routes/chat-compare'
 import { Route as AboutRouteImport } from './routes/about'
 import { Route as IndexRouteImport } from './routes/index'
 
@@ -22,6 +23,11 @@ const DiffRoute = DiffRouteImport.update({
 const ChatRoute = ChatRouteImport.update({
   id: '/chat',
   path: '/chat',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ChatCompareRoute = ChatCompareRouteImport.update({
+  id: '/chat-compare',
+  path: '/chat-compare',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AboutRoute = AboutRouteImport.update({
@@ -39,12 +45,14 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
   '/chat': typeof ChatRoute
+  '/chat-compare': typeof ChatCompareRoute
   '/diff': typeof DiffRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
   '/chat': typeof ChatRoute
+  '/chat-compare': typeof ChatCompareRoute
   '/diff': typeof DiffRoute
 }
 export interface FileRoutesById {
@@ -52,20 +60,22 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
   '/chat': typeof ChatRoute
+  '/chat-compare': typeof ChatCompareRoute
   '/diff': typeof DiffRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/about' | '/chat' | '/diff'
+  fullPaths: '/' | '/about' | '/chat' | '/chat-compare' | '/diff'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/about' | '/chat' | '/diff'
-  id: '__root__' | '/' | '/about' | '/chat' | '/diff'
+  to: '/' | '/about' | '/chat' | '/chat-compare' | '/diff'
+  id: '__root__' | '/' | '/about' | '/chat' | '/chat-compare' | '/diff'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AboutRoute: typeof AboutRoute
   ChatRoute: typeof ChatRoute
+  ChatCompareRoute: typeof ChatCompareRoute
   DiffRoute: typeof DiffRoute
 }
 
@@ -83,6 +93,13 @@ declare module '@tanstack/react-router' {
       path: '/chat'
       fullPath: '/chat'
       preLoaderRoute: typeof ChatRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/chat-compare': {
+      id: '/chat-compare'
+      path: '/chat-compare'
+      fullPath: '/chat-compare'
+      preLoaderRoute: typeof ChatCompareRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/about': {
@@ -106,6 +123,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AboutRoute: AboutRoute,
   ChatRoute: ChatRoute,
+  ChatCompareRoute: ChatCompareRoute,
   DiffRoute: DiffRoute,
 }
 export const routeTree = rootRouteImport

--- a/projects/portfolio/src/client/routes/__root.tsx
+++ b/projects/portfolio/src/client/routes/__root.tsx
@@ -4,6 +4,7 @@ import { AppLayout } from '#/client/components/app-layout'
 import { RouteLoading } from '#/client/components/route-loading'
 import { AboutIcon } from '#/client/components/svg/about-icon'
 import { ChatbotIcon } from '#/client/components/svg/chatbot-icon'
+import { CompareIcon } from '#/client/components/svg/compare-icon'
 import { DashboardIcon } from '#/client/components/svg/dashboard-icon'
 import { DiffIcon } from '#/client/components/svg/diff-icon'
 
@@ -30,6 +31,7 @@ function Root() {
           { label: 'About', icon: <AboutIcon size={18} />, to: '/about' },
           { label: 'Diff', icon: <DiffIcon size={20} />, to: '/diff' },
           { label: 'Chat', icon: <ChatbotIcon size={26} />, to: '/chat' },
+          { label: 'Compare', icon: <CompareIcon size={22} />, to: '/chat-compare' },
         ]}
       >
         <Suspense fallback={<RouteLoading />}>

--- a/projects/portfolio/src/client/routes/chat-compare.tsx
+++ b/projects/portfolio/src/client/routes/chat-compare.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { lazy } from 'react'
+
+const ChatCompare = lazy(() =>
+  import('#/client/pages/chat-compare').then((module) => ({ default: module.ChatCompare }))
+)
+
+export const Route = createFileRoute('/chat-compare')({
+  component: RouteComponent,
+})
+
+function RouteComponent() {
+  return <ChatCompare />
+}

--- a/projects/portfolio/tests/client/components/model-checkbox-list.test.ts
+++ b/projects/portfolio/tests/client/components/model-checkbox-list.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { groupModelsByProvider } from '#/client/components/chat-compare/model-checkbox-list'
+
+describe('groupModelsByProvider', () => {
+  it('provider ごとにモデルを分類し、表示名から provider を省く', () => {
+    expect(groupModelsByProvider(['anthropic/claude-sonnet-4-6', 'openai/gpt-5.2', 'openai/gpt-5.4-mini'])).toEqual([
+      {
+        provider: 'anthropic',
+        models: [{ id: 'anthropic/claude-sonnet-4-6', label: 'claude-sonnet-4-6' }],
+      },
+      {
+        provider: 'openai',
+        models: [
+          { id: 'openai/gpt-5.2', label: 'gpt-5.2' },
+          { id: 'openai/gpt-5.4-mini', label: 'gpt-5.4-mini' },
+        ],
+      },
+    ])
+  })
+
+  it('provider と model に分割できない場合はその他に分類する', () => {
+    expect(groupModelsByProvider(['gpt-5.2', 'openai/', '/gpt-5.4'])).toEqual([
+      {
+        provider: 'その他',
+        models: [
+          { id: 'gpt-5.2', label: 'gpt-5.2' },
+          { id: 'openai/', label: 'openai/' },
+          { id: '/gpt-5.4', label: '/gpt-5.4' },
+        ],
+      },
+    ])
+  })
+})


### PR DESCRIPTION
## Issues

- Close #908

## Why

現在のチャット画面（`/chat`）は1モデルずつの対話に特化しており、複数モデルの出力を同時比較できません。モデル比較用途では、DBに会話履歴を永続化せず、フロント側のメモリ上に保持した会話メッセージ配列を各モデルへ継続的に送信しながら、複数モデルの応答を並列に比較できる画面が必要です。

## Summary

複数のLLMモデルに同じプロンプトを同時投入し、応答を並べて比較できる `/chat-compare` ページを新規追加しました。既存の `POST /api/chat/stream` エンドポイントを再利用し、モデルごとに独立したストリームリクエストを並列実行します。

## Changes

- **ルート定義**: `src/client/routes/chat-compare.tsx` を追加
- **ページコンポーネント**: `src/client/pages/chat-compare/index.tsx` を追加
- **設定パネル**: `CompareSettings` コンポーネント（baseURL, apiKey, apiMode）- localStorage に compare 専用キーで永続化
- **モデル選択**: `ModelCheckboxList` コンポーネント（チェックボックスによる複数選択）
- **会話破棄確認**: `ModelChangeConfirmDialog` コンポーネント（会話済み状態でのモデル選択変更時の確認）
- **比較カラム**: `CompareColumn` コンポーネント（プレーンテキスト表示 + メタ情報）
- **入力エリア**: `CompareComposer` コンポーネント（プロンプト入力 + 送信/停止）
- **レイアウト**: `CompareLayout` コンポーネント（レスポンシブ対応）
- **状態管理**: `useCompareState`（モデルごとのメモリ会話・状態管理）
- **ストリーム管理**: `useCompareStream`（モデルごとの独立ストリームリクエスト、部分失敗許容）
- **設定永続化**: `useCompareSettings`（compare 専用 localStorage 設定管理）
- **ナビゲーション**: サイドバーに `/chat-compare` リンクを追加（CompareIcon）

## Verification

- `bun run lint` - passed (0 warnings, 0 errors)
- `bun run format` - passed (no changes)
- `bun run test` - passed (45 files, 248 tests)

## Screenshot
<img width="1919" height="968" alt="image" src="https://github.com/user-attachments/assets/bcbb3cf0-1dad-4a99-889a-1546d9849963" />

<img width="1918" height="968" alt="image" src="https://github.com/user-attachments/assets/b1a9ca28-971f-4869-820a-76d8be5b0fe2" />

継続会話のテスト
<img width="1841" height="676" alt="image" src="https://github.com/user-attachments/assets/b68e0036-6f33-4f53-b665-e4eb6e3ad4ea" />
