### PR TITLE
feat: add GET / test page for chat, streaming, and ask_user resume

### DIFF
--- a/projects/simple-agent-poc/docs/sse.md
+++ b/projects/simple-agent-poc/docs/sse.md
@@ -156,8 +156,9 @@ Source: `src/simple_agent_poc/application/use_cases.py`
 1. Loads the session by `session_id`. Returns error if not found or not paused.
 2. Injects the user's answer as a tool result message.
 3. Yields `ToolResultEvent` for the `ask_user` call.
-4. Resumes the ReAct loop with the remaining rounds.
-5. Yields `StreamComplete` on finish.
+4. If the same assistant message still has another unanswered `ask_user` tool call, pauses again and yields `SessionPaused` without calling the LLM.
+5. Otherwise, resumes the ReAct loop with the remaining rounds.
+6. Yields `StreamComplete` on finish.
 
 ## CLI Streaming
 

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/api.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/api.py
@@ -7,7 +7,7 @@ from typing import Annotated
 
 from fastapi import Depends, FastAPI, Header, HTTPException
 from pydantic import BaseModel, ConfigDict, field_validator
-from starlette.responses import StreamingResponse
+from starlette.responses import HTMLResponse, StreamingResponse
 
 from simple_agent_poc.application.dto import (
     ContentDelta,
@@ -26,6 +26,7 @@ from simple_agent_poc.core.types import (
     Usage,
     ValidationError,
 )
+from simple_agent_poc.adapters.http.test_page import TEST_PAGE_HTML
 from simple_agent_poc.entrypoints.bootstrap import create_run_agent_use_case_factory
 
 
@@ -253,5 +254,9 @@ def create_app(
                 yield f"event: error\ndata: {json.dumps({'detail': str(error)}, ensure_ascii=False)}\n\n"
 
         return StreamingResponse(event_stream(), media_type="text/event-stream")
+
+    @app.get("/", response_class=HTMLResponse)
+    def test_page() -> HTMLResponse:
+        return HTMLResponse(TEST_PAGE_HTML)
 
     return app

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/test_page.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/test_page.py
@@ -164,6 +164,12 @@ function appendLine(area, className, text) {
   appendLog(area, className, text + "\\n");
 }
 
+function finishLogLine(node) {
+  if (node && !node.textContent.endsWith("\\n")) {
+    node.textContent += "\\n";
+  }
+}
+
 function appendJson(area, className, obj) {
   appendLine(area, className, JSON.stringify(obj, null, 2));
 }
@@ -299,6 +305,7 @@ async function sendStreamMessage(message) {
       appendLine("conv-log", "line-error", "Error: " + e.message);
     }
   } finally {
+    finishLogLine(assistantSpan);
     state.abortController = null;
     setSending(false);
   }
@@ -379,6 +386,7 @@ async function resumeFromPaused() {
       appendLine("conv-log", "line-error", "Error: " + e.message);
     }
   } finally {
+    finishLogLine(assistantSpan);
     state.abortController = null;
     setSending(false);
   }

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/test_page.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/test_page.py
@@ -265,30 +265,30 @@ async function sendStreamMessage(message) {
       return;
     }
     await readSseStream(resp, (event) => {
-      if (event === "delta") {
+      if (event.type === "delta") {
         const d = JSON.parse(event.data);
         assistantText += d.content;
         assistantSpan.textContent = "Assistant: " + assistantText;
         el("conv-log").scrollTop = el("conv-log").scrollHeight;
-      } else if (event === "tool_call") {
+      } else if (event.type === "tool_call") {
         const d = JSON.parse(event.data);
         appendLine("conv-log", "line-tool", "  Tool: " + d.name + "(" + d.arguments + ")");
         appendJson("tool-log", "line-tool", d);
-      } else if (event === "tool_result") {
+      } else if (event.type === "tool_result") {
         const d = JSON.parse(event.data);
         appendLine("conv-log", "line-tool", "  Result: " + truncate(d.result, 200));
         appendJson("tool-log", "line-tool", d);
-      } else if (event === "paused") {
+      } else if (event.type === "paused") {
         const d = JSON.parse(event.data);
         appendLine("conv-log", "line-paused", "  [Paused] " + d.question);
         enterPausedState(d);
-      } else if (event === "complete") {
+      } else if (event.type === "complete") {
         const d = JSON.parse(event.data);
         if (d.session_id) setSessionId(d.session_id);
         if (d.usage) {
           appendLine("raw-log", "line-system", "usage: " + JSON.stringify(d.usage));
         }
-      } else if (event === "error") {
+      } else if (event.type === "error") {
         const d = JSON.parse(event.data);
         appendLine("conv-log", "line-error", "Error: " + (d.detail || "unknown error"));
       }
@@ -304,7 +304,7 @@ async function sendStreamMessage(message) {
   }
 }
 
-function enterPausedState({ sessionId, question, callId }) {
+function enterPausedState({ session_id: sessionId, question, call_id: callId }) {
   state.awaitingAnswer = { sessionId, question, callId };
   setSessionId(sessionId);
   el("paused-question").textContent = "Q: " + question;
@@ -345,30 +345,30 @@ async function resumeFromPaused() {
       return;
     }
     await readSseStream(resp, (event) => {
-      if (event === "delta") {
+      if (event.type === "delta") {
         const d = JSON.parse(event.data);
         assistantText += d.content;
         assistantSpan.textContent = "Assistant: " + assistantText;
         el("conv-log").scrollTop = el("conv-log").scrollHeight;
-      } else if (event === "tool_call") {
+      } else if (event.type === "tool_call") {
         const d = JSON.parse(event.data);
         appendLine("conv-log", "line-tool", "  Tool: " + d.name + "(" + d.arguments + ")");
         appendJson("tool-log", "line-tool", d);
-      } else if (event === "tool_result") {
+      } else if (event.type === "tool_result") {
         const d = JSON.parse(event.data);
         appendLine("conv-log", "line-tool", "  Result: " + truncate(d.result, 200));
         appendJson("tool-log", "line-tool", d);
-      } else if (event === "paused") {
+      } else if (event.type === "paused") {
         const d = JSON.parse(event.data);
         appendLine("conv-log", "line-paused", "  [Paused] " + d.question);
         enterPausedState(d);
-      } else if (event === "complete") {
+      } else if (event.type === "complete") {
         const d = JSON.parse(event.data);
         if (d.session_id) setSessionId(d.session_id);
         if (d.usage) {
           appendLine("raw-log", "line-system", "usage: " + JSON.stringify(d.usage));
         }
-      } else if (event === "error") {
+      } else if (event.type === "error") {
         const d = JSON.parse(event.data);
         appendLine("conv-log", "line-error", "Error: " + (d.detail || "unknown error"));
       }

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/test_page.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/test_page.py
@@ -1,0 +1,439 @@
+"""Development test page for chat, streaming, and ask_user resume."""
+
+TEST_PAGE_HTML = """<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>simple-agent-poc - Test Page</title>
+<style>
+  :root { --bg: #18181b; --surface: #27272a; --border: #3f3f46; --text: #e4e4e7; --muted: #a1a1aa; --accent: #22c55e; --error: #ef4444; --tool: #3b82f6; --pause: #f59e0b; }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: ui-monospace, 'Cascadia Code', monospace; background: var(--bg); color: var(--text); min-height: 100vh; display: flex; flex-direction: column; }
+  header { background: var(--surface); border-bottom: 1px solid var(--border); padding: 12px 16px; display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+  header h1 { font-size: 14px; font-weight: 600; margin-right: auto; }
+  header label { font-size: 12px; color: var(--muted); }
+  header input, header select { background: var(--bg); color: var(--text); border: 1px solid var(--border); border-radius: 4px; padding: 4px 8px; font-family: inherit; font-size: 12px; }
+  header button { background: var(--surface); color: var(--text); border: 1px solid var(--border); border-radius: 4px; padding: 4px 10px; font-family: inherit; font-size: 12px; cursor: pointer; }
+  header button:hover { background: var(--border); }
+  main { flex: 1; display: flex; flex-direction: column; overflow: hidden; }
+  .logs { flex: 1; display: flex; flex-direction: column; overflow: hidden; padding: 8px; gap: 8px; }
+  .log-section { flex: 1; min-height: 0; display: flex; flex-direction: column; }
+  .log-section summary { font-size: 12px; color: var(--muted); cursor: pointer; padding: 4px 0; user-select: none; }
+  .log-section pre { flex: 1; overflow-y: auto; background: var(--surface); border: 1px solid var(--border); border-radius: 4px; padding: 8px; font-family: inherit; font-size: 12px; line-height: 1.5; white-space: pre-wrap; word-break: break-word; }
+  footer { background: var(--surface); border-top: 1px solid var(--border); padding: 8px 12px; }
+  .input-row { display: flex; gap: 6px; }
+  .input-row input[type="text"] { flex: 1; background: var(--bg); color: var(--text); border: 1px solid var(--border); border-radius: 4px; padding: 6px 10px; font-family: inherit; font-size: 13px; }
+  .input-row button { background: var(--accent); color: #000; border: none; border-radius: 4px; padding: 6px 14px; font-family: inherit; font-size: 13px; font-weight: 600; cursor: pointer; }
+  .input-row button:disabled { opacity: 0.4; cursor: not-allowed; }
+  .input-row button.stop { background: var(--error); color: #fff; }
+  .paused-bar { display: none; background: var(--pause); color: #000; padding: 8px 12px; font-size: 13px; font-weight: 600; }
+  .paused-bar.visible { display: flex; gap: 6px; align-items: center; }
+  .paused-bar input[type="text"] { flex: 1; background: rgba(0,0,0,.15); color: #000; border: 1px solid rgba(0,0,0,.2); border-radius: 4px; padding: 4px 8px; font-family: inherit; font-size: 13px; }
+  .paused-bar button { background: rgba(0,0,0,.2); color: #000; border: none; border-radius: 4px; padding: 4px 10px; font-family: inherit; font-size: 13px; font-weight: 600; cursor: pointer; }
+  .line-user { color: var(--muted); }
+  .line-assistant { color: var(--text); }
+  .line-tool { color: var(--tool); }
+  .line-paused { color: var(--pause); }
+  .line-error { color: var(--error); }
+  .line-system { color: var(--muted); font-style: italic; }
+</style>
+</head>
+<body>
+<header>
+  <h1>simple-agent-poc</h1>
+  <label>Mode
+    <select id="mode-select" onchange="onModeChange()">
+      <option value="stream">stream</option>
+      <option value="sync">sync</option>
+    </select>
+  </label>
+  <label>Agent
+    <input type="text" id="agent-id" value="default" size="10" onchange="onAgentIdChange()">
+  </label>
+  <label>Session
+    <input type="text" id="session-id" size="24" placeholder="(new)" onchange="onSessionIdChange()">
+  </label>
+  <button onclick="clearSession()">Clear</button>
+</header>
+<main>
+  <div class="logs">
+    <details class="log-section" open>
+      <summary>Conversation</summary>
+      <pre id="conv-log"></pre>
+    </details>
+    <details class="log-section">
+      <summary>Tool Calls</summary>
+      <pre id="tool-log"></pre>
+    </details>
+    <details class="log-section">
+      <summary>Raw</summary>
+      <pre id="raw-log"></pre>
+    </details>
+  </div>
+  <div class="paused-bar" id="paused-bar">
+    <span id="paused-question"></span>
+    <input type="text" id="paused-answer" placeholder="Type your answer..." onkeydown="if(event.key==='Enter')resumeFromPaused()">
+    <button onclick="resumeFromPaused()">Resume</button>
+    <button onclick="cancelPaused()">Cancel</button>
+  </div>
+</main>
+<footer>
+  <div class="input-row">
+    <input type="text" id="msg-input" placeholder="Type a message..." onkeydown="if(event.key==='Enter'&&!event.shiftKey){event.preventDefault();sendMessage()}">
+    <button id="send-btn" onclick="sendMessage()">Send</button>
+    <button id="stop-btn" class="stop" onclick="stopRequest()" style="display:none">Stop</button>
+  </div>
+</footer>
+<script>
+const state = {
+  mode: "stream",
+  agentId: "default",
+  sessionId: "",
+  awaitingAnswer: null,
+  abortController: null,
+};
+
+const el = (id) => document.getElementById(id);
+
+function onModeChange() {
+  state.mode = el("mode-select").value;
+  persist();
+}
+
+function onAgentIdChange() {
+  state.agentId = el("agent-id").value.trim() || "default";
+  persist();
+}
+
+function onSessionIdChange() {
+  state.sessionId = el("session-id").value.trim();
+  persist();
+}
+
+function setSessionId(id) {
+  state.sessionId = id;
+  el("session-id").value = id;
+  persist();
+}
+
+function persist() {
+  try {
+    localStorage.setItem("sap_test_ui", JSON.stringify({
+      mode: state.mode,
+      agentId: state.agentId,
+      sessionId: state.sessionId,
+    }));
+  } catch (_) {}
+}
+
+function restore() {
+  try {
+    const raw = localStorage.getItem("sap_test_ui");
+    if (!raw) return;
+    const d = JSON.parse(raw);
+    if (d.mode) { state.mode = d.mode; el("mode-select").value = d.mode; }
+    if (d.agentId) { state.agentId = d.agentId; el("agent-id").value = d.agentId; }
+    if (d.sessionId) { state.sessionId = d.sessionId; el("session-id").value = d.sessionId; }
+  } catch (_) {}
+}
+
+function clearSession() {
+  state.sessionId = "";
+  state.awaitingAnswer = null;
+  el("session-id").value = "";
+  el("conv-log").textContent = "";
+  el("tool-log").textContent = "";
+  el("raw-log").textContent = "";
+  el("paused-bar").classList.remove("visible");
+  el("paused-question").textContent = "";
+  el("paused-answer").value = "";
+  persist();
+}
+
+function appendLog(area, className, text) {
+  const pre = el(area);
+  const span = document.createElement("span");
+  if (className) span.className = className;
+  span.textContent = text;
+  pre.appendChild(span);
+  pre.scrollTop = pre.scrollHeight;
+}
+
+function appendLine(area, className, text) {
+  appendLog(area, className, text + "\\n");
+}
+
+function appendJson(area, className, obj) {
+  appendLine(area, className, JSON.stringify(obj, null, 2));
+}
+
+function setSending(sending) {
+  const sendBtn = el("send-btn");
+  const stopBtn = el("stop-btn");
+  const msgInput = el("msg-input");
+  if (sending) {
+    sendBtn.style.display = "none";
+    stopBtn.style.display = "";
+    msgInput.disabled = true;
+  } else {
+    sendBtn.style.display = "";
+    stopBtn.style.display = "none";
+    msgInput.disabled = false;
+    msgInput.focus();
+  }
+}
+
+async function sendMessage() {
+  const message = el("msg-input").value.trim();
+  if (!message) return;
+  if (state.abortController) return;
+  el("msg-input").value = "";
+  appendLine("conv-log", "line-user", "You: " + message);
+  appendLine("raw-log", "line-system", "--- sending message ---");
+  if (state.mode === "stream") {
+    await sendStreamMessage(message);
+  } else {
+    await sendSyncMessage(message);
+  }
+}
+
+async function sendSyncMessage(message) {
+  const controller = new AbortController();
+  state.abortController = controller;
+  setSending(true);
+  try {
+    const headers = { "Content-Type": "application/json" };
+    if (state.sessionId) headers["Session-Id"] = state.sessionId;
+    const resp = await fetch("/api/chat", {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ message, agent_id: state.agentId }),
+      signal: controller.signal,
+    });
+    appendJson("raw-log", "line-system", { status: resp.status });
+    if (!resp.ok) {
+      const err = await resp.json();
+      appendLine("conv-log", "line-error", "Error: " + (err.detail || resp.statusText));
+      appendJson("raw-log", "line-error", err);
+      return;
+    }
+    const data = await resp.json();
+    appendJson("raw-log", "line-system", data);
+    appendLine("conv-log", "line-assistant", "Assistant: " + data.message);
+    if (data.tool_calls && data.tool_calls.length > 0) {
+      for (const tc of data.tool_calls) {
+        appendLine("conv-log", "line-tool", "  Tool: " + tc.name + "(" + tc.arguments + ") -> " + truncate(tc.result, 200));
+        appendJson("tool-log", "line-tool", tc);
+      }
+    }
+    if (data.session_id) setSessionId(data.session_id);
+    if (data.usage) {
+      appendLine("raw-log", "line-system", "usage: " + JSON.stringify(data.usage));
+    }
+  } catch (e) {
+    if (e.name !== "AbortError") {
+      appendLine("conv-log", "line-error", "Error: " + e.message);
+    }
+  } finally {
+    state.abortController = null;
+    setSending(false);
+  }
+}
+
+async function sendStreamMessage(message) {
+  const controller = new AbortController();
+  state.abortController = controller;
+  setSending(true);
+  let assistantText = "";
+  const assistantSpan = document.createElement("span");
+  assistantSpan.className = "line-assistant";
+  assistantSpan.textContent = "Assistant: ";
+  el("conv-log").appendChild(assistantSpan);
+  try {
+    const headers = { "Content-Type": "application/json" };
+    if (state.sessionId) headers["Session-Id"] = state.sessionId;
+    const resp = await fetch("/api/chat/stream", {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ message, agent_id: state.agentId }),
+      signal: controller.signal,
+    });
+    if (!resp.ok) {
+      const err = await resp.text();
+      appendLine("conv-log", "line-error", "Error: " + err);
+      return;
+    }
+    await readSseStream(resp, (event) => {
+      if (event === "delta") {
+        const d = JSON.parse(event.data);
+        assistantText += d.content;
+        assistantSpan.textContent = "Assistant: " + assistantText;
+        el("conv-log").scrollTop = el("conv-log").scrollHeight;
+      } else if (event === "tool_call") {
+        const d = JSON.parse(event.data);
+        appendLine("conv-log", "line-tool", "  Tool: " + d.name + "(" + d.arguments + ")");
+        appendJson("tool-log", "line-tool", d);
+      } else if (event === "tool_result") {
+        const d = JSON.parse(event.data);
+        appendLine("conv-log", "line-tool", "  Result: " + truncate(d.result, 200));
+        appendJson("tool-log", "line-tool", d);
+      } else if (event === "paused") {
+        const d = JSON.parse(event.data);
+        appendLine("conv-log", "line-paused", "  [Paused] " + d.question);
+        enterPausedState(d);
+      } else if (event === "complete") {
+        const d = JSON.parse(event.data);
+        if (d.session_id) setSessionId(d.session_id);
+        if (d.usage) {
+          appendLine("raw-log", "line-system", "usage: " + JSON.stringify(d.usage));
+        }
+      } else if (event === "error") {
+        const d = JSON.parse(event.data);
+        appendLine("conv-log", "line-error", "Error: " + (d.detail || "unknown error"));
+      }
+      appendLine("raw-log", "line-system", "[" + event.type + "] " + event.data);
+    });
+  } catch (e) {
+    if (e.name !== "AbortError") {
+      appendLine("conv-log", "line-error", "Error: " + e.message);
+    }
+  } finally {
+    state.abortController = null;
+    setSending(false);
+  }
+}
+
+function enterPausedState({ sessionId, question, callId }) {
+  state.awaitingAnswer = { sessionId, question, callId };
+  setSessionId(sessionId);
+  el("paused-question").textContent = "Q: " + question;
+  el("paused-answer").value = "";
+  el("paused-bar").classList.add("visible");
+  el("paused-answer").focus();
+}
+
+async function resumeFromPaused() {
+  const answer = el("paused-answer").value.trim();
+  if (!answer || !state.awaitingAnswer) return;
+  const { sessionId } = state.awaitingAnswer;
+  state.awaitingAnswer = null;
+  el("paused-bar").classList.remove("visible");
+  el("paused-question").textContent = "";
+  el("paused-answer").value = "";
+  appendLine("conv-log", "line-user", "You: " + answer);
+  appendLine("raw-log", "line-system", "--- continuing paused session ---");
+
+  const controller = new AbortController();
+  state.abortController = controller;
+  setSending(true);
+  let assistantText = "";
+  const assistantSpan = document.createElement("span");
+  assistantSpan.className = "line-assistant";
+  assistantSpan.textContent = "Assistant: ";
+  el("conv-log").appendChild(assistantSpan);
+  try {
+    const resp = await fetch("/api/chat/continue", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ session_id: sessionId, answer }),
+      signal: controller.signal,
+    });
+    if (!resp.ok) {
+      const err = await resp.text();
+      appendLine("conv-log", "line-error", "Error: " + err);
+      return;
+    }
+    await readSseStream(resp, (event) => {
+      if (event === "delta") {
+        const d = JSON.parse(event.data);
+        assistantText += d.content;
+        assistantSpan.textContent = "Assistant: " + assistantText;
+        el("conv-log").scrollTop = el("conv-log").scrollHeight;
+      } else if (event === "tool_call") {
+        const d = JSON.parse(event.data);
+        appendLine("conv-log", "line-tool", "  Tool: " + d.name + "(" + d.arguments + ")");
+        appendJson("tool-log", "line-tool", d);
+      } else if (event === "tool_result") {
+        const d = JSON.parse(event.data);
+        appendLine("conv-log", "line-tool", "  Result: " + truncate(d.result, 200));
+        appendJson("tool-log", "line-tool", d);
+      } else if (event === "paused") {
+        const d = JSON.parse(event.data);
+        appendLine("conv-log", "line-paused", "  [Paused] " + d.question);
+        enterPausedState(d);
+      } else if (event === "complete") {
+        const d = JSON.parse(event.data);
+        if (d.session_id) setSessionId(d.session_id);
+        if (d.usage) {
+          appendLine("raw-log", "line-system", "usage: " + JSON.stringify(d.usage));
+        }
+      } else if (event === "error") {
+        const d = JSON.parse(event.data);
+        appendLine("conv-log", "line-error", "Error: " + (d.detail || "unknown error"));
+      }
+      appendLine("raw-log", "line-system", "[" + event.type + "] " + event.data);
+    });
+  } catch (e) {
+    if (e.name !== "AbortError") {
+      appendLine("conv-log", "line-error", "Error: " + e.message);
+    }
+  } finally {
+    state.abortController = null;
+    setSending(false);
+  }
+}
+
+function cancelPaused() {
+  state.awaitingAnswer = null;
+  el("paused-bar").classList.remove("visible");
+  el("paused-question").textContent = "";
+  el("paused-answer").value = "";
+}
+
+function stopRequest() {
+  if (state.abortController) {
+    state.abortController.abort();
+    state.abortController = null;
+    appendLine("conv-log", "line-system", "[stopped by user]");
+    setSending(false);
+  }
+}
+
+async function readSseStream(response, onEvent) {
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split("\\n");
+    buffer = lines.pop() || "";
+    let eventType = "";
+    for (const line of lines) {
+      if (line.startsWith("event: ")) {
+        eventType = line.slice(7).trim();
+      } else if (line.startsWith("data: ")) {
+        const data = line.slice(6);
+        try {
+          JSON.parse(data);
+          onEvent({ type: eventType, data });
+        } catch (_) {}
+        eventType = "";
+      }
+    }
+  }
+}
+
+function truncate(s, max) {
+  if (!s) return s;
+  return s.length > max ? s.slice(0, max) + "..." : s;
+}
+
+restore();
+el("msg-input").focus();
+</script>
+</body>
+</html>
+"""

--- a/projects/simple-agent-poc/src/simple_agent_poc/application/use_cases.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/application/use_cases.py
@@ -63,6 +63,32 @@ def _accumulate_tool_call_chunks(
         acc["function"]["arguments"] += fn_args
 
 
+def _find_next_unanswered_ask_user(
+    session: ConversationSession,
+) -> ToolCall | None:
+    """Find the next ask_user tool call in the latest unfinished tool batch."""
+    for idx in range(len(session.messages) - 1, -1, -1):
+        message = session.messages[idx]
+        tool_calls = message.get("tool_calls")
+        if message["role"] != "assistant" or not tool_calls:
+            continue
+
+        answered_tool_call_ids = {
+            msg["tool_call_id"]
+            for msg in session.messages[idx + 1 :]
+            if msg["role"] == "tool" and "tool_call_id" in msg
+        }
+        for tool_call in tool_calls:
+            if (
+                tool_call["id"] not in answered_tool_call_ids
+                and tool_call["function"]["name"] == "ask_user"
+            ):
+                return tool_call
+        return None
+
+    return None
+
+
 class RunAgentUseCase:
     """Reusable execution path for session-aware agent interactions."""
 
@@ -323,6 +349,18 @@ class RunAgentUseCase:
         yield ToolResultEvent(call_id=tc["id"], name="ask_user", result=result)
         resume_round = session.pending_round
         session.resume_with_answer()
+
+        next_ask_user_tc = _find_next_unanswered_ask_user(session)
+        if next_ask_user_tc is not None:
+            session.pause_for_ask_user(next_ask_user_tc, round_idx=resume_round)
+            self._session_store.save(session)
+            ask_user_args = json.loads(next_ask_user_tc["function"]["arguments"])
+            yield SessionPaused(
+                session_id=session.session_id,
+                call_id=next_ask_user_tc["id"],
+                question=ask_user_args.get("question", ""),
+            )
+            return
 
         agent_definition = self._agent_definitions.get(session.agent_id)
         llm_client = self._llm_client_factory(agent_definition)

--- a/projects/simple-agent-poc/tests/test_api.py
+++ b/projects/simple-agent-poc/tests/test_api.py
@@ -310,3 +310,14 @@ class TestSSEEvents:
         assert "event: tool_result" in sse_line
         assert "call_001" in sse_line
         assert "helloworld" in sse_line
+
+    def test_root_returns_html_test_page(self) -> None:
+        app = create_app()
+        client = TestClient(app)
+
+        response = client.get("/")
+
+        assert response.status_code == 200
+        assert "text/html" in response.headers["content-type"]
+        assert "<title>simple-agent-poc - Test Page</title>" in response.text
+        assert '<select id="mode-select"' in response.text

--- a/projects/simple-agent-poc/tests/test_http_stream_api.py
+++ b/projects/simple-agent-poc/tests/test_http_stream_api.py
@@ -288,6 +288,84 @@ class TestStreamPauseContinueAPI:
         assert continue_events[2]["event"] == "complete"
         assert continue_events[3]["event"] == "done"
 
+    def test_chat_continue_pauses_on_next_unanswered_ask_user(self) -> None:
+        first_chunks: list[LLMStreamChunk] = [
+            {
+                "content_delta": None,
+                "tool_call_delta": {
+                    "index": 0,
+                    "id": "call_001",
+                    "type": "function",
+                    "function": {
+                        "name": "ask_user",
+                        "arguments": '{"question": "First number?"}',
+                    },
+                },
+            },
+            {
+                "content_delta": None,
+                "tool_call_delta": {
+                    "index": 1,
+                    "id": "call_002",
+                    "type": "function",
+                    "function": {
+                        "name": "ask_user",
+                        "arguments": '{"question": "Second number?"}',
+                    },
+                },
+            },
+        ]
+        session_store = InMemorySessionStore()
+        tool_executor = build_tool_executor_with_ask_user()
+        registry = build_registry_with_ask_user()
+
+        def fail_if_llm_is_called(_agent_definition):
+            raise AssertionError("LLM must not be called before all tool calls answer")
+
+        app = create_app(
+            use_case_factory=lambda: RunAgentUseCase(
+                llm_client_factory=lambda _agent_definition: StreamingStubLLMClient(
+                    chunks=first_chunks
+                ),
+                session_store=session_store,
+                agent_definitions=registry,
+                tool_executor=tool_executor,
+                is_api_context=True,
+            )
+        )
+        client = TestClient(app)
+
+        stream_resp = client.post("/api/chat/stream", json={"message": "Add numbers"})
+        stream_events = parse_sse_events(stream_resp.text)
+        paused_data = json.loads(stream_events[2]["data"])
+
+        app2 = create_app(
+            use_case_factory=lambda: RunAgentUseCase(
+                llm_client_factory=fail_if_llm_is_called,
+                session_store=session_store,
+                agent_definitions=registry,
+                tool_executor=tool_executor,
+                is_api_context=True,
+            )
+        )
+        client2 = TestClient(app2)
+
+        continue_resp = client2.post(
+            "/api/chat/continue",
+            json={"session_id": paused_data["session_id"], "answer": "1"},
+        )
+
+        assert continue_resp.status_code == 200
+        continue_events = parse_sse_events(continue_resp.text)
+        assert continue_events[0]["event"] == "tool_result"
+        result_data = json.loads(continue_events[0]["data"])
+        assert result_data["call_id"] == "call_001"
+        assert continue_events[1]["event"] == "paused"
+        next_paused_data = json.loads(continue_events[1]["data"])
+        assert next_paused_data["call_id"] == "call_002"
+        assert next_paused_data["question"] == "Second number?"
+        assert continue_events[2]["event"] == "done"
+
     def test_chat_continue_with_unknown_session_returns_error(self) -> None:
         app = create_app(
             use_case_factory=lambda: RunAgentUseCase(

--- a/projects/simple-agent-poc/tests/test_use_cases_stream.py
+++ b/projects/simple-agent-poc/tests/test_use_cases_stream.py
@@ -561,6 +561,86 @@ class TestContinueStream:
         assert session is not None
         assert session.is_paused is False
 
+    def test_continue_stream_pauses_on_next_unanswered_ask_user(self) -> None:
+        first_chunks: list[LLMStreamChunk] = [
+            {
+                "content_delta": None,
+                "tool_call_delta": {
+                    "index": 0,
+                    "id": "call_001",
+                    "type": "function",
+                    "function": {
+                        "name": "ask_user",
+                        "arguments": '{"question": "First number?"}',
+                    },
+                },
+            },
+            {
+                "content_delta": None,
+                "tool_call_delta": {
+                    "index": 1,
+                    "id": "call_002",
+                    "type": "function",
+                    "function": {
+                        "name": "ask_user",
+                        "arguments": '{"question": "Second number?"}',
+                    },
+                },
+            },
+        ]
+        store = InMemorySessionStore()
+        tool_executor = build_tool_executor_with_ask_user()
+
+        first_use_case = RunAgentUseCase(
+            llm_client_factory=MagicMock(
+                return_value=StreamingStubLLMClient(chunks=first_chunks)
+            ),
+            session_store=store,
+            agent_definitions=build_registry_with_ask_user(stream=True),
+            tool_executor=tool_executor,
+            is_api_context=True,
+        )
+
+        first_events = list(
+            first_use_case.execute_stream(RunAgentRequest(message="Add numbers"))
+        )
+        paused = first_events[-1]
+        assert isinstance(paused, SessionPaused)
+        assert paused.call_id == "call_001"
+
+        llm_client_factory = MagicMock()
+        second_use_case = RunAgentUseCase(
+            llm_client_factory=llm_client_factory,
+            session_store=store,
+            agent_definitions=build_registry_with_ask_user(stream=True),
+            tool_executor=tool_executor,
+            is_api_context=True,
+        )
+
+        continue_events = list(
+            second_use_case.continue_stream(
+                ContinueRequest(session_id=paused.session_id, answer="1")
+            )
+        )
+
+        assert continue_events[0] == ToolResultEvent(
+            call_id="call_001",
+            name="ask_user",
+            result='{"answer": "1"}',
+        )
+        assert continue_events[1] == SessionPaused(
+            session_id=paused.session_id,
+            call_id="call_002",
+            question="Second number?",
+        )
+        llm_client_factory.assert_not_called()
+
+        session = store.get(paused.session_id)
+        assert session is not None
+        assert session.is_paused is True
+        assert session.pending_tool_call is not None
+        assert session.pending_tool_call["id"] == "call_002"
+
     def test_continue_stream_with_unknown_session_raises_error(self) -> None:
         use_case = RunAgentUseCase(
             llm_client_factory=MagicMock(),


### PR DESCRIPTION
## Issues

- Close #913

## Why

Swagger UIでは `session_id` 継続、SSEイベント確認、`ask_user` pause/continue の手動検証がしづらいため、単一画面でこれらを素早く確認できる開発用テストページを追加する。

## Summary

`GET /` にピュアなHTML/CSS/JSのテストページを追加し、ブラウザから sync/stream を切り替えて `/api/chat`、`/api/chat/stream`、`/api/chat/continue` を呼び分けられるようにした。既存API仕様は一切変更していない。

## Changes

- `src/simple_agent_poc/adapters/http/test_page.py` を追加し、単一HTML/CSS/JSテストUIを定義
- `src/simple_agent_poc/adapters/http/api.py` に `GET /` を追加し、`HTMLResponse` でテストUIを返す
- `tests/test_api.py` に `GET /` が `text/html` を返すテストを追加

## Verification

- `uv run ruff check .` - passed
- `uv run ty check .` - passed
- `uv run pytest tests/test_api.py tests/test_http_stream_api.py` - 22 passed
