### PR TITLE
Configure agent tool round limit

### DIFF
--- a/projects/simple-agent-poc/agents.yaml
+++ b/projects/simple-agent-poc/agents.yaml
@@ -20,6 +20,7 @@ agents:
       - concat
       - ask_user
     api_type: completion
+    max_tool_rounds: 5
 
   kansaiben:
     model: gpt-5.4-nano
@@ -34,3 +35,4 @@ agents:
       - concat
       - ask_user
     api_type: responses
+    max_tool_rounds: 5

--- a/projects/simple-agent-poc/docs/agent-definition.md
+++ b/projects/simple-agent-poc/docs/agent-definition.md
@@ -41,6 +41,12 @@ The factory selects the client at construction time based on this field.
 
 When `true`, the CLI uses `execute_stream()` with live text output instead of a spinner + synchronous `execute()`. Has no effect on the HTTP API, which always uses streaming for `/api/chat/stream`.
 
+### `max_tool_rounds`
+
+Maximum number of ReAct tool-call rounds for one user message. When omitted or `null`, the default is `5`. The value must be an integer from `1` to `20`; booleans, strings, floats, and out-of-range integers are rejected at startup.
+
+Each round allows the LLM to respond once and optionally request tools. If every allowed round still produces tool calls, execution stops with `LLMError` instead of continuing indefinitely.
+
 ## Validation at Startup
 
 On application startup, `AgentDefinitionRegistry.from_yaml_file()` validates:
@@ -51,6 +57,7 @@ On application startup, `AgentDefinitionRegistry.from_yaml_file()` validates:
 - `api_type` must be `"completion"` or `"responses"`
 - Unknown fields at the root or agent level are rejected
 - `temperature` must be a number or null; `stream` must be a boolean
+- `max_tool_rounds` must be an integer from `1` to `20`, or null
 
 For the exact validation logic, see `agent_definition.py` and its `_optional_*` validators.
 
@@ -77,4 +84,5 @@ agents:
     tools:
       - concat
       - ask_user
+    max_tool_rounds: 5
 ```

--- a/projects/simple-agent-poc/docs/llm-integration.md
+++ b/projects/simple-agent-poc/docs/llm-integration.md
@@ -17,6 +17,12 @@ class LLMClientFactory(Protocol):
 
 The `tools` parameter carries tool definitions resolved from the agent's `tools` list. When `None` or empty, no tools are sent to the LLM.
 
+## Agent ReAct Loop
+
+`RunAgentUseCase` owns orchestration around the LLM client. For each user message, it sends the current session messages to the selected client, records the assistant response, executes requested tools, appends tool results, and calls the LLM again. This ReAct loop continues until the LLM returns a final text response without tool calls.
+
+The loop limit comes from the selected agent definition's `max_tool_rounds` field in `agents.yaml`. The default is `5`, and startup validation restricts configured values to integers from `1` to `20`. This keeps provider-specific LLM clients focused on API translation while agent-level behavior such as tool-loop depth remains in YAML and the application use case.
+
 ## LiteLLMClientFactory
 
 Source: `src/simple_agent_poc/adapters/llm/litellm_client.py`

--- a/projects/simple-agent-poc/docs/session.md
+++ b/projects/simple-agent-poc/docs/session.md
@@ -23,7 +23,7 @@ Source: `src/simple_agent_poc/core/session.py`
 2. Each user turn appends a `role: "user"` message.
 3. The LLM response appends a `role: "assistant"` message (may include `tool_calls`).
 4. If the LLM calls a tool, a `role: "tool"` message is appended with the result and `tool_call_id`.
-5. The ReAct loop may repeat steps 3-4 up to `MAX_TOOL_ROUNDS` times.
+5. The ReAct loop may repeat steps 3-4 up to the agent definition's `max_tool_rounds` value (`5` by default).
 6. This cycle continues for the lifetime of the session.
 
 ### Session Creation

--- a/projects/simple-agent-poc/docs/sse.md
+++ b/projects/simple-agent-poc/docs/sse.md
@@ -135,7 +135,7 @@ Source: `src/simple_agent_poc/application/use_cases.py`
    - If a tool call is `ask_user` in API mode → yields `SessionPaused`, saves session, and returns (SSE disconnects).
    - If a tool call is `ask_user` in CLI mode → yields `ToolCallEvent` and waits for `generator.send(answer)`.
    - If no tool calls → appends accumulated text as assistant message.
-   - Loops up to `MAX_TOOL_ROUNDS = 5` for multi-round tool calls.
+   - Loops up to the agent definition's `max_tool_rounds` value (`5` by default) for multi-round tool calls.
 8. Yields `StreamComplete(...)` with session metadata.
 9. In `finally`: saves the session to the session store.
 

--- a/projects/simple-agent-poc/src/simple_agent_poc/application/use_cases.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/application/use_cases.py
@@ -38,8 +38,6 @@ from simple_agent_poc.core.types import (
     ValidationError,
 )
 
-MAX_TOOL_ROUNDS = 5
-
 
 def _accumulate_tool_call_chunks(
     accumulated: dict[int, ToolCall],
@@ -103,7 +101,7 @@ class RunAgentUseCase:
         tool_call_history: list[ToolCallRecord] = []
 
         try:
-            for _ in range(MAX_TOOL_ROUNDS):
+            for _ in range(agent_definition.max_tool_rounds):
                 response = llm_client.complete(list(session.messages), tools=tools)
 
                 tool_calls = response.get("tool_calls")
@@ -179,7 +177,7 @@ class RunAgentUseCase:
         _accumulated_text = ""
 
         try:
-            for round_idx in range(MAX_TOOL_ROUNDS):
+            for round_idx in range(agent_definition.max_tool_rounds):
                 _accumulated_text = ""
                 accumulated_tool_calls: dict[int, ToolCall] = {}
                 usage_from_stream: Usage | None = None
@@ -334,7 +332,7 @@ class RunAgentUseCase:
         _accumulated_text = ""
 
         try:
-            for round_idx in range(resume_round + 1, MAX_TOOL_ROUNDS):
+            for round_idx in range(resume_round + 1, agent_definition.max_tool_rounds):
                 _accumulated_text = ""
                 accumulated_tool_calls: dict[int, ToolCall] = {}
                 usage_from_stream: Usage | None = None

--- a/projects/simple-agent-poc/src/simple_agent_poc/core/agent_definition.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/core/agent_definition.py
@@ -10,7 +10,15 @@ from simple_agent_poc.core.types import ValidationError
 
 _ROOT_FIELDS = frozenset({"agents"})
 _AGENT_FIELDS = frozenset(
-    {"model", "system_prompt", "temperature", "tools", "api_type", "stream"}
+    {
+        "model",
+        "system_prompt",
+        "temperature",
+        "tools",
+        "api_type",
+        "stream",
+        "max_tool_rounds",
+    }
 )
 _REQUIRED_AGENT_FIELDS = frozenset({"model", "system_prompt"})
 
@@ -26,6 +34,7 @@ class AgentDefinition:
     tools: list[str] = field(default_factory=list)
     api_type: Literal["completion", "responses"] = "completion"
     stream: bool = False
+    max_tool_rounds: int = 5
 
     def format_system_prompt(self, *, current_datetime: str) -> str:
         """Format the system prompt with runtime context."""
@@ -114,6 +123,13 @@ def _build_agent_definition(
         definition.get("stream"),
         f"agents.{agent_id}.stream",
     )
+    max_tool_rounds = _optional_int_min_max(
+        definition.get("max_tool_rounds"),
+        f"agents.{agent_id}.max_tool_rounds",
+        minimum=1,
+        maximum=20,
+        default=5,
+    )
 
     return AgentDefinition(
         agent_id=agent_id,
@@ -123,6 +139,7 @@ def _build_agent_definition(
         tools=tools,
         api_type=api_type,
         stream=stream,
+        max_tool_rounds=max_tool_rounds,
     )
 
 
@@ -185,4 +202,21 @@ def _optional_bool(value: object, path: str) -> bool:
         return False
     if not isinstance(value, bool):
         raise ValidationError(f"{path} must be a boolean")
+    return value
+
+
+def _optional_int_min_max(
+    value: object,
+    path: str,
+    *,
+    minimum: int,
+    maximum: int,
+    default: int,
+) -> int:
+    if value is None:
+        return default
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValidationError(f"{path} must be an integer")
+    if value < minimum or value > maximum:
+        raise ValidationError(f"{path} must be between {minimum} and {maximum}")
     return value

--- a/projects/simple-agent-poc/tests/test_agent_definition.py
+++ b/projects/simple-agent-poc/tests/test_agent_definition.py
@@ -259,3 +259,81 @@ agents:
                     }
                 }
             )
+
+    @pytest.mark.parametrize("value", [1, 5, 20])
+    def test_allows_max_tool_rounds_in_range(self, value: int) -> None:
+        registry = AgentDefinitionRegistry.from_mapping(
+            {
+                "agents": {
+                    "default": {
+                        "model": "gpt-4.1-nano",
+                        "system_prompt": "Prompt",
+                        "max_tool_rounds": value,
+                    }
+                }
+            }
+        )
+
+        assert registry.get("default").max_tool_rounds == value
+
+    def test_max_tool_rounds_defaults_to_five(self) -> None:
+        registry = AgentDefinitionRegistry.from_mapping(
+            {
+                "agents": {
+                    "default": {
+                        "model": "gpt-4.1-nano",
+                        "system_prompt": "Prompt",
+                    }
+                }
+            }
+        )
+
+        assert registry.get("default").max_tool_rounds == 5
+
+    def test_max_tool_rounds_defaults_to_five_when_null(self) -> None:
+        registry = AgentDefinitionRegistry.from_mapping(
+            {
+                "agents": {
+                    "default": {
+                        "model": "gpt-4.1-nano",
+                        "system_prompt": "Prompt",
+                        "max_tool_rounds": None,
+                    }
+                }
+            }
+        )
+
+        assert registry.get("default").max_tool_rounds == 5
+
+    @pytest.mark.parametrize("value", [0, 21])
+    def test_rejects_max_tool_rounds_outside_range(self, value: int) -> None:
+        with pytest.raises(
+            ValidationError,
+            match="max_tool_rounds must be between 1 and 20",
+        ):
+            AgentDefinitionRegistry.from_mapping(
+                {
+                    "agents": {
+                        "default": {
+                            "model": "gpt-4.1-nano",
+                            "system_prompt": "Prompt",
+                            "max_tool_rounds": value,
+                        }
+                    }
+                }
+            )
+
+    @pytest.mark.parametrize("value", [True, "5", 5.0])
+    def test_rejects_non_int_max_tool_rounds(self, value: object) -> None:
+        with pytest.raises(ValidationError, match="max_tool_rounds must be an integer"):
+            AgentDefinitionRegistry.from_mapping(
+                {
+                    "agents": {
+                        "default": {
+                            "model": "gpt-4.1-nano",
+                            "system_prompt": "Prompt",
+                            "max_tool_rounds": value,
+                        }
+                    }
+                }
+            )

--- a/projects/simple-agent-poc/tests/test_use_cases.py
+++ b/projects/simple-agent-poc/tests/test_use_cases.py
@@ -5,6 +5,7 @@ from collections.abc import Iterator
 from simple_agent_poc.adapters.session_store.in_memory import InMemorySessionStore
 from simple_agent_poc.application.dto import (
     ContentDelta,
+    ContinueRequest,
     RunAgentRequest,
     StreamComplete,
     ToolCallEvent,
@@ -12,6 +13,7 @@ from simple_agent_poc.application.dto import (
 )
 from simple_agent_poc.application.use_cases import RunAgentUseCase
 from simple_agent_poc.core.agent_definition import AgentDefinitionRegistry
+from simple_agent_poc.core.session import ConversationSession
 from simple_agent_poc.core.types import (
     LLMError,
     LLMResponse,
@@ -111,6 +113,23 @@ def _usage() -> Usage:
     return {"prompt_tokens": 20, "completion_tokens": 10, "total_tokens": 30}
 
 
+def _agent_definitions_with_max_tool_rounds(
+    max_tool_rounds: int,
+) -> AgentDefinitionRegistry:
+    return AgentDefinitionRegistry.from_mapping(
+        {
+            "agents": {
+                "default": {
+                    "model": "test-model",
+                    "system_prompt": "You are a helpful assistant.",
+                    "tools": ["concat"],
+                    "max_tool_rounds": max_tool_rounds,
+                }
+            }
+        }
+    )
+
+
 def test_execute_yields_final_response_without_tools(default_agent_def, tool_registry):
     """Without tools, the agent returns a normal text response."""
     fake_llm = FakeLLMClient(rounds=[])
@@ -152,7 +171,7 @@ def test_execute_with_tool_call(default_agent_def, tool_registry):
 
 
 def test_execute_exceeds_max_tool_rounds(default_agent_def, tool_registry):
-    """After MAX_TOOL_ROUNDS, an LLMError is raised."""
+    """After max_tool_rounds (default 5), an LLMError is raised."""
     rounds = []
     for _ in range(5):
         rounds.append(
@@ -181,17 +200,7 @@ def test_execute_exceeds_max_tool_rounds(default_agent_def, tool_registry):
 
 def test_execute_uses_agent_max_tool_rounds(tool_registry):
     """The ReAct loop stops at the agent's configured max_tool_rounds."""
-    agent_definitions = AgentDefinitionRegistry.from_mapping(
-        {
-            "agents": {
-                "default": {
-                    "model": "test-model",
-                    "system_prompt": "You are a helpful assistant.",
-                    "max_tool_rounds": 3,
-                }
-            }
-        }
-    )
+    agent_definitions = _agent_definitions_with_max_tool_rounds(3)
     rounds = []
     for _ in range(3):
         rounds.append(
@@ -282,6 +291,87 @@ def test_execute_stream_with_tool_call(default_agent_def, tool_registry):
     assert len(tool_result_events) >= 1
     assert tool_result_events[0].name == "concat"
     assert "helloworld" in tool_result_events[0].result
+
+
+def test_execute_stream_uses_agent_max_tool_rounds(tool_registry):
+    """The streaming ReAct loop stops at the configured max_tool_rounds."""
+    agent_definitions = _agent_definitions_with_max_tool_rounds(3)
+    rounds = []
+    for _ in range(3):
+        rounds.append(
+            {
+                "content": "",
+                "usage": _usage(),
+                "model": "fake",
+                "response_time": 0.1,
+                "tool_calls": _concat_tool_call(),
+            }
+        )
+
+    fake_llm = FakeLLMClient(rounds=rounds)
+    use_case = RunAgentUseCase(
+        llm_client_factory=FakeLLMClientFactory(fake_llm),
+        session_store=InMemorySessionStore(),
+        agent_definitions=agent_definitions,
+        tool_executor=tool_registry,
+    )
+
+    try:
+        list(use_case.execute_stream(RunAgentRequest(message="loop")))
+        assert False, "Expected LLMError"
+    except LLMError:
+        pass
+    assert fake_llm._call_count == 3
+
+
+def test_continue_stream_uses_agent_max_tool_rounds(tool_registry):
+    """The resumed streaming ReAct loop stops at the remaining max_tool_rounds."""
+    agent_definitions = _agent_definitions_with_max_tool_rounds(2)
+    store = InMemorySessionStore()
+    ask_user_tool_call: ToolCall = {
+        "id": "call_ask_user",
+        "type": "function",
+        "function": {
+            "name": "ask_user",
+            "arguments": '{"question": "Continue?"}',
+        },
+    }
+    session = ConversationSession.start(
+        session_id="paused-session",
+        system_prompt="You are a helpful assistant.",
+    )
+    session.append_assistant_message("", tool_calls=[ask_user_tool_call])
+    session.pause_for_ask_user(ask_user_tool_call, round_idx=0)
+    store.save(session)
+
+    fake_llm = FakeLLMClient(
+        rounds=[
+            {
+                "content": "",
+                "usage": _usage(),
+                "model": "fake",
+                "response_time": 0.1,
+                "tool_calls": _concat_tool_call(),
+            }
+        ]
+    )
+    use_case = RunAgentUseCase(
+        llm_client_factory=FakeLLMClientFactory(fake_llm),
+        session_store=store,
+        agent_definitions=agent_definitions,
+        tool_executor=tool_registry,
+    )
+
+    try:
+        list(
+            use_case.continue_stream(
+                ContinueRequest(session_id="paused-session", answer="yes")
+            )
+        )
+        assert False, "Expected LLMError"
+    except LLMError:
+        pass
+    assert fake_llm._call_count == 1
 
 
 def test_execute_stream_final_complete(default_agent_def, tool_registry):

--- a/projects/simple-agent-poc/tests/test_use_cases.py
+++ b/projects/simple-agent-poc/tests/test_use_cases.py
@@ -11,6 +11,7 @@ from simple_agent_poc.application.dto import (
     ToolResultEvent,
 )
 from simple_agent_poc.application.use_cases import RunAgentUseCase
+from simple_agent_poc.core.agent_definition import AgentDefinitionRegistry
 from simple_agent_poc.core.types import (
     LLMError,
     LLMResponse,
@@ -176,6 +177,47 @@ def test_execute_exceeds_max_tool_rounds(default_agent_def, tool_registry):
         assert False, "Expected LLMError"
     except LLMError:
         pass
+
+
+def test_execute_uses_agent_max_tool_rounds(tool_registry):
+    """The ReAct loop stops at the agent's configured max_tool_rounds."""
+    agent_definitions = AgentDefinitionRegistry.from_mapping(
+        {
+            "agents": {
+                "default": {
+                    "model": "test-model",
+                    "system_prompt": "You are a helpful assistant.",
+                    "max_tool_rounds": 3,
+                }
+            }
+        }
+    )
+    rounds = []
+    for _ in range(3):
+        rounds.append(
+            {
+                "content": "",
+                "usage": _usage(),
+                "model": "fake",
+                "response_time": 0.1,
+                "tool_calls": _concat_tool_call(),
+            }
+        )
+
+    fake_llm = FakeLLMClient(rounds=rounds)
+    use_case = RunAgentUseCase(
+        llm_client_factory=FakeLLMClientFactory(fake_llm),
+        session_store=InMemorySessionStore(),
+        agent_definitions=agent_definitions,
+        tool_executor=tool_registry,
+    )
+
+    try:
+        use_case.execute(RunAgentRequest(message="loop"))
+        assert False, "Expected LLMError"
+    except LLMError:
+        pass
+    assert fake_llm._call_count == 3
 
 
 def test_execute_blank_message_rejected(default_agent_def, tool_registry):


### PR DESCRIPTION
## Issues

- Close #911

## Why

The ReAct tool-loop limit was hardcoded in `use_cases.py`, so all agents shared the same behavior regardless of model or YAML configuration.

## Summary

Move the tool-loop limit into agent definitions as `max_tool_rounds`, with a default of `5` for backward compatibility.

## Changes

- Add `AgentDefinition.max_tool_rounds` with startup validation for integer values from `1` to `20`
- Use `agent_definition.max_tool_rounds` in sync, streaming, and continue-stream ReAct loops
- Add sample YAML values, schema documentation, and LLM/session/SSE docs updates
- Add tests for defaults, valid values, invalid values, and configured loop limits

## Verification

- `uv run ruff format .` - passed
- `uv run ruff check .` - passed
- `uv run pytest tests/test_agent_definition.py tests/test_use_cases.py` - passed
- `uv run ty check .` - passed
- `uv run pytest` - passed
