### PR TITLE
feat: add sync ask_user support for non-stream CLI and HTTP API

### DIFF
--- a/projects/simple-agent-poc/docs/api.md
+++ b/projects/simple-agent-poc/docs/api.md
@@ -19,9 +19,9 @@ Starts Uvicorn on `127.0.0.1:8000`. Source: `src/simple_agent_poc/entrypoints/ma
 
 ## Endpoints
 
-### `POST /api/chat`
+### `POST /api/chat/sync`
 
-Synchronous (non-streaming) agent execution. Supports tool calls via the ReAct loop.
+Synchronous (non-streaming) agent execution. Supports tool calls via the ReAct loop and `ask_user` pause/resume.
 
 #### Request
 
@@ -42,10 +42,13 @@ Synchronous (non-streaming) agent execution. Supports tool calls via the ReAct l
 Headers:
 - `Session-Id: <session_id>` (optional) — Primary session transport. Takes priority over body `session_id`.
 
-#### Response (200)
+#### Response (200) — completed
+
+When the agent finishes normally:
 
 ```json
 {
+  "status": "completed",
   "message": "Hello! How can I help?",
   "usage": {
     "prompt_tokens": 50,
@@ -68,12 +71,35 @@ Headers:
 
 | Field | Type | Description |
 |:---|:---|:---|
+| `status` | `"completed"` | Discriminator for a completed response |
 | `message` | `str` | Agent's full response text |
-| `usage` | `Usage` | Token usage: `prompt_tokens`, `completion_tokens`, `total_tokens` |
+| `usage` | `Usage?` | Token usage: `prompt_tokens`, `completion_tokens`, `total_tokens` |
 | `model` | `str` | Model name as configured |
 | `response_time` | `float` | Seconds from LLM call start to response receipt |
 | `session_id` | `str` | Session ID for continuing the conversation |
 | `tool_calls` | `list[ToolCallRecord]` | Tool calls made during execution with their results |
+
+#### Response (200) — paused
+
+When the agent calls `ask_user` and needs user input:
+
+```json
+{
+  "status": "paused",
+  "session_id": "abc123...",
+  "call_id": "call_001",
+  "question": "What is your name?",
+  "tool_calls": []
+}
+```
+
+| Field | Type | Description |
+|:---|:---|:---|
+| `status` | `"paused"` | Discriminator for a paused response |
+| `session_id` | `str` | Session ID for continuing the conversation |
+| `call_id` | `str` | ID of the pending `ask_user` tool call |
+| `question` | `str` | Question text from `ask_user` arguments |
+| `tool_calls` | `list[ToolCallRecord]` | Non-ask_user tool calls executed before pausing |
 
 #### Error Responses
 
@@ -83,13 +109,43 @@ Headers:
 | `400` | unknown `agent_id`, changing `agent_id` for existing session, conflicting session identifiers |
 | `404` | `session_id` not found in the session store |
 
+### `POST /api/chat/sync/continue`
+
+Resumes a paused session synchronously. Returns the same discriminated shape as `/api/chat/sync`.
+
+#### Request
+
+```json
+{
+  "session_id": "abc123...",
+  "answer": "My name is Alice"
+}
+```
+
+| Field | Type | Required | Description |
+|:---|:---|:---|:---|
+| `session_id` | `str` | yes | The session ID from the `paused` response |
+| `answer` | `str` | yes | User's answer to the `ask_user` question |
+
+#### Response (200)
+
+Same discriminated shape as `/api/chat/sync` (either `"completed"` or `"paused"`). If multiple `ask_user` calls were in the same batch, a `"paused"` response is returned for each unanswered question without calling the LLM.
+
+#### Error Responses
+
+| Status | Condition |
+|:---|:---|
+| `422` | `session_id` or `answer` blank (Pydantic validation) |
+| `400` | session is not paused, `session_id` not found |
+| `404` | `session_id` not found |
+
 ### `POST /api/chat/stream`
 
 Streaming agent execution via Server-Sent Events (SSE). Supports tool calls, and may disconnect with `paused` event when `ask_user` is called.
 
 #### Request
 
-Same schema as `/api/chat`. Supports `Session-Id` header with the same `resolve_session_id()` logic.
+Same schema as `/api/chat/sync`. Supports `Session-Id` header with the same `resolve_session_id()` logic.
 
 #### Response
 
@@ -97,9 +153,9 @@ Media type: `text/event-stream`
 
 See [docs/sse.md](sse.md) for the full SSE event specification.
 
-### `POST /api/chat/continue`
+### `POST /api/chat/stream/continue`
 
-Resumes a paused session (after `ask_user` was called). Returns SSE events.
+Resumes a paused session (after `ask_user` was called in streaming mode). Returns SSE events.
 
 #### Request
 
@@ -123,12 +179,14 @@ Same SSE format as `/api/chat/stream`. The sequence is:
 3. `event: complete` — stream finished
 4. `event: done` — end of stream
 
+Or if another `ask_user` was in the same batch:
+1. `event: tool_result` — the answer injected as tool result
+2. `event: paused` — next `ask_user` pause notification
+3. `event: done` — end of stream
+
 #### Error Responses
 
-| Status | Condition |
-|:---|:---|
-| `400` | `session_id` not found, session is not paused, answer blank |
-| `422` | `session_id` or `answer` blank (Pydantic validation) |
+Errors are delivered as SSE `error` events within the stream.
 
 ## Session Resolution
 

--- a/projects/simple-agent-poc/docs/api.md
+++ b/projects/simple-agent-poc/docs/api.md
@@ -136,7 +136,7 @@ Same discriminated shape as `/api/chat/sync` (either `"completed"` or `"paused"`
 | Status | Condition |
 |:---|:---|
 | `422` | `session_id` or `answer` blank (Pydantic validation) |
-| `400` | session is not paused, `session_id` not found |
+| `400` | session is not paused |
 | `404` | `session_id` not found |
 
 ### `POST /api/chat/stream`

--- a/projects/simple-agent-poc/docs/cli.md
+++ b/projects/simple-agent-poc/docs/cli.md
@@ -44,7 +44,7 @@ The adapter uses protocol-based dependency injection for testability. All render
 
 ### Interactive Loop
 
-The loop handles both sync and streaming modes. In streaming mode, the generator is used with `send()` to support interactive tool calls:
+The loop handles both sync and streaming modes:
 
 ```
 while True:
@@ -61,14 +61,34 @@ while True:
             if event is StreamComplete → show stats, capture session_id
     else:
         response = with_indicator("Thinking", lambda: use_case.execute(request))
+        while response is RunAgentPaused:
+            answer = ask_user_question(response.question)
+            response = with_indicator(
+                "Thinking",
+                lambda: use_case.continue_sync(ContinueRequest(
+                    session_id=response.session_id, answer=answer
+                ))
+            )
         show_agent_response(response)
 
     self._session_id = response.session_id
 ```
 
-### `generator.send()` Pattern (ask\_user)
+### Sync `ask_user` Loop (Non-Stream Mode)
 
-When the LLM calls `ask_user` in CLI mode, the `execute_stream()` generator yields a `ToolCallEvent` and **pauses**, waiting for the adapter to send the user's answer back:
+When `stream: false` (default), `execute()` returns `RunAgentResponse | RunAgentPaused`. If `RunAgentPaused` is returned:
+
+1. The indicator stops automatically (via `finally` in `with_indicator`).
+2. `ask_user_question(question)` displays the question and reads the user's answer from stdin.
+3. `continue_sync(ContinueRequest(session_id, answer))` is called with a new indicator.
+4. If `continue_sync` returns another `RunAgentPaused` (multiple `ask_user` in same batch), the loop repeats.
+5. When `RunAgentResponse` is finally returned, it is rendered via `show_agent_response()`.
+
+The user never needs to know the `session_id` — it is managed internally by the adapter.
+
+### `generator.send()` Pattern (Stream Mode, ask\_user)
+
+When the LLM calls `ask_user` in CLI streaming mode, the `execute_stream()` generator yields a `ToolCallEvent` and **pauses**, waiting for the adapter to send the user's answer back:
 
 1. Generator yields `ToolCallEvent(name="ask_user", arguments={"question": "..."})`.
 2. CLI renderer displays the question and prompts for input via `ask_user_question()`.
@@ -137,12 +157,12 @@ If no `StreamComplete` arrives at all, raises `RuntimeError`.
 ### ask_user_question(question)
 
 ```python
-def ask_user_question(self, question: str) -> str:
-    console.print(f"[bold yellow]? {question}[/bold yellow]")
+def ask_user_question(question: str) -> str:
+    print(f"\n  💬 ask_user: {question}")
     return input("  Answer > ").strip()
 ```
 
-Displays the `ask_user` question and reads the user's typed answer from stdin.
+Displays the `ask_user` question and reads the user's typed answer from stdin. Used by both sync and stream modes.
 
 ### show_error(error)
 

--- a/projects/simple-agent-poc/docs/types.md
+++ b/projects/simple-agent-poc/docs/types.md
@@ -163,7 +163,31 @@ class ContinueRequest:
     answer: str
 ```
 
-Request DTO for `POST /api/chat/continue`. Contains the user's answer to an `ask_user` question.
+Request DTO for resuming a paused session. Contains the user's answer to an `ask_user` question.
+
+### RunAgentPaused
+
+```python
+@dataclass(frozen=True, slots=True)
+class RunAgentPaused:
+    session_id: str
+    call_id: str
+    question: str
+    tool_call_history: list[ToolCallRecord]
+```
+
+Returned by `RunAgentUseCase.execute()` and `RunAgentUseCase.continue_sync()` when the agent calls `ask_user` during synchronous execution. The caller should present the question, collect an answer, and resume via `continue_sync()`.
+
+### Sync Result Union
+
+The synchronous execution methods return a discriminated union:
+
+```python
+# execute() / continue_sync() return type:
+RunAgentResponse | RunAgentPaused
+```
+
+Callers check with `isinstance()` to determine whether the result is a completed response or requires user input.
 
 ## HTTP Schemas
 
@@ -180,19 +204,34 @@ class ChatRequest(BaseModel):
 
 Validators reject blank `message` and blank `agent_id` after stripping.
 
-### ChatResponse
+### SyncChatResponse
 
 ```python
-class ChatResponse(BaseModel):
-    message: str
-    usage: Usage
-    model: str
-    response_time: float
+class SyncChatResponse(BaseModel):
+    status: Literal["completed", "paused"]
     session_id: str
-    tool_calls: list[ToolCallRecord]
+    tool_calls: list[ToolCallRecord] = []
+    message: str = ""
+    usage: Usage | None = None
+    model: str = ""
+    response_time: float = 0.0
+    call_id: str = ""
+    question: str = ""
 ```
 
-Factory method: `from_use_case_response(response)`.
+Discriminated by `status`. When `"completed"`, `message`/`usage`/`model`/`response_time` are populated. When `"paused"`, `call_id`/`question` are populated.
+
+Factory methods: `from_completed(response)` / `from_paused(paused)`.
+
+### ResumeRequest
+
+```python
+class ResumeRequest(BaseModel):
+    session_id: str
+    answer: str
+```
+
+Used by both `/api/chat/sync/continue` and `/api/chat/stream/continue`. Validators reject blank `session_id` and blank `answer` after stripping.
 
 ## Entity
 

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/cli/adapter.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/cli/adapter.py
@@ -5,6 +5,8 @@ from typing import Protocol
 
 from simple_agent_poc.application.dto import (
     ContentDelta,
+    ContinueRequest,
+    RunAgentPaused,
     RunAgentRequest,
     RunAgentResponse,
     SessionPaused,
@@ -14,6 +16,7 @@ from simple_agent_poc.application.dto import (
 )
 from simple_agent_poc.application.use_cases import RunAgentUseCase
 from simple_agent_poc.adapters.cli.renderer import (
+    ask_user_question,
     get_user_input,
     show_agent_response,
     show_error,
@@ -31,8 +34,8 @@ class IndicatorRunner(Protocol):
     def __call__(
         self,
         message: str,
-        operation: Callable[[], RunAgentResponse],
-    ) -> RunAgentResponse: ...
+        operation: Callable[[], RunAgentResponse | RunAgentPaused],
+    ) -> RunAgentResponse | RunAgentPaused: ...
 
 
 class StreamingRenderer(Protocol):
@@ -124,6 +127,20 @@ class CLIAdapter:
                             )
                         ),
                     )
+                    while isinstance(response, RunAgentPaused):
+                        answer = ask_user_question(response.question)
+                        paused_session_id = response.session_id
+                        response = self._indicator_runner(
+                            "Thinking",
+                            lambda sid=paused_session_id, ans=answer: (
+                                self._run_agent.continue_sync(
+                                    ContinueRequest(
+                                        session_id=sid,
+                                        answer=ans,
+                                    )
+                                )
+                            ),
+                        )
                     self._session_id = response.session_id
                     self._response_renderer(response)
             except KeyboardInterrupt:

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/api.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/api.py
@@ -156,7 +156,11 @@ def create_app(
     def get_run_agent_use_case() -> RunAgentUseCase:
         return factory()
 
-    @app.post("/api/chat/sync", response_model=SyncChatResponse)
+    @app.post(
+        "/api/chat/sync",
+        response_model=SyncChatResponse,
+        response_model_exclude_unset=True,
+    )
     def chat_sync(
         request: ChatRequest,
         run_agent: Annotated[RunAgentUseCase, Depends(get_run_agent_use_case)],
@@ -190,7 +194,11 @@ def create_app(
             return SyncChatResponse.from_paused(result)
         return SyncChatResponse.from_completed(result)
 
-    @app.post("/api/chat/sync/continue", response_model=SyncChatResponse)
+    @app.post(
+        "/api/chat/sync/continue",
+        response_model=SyncChatResponse,
+        response_model_exclude_unset=True,
+    )
     def chat_sync_continue(
         request: ResumeRequest,
         run_agent: Annotated[RunAgentUseCase, Depends(get_run_agent_use_case)],

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/api.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/api.py
@@ -3,7 +3,7 @@
 import json
 from dataclasses import asdict
 from collections.abc import Callable
-from typing import Annotated
+from typing import Annotated, Literal
 
 from fastapi import Depends, FastAPI, Header, HTTPException
 from pydantic import BaseModel, ConfigDict, field_validator
@@ -11,6 +11,8 @@ from starlette.responses import HTMLResponse, StreamingResponse
 
 from simple_agent_poc.application.dto import (
     ContentDelta,
+    ContinueRequest,
+    RunAgentPaused,
     RunAgentRequest,
     RunAgentResponse,
     SessionPaused,
@@ -56,20 +58,27 @@ class ChatRequest(BaseModel):
         return value
 
 
-class ChatResponse(BaseModel):
-    """HTTP response schema for chat execution."""
+class SyncChatResponse(BaseModel):
+    """HTTP response schema for synchronous chat execution.
 
-    message: str
-    usage: Usage
-    model: str
-    response_time: float
+    Uses a ``status`` field to discriminate between completed and paused.
+    """
+
+    status: Literal["completed", "paused"]
     session_id: str
     tool_calls: list[ToolCallRecord] = []
+    message: str = ""
+    usage: Usage | None = None
+    model: str = ""
+    response_time: float = 0.0
+    call_id: str = ""
+    question: str = ""
 
     @classmethod
-    def from_use_case_response(cls, response: RunAgentResponse) -> "ChatResponse":
-        """Build the HTTP response payload from the application DTO."""
+    def from_completed(cls, response: RunAgentResponse) -> "SyncChatResponse":
+        """Build from a completed use case response."""
         return cls(
+            status="completed",
             message=response.message,
             usage=response.usage,
             model=response.model,
@@ -78,8 +87,19 @@ class ChatResponse(BaseModel):
             tool_calls=response.tool_call_history,
         )
 
+    @classmethod
+    def from_paused(cls, paused: RunAgentPaused) -> "SyncChatResponse":
+        """Build from a paused use case response."""
+        return cls(
+            status="paused",
+            session_id=paused.session_id,
+            call_id=paused.call_id,
+            question=paused.question,
+            tool_calls=paused.tool_call_history,
+        )
 
-class ContinueRequest(BaseModel):
+
+class ResumeRequest(BaseModel):
     """HTTP request schema for resuming a paused session."""
 
     model_config = ConfigDict(str_strip_whitespace=True)
@@ -136,8 +156,8 @@ def create_app(
     def get_run_agent_use_case() -> RunAgentUseCase:
         return factory()
 
-    @app.post("/api/chat", response_model=ChatResponse)
-    def chat(
+    @app.post("/api/chat/sync", response_model=SyncChatResponse)
+    def chat_sync(
         request: ChatRequest,
         run_agent: Annotated[RunAgentUseCase, Depends(get_run_agent_use_case)],
         *,
@@ -145,9 +165,9 @@ def create_app(
             str | None,
             Header(alias="Session-Id"),
         ] = None,
-    ) -> ChatResponse:
+    ) -> SyncChatResponse:
         try:
-            response = run_agent.execute(
+            result = run_agent.execute(
                 RunAgentRequest(
                     message=request.message,
                     session_id=resolve_session_id(
@@ -166,7 +186,38 @@ def create_app(
                 status_code=400, detail=error.display_message
             ) from error
 
-        return ChatResponse.from_use_case_response(response)
+        if isinstance(result, RunAgentPaused):
+            return SyncChatResponse.from_paused(result)
+        return SyncChatResponse.from_completed(result)
+
+    @app.post("/api/chat/sync/continue", response_model=SyncChatResponse)
+    def chat_sync_continue(
+        request: ResumeRequest,
+        run_agent: Annotated[RunAgentUseCase, Depends(get_run_agent_use_case)],
+    ) -> SyncChatResponse:
+        try:
+            result = run_agent.continue_sync(
+                ContinueRequest(
+                    session_id=request.session_id,
+                    answer=request.answer,
+                )
+            )
+        except SessionNotFoundError as error:
+            raise HTTPException(
+                status_code=404, detail=error.display_message
+            ) from error
+        except SessionNotPausedError as error:
+            raise HTTPException(
+                status_code=400, detail=error.display_message
+            ) from error
+        except ValidationError as error:
+            raise HTTPException(
+                status_code=400, detail=error.display_message
+            ) from error
+
+        if isinstance(result, RunAgentPaused):
+            return SyncChatResponse.from_paused(result)
+        return SyncChatResponse.from_completed(result)
 
     @app.post("/api/chat/stream")
     def chat_stream(
@@ -214,19 +265,15 @@ def create_app(
 
         return StreamingResponse(event_stream(), media_type="text/event-stream")
 
-    @app.post("/api/chat/continue")
-    def chat_continue(
-        request: ContinueRequest,
+    @app.post("/api/chat/stream/continue")
+    def chat_stream_continue(
+        request: ResumeRequest,
         run_agent: Annotated[RunAgentUseCase, Depends(get_run_agent_use_case)],
     ):
-        from simple_agent_poc.application.dto import (
-            ContinueRequest as AppContinueRequest,
-        )
-
         def event_stream():
             try:
                 for event in run_agent.continue_stream(
-                    AppContinueRequest(
+                    ContinueRequest(
                         session_id=request.session_id,
                         answer=request.answer,
                     )

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/test_page.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/test_page.py
@@ -211,7 +211,7 @@ async function sendSyncMessage(message) {
   try {
     const headers = { "Content-Type": "application/json" };
     if (state.sessionId) headers["Session-Id"] = state.sessionId;
-    const resp = await fetch("/api/chat", {
+    const resp = await fetch("/api/chat/sync", {
       method: "POST",
       headers,
       body: JSON.stringify({ message, agent_id: state.agentId }),
@@ -226,6 +226,11 @@ async function sendSyncMessage(message) {
     }
     const data = await resp.json();
     appendJson("raw-log", "line-system", data);
+    if (data.status === "paused") {
+      appendLine("conv-log", "line-paused", "  [Paused] " + data.question);
+      enterPausedState({ session_id: data.session_id, question: data.question, call_id: data.call_id, mode: "sync" });
+      return;
+    }
     appendLine("conv-log", "line-assistant", "Assistant: " + data.message);
     if (data.tool_calls && data.tool_calls.length > 0) {
       for (const tc of data.tool_calls) {
@@ -311,8 +316,8 @@ async function sendStreamMessage(message) {
   }
 }
 
-function enterPausedState({ session_id: sessionId, question, call_id: callId }) {
-  state.awaitingAnswer = { sessionId, question, callId };
+function enterPausedState({ session_id: sessionId, question, call_id: callId, mode = "stream" }) {
+  state.awaitingAnswer = { sessionId, question, callId, mode };
   setSessionId(sessionId);
   el("paused-question").textContent = "Q: " + question;
   el("paused-answer").value = "";
@@ -323,7 +328,7 @@ function enterPausedState({ session_id: sessionId, question, call_id: callId }) 
 async function resumeFromPaused() {
   const answer = el("paused-answer").value.trim();
   if (!answer || !state.awaitingAnswer) return;
-  const { sessionId } = state.awaitingAnswer;
+  const { sessionId, mode } = state.awaitingAnswer;
   state.awaitingAnswer = null;
   el("paused-bar").classList.remove("visible");
   el("paused-question").textContent = "";
@@ -331,6 +336,60 @@ async function resumeFromPaused() {
   appendLine("conv-log", "line-user", "You: " + answer);
   appendLine("raw-log", "line-system", "--- continuing paused session ---");
 
+  if (mode === "sync") {
+    await continueSync(sessionId, answer);
+  } else {
+    await continueStream(sessionId, answer);
+  }
+}
+
+async function continueSync(sessionId, answer) {
+  const controller = new AbortController();
+  state.abortController = controller;
+  setSending(true);
+  try {
+    const resp = await fetch("/api/chat/sync/continue", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ session_id: sessionId, answer }),
+      signal: controller.signal,
+    });
+    appendJson("raw-log", "line-system", { status: resp.status });
+    if (!resp.ok) {
+      const err = await resp.json();
+      appendLine("conv-log", "line-error", "Error: " + (err.detail || resp.statusText));
+      appendJson("raw-log", "line-error", err);
+      return;
+    }
+    const data = await resp.json();
+    appendJson("raw-log", "line-system", data);
+    if (data.status === "paused") {
+      appendLine("conv-log", "line-paused", "  [Paused] " + data.question);
+      enterPausedState({ session_id: data.session_id, question: data.question, call_id: data.call_id, mode: "sync" });
+      return;
+    }
+    appendLine("conv-log", "line-assistant", "Assistant: " + data.message);
+    if (data.tool_calls && data.tool_calls.length > 0) {
+      for (const tc of data.tool_calls) {
+        appendLine("conv-log", "line-tool", "  Tool: " + tc.name + "(" + tc.arguments + ") -> " + truncate(tc.result, 200));
+        appendJson("tool-log", "line-tool", tc);
+      }
+    }
+    if (data.session_id) setSessionId(data.session_id);
+    if (data.usage) {
+      appendLine("raw-log", "line-system", "usage: " + JSON.stringify(data.usage));
+    }
+  } catch (e) {
+    if (e.name !== "AbortError") {
+      appendLine("conv-log", "line-error", "Error: " + e.message);
+    }
+  } finally {
+    state.abortController = null;
+    setSending(false);
+  }
+}
+
+async function continueStream(sessionId, answer) {
   const controller = new AbortController();
   state.abortController = controller;
   setSending(true);
@@ -340,7 +399,7 @@ async function resumeFromPaused() {
   assistantSpan.textContent = "Assistant: ";
   el("conv-log").appendChild(assistantSpan);
   try {
-    const resp = await fetch("/api/chat/continue", {
+    const resp = await fetch("/api/chat/stream/continue", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ session_id: sessionId, answer }),
@@ -368,7 +427,7 @@ async function resumeFromPaused() {
       } else if (event.type === "paused") {
         const d = JSON.parse(event.data);
         appendLine("conv-log", "line-paused", "  [Paused] " + d.question);
-        enterPausedState(d);
+        enterPausedState({ session_id: d.session_id, question: d.question, call_id: d.call_id, mode: "stream" });
       } else if (event.type === "complete") {
         const d = JSON.parse(event.data);
         if (d.session_id) setSessionId(d.session_id);

--- a/projects/simple-agent-poc/src/simple_agent_poc/application/dto.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/application/dto.py
@@ -104,3 +104,13 @@ class SessionPaused:
     session_id: str
     call_id: str
     question: str
+
+
+@dataclass(frozen=True, slots=True)
+class RunAgentPaused:
+    """Pause result returned by sync execution when ask_user is called."""
+
+    session_id: str
+    call_id: str
+    question: str
+    tool_call_history: list[ToolCallRecord]

--- a/projects/simple-agent-poc/src/simple_agent_poc/application/use_cases.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/application/use_cases.py
@@ -126,61 +126,13 @@ class RunAgentUseCase:
             raise ValidationError("agent_id cannot be changed for an existing session")
         session.append_user_message(request.message)
 
-        llm_client = self._llm_client_factory(agent_definition)
-        tools = self._resolve_tools(agent_definition)
-
         tool_call_history: list[ToolCallRecord] = []
 
         try:
-            for round_idx in range(agent_definition.max_tool_rounds):
-                response = llm_client.complete(list(session.messages), tools=tools)
-
-                tool_calls = response.get("tool_calls")
-                if not tool_calls:
-                    session.append_assistant_message(response["content"])
-                    return RunAgentResponse.from_llm_response(
-                        response,
-                        session_id=session.session_id,
-                        tool_call_history=tool_call_history,
-                    )
-
-                if self._tool_executor is None:
-                    raise LLMError(
-                        "Tool call requested but no tool executor configured",
-                        display_message="Tool call requested but no tool executor configured.",
-                    )
-                session.append_assistant_message(
-                    response["content"] or "", tool_calls=tool_calls
-                )
-
-                ask_user_tcs = [
-                    tc for tc in tool_calls if tc["function"]["name"] == "ask_user"
-                ]
-                for tc in tool_calls:
-                    if tc["function"]["name"] == "ask_user":
-                        continue
-                    result = self._tool_executor.execute(tc)
-                    session.append_tool_message(result, tool_call_id=tc["id"])
-                    tool_call_history.append(
-                        ToolCallRecord(
-                            call_id=tc["id"],
-                            name=tc["function"]["name"],
-                            arguments=tc["function"]["arguments"],
-                            result=result,
-                        )
-                    )
-
-                if ask_user_tcs:
-                    return self._build_paused_result(
-                        session=session,
-                        ask_user_tc=ask_user_tcs[0],
-                        round_idx=round_idx,
-                        tool_call_history=tool_call_history,
-                    )
-
-            raise LLMError(
-                "Exceeded maximum tool call rounds",
-                display_message="Exceeded maximum tool call rounds.",
+            return self._run_react_loop(
+                session=session,
+                start_round=0,
+                tool_call_history=tool_call_history,
             )
         finally:
             self._session_store.save(session)
@@ -195,7 +147,7 @@ class RunAgentUseCase:
                 f"Session not found: {request.session_id}",
                 display_message="Session not found.",
             )
-        if not session.is_paused or session.pending_tool_call is None:
+        if not session.is_paused:
             raise SessionNotPausedError(
                 f"Session {request.session_id} is not in a paused state",
                 display_message="Session is not in a paused state.",
@@ -218,63 +170,76 @@ class RunAgentUseCase:
                 tool_call_history=tool_call_history,
             )
 
+        try:
+            return self._run_react_loop(
+                session=session,
+                start_round=resume_round + 1,
+                tool_call_history=tool_call_history,
+            )
+        finally:
+            self._session_store.save(session)
+
+    def _run_react_loop(
+        self,
+        *,
+        session: ConversationSession,
+        start_round: int,
+        tool_call_history: list[ToolCallRecord],
+    ) -> RunAgentResponse | RunAgentPaused:
         agent_definition = self._agent_definitions.get(session.agent_id)
         llm_client = self._llm_client_factory(agent_definition)
         tools = self._resolve_tools(agent_definition)
 
-        try:
-            for round_idx in range(resume_round + 1, agent_definition.max_tool_rounds):
-                response = llm_client.complete(list(session.messages), tools=tools)
+        for round_idx in range(start_round, agent_definition.max_tool_rounds):
+            response = llm_client.complete(list(session.messages), tools=tools)
 
-                tool_calls = response.get("tool_calls")
-                if not tool_calls:
-                    session.append_assistant_message(response["content"])
-                    return RunAgentResponse.from_llm_response(
-                        response,
-                        session_id=session.session_id,
-                        tool_call_history=tool_call_history,
-                    )
-
-                if self._tool_executor is None:
-                    raise LLMError(
-                        "Tool call requested but no tool executor configured",
-                        display_message="Tool call requested but no tool executor configured.",
-                    )
-                session.append_assistant_message(
-                    response["content"] or "", tool_calls=tool_calls
+            tool_calls = response.get("tool_calls")
+            if not tool_calls:
+                session.append_assistant_message(response["content"])
+                return RunAgentResponse.from_llm_response(
+                    response,
+                    session_id=session.session_id,
+                    tool_call_history=tool_call_history,
                 )
 
-                ask_user_tcs = [
-                    tc for tc in tool_calls if tc["function"]["name"] == "ask_user"
-                ]
-                for tc in tool_calls:
-                    if tc["function"]["name"] == "ask_user":
-                        continue
-                    result = self._tool_executor.execute(tc)
-                    session.append_tool_message(result, tool_call_id=tc["id"])
-                    tool_call_history.append(
-                        ToolCallRecord(
-                            call_id=tc["id"],
-                            name=tc["function"]["name"],
-                            arguments=tc["function"]["arguments"],
-                            result=result,
-                        )
-                    )
-
-                if ask_user_tcs:
-                    return self._build_paused_result(
-                        session=session,
-                        ask_user_tc=ask_user_tcs[0],
-                        round_idx=round_idx,
-                        tool_call_history=tool_call_history,
-                    )
-
-            raise LLMError(
-                "Exceeded maximum tool call rounds",
-                display_message="Exceeded maximum tool call rounds.",
+            if self._tool_executor is None:
+                raise LLMError(
+                    "Tool call requested but no tool executor configured",
+                    display_message="Tool call requested but no tool executor configured.",
+                )
+            session.append_assistant_message(
+                response["content"] or "", tool_calls=tool_calls
             )
-        finally:
-            self._session_store.save(session)
+
+            ask_user_tcs = [
+                tc for tc in tool_calls if tc["function"]["name"] == "ask_user"
+            ]
+            for tc in tool_calls:
+                if tc["function"]["name"] == "ask_user":
+                    continue
+                result = self._tool_executor.execute(tc)
+                session.append_tool_message(result, tool_call_id=tc["id"])
+                tool_call_history.append(
+                    ToolCallRecord(
+                        call_id=tc["id"],
+                        name=tc["function"]["name"],
+                        arguments=tc["function"]["arguments"],
+                        result=result,
+                    )
+                )
+
+            if ask_user_tcs:
+                return self._build_paused_result(
+                    session=session,
+                    ask_user_tc=ask_user_tcs[0],
+                    round_idx=round_idx,
+                    tool_call_history=tool_call_history,
+                )
+
+        raise LLMError(
+            "Exceeded maximum tool call rounds",
+            display_message="Exceeded maximum tool call rounds.",
+        )
 
     def execute_stream(
         self, request: RunAgentRequest
@@ -442,7 +407,7 @@ class RunAgentUseCase:
                 f"Session not found: {request.session_id}",
                 display_message="Session not found.",
             )
-        if not session.is_paused or session.pending_tool_call is None:
+        if not session.is_paused:
             raise SessionNotPausedError(
                 f"Session {request.session_id} is not in a paused state",
                 display_message="Session is not in a paused state.",

--- a/projects/simple-agent-poc/src/simple_agent_poc/application/use_cases.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/application/use_cases.py
@@ -9,6 +9,7 @@ from uuid import uuid4
 from simple_agent_poc.application.dto import (
     ContentDelta,
     ContinueRequest,
+    RunAgentPaused,
     RunAgentRequest,
     RunAgentResponse,
     SessionPaused,
@@ -107,8 +108,14 @@ class RunAgentUseCase:
         self._tool_executor = tool_executor
         self._is_api_context = is_api_context
 
-    def execute(self, request: RunAgentRequest) -> RunAgentResponse:
-        """Run the agent for a single user message with ReAct tool loop."""
+    def execute(
+        self, request: RunAgentRequest
+    ) -> RunAgentResponse | RunAgentPaused:
+        """Run the agent for a single user message with ReAct tool loop.
+
+        Returns ``RunAgentPaused`` when an ``ask_user`` tool call is encountered,
+        so the caller can provide an answer via ``continue_sync()``.
+        """
         if not request.message.strip():
             raise ValidationError("message must not be blank")
 
@@ -127,7 +134,7 @@ class RunAgentUseCase:
         tool_call_history: list[ToolCallRecord] = []
 
         try:
-            for _ in range(agent_definition.max_tool_rounds):
+            for round_idx in range(agent_definition.max_tool_rounds):
                 response = llm_client.complete(list(session.messages), tools=tools)
 
                 tool_calls = response.get("tool_calls")
@@ -147,12 +154,15 @@ class RunAgentUseCase:
                 session.append_assistant_message(
                     response["content"] or "", tool_calls=tool_calls
                 )
+
+                ask_user_tcs = [
+                    tc
+                    for tc in tool_calls
+                    if tc["function"]["name"] == "ask_user"
+                ]
                 for tc in tool_calls:
                     if tc["function"]["name"] == "ask_user":
-                        raise LLMError(
-                            "Tool call 'ask_user' is not supported in non-streaming mode.",
-                            display_message="ask_user はストリーミングモードでのみご利用いただけます。",
-                        )
+                        continue
                     result = self._tool_executor.execute(tc)
                     session.append_tool_message(result, tool_call_id=tc["id"])
                     tool_call_history.append(
@@ -162,6 +172,109 @@ class RunAgentUseCase:
                             arguments=tc["function"]["arguments"],
                             result=result,
                         )
+                    )
+
+                if ask_user_tcs:
+                    return self._build_paused_result(
+                        session=session,
+                        ask_user_tc=ask_user_tcs[0],
+                        round_idx=round_idx,
+                        tool_call_history=tool_call_history,
+                    )
+
+            raise LLMError(
+                "Exceeded maximum tool call rounds",
+                display_message="Exceeded maximum tool call rounds.",
+            )
+        finally:
+            self._session_store.save(session)
+
+    def continue_sync(
+        self, request: ContinueRequest
+    ) -> RunAgentResponse | RunAgentPaused:
+        """Resume a paused session synchronously with the user's answer."""
+        session = self._session_store.get(request.session_id)
+        if session is None:
+            raise SessionNotFoundError(
+                f"Session not found: {request.session_id}",
+                display_message="Session not found.",
+            )
+        if not session.is_paused or session.pending_tool_call is None:
+            raise SessionNotPausedError(
+                f"Session {request.session_id} is not in a paused state",
+                display_message="Session is not in a paused state.",
+            )
+
+        tc = session.pending_tool_call
+        result = json.dumps({"answer": request.answer}, ensure_ascii=False)
+        session.append_tool_message(result, tool_call_id=tc["id"])
+        resume_round = session.pending_round
+        session.resume_with_answer()
+
+        tool_call_history: list[ToolCallRecord] = []
+
+        next_ask_user_tc = _find_next_unanswered_ask_user(session)
+        if next_ask_user_tc is not None:
+            return self._build_paused_result(
+                session=session,
+                ask_user_tc=next_ask_user_tc,
+                round_idx=resume_round,
+                tool_call_history=tool_call_history,
+            )
+
+        agent_definition = self._agent_definitions.get(session.agent_id)
+        llm_client = self._llm_client_factory(agent_definition)
+        tools = self._resolve_tools(agent_definition)
+
+        try:
+            for round_idx in range(
+                resume_round + 1, agent_definition.max_tool_rounds
+            ):
+                response = llm_client.complete(list(session.messages), tools=tools)
+
+                tool_calls = response.get("tool_calls")
+                if not tool_calls:
+                    session.append_assistant_message(response["content"])
+                    return RunAgentResponse.from_llm_response(
+                        response,
+                        session_id=session.session_id,
+                        tool_call_history=tool_call_history,
+                    )
+
+                if self._tool_executor is None:
+                    raise LLMError(
+                        "Tool call requested but no tool executor configured",
+                        display_message="Tool call requested but no tool executor configured.",
+                    )
+                session.append_assistant_message(
+                    response["content"] or "", tool_calls=tool_calls
+                )
+
+                ask_user_tcs = [
+                    tc
+                    for tc in tool_calls
+                    if tc["function"]["name"] == "ask_user"
+                ]
+                for tc in tool_calls:
+                    if tc["function"]["name"] == "ask_user":
+                        continue
+                    result = self._tool_executor.execute(tc)
+                    session.append_tool_message(result, tool_call_id=tc["id"])
+                    tool_call_history.append(
+                        ToolCallRecord(
+                            call_id=tc["id"],
+                            name=tc["function"]["name"],
+                            arguments=tc["function"]["arguments"],
+                            result=result,
+                        )
+                    )
+
+                if ask_user_tcs:
+                    return self._build_paused_result(
+                        session=session,
+                        ask_user_tc=ask_user_tcs[0],
+                        round_idx=round_idx,
+                        tool_call_history=tool_call_history,
                     )
 
             raise LLMError(
@@ -473,6 +586,23 @@ class RunAgentUseCase:
             raise
         finally:
             self._session_store.save(session)
+
+    def _build_paused_result(
+        self,
+        *,
+        session: ConversationSession,
+        ask_user_tc: ToolCall,
+        round_idx: int,
+        tool_call_history: list[ToolCallRecord],
+    ) -> RunAgentPaused:
+        session.pause_for_ask_user(ask_user_tc, round_idx=round_idx)
+        ask_user_args = json.loads(ask_user_tc["function"]["arguments"])
+        return RunAgentPaused(
+            session_id=session.session_id,
+            call_id=ask_user_tc["id"],
+            question=ask_user_args.get("question", ""),
+            tool_call_history=tool_call_history,
+        )
 
     def _load_session(
         self,

--- a/projects/simple-agent-poc/src/simple_agent_poc/application/use_cases.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/application/use_cases.py
@@ -154,6 +154,8 @@ class RunAgentUseCase:
             )
 
         tc = session.pending_tool_call
+        if tc is None:
+            raise RuntimeError("Session is paused but no pending tool call found")
         result = json.dumps({"answer": request.answer}, ensure_ascii=False)
         session.append_tool_message(result, tool_call_id=tc["id"])
         resume_round = session.pending_round
@@ -414,6 +416,8 @@ class RunAgentUseCase:
             )
 
         tc = session.pending_tool_call
+        if tc is None:
+            raise RuntimeError("Session is paused but no pending tool call found")
         result = json.dumps({"answer": request.answer}, ensure_ascii=False)
         session.append_tool_message(result, tool_call_id=tc["id"])
         yield ToolResultEvent(call_id=tc["id"], name="ask_user", result=result)

--- a/projects/simple-agent-poc/src/simple_agent_poc/application/use_cases.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/application/use_cases.py
@@ -108,9 +108,7 @@ class RunAgentUseCase:
         self._tool_executor = tool_executor
         self._is_api_context = is_api_context
 
-    def execute(
-        self, request: RunAgentRequest
-    ) -> RunAgentResponse | RunAgentPaused:
+    def execute(self, request: RunAgentRequest) -> RunAgentResponse | RunAgentPaused:
         """Run the agent for a single user message with ReAct tool loop.
 
         Returns ``RunAgentPaused`` when an ``ask_user`` tool call is encountered,
@@ -156,9 +154,7 @@ class RunAgentUseCase:
                 )
 
                 ask_user_tcs = [
-                    tc
-                    for tc in tool_calls
-                    if tc["function"]["name"] == "ask_user"
+                    tc for tc in tool_calls if tc["function"]["name"] == "ask_user"
                 ]
                 for tc in tool_calls:
                     if tc["function"]["name"] == "ask_user":
@@ -227,9 +223,7 @@ class RunAgentUseCase:
         tools = self._resolve_tools(agent_definition)
 
         try:
-            for round_idx in range(
-                resume_round + 1, agent_definition.max_tool_rounds
-            ):
+            for round_idx in range(resume_round + 1, agent_definition.max_tool_rounds):
                 response = llm_client.complete(list(session.messages), tools=tools)
 
                 tool_calls = response.get("tool_calls")
@@ -251,9 +245,7 @@ class RunAgentUseCase:
                 )
 
                 ask_user_tcs = [
-                    tc
-                    for tc in tool_calls
-                    if tc["function"]["name"] == "ask_user"
+                    tc for tc in tool_calls if tc["function"]["name"] == "ask_user"
                 ]
                 for tc in tool_calls:
                     if tc["function"]["name"] == "ask_user":

--- a/projects/simple-agent-poc/tests/test_api.py
+++ b/projects/simple-agent-poc/tests/test_api.py
@@ -85,10 +85,11 @@ class TestAPI:
         )
         client = TestClient(app)
 
-        response = client.post("/api/chat", json={"message": "Hello"})
+        response = client.post("/api/chat/sync", json={"message": "Hello"})
 
         assert response.status_code == 200
         data = response.json()
+        assert data["status"] == "completed"
         assert data["message"] == "Hello, user!"
         assert data["model"] == "stub-model"
         assert data["session_id"]
@@ -97,7 +98,7 @@ class TestAPI:
         app = create_app(use_case_factory=unused_use_case_factory)
         client = TestClient(app)
 
-        response = client.post("/api/chat", json={})
+        response = client.post("/api/chat/sync", json={})
 
         assert response.status_code == 422
 
@@ -105,7 +106,7 @@ class TestAPI:
         app = create_app(use_case_factory=unused_use_case_factory)
         client = TestClient(app)
 
-        response = client.post("/api/chat", json={"message": "   "})
+        response = client.post("/api/chat/sync", json={"message": "   "})
 
         assert response.status_code == 422
 
@@ -124,10 +125,10 @@ class TestAPI:
         )
         client = TestClient(app)
 
-        first_response = client.post("/api/chat", json={"message": "Hello"})
+        first_response = client.post("/api/chat/sync", json={"message": "Hello"})
         session_id = first_response.json()["session_id"]
         second_response = client.post(
-            "/api/chat",
+            "/api/chat/sync",
             headers={"Session-Id": session_id},
             json={"message": "Again"},
         )
@@ -157,10 +158,10 @@ class TestAPI:
         )
         client = TestClient(app)
 
-        first_response = client.post("/api/chat", json={"message": "Hello"})
+        first_response = client.post("/api/chat/sync", json={"message": "Hello"})
         session_id = first_response.json()["session_id"]
         second_response = client.post(
-            "/api/chat",
+            "/api/chat/sync",
             json={"message": "Again", "session_id": session_id},
         )
 
@@ -181,7 +182,7 @@ class TestAPI:
         client = TestClient(app)
 
         response = client.post(
-            "/api/chat",
+            "/api/chat/sync",
             headers={"Session-Id": "missing-session"},
             json={"message": "Hello"},
         )
@@ -202,7 +203,7 @@ class TestAPI:
         client = TestClient(app)
 
         response = client.post(
-            "/api/chat",
+            "/api/chat/sync",
             headers={"Session-Id": "header-session"},
             json={"message": "Hello", "session_id": "body-session"},
         )
@@ -227,7 +228,7 @@ class TestAPI:
         client = TestClient(app)
 
         response = client.post(
-            "/api/chat",
+            "/api/chat/sync",
             json={"message": "Hello", "agent_id": "researcher"},
         )
 
@@ -242,7 +243,7 @@ class TestAPI:
         client = TestClient(app)
 
         response = client.post(
-            "/api/chat",
+            "/api/chat/sync",
             json={"message": "Hello", "agent_id": "missing"},
         )
 
@@ -262,10 +263,10 @@ class TestAPI:
         )
         client = TestClient(app)
 
-        first_response = client.post("/api/chat", json={"message": "Hello"})
+        first_response = client.post("/api/chat/sync", json={"message": "Hello"})
         session_id = first_response.json()["session_id"]
         second_response = client.post(
-            "/api/chat",
+            "/api/chat/sync",
             headers={"Session-Id": session_id},
             json={"message": "Again", "agent_id": "researcher"},
         )

--- a/projects/simple-agent-poc/tests/test_application.py
+++ b/projects/simple-agent-poc/tests/test_application.py
@@ -149,6 +149,7 @@ class TestRunAgentUseCase:
             RunAgentRequest(message="Hello", agent_id="researcher")
         )
 
+        assert isinstance(response, RunAgentResponse)
         assert response.model == "research-model"
         llm_client_factory.assert_called_once()
         assert llm_client_factory.call_args.args[0].agent_id == "researcher"

--- a/projects/simple-agent-poc/tests/test_cli.py
+++ b/projects/simple-agent-poc/tests/test_cli.py
@@ -6,13 +6,13 @@ from unittest.mock import MagicMock
 import pytest
 
 from simple_agent_poc.adapters.cli.adapter import CLIAdapter
-from simple_agent_poc.application.dto import RunAgentResponse
+from simple_agent_poc.application.dto import RunAgentPaused, RunAgentResponse
 
 
 def passthrough_indicator(
     message: str,
-    operation: Callable[[], RunAgentResponse],
-) -> RunAgentResponse:
+    operation: Callable[[], RunAgentResponse | RunAgentPaused],
+) -> RunAgentResponse | RunAgentPaused:
     """Run the operation immediately for deterministic tests."""
     assert message == "Thinking"
     return operation()

--- a/projects/simple-agent-poc/tests/test_http_stream_api.py
+++ b/projects/simple-agent-poc/tests/test_http_stream_api.py
@@ -277,7 +277,7 @@ class TestStreamPauseContinueAPI:
         client2 = TestClient(app2)
 
         continue_resp = client2.post(
-            "/api/chat/continue",
+            "/api/chat/stream/continue",
             json={"session_id": session_id, "answer": "Alice"},
         )
 
@@ -351,7 +351,7 @@ class TestStreamPauseContinueAPI:
         client2 = TestClient(app2)
 
         continue_resp = client2.post(
-            "/api/chat/continue",
+            "/api/chat/stream/continue",
             json={"session_id": paused_data["session_id"], "answer": "1"},
         )
 
@@ -380,7 +380,7 @@ class TestStreamPauseContinueAPI:
         client = TestClient(app)
 
         response = client.post(
-            "/api/chat/continue",
+            "/api/chat/stream/continue",
             json={"session_id": "missing", "answer": "no"},
         )
 
@@ -414,7 +414,7 @@ class TestStreamPauseContinueAPI:
         client = TestClient(app)
 
         response = client.post(
-            "/api/chat/continue",
+            "/api/chat/stream/continue",
             json={"session_id": "active", "answer": "no"},
         )
 
@@ -437,7 +437,7 @@ class TestStreamPauseContinueAPI:
         client = TestClient(app)
 
         response = client.post(
-            "/api/chat/continue",
+            "/api/chat/stream/continue",
             json={"session_id": "abc", "answer": "   "},
         )
 

--- a/projects/simple-agent-poc/tests/test_use_cases.py
+++ b/projects/simple-agent-poc/tests/test_use_cases.py
@@ -398,6 +398,7 @@ def test_execute_stream_final_complete(default_agent_def, tool_registry):
 # Sync ask_user pause / resume
 # ---------------------------------------------------------------------------
 
+
 def _ask_user_tool_call() -> list[ToolCall]:
     return [
         {
@@ -543,9 +544,7 @@ def test_continue_sync_pauses_on_next_unanswered_ask_user():
         system_prompt="You are a helpful assistant.",
     )
     session.append_user_message("hello")
-    session.append_assistant_message(
-        "", tool_calls=[ask_user_tc_1, ask_user_tc_2]
-    )
+    session.append_assistant_message("", tool_calls=[ask_user_tc_1, ask_user_tc_2])
     session.pause_for_ask_user(ask_user_tc_1, round_idx=0)
     store.save(session)
 
@@ -586,9 +585,7 @@ def test_continue_sync_with_unknown_session_raises_error():
     )
 
     try:
-        use_case.continue_sync(
-            ContinueRequest(session_id="missing", answer="no")
-        )
+        use_case.continue_sync(ContinueRequest(session_id="missing", answer="no"))
         assert False, "Expected SessionNotFoundError"
     except SessionNotFoundError:
         pass

--- a/projects/simple-agent-poc/tests/test_use_cases.py
+++ b/projects/simple-agent-poc/tests/test_use_cases.py
@@ -6,7 +6,9 @@ from simple_agent_poc.adapters.session_store.in_memory import InMemorySessionSto
 from simple_agent_poc.application.dto import (
     ContentDelta,
     ContinueRequest,
+    RunAgentPaused,
     RunAgentRequest,
+    RunAgentResponse,
     StreamComplete,
     ToolCallEvent,
     ToolResultEvent,
@@ -19,6 +21,8 @@ from simple_agent_poc.core.types import (
     LLMResponse,
     LLMStreamChunk,
     Message,
+    SessionNotFoundError,
+    SessionNotPausedError,
     ToolCall,
     ToolDefinition,
     Usage,
@@ -141,6 +145,7 @@ def test_execute_yields_final_response_without_tools(default_agent_def, tool_reg
         tool_executor=tool_registry,
     )
     response = use_case.execute(RunAgentRequest(message="hello"))
+    assert isinstance(response, RunAgentResponse)
     assert response.message == "Done."
     assert response.session_id
 
@@ -166,6 +171,7 @@ def test_execute_with_tool_call(default_agent_def, tool_registry):
         tool_executor=tool_registry,
     )
     response = use_case.execute(RunAgentRequest(message="concat hello world"))
+    assert isinstance(response, RunAgentResponse)
     assert "helloworld" in response.message.lower() or "Done" in response.message
     assert response.session_id
 
@@ -386,3 +392,241 @@ def test_execute_stream_final_complete(default_agent_def, tool_registry):
     events = list(use_case.execute_stream(RunAgentRequest(message="hello")))
     assert isinstance(events[-1], StreamComplete)
     assert events[-1].session_id
+
+
+# ---------------------------------------------------------------------------
+# Sync ask_user pause / resume
+# ---------------------------------------------------------------------------
+
+def _ask_user_tool_call() -> list[ToolCall]:
+    return [
+        {
+            "id": "call_ask_001",
+            "type": "function",
+            "function": {
+                "name": "ask_user",
+                "arguments": '{"question": "What is your name?"}',
+            },
+        }
+    ]
+
+
+def _agent_definitions_with_ask_user() -> AgentDefinitionRegistry:
+    return AgentDefinitionRegistry.from_mapping(
+        {
+            "agents": {
+                "default": {
+                    "model": "test-model",
+                    "system_prompt": "You are a helpful assistant.",
+                    "tools": ["ask_user"],
+                },
+            }
+        }
+    )
+
+
+def test_execute_returns_paused_on_ask_user():
+    """Sync execute() returns RunAgentPaused when LLM calls ask_user."""
+    fake_llm = FakeLLMClient(
+        rounds=[
+            {
+                "content": "",
+                "usage": _usage(),
+                "model": "fake",
+                "response_time": 0.1,
+                "tool_calls": _ask_user_tool_call(),
+            },
+        ]
+    )
+    from simple_agent_poc.adapters.tools.registry import BuiltinToolRegistry
+    from simple_agent_poc.adapters.tools.ask_user import (
+        TOOL_DEFINITION as ASK_USER_TOOL_DEF,
+    )
+    from simple_agent_poc.adapters.tools.ask_user import (
+        execute as ask_user_execute,
+    )
+
+    tool_executor = BuiltinToolRegistry()
+    tool_executor.register(ASK_USER_TOOL_DEF, ask_user_execute)
+
+    use_case = RunAgentUseCase(
+        llm_client_factory=FakeLLMClientFactory(fake_llm),
+        session_store=InMemorySessionStore(),
+        agent_definitions=_agent_definitions_with_ask_user(),
+        tool_executor=tool_executor,
+    )
+    result = use_case.execute(RunAgentRequest(message="hello"))
+    assert isinstance(result, RunAgentPaused)
+    assert result.question == "What is your name?"
+    assert result.call_id == "call_ask_001"
+
+
+def test_continue_sync_resumes_and_completes():
+    """continue_sync() resumes a paused session and returns final response."""
+    from simple_agent_poc.adapters.tools.registry import BuiltinToolRegistry
+    from simple_agent_poc.adapters.tools.ask_user import (
+        TOOL_DEFINITION as ASK_USER_TOOL_DEF,
+    )
+    from simple_agent_poc.adapters.tools.ask_user import (
+        execute as ask_user_execute,
+    )
+
+    tool_executor = BuiltinToolRegistry()
+    tool_executor.register(ASK_USER_TOOL_DEF, ask_user_execute)
+
+    ask_user_tc: ToolCall = {
+        "id": "call_ask_001",
+        "type": "function",
+        "function": {
+            "name": "ask_user",
+            "arguments": '{"question": "What is your name?"}',
+        },
+    }
+    store = InMemorySessionStore()
+    session = ConversationSession.start(
+        session_id="paused-session",
+        system_prompt="You are a helpful assistant.",
+    )
+    session.append_user_message("hello")
+    session.append_assistant_message("", tool_calls=[ask_user_tc])
+    session.pause_for_ask_user(ask_user_tc, round_idx=0)
+    store.save(session)
+
+    fake_llm = FakeLLMClient(rounds=[])
+    use_case = RunAgentUseCase(
+        llm_client_factory=FakeLLMClientFactory(fake_llm),
+        session_store=store,
+        agent_definitions=_agent_definitions_with_ask_user(),
+        tool_executor=tool_executor,
+    )
+
+    result = use_case.continue_sync(
+        ContinueRequest(session_id="paused-session", answer="Alice")
+    )
+
+    assert isinstance(result, RunAgentResponse)
+    assert result.message == "Done."
+
+
+def test_continue_sync_pauses_on_next_unanswered_ask_user():
+    """continue_sync() returns RunAgentPaused when another ask_user is pending."""
+    from simple_agent_poc.adapters.tools.registry import BuiltinToolRegistry
+    from simple_agent_poc.adapters.tools.ask_user import (
+        TOOL_DEFINITION as ASK_USER_TOOL_DEF,
+    )
+    from simple_agent_poc.adapters.tools.ask_user import (
+        execute as ask_user_execute,
+    )
+
+    tool_executor = BuiltinToolRegistry()
+    tool_executor.register(ASK_USER_TOOL_DEF, ask_user_execute)
+
+    ask_user_tc_1: ToolCall = {
+        "id": "call_ask_001",
+        "type": "function",
+        "function": {
+            "name": "ask_user",
+            "arguments": '{"question": "First question?"}',
+        },
+    }
+    ask_user_tc_2: ToolCall = {
+        "id": "call_ask_002",
+        "type": "function",
+        "function": {
+            "name": "ask_user",
+            "arguments": '{"question": "Second question?"}',
+        },
+    }
+    store = InMemorySessionStore()
+    session = ConversationSession.start(
+        session_id="paused-session",
+        system_prompt="You are a helpful assistant.",
+    )
+    session.append_user_message("hello")
+    session.append_assistant_message(
+        "", tool_calls=[ask_user_tc_1, ask_user_tc_2]
+    )
+    session.pause_for_ask_user(ask_user_tc_1, round_idx=0)
+    store.save(session)
+
+    fake_llm = FakeLLMClient(rounds=[])
+    use_case = RunAgentUseCase(
+        llm_client_factory=FakeLLMClientFactory(fake_llm),
+        session_store=store,
+        agent_definitions=_agent_definitions_with_ask_user(),
+        tool_executor=tool_executor,
+    )
+    result = use_case.continue_sync(
+        ContinueRequest(session_id="paused-session", answer="Answer 1")
+    )
+
+    assert isinstance(result, RunAgentPaused)
+    assert result.question == "Second question?"
+    assert result.call_id == "call_ask_002"
+
+
+def test_continue_sync_with_unknown_session_raises_error():
+    """continue_sync() raises SessionNotFoundError for unknown session."""
+    from simple_agent_poc.adapters.tools.registry import BuiltinToolRegistry
+    from simple_agent_poc.adapters.tools.ask_user import (
+        TOOL_DEFINITION as ASK_USER_TOOL_DEF,
+    )
+    from simple_agent_poc.adapters.tools.ask_user import (
+        execute as ask_user_execute,
+    )
+
+    tool_executor = BuiltinToolRegistry()
+    tool_executor.register(ASK_USER_TOOL_DEF, ask_user_execute)
+
+    use_case = RunAgentUseCase(
+        llm_client_factory=FakeLLMClientFactory(FakeLLMClient(rounds=[])),
+        session_store=InMemorySessionStore(),
+        agent_definitions=_agent_definitions_with_ask_user(),
+        tool_executor=tool_executor,
+    )
+
+    try:
+        use_case.continue_sync(
+            ContinueRequest(session_id="missing", answer="no")
+        )
+        assert False, "Expected SessionNotFoundError"
+    except SessionNotFoundError:
+        pass
+
+
+def test_continue_sync_with_non_paused_session_raises_error():
+    """continue_sync() raises SessionNotPausedError when session is active."""
+    from simple_agent_poc.adapters.tools.registry import BuiltinToolRegistry
+    from simple_agent_poc.adapters.tools.ask_user import (
+        TOOL_DEFINITION as ASK_USER_TOOL_DEF,
+    )
+    from simple_agent_poc.adapters.tools.ask_user import (
+        execute as ask_user_execute,
+    )
+
+    tool_executor = BuiltinToolRegistry()
+    tool_executor.register(ASK_USER_TOOL_DEF, ask_user_execute)
+
+    store = InMemorySessionStore()
+    session = ConversationSession.start(
+        session_id="active-session",
+        system_prompt="System prompt",
+    )
+    session.append_user_message("Hello")
+    session.append_assistant_message("Hi")
+    store.save(session)
+
+    use_case = RunAgentUseCase(
+        llm_client_factory=FakeLLMClientFactory(FakeLLMClient(rounds=[])),
+        session_store=store,
+        agent_definitions=_agent_definitions_with_ask_user(),
+        tool_executor=tool_executor,
+    )
+
+    try:
+        use_case.continue_sync(
+            ContinueRequest(session_id="active-session", answer="no")
+        )
+        assert False, "Expected SessionNotPausedError"
+    except SessionNotPausedError:
+        pass


### PR DESCRIPTION
## Issues

- Close #916

## Why

`ask_user` tool call was not usable in sync (non-streaming) mode — `RunAgentUseCase.execute()` raised `LLMError` when encountering it. This prevented `stream: false` agents from using `ask_user` in both CLI and HTTP API.

## Summary

Added synchronous pause/resume support for `ask_user` tool calls. `execute()` now returns `RunAgentPaused` instead of throwing an error, and the new `continue_sync()` method resumes execution. Both CLI and HTTP API endpoints support the new flow.

## Changes

- **`dto.py`**: Add `RunAgentPaused` DTO with `session_id`, `call_id`, `question`, `tool_call_history`
- **`use_cases.py`**: `execute()` returns `RunAgentResponse | RunAgentPaused`; `ask_user` triggers pause instead of error. Add `continue_sync()` for synchronous resume. Extract `_build_paused_result()` helper.
- **`adapter.py` (CLI)**: Non-stream mode handles `RunAgentPaused` with immediate `ask_user_question()` → `continue_sync()` loop. Update `IndicatorRunner` protocol return type.
- **`api.py` (HTTP)**: Reorganize endpoints:
  - `POST /api/chat/sync` — sync execution, JSON with `status: "completed"|"paused"`
  - `POST /api/chat/sync/continue` — sync resume, same discriminated shape
  - `POST /api/chat/stream` — streaming (unchanged path)
  - `POST /api/chat/stream/continue` — streaming resume (renamed from `/api/chat/continue`)
  - Remove old `/api/chat` and `/api/chat/continue`
- **`test_page.py`**: JS updated for new endpoints, sync mode pause/resume with `continueSync()` / `continueStream()` split
- **Tests**: Added 5 new tests for sync `execute()` pause, `continue_sync()` resume, multi ask_user, error cases. Updated all existing tests for new URLs and return types.

## Verification

- `uv run ruff check .` — passed
- `uv run ty check .` — passed
- `uv run pytest tests/` — 179 passed
