### PR TITLE
feat(simple-agent-poc): redesign ask_user with questions array schema (Phase 1)

### DIFF
--- a/projects/simple-agent-poc/docs/api.md
+++ b/projects/simple-agent-poc/docs/api.md
@@ -88,7 +88,14 @@ When the agent calls `ask_user` and needs user input:
   "status": "paused",
   "session_id": "abc123...",
   "call_id": "call_001",
-  "question": "What is your name?",
+  "questions": [
+    {
+      "question": "What is your name?",
+      "header": "Name",
+      "type": "text",
+      "placeholder": "e.g. Alice"
+    }
+  ],
   "tool_calls": []
 }
 ```
@@ -98,7 +105,7 @@ When the agent calls `ask_user` and needs user input:
 | `status` | `"paused"` | Discriminator for a paused response |
 | `session_id` | `str` | Session ID for continuing the conversation |
 | `call_id` | `str` | ID of the pending `ask_user` tool call |
-| `question` | `str` | Question text from `ask_user` arguments |
+| `questions` | `list[dict]` | Question items from `ask_user` arguments. Each item has `question` (text), `header` (short label), `type` (`"text"` in Phase 1), and optional `placeholder` |
 | `tool_calls` | `list[ToolCallRecord]` | Non-ask_user tool calls executed before pausing |
 
 #### Error Responses

--- a/projects/simple-agent-poc/docs/architecture.md
+++ b/projects/simple-agent-poc/docs/architecture.md
@@ -47,7 +47,7 @@ Own transport-specific integration details.
 - `src/simple_agent_poc/adapters/tools/registry.py` — `BuiltinToolRegistry`
 - `src/simple_agent_poc/adapters/tools/concat.py` — `concat` tool
 - `src/simple_agent_poc/adapters/tools/get_current_time.py` — `get_current_time` tool
-- `src/simple_agent_poc/adapters/tools/ask_user.py` — `ask_user` interactive tool
+- `src/simple_agent_poc/adapters/tools/ask_user.py` — `ask_user` interactive tool (Gemini CLI / Claude Code compatible `questions` array schema)
 
 Adapters call the application layer. They translate external inputs into DTOs and translate use case outputs into transport-specific output.
 

--- a/projects/simple-agent-poc/docs/cli.md
+++ b/projects/simple-agent-poc/docs/cli.md
@@ -62,7 +62,7 @@ while True:
     else:
         response = with_indicator("Thinking", lambda: use_case.execute(request))
         while response is RunAgentPaused:
-            answer = ask_user_question(response.question)
+            answer = ask_user_question(response.questions)
             response = with_indicator(
                 "Thinking",
                 lambda: use_case.continue_sync(ContinueRequest(
@@ -79,7 +79,7 @@ while True:
 When `stream: false` (default), `execute()` returns `RunAgentResponse | RunAgentPaused`. If `RunAgentPaused` is returned:
 
 1. The indicator stops automatically (via `finally` in `with_indicator`).
-2. `ask_user_question(question)` displays the question and reads the user's answer from stdin.
+2. `ask_user_question(questions)` displays the question and reads the user's answer from stdin.
 3. `continue_sync(ContinueRequest(session_id, answer))` is called with a new indicator.
 4. If `continue_sync` returns another `RunAgentPaused` (multiple `ask_user` in same batch), the loop repeats.
 5. When `RunAgentResponse` is finally returned, it is rendered via `show_agent_response()`.
@@ -144,7 +144,7 @@ Agent: <response.message>
 1. Starts `LoadingIndicator`.
 2. On `ContentDelta`: stops indicator, prints `"Agent: "`, writes delta text in-place.
 3. On `ToolCallEvent`: displays the tool call being made.
-4. **For `ask_user`**: calls `ask_user_question(question)` which displays the question and reads user input, then `generator.send(answer)` to resume the stream.
+4. **For `ask_user`**: calls `ask_user_question(questions)` which displays the question with header/placeholder and reads user input, then `generator.send(answer)` to resume the stream.
 5. On `ToolResultEvent`: displays the tool result.
 6. On `SessionPaused`: displays the pause notification (API mode only; not expected in CLI).
 7. On `StreamComplete`: prints newline, then stats line (same format as `show_agent_response`).
@@ -154,15 +154,25 @@ If no `ContentDelta` was received before `StreamComplete`, the indicator is stop
 
 If no `StreamComplete` arrives at all, raises `RuntimeError`.
 
-### ask_user_question(question)
+### ask_user_question(questions)
 
 ```python
-def ask_user_question(question: str) -> str:
-    print(f"\n  💬 ask_user: {question}")
-    return input("  Answer > ").strip()
+def ask_user_question(questions: list[dict]) -> str:
+    if not questions:
+        return ""
+    q = questions[0]
+    header = q.get("header", "")
+    question_text = q.get("question", "")
+    placeholder = q.get("placeholder", "")
+    label = f"[{header}] " if header else ""
+    prompt = f"  {label}{question_text}"
+    if placeholder:
+        prompt += f" ({placeholder})"
+    prompt += " > "
+    return input(prompt).strip()
 ```
 
-Displays the `ask_user` question and reads the user's typed answer from stdin. Used by both sync and stream modes.
+Displays the `ask_user` question and reads the user's typed answer from stdin. Phase 1 では `questions` 配列の最初の要素のみを処理する。`header` があれば `[Header]` 形式のラベルを表示し、`placeholder` があれば入力ヒントとして表示する。Used by both sync and stream modes.
 
 ### show_error(error)
 

--- a/projects/simple-agent-poc/docs/sse.md
+++ b/projects/simple-agent-poc/docs/sse.md
@@ -59,7 +59,7 @@ Emitted after a tool executes. Contains:
 
 ```text
 event: paused
-data: {"session_id": "abc123...", "call_id": "call_def456", "question": "What is your preference?"}
+data: {"session_id": "abc123...", "call_id": "call_def456", "questions": [{"question": "What is your preference?", "header": "Preference", "type": "text"}]}
 ```
 
 Emitted when `ask_user` is called in API mode. The SSE stream disconnects after this event. The client must send the answer via `POST /api/chat/continue` to resume. Contains:
@@ -68,7 +68,7 @@ Emitted when `ask_user` is called in API mode. The SSE stream disconnects after 
 |:---|:---|:---|
 | `session_id` | `str` | Session ID to use for the continue request |
 | `call_id` | `str` | Tool call ID (for reference) |
-| `question` | `str` | The question to display to the user |
+| `questions` | `list[dict]` | Question items from `ask_user`. Each has `question`, `header`, `type` (`"text"`), and optional `placeholder` |
 
 ### `complete` — Stream Finished
 

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/cli/adapter.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/cli/adapter.py
@@ -128,7 +128,7 @@ class CLIAdapter:
                         ),
                     )
                     while isinstance(response, RunAgentPaused):
-                        answer = ask_user_question(response.question)
+                        answer = ask_user_question(response.questions)
                         paused_session_id = response.session_id
                         response = self._indicator_runner(
                             "Thinking",

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/cli/renderer.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/cli/renderer.py
@@ -85,10 +85,22 @@ def get_user_input() -> str:
     return input("> ")
 
 
-def ask_user_question(question: str) -> str:
-    """Display an ask_user question and return the user's answer."""
-    print(f"\n  💬 ask_user: {question}")
-    return input("  Answer > ").strip()
+def ask_user_question(questions: list[dict]) -> str:
+    """Display ask_user questions and return the user's answer.
+
+    Phase 1 では questions 配列の最初の要素のみ処理する。"""
+    if not questions:
+        return ""
+    q = questions[0]
+    header = q.get("header", "")
+    question_text = q.get("question", "")
+    placeholder = q.get("placeholder", "")
+    label = f"[{header}] " if header else ""
+    prompt = f"  {label}{question_text}"
+    if placeholder:
+        prompt += f" ({placeholder})"
+    prompt += " > "
+    return input(prompt).strip()
 
 
 def show_agent_response(response: RunAgentResponse) -> None:
@@ -180,7 +192,7 @@ def show_streaming_response(
 
                 if event.name == "ask_user":
                     args = json.loads(event.arguments)
-                    answer = ask_user_question(args.get("question", ""))
+                    answer = ask_user_question(args.get("questions", []))
                     try:
                         next_event = stream.send(answer)
                     except StopIteration:
@@ -198,8 +210,14 @@ def show_streaming_response(
                 sys.stdout.flush()
             elif isinstance(event, SessionPaused):
                 indicator.stop()
-                sys.stdout.write(f"\n  💬 ask_user: {event.question}\n")
-                sys.stdout.flush()
+                questions = event.questions
+                if questions:
+                    q = questions[0]
+                    header = q.get("header", "")
+                    question_text = q.get("question", "")
+                    label = f"[{header}] " if header else ""
+                    sys.stdout.write(f"\n  💬 ask_user: {label}{question_text}\n")
+                    sys.stdout.flush()
             elif isinstance(event, StreamComplete):
                 complete = event
                 if not started:

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/api.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/api.py
@@ -72,7 +72,7 @@ class SyncChatResponse(BaseModel):
     model: str = ""
     response_time: float = 0.0
     call_id: str = ""
-    question: str = ""
+    questions: list[dict] = []
 
     @classmethod
     def from_completed(cls, response: RunAgentResponse) -> "SyncChatResponse":
@@ -94,7 +94,7 @@ class SyncChatResponse(BaseModel):
             status="paused",
             session_id=paused.session_id,
             call_id=paused.call_id,
-            question=paused.question,
+            questions=paused.questions,
             tool_calls=paused.tool_call_history,
         )
 

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/test_page.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/test_page.py
@@ -227,8 +227,10 @@ async function sendSyncMessage(message) {
     const data = await resp.json();
     appendJson("raw-log", "line-system", data);
     if (data.status === "paused") {
-      appendLine("conv-log", "line-paused", "  [Paused] " + data.question);
-      enterPausedState({ session_id: data.session_id, question: data.question, call_id: data.call_id, mode: "sync" });
+      const qs = data.questions || [];
+      const firstQ = qs.length > 0 ? qs[0].question : "";
+      appendLine("conv-log", "line-paused", "  [Paused] " + firstQ);
+      enterPausedState({ session_id: data.session_id, questions: qs, call_id: data.call_id, mode: "sync" });
       return;
     }
     appendLine("conv-log", "line-assistant", "Assistant: " + data.message);
@@ -291,7 +293,9 @@ async function sendStreamMessage(message) {
         appendJson("tool-log", "line-tool", d);
       } else if (event.type === "paused") {
         const d = JSON.parse(event.data);
-        appendLine("conv-log", "line-paused", "  [Paused] " + d.question);
+        const qs = d.questions || [];
+        const firstQ = qs.length > 0 ? qs[0].question : "";
+        appendLine("conv-log", "line-paused", "  [Paused] " + firstQ);
         enterPausedState(d);
       } else if (event.type === "complete") {
         const d = JSON.parse(event.data);
@@ -316,10 +320,12 @@ async function sendStreamMessage(message) {
   }
 }
 
-function enterPausedState({ session_id: sessionId, question, call_id: callId, mode = "stream" }) {
-  state.awaitingAnswer = { sessionId, question, callId, mode };
+function enterPausedState({ session_id: sessionId, questions, call_id: callId, mode = "stream" }) {
+  const qs = questions || [];
+  const questionText = qs.length > 0 ? qs[0].question : "";
+  state.awaitingAnswer = { sessionId, questions, callId, mode };
   setSessionId(sessionId);
-  el("paused-question").textContent = "Q: " + question;
+  el("paused-question").textContent = "Q: " + questionText;
   el("paused-answer").value = "";
   el("paused-bar").classList.add("visible");
   el("paused-answer").focus();
@@ -364,8 +370,10 @@ async function continueSync(sessionId, answer) {
     const data = await resp.json();
     appendJson("raw-log", "line-system", data);
     if (data.status === "paused") {
-      appendLine("conv-log", "line-paused", "  [Paused] " + data.question);
-      enterPausedState({ session_id: data.session_id, question: data.question, call_id: data.call_id, mode: "sync" });
+      const qs = data.questions || [];
+      const firstQ = qs.length > 0 ? qs[0].question : "";
+      appendLine("conv-log", "line-paused", "  [Paused] " + firstQ);
+      enterPausedState({ session_id: data.session_id, questions: qs, call_id: data.call_id, mode: "sync" });
       return;
     }
     appendLine("conv-log", "line-assistant", "Assistant: " + data.message);
@@ -426,8 +434,10 @@ async function continueStream(sessionId, answer) {
         appendJson("tool-log", "line-tool", d);
       } else if (event.type === "paused") {
         const d = JSON.parse(event.data);
-        appendLine("conv-log", "line-paused", "  [Paused] " + d.question);
-        enterPausedState({ session_id: d.session_id, question: d.question, call_id: d.call_id, mode: "stream" });
+        const qs = d.questions || [];
+        const firstQ = qs.length > 0 ? qs[0].question : "";
+        appendLine("conv-log", "line-paused", "  [Paused] " + firstQ);
+        enterPausedState({ session_id: d.session_id, questions: qs, call_id: d.call_id, mode: "stream" });
       } else if (event.type === "complete") {
         const d = JSON.parse(event.data);
         if (d.session_id) setSessionId(d.session_id);

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/tools/ask_user.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/tools/ask_user.py
@@ -40,7 +40,7 @@ TOOL_DEFINITION: ToolDefinition = {
                                 "description": "入力欄のプレースホルダー",
                             },
                         },
-                        "required": ["question", "header", "type"],
+                        "required": ["question", "type"],
                     },
                 },
             },

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/tools/ask_user.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/tools/ask_user.py
@@ -9,29 +9,64 @@ TOOL_DEFINITION: ToolDefinition = {
     "type": "function",
     "function": {
         "name": "ask_user",
-        "description": "ユーザーに対して質問を行い、回答を取得します。",
+        "description": (
+            "ユーザーに質問し、テキスト入力で回答を得ます。"
+            "追加情報が必要な場合に使います。"
+        ),
         "parameters": {
             "type": "object",
             "properties": {
-                "question": {
-                    "type": "string",
-                    "description": "ユーザーに尋ねる質問内容",
+                "questions": {
+                    "type": "array",
+                    "description": "質問のリスト",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "question": {
+                                "type": "string",
+                                "description": "ユーザーに表示する質問文",
+                            },
+                            "header": {
+                                "type": "string",
+                                "description": "質問の短いラベル（最大16文字）",
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["text"],
+                                "description": "質問の種類",
+                            },
+                            "placeholder": {
+                                "type": "string",
+                                "description": "入力欄のプレースホルダー",
+                            },
+                        },
+                        "required": ["question", "header", "type"],
+                    },
                 },
             },
-            "required": ["question"],
+            "required": ["questions"],
         },
     },
 }
 
 
 def execute(arguments: dict[str, Any]) -> str:
-    question = arguments.get("question", "")
+    questions = arguments.get("questions", [])
+    if not questions:
+        return json.dumps(
+            {"answers": {}},
+            ensure_ascii=False,
+        )
+    q = questions[0]
+    question_text = q.get("question", "")
     return json.dumps(
         {
-            "answer": (
-                f"このツールは API ストリーミングモードでのみ利用可能です。"
-                f"質問「{question}」には回答できませんでした。"
-            ),
+            "answers": {
+                question_text: (
+                    "このツールは API ストリーミングモードでのみ利用可能です。"
+                    f"質問「{question_text}」には回答できませんでした。"
+                ),
+            },
         },
         ensure_ascii=False,
     )

--- a/projects/simple-agent-poc/src/simple_agent_poc/application/dto.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/application/dto.py
@@ -103,7 +103,7 @@ class SessionPaused:
 
     session_id: str
     call_id: str
-    question: str
+    questions: list[dict]
 
 
 @dataclass(frozen=True, slots=True)
@@ -112,5 +112,5 @@ class RunAgentPaused:
 
     session_id: str
     call_id: str
-    question: str
+    questions: list[dict]
     tool_call_history: list[ToolCallRecord]

--- a/projects/simple-agent-poc/src/simple_agent_poc/application/use_cases.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/application/use_cases.py
@@ -156,7 +156,12 @@ class RunAgentUseCase:
         tc = session.pending_tool_call
         if tc is None:
             raise RuntimeError("Session is paused but no pending tool call found")
-        result = json.dumps({"answer": request.answer}, ensure_ascii=False)
+        pending_args = json.loads(tc["function"]["arguments"])
+        questions = pending_args.get("questions", [])
+        question_text = questions[0]["question"] if questions else ""
+        result = json.dumps(
+            {"answers": {question_text: request.answer}}, ensure_ascii=False
+        )
         session.append_tool_message(result, tool_call_id=tc["id"])
         resume_round = session.pending_round
         session.resume_with_answer()
@@ -341,7 +346,7 @@ class RunAgentUseCase:
                         yield SessionPaused(
                             session_id=session.session_id,
                             call_id=ask_user_tc["id"],
-                            question=ask_user_args.get("question", ""),
+                            questions=ask_user_args.get("questions", []),
                         )
                         return
 
@@ -353,8 +358,14 @@ class RunAgentUseCase:
                                 arguments=tc["function"]["arguments"],
                             )
                             user_answer = yield event
+                            ask_user_args = json.loads(tc["function"]["arguments"])
+                            questions = ask_user_args.get("questions", [])
+                            question_text = (
+                                questions[0]["question"] if questions else ""
+                            )
                             result = json.dumps(
-                                {"answer": user_answer or ""}, ensure_ascii=False
+                                {"answers": {question_text: user_answer or ""}},
+                                ensure_ascii=False,
                             )
                         else:
                             yield ToolCallEvent(
@@ -418,7 +429,12 @@ class RunAgentUseCase:
         tc = session.pending_tool_call
         if tc is None:
             raise RuntimeError("Session is paused but no pending tool call found")
-        result = json.dumps({"answer": request.answer}, ensure_ascii=False)
+        pending_args = json.loads(tc["function"]["arguments"])
+        questions = pending_args.get("questions", [])
+        question_text = questions[0]["question"] if questions else ""
+        result = json.dumps(
+            {"answers": {question_text: request.answer}}, ensure_ascii=False
+        )
         session.append_tool_message(result, tool_call_id=tc["id"])
         yield ToolResultEvent(call_id=tc["id"], name="ask_user", result=result)
         resume_round = session.pending_round
@@ -432,7 +448,7 @@ class RunAgentUseCase:
             yield SessionPaused(
                 session_id=session.session_id,
                 call_id=next_ask_user_tc["id"],
-                question=ask_user_args.get("question", ""),
+                questions=ask_user_args.get("questions", []),
             )
             return
 
@@ -510,7 +526,7 @@ class RunAgentUseCase:
                         yield SessionPaused(
                             session_id=session.session_id,
                             call_id=ask_user_tc["id"],
-                            question=ask_user_args.get("question", ""),
+                            questions=ask_user_args.get("questions", []),
                         )
                         return
 
@@ -561,7 +577,7 @@ class RunAgentUseCase:
         return RunAgentPaused(
             session_id=session.session_id,
             call_id=ask_user_tc["id"],
-            question=ask_user_args.get("question", ""),
+            questions=ask_user_args.get("questions", []),
             tool_call_history=tool_call_history,
         )
 

--- a/projects/simple-agent-poc/tests/helpers.py
+++ b/projects/simple-agent-poc/tests/helpers.py
@@ -1,0 +1,19 @@
+"""Shared test helpers for simple-agent-poc tests."""
+
+import json
+
+
+def _questions_args(
+    *, question_text: str = "What is your name?", header: str = "Name"
+) -> str:
+    return json.dumps(
+        {
+            "questions": [
+                {
+                    "question": question_text,
+                    "header": header,
+                    "type": "text",
+                }
+            ]
+        }
+    )

--- a/projects/simple-agent-poc/tests/test_http_stream_api.py
+++ b/projects/simple-agent-poc/tests/test_http_stream_api.py
@@ -18,6 +18,8 @@ from simple_agent_poc.application.use_cases import RunAgentUseCase
 from simple_agent_poc.core.agent_definition import AgentDefinitionRegistry
 from simple_agent_poc.core.types import LLMResponse, LLMStreamChunk, Message
 
+from tests.helpers import _questions_args
+
 
 class StreamingStubLLMClient:
     """Stub LLM client for streaming HTTP tests."""
@@ -188,20 +190,6 @@ def build_tool_executor_with_ask_user() -> BuiltinToolRegistry:
     return registry
 
 
-def _questions_args(*, question_text: str = "Your name?") -> str:
-    return json.dumps(
-        {
-            "questions": [
-                {
-                    "question": question_text,
-                    "header": "Q",
-                    "type": "text",
-                }
-            ]
-        }
-    )
-
-
 class TestStreamPauseContinueAPI:
     """Tests for SSE pause/continue via HTTP."""
 
@@ -215,7 +203,7 @@ class TestStreamPauseContinueAPI:
                     "type": "function",
                     "function": {
                         "name": "ask_user",
-                        "arguments": _questions_args(),
+                        "arguments": _questions_args(question_text="Your name?"),
                     },
                 },
             },
@@ -256,7 +244,7 @@ class TestStreamPauseContinueAPI:
                     "type": "function",
                     "function": {
                         "name": "ask_user",
-                        "arguments": _questions_args(),
+                        "arguments": _questions_args(question_text="Your name?"),
                     },
                 },
             },

--- a/projects/simple-agent-poc/tests/test_http_stream_api.py
+++ b/projects/simple-agent-poc/tests/test_http_stream_api.py
@@ -188,6 +188,20 @@ def build_tool_executor_with_ask_user() -> BuiltinToolRegistry:
     return registry
 
 
+def _questions_args(*, question_text: str = "Your name?") -> str:
+    return json.dumps(
+        {
+            "questions": [
+                {
+                    "question": question_text,
+                    "header": "Q",
+                    "type": "text",
+                }
+            ]
+        }
+    )
+
+
 class TestStreamPauseContinueAPI:
     """Tests for SSE pause/continue via HTTP."""
 
@@ -201,7 +215,7 @@ class TestStreamPauseContinueAPI:
                     "type": "function",
                     "function": {
                         "name": "ask_user",
-                        "arguments": '{"question": "Your name?"}',
+                        "arguments": _questions_args(),
                     },
                 },
             },
@@ -230,7 +244,7 @@ class TestStreamPauseContinueAPI:
         assert events[1]["event"] == "paused"
         paused_data = json.loads(events[1]["data"])
         assert "session_id" in paused_data
-        assert paused_data["question"] == "Your name?"
+        assert paused_data["questions"][0]["question"] == "Your name?"
 
     def test_chat_continue_resumes_session(self) -> None:
         first_chunks: list[LLMStreamChunk] = [
@@ -242,7 +256,7 @@ class TestStreamPauseContinueAPI:
                     "type": "function",
                     "function": {
                         "name": "ask_user",
-                        "arguments": '{"question": "Your name?"}',
+                        "arguments": _questions_args(),
                     },
                 },
             },
@@ -298,7 +312,7 @@ class TestStreamPauseContinueAPI:
                     "type": "function",
                     "function": {
                         "name": "ask_user",
-                        "arguments": '{"question": "First number?"}',
+                        "arguments": _questions_args(question_text="First number?"),
                     },
                 },
             },
@@ -310,7 +324,7 @@ class TestStreamPauseContinueAPI:
                     "type": "function",
                     "function": {
                         "name": "ask_user",
-                        "arguments": '{"question": "Second number?"}',
+                        "arguments": _questions_args(question_text="Second number?"),
                     },
                 },
             },
@@ -363,7 +377,7 @@ class TestStreamPauseContinueAPI:
         assert continue_events[1]["event"] == "paused"
         next_paused_data = json.loads(continue_events[1]["data"])
         assert next_paused_data["call_id"] == "call_002"
-        assert next_paused_data["question"] == "Second number?"
+        assert next_paused_data["questions"][0]["question"] == "Second number?"
         assert continue_events[2]["event"] == "done"
 
     def test_chat_continue_with_unknown_session_returns_error(self) -> None:

--- a/projects/simple-agent-poc/tests/test_use_cases.py
+++ b/projects/simple-agent-poc/tests/test_use_cases.py
@@ -339,7 +339,7 @@ def test_continue_stream_uses_agent_max_tool_rounds(tool_registry):
         "type": "function",
         "function": {
             "name": "ask_user",
-            "arguments": '{"question": "Continue?"}',
+            "arguments": _questions_args(question_text="Continue?"),
         },
     }
     session = ConversationSession.start(
@@ -399,6 +399,22 @@ def test_execute_stream_final_complete(default_agent_def, tool_registry):
 # ---------------------------------------------------------------------------
 
 
+def _questions_args(*, question_text: str = "What is your name?") -> str:
+    import json
+
+    return json.dumps(
+        {
+            "questions": [
+                {
+                    "question": question_text,
+                    "header": "Name",
+                    "type": "text",
+                }
+            ]
+        }
+    )
+
+
 def _ask_user_tool_call() -> list[ToolCall]:
     return [
         {
@@ -406,7 +422,7 @@ def _ask_user_tool_call() -> list[ToolCall]:
             "type": "function",
             "function": {
                 "name": "ask_user",
-                "arguments": '{"question": "What is your name?"}',
+                "arguments": _questions_args(),
             },
         }
     ]
@@ -458,7 +474,9 @@ def test_execute_returns_paused_on_ask_user():
     )
     result = use_case.execute(RunAgentRequest(message="hello"))
     assert isinstance(result, RunAgentPaused)
-    assert result.question == "What is your name?"
+    assert result.questions[0]["question"] == "What is your name?"
+    assert result.questions[0]["header"] == "Name"
+    assert result.questions[0]["type"] == "text"
     assert result.call_id == "call_ask_001"
 
 
@@ -480,7 +498,7 @@ def test_continue_sync_resumes_and_completes():
         "type": "function",
         "function": {
             "name": "ask_user",
-            "arguments": '{"question": "What is your name?"}',
+            "arguments": _questions_args(),
         },
     }
     store = InMemorySessionStore()
@@ -527,7 +545,7 @@ def test_continue_sync_pauses_on_next_unanswered_ask_user():
         "type": "function",
         "function": {
             "name": "ask_user",
-            "arguments": '{"question": "First question?"}',
+            "arguments": _questions_args(question_text="First question?"),
         },
     }
     ask_user_tc_2: ToolCall = {
@@ -535,7 +553,7 @@ def test_continue_sync_pauses_on_next_unanswered_ask_user():
         "type": "function",
         "function": {
             "name": "ask_user",
-            "arguments": '{"question": "Second question?"}',
+            "arguments": _questions_args(question_text="Second question?"),
         },
     }
     store = InMemorySessionStore()
@@ -560,7 +578,7 @@ def test_continue_sync_pauses_on_next_unanswered_ask_user():
     )
 
     assert isinstance(result, RunAgentPaused)
-    assert result.question == "Second question?"
+    assert result.questions[0]["question"] == "Second question?"
     assert result.call_id == "call_ask_002"
 
 

--- a/projects/simple-agent-poc/tests/test_use_cases.py
+++ b/projects/simple-agent-poc/tests/test_use_cases.py
@@ -2,6 +2,8 @@
 
 from collections.abc import Iterator
 
+from tests.helpers import _questions_args
+
 from simple_agent_poc.adapters.session_store.in_memory import InMemorySessionStore
 from simple_agent_poc.application.dto import (
     ContentDelta,
@@ -397,22 +399,6 @@ def test_execute_stream_final_complete(default_agent_def, tool_registry):
 # ---------------------------------------------------------------------------
 # Sync ask_user pause / resume
 # ---------------------------------------------------------------------------
-
-
-def _questions_args(*, question_text: str = "What is your name?") -> str:
-    import json
-
-    return json.dumps(
-        {
-            "questions": [
-                {
-                    "question": question_text,
-                    "header": "Name",
-                    "type": "text",
-                }
-            ]
-        }
-    )
 
 
 def _ask_user_tool_call() -> list[ToolCall]:

--- a/projects/simple-agent-poc/tests/test_use_cases_stream.py
+++ b/projects/simple-agent-poc/tests/test_use_cases_stream.py
@@ -5,6 +5,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from tests.helpers import _questions_args
+
 from simple_agent_poc.adapters.session_store.in_memory import InMemorySessionStore
 from simple_agent_poc.application.dto import (
     ContentDelta,
@@ -394,22 +396,6 @@ def build_tool_executor_with_ask_user() -> BuiltinToolRegistry:
     return registry
 
 
-def _questions_args(*, question_text: str = "What is your name?") -> str:
-    import json
-
-    return json.dumps(
-        {
-            "questions": [
-                {
-                    "question": question_text,
-                    "header": "Q",
-                    "type": "text",
-                }
-            ]
-        }
-    )
-
-
 class TestExecuteStreamPause:
     """Tests for execute_stream pause on ask_user in API mode."""
 
@@ -649,7 +635,9 @@ class TestContinueStream:
         assert continue_events[1] == SessionPaused(
             session_id=paused.session_id,
             call_id="call_002",
-            questions=[{"question": "Second number?", "header": "Q", "type": "text"}],
+            questions=[
+                {"question": "Second number?", "header": "Name", "type": "text"}
+            ],
         )
         llm_client_factory.assert_not_called()
 

--- a/projects/simple-agent-poc/tests/test_use_cases_stream.py
+++ b/projects/simple-agent-poc/tests/test_use_cases_stream.py
@@ -394,6 +394,22 @@ def build_tool_executor_with_ask_user() -> BuiltinToolRegistry:
     return registry
 
 
+def _questions_args(*, question_text: str = "What is your name?") -> str:
+    import json
+
+    return json.dumps(
+        {
+            "questions": [
+                {
+                    "question": question_text,
+                    "header": "Q",
+                    "type": "text",
+                }
+            ]
+        }
+    )
+
+
 class TestExecuteStreamPause:
     """Tests for execute_stream pause on ask_user in API mode."""
 
@@ -407,7 +423,9 @@ class TestExecuteStreamPause:
                     "type": "function",
                     "function": {
                         "name": "ask_user",
-                        "arguments": '{"question": "What is your name?"}',
+                        "arguments": _questions_args(
+                            question_text="What is your name?"
+                        ),
                     },
                 },
             },
@@ -429,7 +447,7 @@ class TestExecuteStreamPause:
         assert isinstance(events[0], ToolCallEvent)
         assert events[0].name == "ask_user"
         assert isinstance(events[1], SessionPaused)
-        assert events[1].question == "What is your name?"
+        assert events[1].questions[0]["question"] == "What is your name?"
 
         session = store.get(events[1].session_id)
         assert session is not None
@@ -447,7 +465,7 @@ class TestExecuteStreamPause:
                     "type": "function",
                     "function": {
                         "name": "ask_user",
-                        "arguments": '{"question": "What?"}',
+                        "arguments": _questions_args(question_text="What?"),
                     },
                 },
             },
@@ -504,7 +522,7 @@ class TestContinueStream:
                     "type": "function",
                     "function": {
                         "name": "ask_user",
-                        "arguments": '{"question": "Your name?"}',
+                        "arguments": _questions_args(question_text="Your name?"),
                     },
                 },
             },
@@ -571,7 +589,7 @@ class TestContinueStream:
                     "type": "function",
                     "function": {
                         "name": "ask_user",
-                        "arguments": '{"question": "First number?"}',
+                        "arguments": _questions_args(question_text="First number?"),
                     },
                 },
             },
@@ -583,7 +601,7 @@ class TestContinueStream:
                     "type": "function",
                     "function": {
                         "name": "ask_user",
-                        "arguments": '{"question": "Second number?"}',
+                        "arguments": _questions_args(question_text="Second number?"),
                     },
                 },
             },
@@ -626,12 +644,12 @@ class TestContinueStream:
         assert continue_events[0] == ToolResultEvent(
             call_id="call_001",
             name="ask_user",
-            result='{"answer": "1"}',
+            result='{"answers": {"First number?": "1"}}',
         )
         assert continue_events[1] == SessionPaused(
             session_id=paused.session_id,
             call_id="call_002",
-            question="Second number?",
+            questions=[{"question": "Second number?", "header": "Q", "type": "text"}],
         )
         llm_client_factory.assert_not_called()
 


### PR DESCRIPTION
## Issues

- Refs #922

## Why

#915 で検討した不足引数補完アプローチから、Gemini CLI / Claude Code Agent SDK 準拠の汎用質問ツールへ方針転換。Phase 1 として `questions` 配列ベースのスキーマと `text` タイプを実装し、後の Phase で拡張可能な土台を作る。

## Summary

`ask_user` ツールのスキーマをフラットな `{question: string}` から Gemini CLI / Claude Code 互換の `{questions: array}` に再設計。回答形式も Claude 方式 `{"answers": {question_text: answer}}` に変更。Phase 1 では `type: "text"` のみをサポートし、単一質問を処理する。

## Changes

- `ask_user.py`: `TOOL_DEFINITION` を `questions` 配列スキーマに置換（`question`, `header`, `type`, `placeholder`）
- `dto.py`: `SessionPaused.question` / `RunAgentPaused.question` → `questions: list[dict]`
- `use_cases.py`: 回答形式を `{"answers": {question_text: answer}}` に変更、`questions` パース処理を追加
- `renderer.py`: `ask_user_question()` を `questions` 配列対応に拡張（`header` / `placeholder` 表示）
- `api.py`: `SyncChatResponse.question` → `questions: list[dict]`
- `adapter.py`: CLI での `response.questions` 引き渡し修正
- `test_page.py`: JavaScript で `data.questions[n].question` を参照するよう更新
- テスト更新: ツールコール引数とアサーションを新スキーマ準拠に

## Verification

- `uv run ruff check .` - passed
- `uv run ruff format --check .` - passed
- `uv run ty check` - passed
- `uv run pytest` - 179 passed
