### PR TITLE
feat(portfolio): add chat compare timeout retries

### DIFF
--- a/projects/portfolio/src/client/components/chat-compare/compare-column.tsx
+++ b/projects/portfolio/src/client/components/chat-compare/compare-column.tsx
@@ -103,7 +103,8 @@ function CompareMessage({ copied, message, onCopy }: { copied: boolean; message:
 }
 
 export function CompareColumn({ state }: CompareColumnProps) {
-  const { model, status, messages, content, reasoningContent, usage, finishReason, responseTimeMs, error } = state
+  const { model, status, messages, content, reasoningContent, usage, finishReason, responseTimeMs, error, retryAttempt } =
+    state
   const showMeta = status === 'done' && (finishReason || usage || responseTimeMs !== null)
   const [copiedId, setCopiedId] = useState('')
   const copyMessage = useCallback(async (message: string, index: number) => {
@@ -125,6 +126,11 @@ export function CompareColumn({ state }: CompareColumnProps) {
         {status === 'streaming' && (
           <span className='ml-1 inline-block h-2 w-2 animate-pulse rounded-full bg-primary-600 align-middle' />
         )}
+        {status === 'retrying' && (
+          <span className='ml-2 rounded-full bg-amber-100 px-2 py-0.5 align-middle font-medium text-[11px] text-amber-700 dark:bg-amber-900/40 dark:text-amber-300'>
+            Retry {retryAttempt}/1
+          </span>
+        )}
       </div>
       <div className='min-h-0 flex-1 overflow-y-auto px-3 py-2'>
         {messages.map((message, index) => (
@@ -142,6 +148,11 @@ export function CompareColumn({ state }: CompareColumnProps) {
         {error && (
           <div className='mt-2 rounded-md bg-red-50 p-2 text-red-600 text-sm dark:bg-red-900/30 dark:text-red-400'>
             {error}
+          </div>
+        )}
+        {status === 'retrying' && (
+          <div className='mt-2 rounded-md bg-amber-50 p-2 text-amber-700 text-sm dark:bg-amber-900/20 dark:text-amber-300'>
+            60秒間応答がなかったため再試行しています。
           </div>
         )}
         {status === 'streaming' && (

--- a/projects/portfolio/src/client/components/chat-compare/compare-column.tsx
+++ b/projects/portfolio/src/client/components/chat-compare/compare-column.tsx
@@ -103,8 +103,18 @@ function CompareMessage({ copied, message, onCopy }: { copied: boolean; message:
 }
 
 export function CompareColumn({ state }: CompareColumnProps) {
-  const { model, status, messages, content, reasoningContent, usage, finishReason, responseTimeMs, error, retryAttempt } =
-    state
+  const {
+    model,
+    status,
+    messages,
+    content,
+    reasoningContent,
+    usage,
+    finishReason,
+    responseTimeMs,
+    error,
+    retryAttempt,
+  } = state
   const showMeta = status === 'done' && (finishReason || usage || responseTimeMs !== null)
   const [copiedId, setCopiedId] = useState('')
   const copyMessage = useCallback(async (message: string, index: number) => {
@@ -128,7 +138,7 @@ export function CompareColumn({ state }: CompareColumnProps) {
         )}
         {status === 'retrying' && (
           <span className='ml-2 rounded-full bg-amber-100 px-2 py-0.5 align-middle font-medium text-[11px] text-amber-700 dark:bg-amber-900/40 dark:text-amber-300'>
-            Retry {retryAttempt}/1
+            リトライ {retryAttempt}/1
           </span>
         )}
       </div>

--- a/projects/portfolio/src/client/components/chat-compare/hooks/use-compare-state.ts
+++ b/projects/portfolio/src/client/components/chat-compare/hooks/use-compare-state.ts
@@ -89,11 +89,6 @@ export function useCompareState() {
       [model]: {
         ...prev[model],
         status: 'error' as const,
-        content: '',
-        reasoningContent: '',
-        usage: null,
-        finishReason: null,
-        responseTimeMs: null,
         error,
       },
     }))

--- a/projects/portfolio/src/client/components/chat-compare/hooks/use-compare-state.ts
+++ b/projects/portfolio/src/client/components/chat-compare/hooks/use-compare-state.ts
@@ -3,7 +3,7 @@ import type { ApiChatMessage, ChatUsage } from '#/types'
 
 export interface ModelStreamState {
   model: string
-  status: 'idle' | 'streaming' | 'done' | 'error'
+  status: 'idle' | 'streaming' | 'retrying' | 'done' | 'error'
   messages: ApiChatMessage[]
   content: string
   reasoningContent: string
@@ -11,6 +11,7 @@ export interface ModelStreamState {
   finishReason: string | null
   responseTimeMs: number | null
   error: string | null
+  retryAttempt: number
 }
 
 function createModelStreamState(model: string): ModelStreamState {
@@ -24,6 +25,7 @@ function createModelStreamState(model: string): ModelStreamState {
     finishReason: null,
     responseTimeMs: null,
     error: null,
+    retryAttempt: 0,
   }
 }
 
@@ -87,7 +89,29 @@ export function useCompareState() {
       [model]: {
         ...prev[model],
         status: 'error' as const,
+        content: '',
+        reasoningContent: '',
+        usage: null,
+        finishReason: null,
+        responseTimeMs: null,
         error,
+      },
+    }))
+  }, [])
+
+  const setModelRetrying = useCallback((model: string, attempt: number) => {
+    setModelStates((prev) => ({
+      ...prev,
+      [model]: {
+        ...prev[model],
+        status: 'retrying' as const,
+        content: '',
+        reasoningContent: '',
+        usage: null,
+        finishReason: null,
+        responseTimeMs: null,
+        error: null,
+        retryAttempt: attempt,
       },
     }))
   }, [])
@@ -107,6 +131,7 @@ export function useCompareState() {
           finishReason: null,
           responseTimeMs: null,
           error: null,
+          retryAttempt: 0,
         },
       }
     })
@@ -134,6 +159,7 @@ export function useCompareState() {
         finishReason: null,
         responseTimeMs: null,
         error: null,
+        retryAttempt: 0,
       },
     }))
   }, [])
@@ -173,6 +199,7 @@ export function useCompareState() {
     updateStreamingContent,
     setModelDone,
     setModelError,
+    setModelRetrying,
     resetModelStream,
     appendAssistantMessage,
     setModelStreaming,

--- a/projects/portfolio/src/client/components/chat-compare/hooks/use-compare-stream.ts
+++ b/projects/portfolio/src/client/components/chat-compare/hooks/use-compare-stream.ts
@@ -209,7 +209,10 @@ async function runModelStreamWithRetry(
         responseTimeMs: Date.now() - startTime,
         content: accumulated.content,
       })
+      return
     }
+
+    callbacks.onStreamError(model, buildIncompleteStreamError())
   } catch (error) {
     clearIdleTimer()
 
@@ -249,6 +252,10 @@ function buildTimeoutError(attempt: number): string {
   }
 
   return `${seconds}秒間応答がなかったため停止しました。`
+}
+
+function buildIncompleteStreamError(): string {
+  return 'ストリームが完了イベントなしで終了しました。'
 }
 
 function isAbortError(error: unknown): error is { name: string } {

--- a/projects/portfolio/src/client/components/chat-compare/hooks/use-compare-stream.ts
+++ b/projects/portfolio/src/client/components/chat-compare/hooks/use-compare-stream.ts
@@ -1,5 +1,5 @@
 import { hc } from 'hono/client'
-import { useCallback, useRef } from 'react'
+import { type MutableRefObject, useCallback, useRef } from 'react'
 import { parseChatStreamEvent, updateChatStream } from '#/client/components/chat/hooks/chat-response'
 import type { AppType } from '#/server/app.d'
 import type { ApiChatMessage, ChatUsage } from '#/types'
@@ -7,6 +7,9 @@ import type { CompareSettings } from './use-compare-settings'
 import type { ModelStreamState } from './use-compare-state'
 
 const client = hc<AppType>('/')
+
+export const STREAM_IDLE_TIMEOUT_MS = 60_000
+export const STREAM_MAX_RETRY_ATTEMPTS = 1
 
 interface StreamCallbacks {
   onStreamContent: (model: string, content: string, reasoningContent: string) => void
@@ -20,14 +23,29 @@ interface StreamCallbacks {
     }
   ) => void
   onStreamError: (model: string, error: string) => void
+  onStreamRetry: (model: string, attempt: number) => void
+}
+
+interface ModelRuntime {
+  controller: AbortController
+  timerId: ReturnType<typeof setTimeout> | null
+  cancelled: boolean
+  timedOut: boolean
 }
 
 export function useCompareStream() {
-  const abortControllerRef = useRef<AbortController | null>(null)
+  const runtimesRef = useRef<Map<string, ModelRuntime>>(new Map())
 
   const cancelAll = useCallback(() => {
-    abortControllerRef.current?.abort()
-    abortControllerRef.current = null
+    for (const runtime of runtimesRef.current.values()) {
+      runtime.cancelled = true
+      if (runtime.timerId) {
+        clearTimeout(runtime.timerId)
+        runtime.timerId = null
+      }
+      runtime.controller.abort()
+    }
+    runtimesRef.current.clear()
   }, [])
 
   const submitCompare = useCallback(
@@ -40,41 +58,38 @@ export function useCompareStream() {
     ) => {
       if (selectedModels.length === 0) return
 
-      const models = selectedModels
-
-      const controller = new AbortController()
-      abortControllerRef.current = controller
+      cancelAll()
 
       const header = {
         'api-key': settings.apiKey,
         'base-url': settings.baseURL,
       }
 
-      const promises = models.map((model) =>
-        runModelStream(
+      const promises = selectedModels.map((model) =>
+        runModelStreamWithRetry(
           model,
           header,
           {
             apiMode: settings.apiMode,
             model,
-            messages: [...modelStates[model].messages, userMessage],
+            messages: [...(modelStates[model]?.messages ?? []), userMessage],
           },
-          controller.signal,
-          (content, reasoningContent) => callbacks.onStreamContent(model, content, reasoningContent),
-          (result) => callbacks.onStreamDone(model, result),
-          (error) => callbacks.onStreamError(model, error)
+          callbacks,
+          runtimesRef,
+          0
         )
       )
 
       await Promise.allSettled(promises)
+      runtimesRef.current.clear()
     },
-    []
+    [cancelAll]
   )
 
   return { submitCompare, cancelAll }
 }
 
-async function runModelStream(
+async function runModelStreamWithRetry(
   model: string,
   header: { 'api-key': string; 'base-url': string },
   body: {
@@ -82,12 +97,36 @@ async function runModelStream(
     model: string
     messages: ApiChatMessage[]
   },
-  signal: AbortSignal,
-  onContent: (content: string, reasoningContent: string) => void,
-  onDone: (result: { finishReason: string; usage: ChatUsage | null; responseTimeMs: number; content: string }) => void,
-  onError: (error: string) => void
+  callbacks: StreamCallbacks,
+  runtimesRef: MutableRefObject<Map<string, ModelRuntime>>,
+  attempt: number
 ): Promise<void> {
   const startTime = Date.now()
+  const controller = new AbortController()
+  const runtime: ModelRuntime = {
+    controller,
+    timerId: null,
+    cancelled: false,
+    timedOut: false,
+  }
+
+  const clearIdleTimer = () => {
+    if (runtime.timerId) {
+      clearTimeout(runtime.timerId)
+      runtime.timerId = null
+    }
+  }
+
+  const scheduleIdleTimer = () => {
+    clearIdleTimer()
+    runtime.timerId = setTimeout(() => {
+      runtime.timedOut = true
+      runtime.controller.abort()
+    }, STREAM_IDLE_TIMEOUT_MS)
+  }
+
+  runtimesRef.current.set(model, runtime)
+  scheduleIdleTimer()
 
   try {
     const res = await client.api.chat.stream.$post(
@@ -95,18 +134,20 @@ async function runModelStream(
         header,
         json: body,
       } as never,
-      { init: { signal } }
+      { init: { signal: runtime.controller.signal } }
     )
 
     if (!res.ok) {
+      clearIdleTimer()
       const errorData = (await res.json()) as { error?: string }
-      onError(errorData?.error || `HTTP ${res.status}`)
+      callbacks.onStreamError(model, errorData?.error || `HTTP ${res.status}`)
       return
     }
 
     const reader = res.body?.getReader()
     if (!reader) {
-      onError('Failed to get response reader')
+      clearIdleTimer()
+      callbacks.onStreamError(model, 'Failed to get response reader')
       return
     }
 
@@ -133,6 +174,7 @@ async function runModelStream(
 
         const jsonStr = line.replace(/^data:\s*/, '')
         if (jsonStr === '[DONE]') {
+          scheduleIdleTimer()
           running = false
           break
         }
@@ -140,9 +182,10 @@ async function runModelStream(
         try {
           const event = parseChatStreamEvent(jsonStr)
           accumulated = updateChatStream(accumulated, event)
+          scheduleIdleTimer()
 
           if (event.event === 'delta') {
-            onContent(accumulated.content, accumulated.reasoningContent)
+            callbacks.onStreamContent(model, accumulated.content, accumulated.reasoningContent)
           }
           if (event.event === 'finish') {
             finishReason = event.finishReason
@@ -157,17 +200,57 @@ async function runModelStream(
       }
     }
 
+    clearIdleTimer()
+
     if (receivedFinish) {
-      const responseTimeMs = Date.now() - startTime
-      onDone({
+      callbacks.onStreamDone(model, {
         finishReason,
         usage,
-        responseTimeMs,
+        responseTimeMs: Date.now() - startTime,
         content: accumulated.content,
       })
     }
   } catch (error) {
-    if (error instanceof Error && error.name === 'AbortError') return
-    onError(error instanceof Error ? error.message : 'Unknown error')
+    clearIdleTimer()
+
+    if (isAbortError(error)) {
+      if (runtime.cancelled) return
+
+      if (runtime.timedOut) {
+        if (attempt < STREAM_MAX_RETRY_ATTEMPTS) {
+          const nextAttempt = attempt + 1
+          callbacks.onStreamRetry(model, nextAttempt)
+          await runModelStreamWithRetry(model, header, body, callbacks, runtimesRef, nextAttempt)
+          return
+        }
+
+        callbacks.onStreamError(model, buildTimeoutError(attempt))
+        return
+      }
+
+      return
+    }
+
+    callbacks.onStreamError(model, error instanceof Error ? error.message : 'Unknown error')
+  } finally {
+    clearIdleTimer()
+
+    if (runtimesRef.current.get(model) === runtime) {
+      runtimesRef.current.delete(model)
+    }
   }
+}
+
+function buildTimeoutError(attempt: number): string {
+  const seconds = STREAM_IDLE_TIMEOUT_MS / 1000
+
+  if (attempt > 0) {
+    return `${seconds}秒間応答がなかったため停止しました。${attempt}回リトライしました。`
+  }
+
+  return `${seconds}秒間応答がなかったため停止しました。`
+}
+
+function isAbortError(error: unknown): error is { name: string } {
+  return typeof error === 'object' && error !== null && 'name' in error && error.name === 'AbortError'
 }

--- a/projects/portfolio/src/client/pages/chat-compare/index.tsx
+++ b/projects/portfolio/src/client/pages/chat-compare/index.tsx
@@ -30,6 +30,7 @@ export function ChatCompare() {
     updateStreamingContent,
     setModelDone,
     setModelError,
+    setModelRetrying,
     resetModelStream,
     appendAssistantMessage,
     setModelStreaming,
@@ -118,26 +119,31 @@ export function ChatCompare() {
       setModelStreaming(model)
     }
 
-    await submitCompare(settings, modelStates, models, userMessage, {
-      onStreamContent: (model, content, reasoningContent) => {
-        updateStreamingContent(model, content, reasoningContent)
-      },
-      onStreamDone: (model, result) => {
-        setModelDone(model, {
-          finishReason: result.finishReason,
-          usage: result.usage,
-          responseTimeMs: result.responseTimeMs,
-        })
-        if (result.content) {
-          appendAssistantMessage(model, { role: 'assistant', content: result.content })
-        }
-      },
-      onStreamError: (model, error) => {
-        setModelError(model, error)
-      },
-    })
-
-    setIsSubmitting(false)
+    try {
+      await submitCompare(settings, modelStates, models, userMessage, {
+        onStreamContent: (model, content, reasoningContent) => {
+          updateStreamingContent(model, content, reasoningContent)
+        },
+        onStreamDone: (model, result) => {
+          setModelDone(model, {
+            finishReason: result.finishReason,
+            usage: result.usage,
+            responseTimeMs: result.responseTimeMs,
+          })
+          if (result.content) {
+            appendAssistantMessage(model, { role: 'assistant', content: result.content })
+          }
+        },
+        onStreamError: (model, error) => {
+          setModelError(model, error)
+        },
+        onStreamRetry: (model, attempt) => {
+          setModelRetrying(model, attempt)
+        },
+      })
+    } finally {
+      setIsSubmitting(false)
+    }
   }, [
     appendAssistantMessage,
     appendUserMessageToAll,
@@ -147,6 +153,7 @@ export function ChatCompare() {
     selectedModels,
     setModelDone,
     setModelError,
+    setModelRetrying,
     setModelStreaming,
     setIsSubmitting,
     settings,
@@ -267,6 +274,7 @@ export function ChatCompare() {
                     finishReason: null,
                     responseTimeMs: null,
                     error: null,
+                    retryAttempt: 0,
                   }
                 }
               />

--- a/projects/portfolio/src/server/features/chat/chat.ts
+++ b/projects/portfolio/src/server/features/chat/chat.ts
@@ -27,6 +27,9 @@ interface Chat {
       reasoningEffort?: 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'
       stream: boolean
       includeUsage?: boolean
+    },
+    requestOptions?: {
+      signal?: AbortSignal
     }
   ): Promise<Completions>
 }
@@ -58,6 +61,9 @@ export const chat: Chat = {
       reasoningEffort?: 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'
       stream: boolean
       includeUsage?: boolean
+    },
+    requestOptions?: {
+      signal?: AbortSignal
     }
   ): Promise<Completions> {
     const openai = new OpenAI({
@@ -66,29 +72,35 @@ export const chat: Chat = {
     })
 
     if (apiMode === 'responses') {
-      return (await openai.responses.create({
-        model,
-        input: convertToResponsesInput(messages),
-        temperature,
-        max_output_tokens: maxTokens,
-        reasoning: reasoningEffort ? { effort: reasoningEffort } : undefined,
-        stream,
-      })) as ResponsesCompletion | ResponsesStreamChunk
+      return (await openai.responses.create(
+        {
+          model,
+          input: convertToResponsesInput(messages),
+          temperature,
+          max_output_tokens: maxTokens,
+          reasoning: reasoningEffort ? { effort: reasoningEffort } : undefined,
+          stream,
+        },
+        requestOptions
+      )) as ResponsesCompletion | ResponsesStreamChunk
     }
 
-    const completion = await openai.chat.completions.create({
-      model,
-      messages,
-      temperature,
-      max_tokens: maxTokens,
-      reasoning_effort: reasoningEffort,
-      stream,
-      stream_options: includeUsage
-        ? {
-            include_usage: !!includeUsage,
-          }
-        : undefined,
-    })
+    const completion = await openai.chat.completions.create(
+      {
+        model,
+        messages,
+        temperature,
+        max_tokens: maxTokens,
+        reasoning_effort: reasoningEffort,
+        stream,
+        stream_options: includeUsage
+          ? {
+              include_usage: !!includeUsage,
+            }
+          : undefined,
+      },
+      requestOptions
+    )
     return completion as Completions
   },
 }

--- a/projects/portfolio/src/server/routes/chat.ts
+++ b/projects/portfolio/src/server/routes/chat.ts
@@ -300,6 +300,9 @@ const chatRoutes = new Hono<HonoEnv>()
           reasoningEffort: req.reasoningEffort,
           stream: true,
           includeUsage: true,
+        },
+        {
+          signal: c.req.raw.signal,
         }
       )
     } catch (err) {

--- a/projects/portfolio/tests/client/components/compare-column.test.tsx
+++ b/projects/portfolio/tests/client/components/compare-column.test.tsx
@@ -23,7 +23,7 @@ describe('CompareColumn', () => {
       />
     )
 
-    expect(screen.getByText('Retry 1/1')).toBeTruthy()
+    expect(screen.getByText('リトライ 1/1')).toBeTruthy()
     expect(screen.getByText('60秒間応答がなかったため再試行しています。')).toBeTruthy()
   })
 

--- a/projects/portfolio/tests/client/components/compare-column.test.tsx
+++ b/projects/portfolio/tests/client/components/compare-column.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { CompareColumn } from '#/client/components/chat-compare/compare-column'
+
+describe('CompareColumn', () => {
+  it('retrying 状態では再試行中表示を出す', () => {
+    render(
+      <CompareColumn
+        state={{
+          model: 'openai/gpt-5.2',
+          status: 'retrying',
+          messages: [],
+          content: '',
+          reasoningContent: '',
+          usage: null,
+          finishReason: null,
+          responseTimeMs: null,
+          error: null,
+          retryAttempt: 1,
+        }}
+      />
+    )
+
+    expect(screen.getByText('Retry 1/1')).toBeTruthy()
+    expect(screen.getByText('60秒間応答がなかったため再試行しています。')).toBeTruthy()
+  })
+
+  it('error 状態では最終エラーを表示する', () => {
+    render(
+      <CompareColumn
+        state={{
+          model: 'openai/gpt-5.2',
+          status: 'error',
+          messages: [],
+          content: '',
+          reasoningContent: '',
+          usage: null,
+          finishReason: null,
+          responseTimeMs: null,
+          error: '60秒間応答がなかったため停止しました。1回リトライしました。',
+          retryAttempt: 1,
+        }}
+      />
+    )
+
+    expect(screen.getByText('60秒間応答がなかったため停止しました。1回リトライしました。')).toBeTruthy()
+  })
+})

--- a/projects/portfolio/tests/client/hooks/use-compare-state.test.ts
+++ b/projects/portfolio/tests/client/hooks/use-compare-state.test.ts
@@ -1,0 +1,29 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { useCompareState } from '#/client/components/chat-compare/hooks/use-compare-state'
+
+describe('useCompareState', () => {
+  it('setModelRetrying は retry 状態へ切り替え、途中表示と error をクリアする', () => {
+    const { result } = renderHook(() => useCompareState())
+
+    act(() => {
+      result.current.initModelStates(['openai/gpt-5.2'])
+      result.current.setModelStreaming('openai/gpt-5.2')
+      result.current.updateStreamingContent('openai/gpt-5.2', 'partial', 'thinking')
+      result.current.setModelError('openai/gpt-5.2', 'previous error')
+      result.current.setModelRetrying('openai/gpt-5.2', 1)
+    })
+
+    expect(result.current.modelStates['openai/gpt-5.2']).toEqual(
+      expect.objectContaining({
+        status: 'retrying',
+        content: '',
+        reasoningContent: '',
+        error: null,
+        retryAttempt: 1,
+      })
+    )
+  })
+})

--- a/projects/portfolio/tests/client/hooks/use-compare-state.test.ts
+++ b/projects/portfolio/tests/client/hooks/use-compare-state.test.ts
@@ -26,4 +26,24 @@ describe('useCompareState', () => {
       })
     )
   })
+
+  it('setModelError は途中表示を保持して error 状態へ切り替える', () => {
+    const { result } = renderHook(() => useCompareState())
+
+    act(() => {
+      result.current.initModelStates(['openai/gpt-5.2'])
+      result.current.setModelStreaming('openai/gpt-5.2')
+      result.current.updateStreamingContent('openai/gpt-5.2', 'partial', 'thinking')
+      result.current.setModelError('openai/gpt-5.2', 'stream failed')
+    })
+
+    expect(result.current.modelStates['openai/gpt-5.2']).toEqual(
+      expect.objectContaining({
+        status: 'error',
+        content: 'partial',
+        reasoningContent: 'thinking',
+        error: 'stream failed',
+      })
+    )
+  })
 })

--- a/projects/portfolio/tests/client/hooks/use-compare-stream.test.tsx
+++ b/projects/portfolio/tests/client/hooks/use-compare-stream.test.tsx
@@ -262,6 +262,20 @@ describe('useCompareStream', () => {
       })
     )
     expect(callbacks.onStreamError).not.toHaveBeenCalled()
+    expect(chatStreamPostMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        json: {
+          apiMode: 'chat_completions',
+          model: 'openai/gpt-5.2',
+          messages: [
+            { role: 'user', content: 'previous question' },
+            { role: 'user', content: 'hello' },
+          ],
+        },
+      }),
+      expect.anything()
+    )
   })
 
   it('2 回目もタイムアウトした場合はエラーで終了する', async () => {

--- a/projects/portfolio/tests/client/hooks/use-compare-stream.test.tsx
+++ b/projects/portfolio/tests/client/hooks/use-compare-stream.test.tsx
@@ -1,0 +1,308 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('useCompareStream', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.useRealTimers()
+  })
+
+  const importSubject = async () => {
+    const chatStreamPostMock = vi.fn()
+
+    vi.doMock('hono/client', () => ({
+      hc: () => ({
+        api: {
+          chat: {
+            stream: {
+              $post: chatStreamPostMock,
+            },
+          },
+        },
+      }),
+    }))
+
+    const mod = await import('#/client/components/chat-compare/hooks/use-compare-stream')
+
+    return {
+      useCompareStream: mod.useCompareStream,
+      chatStreamPostMock,
+      STREAM_IDLE_TIMEOUT_MS: mod.STREAM_IDLE_TIMEOUT_MS,
+    }
+  }
+
+  const settings = {
+    schemaVersion: '1.0.0',
+    apiKey: 'api-key',
+    baseURL: 'https://example.com',
+    apiMode: 'chat_completions' as const,
+  }
+
+  const modelStates = {
+    'openai/gpt-5.2': {
+      model: 'openai/gpt-5.2',
+      status: 'idle' as const,
+      messages: [{ role: 'user' as const, content: 'previous question' }],
+      content: '',
+      reasoningContent: '',
+      usage: null,
+      finishReason: null,
+      responseTimeMs: null,
+      error: null,
+      retryAttempt: 0,
+    },
+    'openai/gpt-5.4-mini': {
+      model: 'openai/gpt-5.4-mini',
+      status: 'idle' as const,
+      messages: [{ role: 'user' as const, content: 'previous question' }],
+      content: '',
+      reasoningContent: '',
+      usage: null,
+      finishReason: null,
+      responseTimeMs: null,
+      error: null,
+      retryAttempt: 0,
+    },
+  }
+
+  const userMessage = { role: 'user' as const, content: 'hello' }
+
+  const createCallbacks = () => ({
+    onStreamContent: vi.fn(),
+    onStreamDone: vi.fn(),
+    onStreamError: vi.fn(),
+    onStreamRetry: vi.fn(),
+  })
+
+  const createReaderFromChunks = (chunks: Uint8Array[]) => ({
+    getReader() {
+      let index = 0
+
+      return {
+        read: async () => {
+          if (index >= chunks.length) {
+            return { done: true, value: undefined }
+          }
+
+          return { done: false, value: chunks[index++] }
+        },
+      }
+    },
+  })
+
+  const createHangingBody = (signal: AbortSignal) => ({
+    getReader() {
+      return {
+        read: async () =>
+          new Promise<{ done: boolean; value?: Uint8Array }>((_resolve, reject) => {
+            const abort = () => reject(new DOMException('Aborted', 'AbortError'))
+            if (signal.aborted) {
+              abort()
+              return
+            }
+            signal.addEventListener('abort', abort, { once: true })
+          }),
+      }
+    },
+  })
+
+  it('タイムアウトしたモデルだけ 1 回自動リトライして完了する', async () => {
+    const { useCompareStream, chatStreamPostMock, STREAM_IDLE_TIMEOUT_MS } = await importSubject()
+    const encoder = new TextEncoder()
+    const callbacks = createCallbacks()
+
+    chatStreamPostMock
+      .mockImplementationOnce((_req: unknown, options: { init: { signal: AbortSignal } }) =>
+        Promise.resolve({
+          ok: true,
+          body: createHangingBody(options.init.signal),
+        })
+      )
+      .mockResolvedValueOnce({
+        ok: true,
+        body: createReaderFromChunks([
+          encoder.encode('data: {"event":"delta","id":"chunk-1","created":1,"model":"openai/gpt-5.2","content":"retry"}\n'),
+          encoder.encode('data: {"event":"finish","id":"chunk-1","created":1,"model":"openai/gpt-5.2","finishReason":"stop"}\n'),
+          encoder.encode('data: [DONE]\n'),
+        ]),
+      })
+
+    const { result } = renderHook(() => useCompareStream())
+
+    let promise: Promise<void> | undefined
+    act(() => {
+      promise = result.current.submitCompare(
+        settings,
+        { 'openai/gpt-5.2': modelStates['openai/gpt-5.2'] },
+        ['openai/gpt-5.2'],
+        userMessage,
+        callbacks
+      )
+    })
+
+    await vi.advanceTimersByTimeAsync(STREAM_IDLE_TIMEOUT_MS)
+    await promise
+
+    expect(chatStreamPostMock).toHaveBeenCalledTimes(2)
+    expect(callbacks.onStreamRetry).toHaveBeenCalledWith('openai/gpt-5.2', 1)
+    expect(callbacks.onStreamDone).toHaveBeenCalledWith(
+      'openai/gpt-5.2',
+      expect.objectContaining({
+        finishReason: 'stop',
+        content: 'retry',
+      })
+    )
+    expect(callbacks.onStreamError).not.toHaveBeenCalled()
+    expect(chatStreamPostMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        json: {
+          apiMode: 'chat_completions',
+          model: 'openai/gpt-5.2',
+          messages: [
+            { role: 'user', content: 'previous question' },
+            { role: 'user', content: 'hello' },
+          ],
+        },
+      }),
+      expect.anything()
+    )
+  })
+
+  it('2 回目もタイムアウトした場合はエラーで終了する', async () => {
+    const { useCompareStream, chatStreamPostMock, STREAM_IDLE_TIMEOUT_MS } = await importSubject()
+    const callbacks = createCallbacks()
+
+    chatStreamPostMock.mockImplementation((_req: unknown, options: { init: { signal: AbortSignal } }) =>
+      Promise.resolve({
+        ok: true,
+        body: createHangingBody(options.init.signal),
+      })
+    )
+
+    const { result } = renderHook(() => useCompareStream())
+
+    let promise: Promise<void> | undefined
+    act(() => {
+      promise = result.current.submitCompare(
+        settings,
+        { 'openai/gpt-5.2': modelStates['openai/gpt-5.2'] },
+        ['openai/gpt-5.2'],
+        userMessage,
+        callbacks
+      )
+    })
+
+    await vi.advanceTimersByTimeAsync(STREAM_IDLE_TIMEOUT_MS * 2)
+    await promise
+
+    expect(chatStreamPostMock).toHaveBeenCalledTimes(2)
+    expect(callbacks.onStreamRetry).toHaveBeenCalledTimes(1)
+    expect(callbacks.onStreamError).toHaveBeenCalledWith(
+      'openai/gpt-5.2',
+      '60秒間応答がなかったため停止しました。1回リトライしました。'
+    )
+    expect(callbacks.onStreamDone).not.toHaveBeenCalled()
+  })
+
+  it('1 モデルだけタイムアウトしても他モデルの完了は維持される', async () => {
+    const { useCompareStream, chatStreamPostMock, STREAM_IDLE_TIMEOUT_MS } = await importSubject()
+    const encoder = new TextEncoder()
+    const callbacks = createCallbacks()
+
+    chatStreamPostMock.mockImplementation((req: { json: { model: string } }, options: { init: { signal: AbortSignal } }) => {
+      if (req.json.model === 'openai/gpt-5.4-mini') {
+        return Promise.resolve({
+          ok: true,
+          body: createReaderFromChunks([
+            encoder.encode(
+              'data: {"event":"delta","id":"chunk-fast","created":1,"model":"openai/gpt-5.4-mini","content":"fast"}\n'
+            ),
+            encoder.encode(
+              'data: {"event":"finish","id":"chunk-fast","created":1,"model":"openai/gpt-5.4-mini","finishReason":"stop"}\n'
+            ),
+            encoder.encode('data: [DONE]\n'),
+          ]),
+        })
+      }
+
+      return Promise.resolve({
+        ok: true,
+        body: createHangingBody(options.init.signal),
+      })
+    })
+
+    const { result } = renderHook(() => useCompareStream())
+
+    let promise: Promise<void> | undefined
+    act(() => {
+      promise = result.current.submitCompare(
+        settings,
+        modelStates,
+        ['openai/gpt-5.2', 'openai/gpt-5.4-mini'],
+        userMessage,
+        callbacks
+      )
+    })
+
+    await vi.advanceTimersByTimeAsync(STREAM_IDLE_TIMEOUT_MS * 2)
+    await promise
+
+    expect(callbacks.onStreamDone).toHaveBeenCalledWith(
+      'openai/gpt-5.4-mini',
+      expect.objectContaining({
+        finishReason: 'stop',
+        content: 'fast',
+      })
+    )
+    expect(callbacks.onStreamError).toHaveBeenCalledWith(
+      'openai/gpt-5.2',
+      '60秒間応答がなかったため停止しました。1回リトライしました。'
+    )
+  })
+
+  it('cancelAll で全モデルを停止し、エラーにしない', async () => {
+    const { useCompareStream, chatStreamPostMock } = await importSubject()
+    const callbacks = createCallbacks()
+    const seenSignals: AbortSignal[] = []
+
+    chatStreamPostMock.mockImplementation((_req: unknown, options: { init: { signal: AbortSignal } }) => {
+      seenSignals.push(options.init.signal)
+      return Promise.resolve({
+        ok: true,
+        body: createHangingBody(options.init.signal),
+      })
+    })
+
+    const { result } = renderHook(() => useCompareStream())
+
+    let promise: Promise<void> | undefined
+    act(() => {
+      promise = result.current.submitCompare(
+        settings,
+        modelStates,
+        ['openai/gpt-5.2', 'openai/gpt-5.4-mini'],
+        userMessage,
+        callbacks
+      )
+    })
+
+    act(() => {
+      result.current.cancelAll()
+    })
+
+    await promise
+
+    expect(seenSignals).toHaveLength(2)
+    expect(seenSignals.every((signal) => signal.aborted)).toBe(true)
+    expect(callbacks.onStreamError).not.toHaveBeenCalled()
+    expect(callbacks.onStreamDone).not.toHaveBeenCalled()
+  })
+})

--- a/projects/portfolio/tests/client/hooks/use-compare-stream.test.tsx
+++ b/projects/portfolio/tests/client/hooks/use-compare-stream.test.tsx
@@ -113,7 +113,30 @@ describe('useCompareStream', () => {
     },
   })
 
-  it('タイムアウトしたモデルだけ 1 回自動リトライして完了する', async () => {
+  const createBodyFromChunksThenHang = (chunks: Uint8Array[], signal: AbortSignal) => ({
+    getReader() {
+      let index = 0
+
+      return {
+        read: async () => {
+          if (index < chunks.length) {
+            return { done: false, value: chunks[index++] }
+          }
+
+          return new Promise<{ done: boolean; value?: Uint8Array }>((_resolve, reject) => {
+            const abort = () => reject(new DOMException('Aborted', 'AbortError'))
+            if (signal.aborted) {
+              abort()
+              return
+            }
+            signal.addEventListener('abort', abort, { once: true })
+          })
+        },
+      }
+    },
+  })
+
+  it('SSE 確立後に最初の chunk が来ない場合は 1 回自動リトライして完了する', async () => {
     const { useCompareStream, chatStreamPostMock, STREAM_IDLE_TIMEOUT_MS } = await importSubject()
     const encoder = new TextEncoder()
     const callbacks = createCallbacks()
@@ -178,6 +201,67 @@ describe('useCompareStream', () => {
       }),
       expect.anything()
     )
+  })
+
+  it('delta 受信後に次の chunk が来ない場合も 1 回自動リトライして完了する', async () => {
+    const { useCompareStream, chatStreamPostMock, STREAM_IDLE_TIMEOUT_MS } = await importSubject()
+    const encoder = new TextEncoder()
+    const callbacks = createCallbacks()
+
+    chatStreamPostMock
+      .mockImplementationOnce((_req: unknown, options: { init: { signal: AbortSignal } }) =>
+        Promise.resolve({
+          ok: true,
+          body: createBodyFromChunksThenHang(
+            [
+              encoder.encode(
+                'data: {"event":"delta","id":"chunk-1","created":1,"model":"openai/gpt-5.2","content":"partial"}\n'
+              ),
+            ],
+            options.init.signal
+          ),
+        })
+      )
+      .mockResolvedValueOnce({
+        ok: true,
+        body: createReaderFromChunks([
+          encoder.encode(
+            'data: {"event":"delta","id":"chunk-2","created":1,"model":"openai/gpt-5.2","content":"retry"}\n'
+          ),
+          encoder.encode(
+            'data: {"event":"finish","id":"chunk-2","created":1,"model":"openai/gpt-5.2","finishReason":"stop"}\n'
+          ),
+          encoder.encode('data: [DONE]\n'),
+        ]),
+      })
+
+    const { result } = renderHook(() => useCompareStream())
+
+    let promise: Promise<void> | undefined
+    act(() => {
+      promise = result.current.submitCompare(
+        settings,
+        { 'openai/gpt-5.2': modelStates['openai/gpt-5.2'] },
+        ['openai/gpt-5.2'],
+        userMessage,
+        callbacks
+      )
+    })
+
+    await vi.advanceTimersByTimeAsync(STREAM_IDLE_TIMEOUT_MS)
+    await promise
+
+    expect(chatStreamPostMock).toHaveBeenCalledTimes(2)
+    expect(callbacks.onStreamContent).toHaveBeenCalledWith('openai/gpt-5.2', 'partial', '')
+    expect(callbacks.onStreamRetry).toHaveBeenCalledWith('openai/gpt-5.2', 1)
+    expect(callbacks.onStreamDone).toHaveBeenCalledWith(
+      'openai/gpt-5.2',
+      expect.objectContaining({
+        finishReason: 'stop',
+        content: 'retry',
+      })
+    )
+    expect(callbacks.onStreamError).not.toHaveBeenCalled()
   })
 
   it('2 回目もタイムアウトした場合はエラーで終了する', async () => {

--- a/projects/portfolio/tests/client/hooks/use-compare-stream.test.tsx
+++ b/projects/portfolio/tests/client/hooks/use-compare-stream.test.tsx
@@ -128,8 +128,12 @@ describe('useCompareStream', () => {
       .mockResolvedValueOnce({
         ok: true,
         body: createReaderFromChunks([
-          encoder.encode('data: {"event":"delta","id":"chunk-1","created":1,"model":"openai/gpt-5.2","content":"retry"}\n'),
-          encoder.encode('data: {"event":"finish","id":"chunk-1","created":1,"model":"openai/gpt-5.2","finishReason":"stop"}\n'),
+          encoder.encode(
+            'data: {"event":"delta","id":"chunk-1","created":1,"model":"openai/gpt-5.2","content":"retry"}\n'
+          ),
+          encoder.encode(
+            'data: {"event":"finish","id":"chunk-1","created":1,"model":"openai/gpt-5.2","finishReason":"stop"}\n'
+          ),
           encoder.encode('data: [DONE]\n'),
         ]),
       })
@@ -217,27 +221,29 @@ describe('useCompareStream', () => {
     const encoder = new TextEncoder()
     const callbacks = createCallbacks()
 
-    chatStreamPostMock.mockImplementation((req: { json: { model: string } }, options: { init: { signal: AbortSignal } }) => {
-      if (req.json.model === 'openai/gpt-5.4-mini') {
+    chatStreamPostMock.mockImplementation(
+      (req: { json: { model: string } }, options: { init: { signal: AbortSignal } }) => {
+        if (req.json.model === 'openai/gpt-5.4-mini') {
+          return Promise.resolve({
+            ok: true,
+            body: createReaderFromChunks([
+              encoder.encode(
+                'data: {"event":"delta","id":"chunk-fast","created":1,"model":"openai/gpt-5.4-mini","content":"fast"}\n'
+              ),
+              encoder.encode(
+                'data: {"event":"finish","id":"chunk-fast","created":1,"model":"openai/gpt-5.4-mini","finishReason":"stop"}\n'
+              ),
+              encoder.encode('data: [DONE]\n'),
+            ]),
+          })
+        }
+
         return Promise.resolve({
           ok: true,
-          body: createReaderFromChunks([
-            encoder.encode(
-              'data: {"event":"delta","id":"chunk-fast","created":1,"model":"openai/gpt-5.4-mini","content":"fast"}\n'
-            ),
-            encoder.encode(
-              'data: {"event":"finish","id":"chunk-fast","created":1,"model":"openai/gpt-5.4-mini","finishReason":"stop"}\n'
-            ),
-            encoder.encode('data: [DONE]\n'),
-          ]),
+          body: createHangingBody(options.init.signal),
         })
       }
-
-      return Promise.resolve({
-        ok: true,
-        body: createHangingBody(options.init.signal),
-      })
-    })
+    )
 
     const { result } = renderHook(() => useCompareStream())
 
@@ -303,6 +309,41 @@ describe('useCompareStream', () => {
     expect(seenSignals).toHaveLength(2)
     expect(seenSignals.every((signal) => signal.aborted)).toBe(true)
     expect(callbacks.onStreamError).not.toHaveBeenCalled()
+    expect(callbacks.onStreamDone).not.toHaveBeenCalled()
+  })
+
+  it('finish イベントなしで完了した場合はエラーにする', async () => {
+    const { useCompareStream, chatStreamPostMock } = await importSubject()
+    const encoder = new TextEncoder()
+    const callbacks = createCallbacks()
+
+    chatStreamPostMock.mockResolvedValueOnce({
+      ok: true,
+      body: createReaderFromChunks([
+        encoder.encode(
+          'data: {"event":"delta","id":"chunk-1","created":1,"model":"openai/gpt-5.2","content":"partial"}\n'
+        ),
+        encoder.encode('data: [DONE]\n'),
+      ]),
+    })
+
+    const { result } = renderHook(() => useCompareStream())
+
+    await act(async () => {
+      await result.current.submitCompare(
+        settings,
+        { 'openai/gpt-5.2': modelStates['openai/gpt-5.2'] },
+        ['openai/gpt-5.2'],
+        userMessage,
+        callbacks
+      )
+    })
+
+    expect(callbacks.onStreamContent).toHaveBeenCalledWith('openai/gpt-5.2', 'partial', '')
+    expect(callbacks.onStreamError).toHaveBeenCalledWith(
+      'openai/gpt-5.2',
+      'ストリームが完了イベントなしで終了しました。'
+    )
     expect(callbacks.onStreamDone).not.toHaveBeenCalled()
   })
 })

--- a/projects/portfolio/tests/features/chat/chat.test.ts
+++ b/projects/portfolio/tests/features/chat/chat.test.ts
@@ -40,6 +40,7 @@ describe('chat.completions', () => {
   it('OpenAI 呼び出しにリクエストを正しく変換する', async () => {
     const { chat, completionsCreateMock } = await importSubject()
     completionsCreateMock.mockResolvedValue({ id: 'completion-1' })
+    const signal = new AbortController().signal
 
     await chat.completions(
       {
@@ -55,20 +56,28 @@ describe('chat.completions', () => {
         reasoningEffort: 'high',
         stream: false,
         includeUsage: true,
+      },
+      {
+        signal,
       }
     )
 
-    expect(completionsCreateMock).toHaveBeenCalledWith({
-      model: 'gpt-4.1',
-      messages: [{ role: 'system', content: 'You are a tester.' }],
-      temperature: 0.4,
-      max_tokens: 256,
-      reasoning_effort: 'high',
-      stream: false,
-      stream_options: {
-        include_usage: true,
+    expect(completionsCreateMock).toHaveBeenCalledWith(
+      {
+        model: 'gpt-4.1',
+        messages: [{ role: 'system', content: 'You are a tester.' }],
+        temperature: 0.4,
+        max_tokens: 256,
+        reasoning_effort: 'high',
+        stream: false,
+        stream_options: {
+          include_usage: true,
+        },
       },
-    })
+      {
+        signal,
+      }
+    )
   })
 
   it('OpenAI クライアントに apiKey と baseURL が渡される', async () => {
@@ -99,6 +108,7 @@ describe('chat.completions', () => {
   it('responses モードでは assistant 履歴と画像入力を Responses input へ変換する', async () => {
     const { chat, responsesCreateMock } = await importSubject()
     responsesCreateMock.mockResolvedValue({ id: 'resp-1' })
+    const signal = new AbortController().signal
 
     await chat.completions(
       {
@@ -123,35 +133,43 @@ describe('chat.completions', () => {
         maxTokens: 256,
         reasoningEffort: 'high',
         stream: false,
+      },
+      {
+        signal,
       }
     )
 
-    expect(responsesCreateMock).toHaveBeenCalledWith({
-      model: 'gpt-4.1',
-      input: [
-        {
-          type: 'message',
-          role: 'system',
-          content: 'You are a tester.',
-        },
-        {
-          type: 'message',
-          role: 'user',
-          content: [
-            { type: 'input_text', text: 'describe this image' },
-            { type: 'input_image', image_url: 'data:image/png;base64,abc', detail: 'auto' },
-          ],
-        },
-        {
-          type: 'message',
-          role: 'assistant',
-          content: 'previous answer',
-        },
-      ],
-      temperature: 0.4,
-      max_output_tokens: 256,
-      reasoning: { effort: 'high' },
-      stream: false,
-    })
+    expect(responsesCreateMock).toHaveBeenCalledWith(
+      {
+        model: 'gpt-4.1',
+        input: [
+          {
+            type: 'message',
+            role: 'system',
+            content: 'You are a tester.',
+          },
+          {
+            type: 'message',
+            role: 'user',
+            content: [
+              { type: 'input_text', text: 'describe this image' },
+              { type: 'input_image', image_url: 'data:image/png;base64,abc', detail: 'auto' },
+            ],
+          },
+          {
+            type: 'message',
+            role: 'assistant',
+            content: 'previous answer',
+          },
+        ],
+        temperature: 0.4,
+        max_output_tokens: 256,
+        reasoning: { effort: 'high' },
+        stream: false,
+      },
+      {
+        signal,
+      }
+    )
   })
 })

--- a/projects/portfolio/tests/routes/chat.test.ts
+++ b/projects/portfolio/tests/routes/chat.test.ts
@@ -511,6 +511,39 @@ describe('chatRoutes', () => {
       expect(body).toContain('"event":"usage"')
     })
 
+    it('request signal を upstream 呼び出しへ伝播する', async () => {
+      const { chatRoutes, completionsMock } = await importSubject()
+      completionsMock.mockResolvedValue({
+        controller: { abort: vi.fn() },
+        [Symbol.asyncIterator]: createStreamChunk,
+      })
+
+      const res = await chatRoutes.request('/api/chat/stream', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'api-key': 'api-key',
+          'base-url': 'https://example.com',
+        },
+        body: JSON.stringify({
+          model: 'gpt-test',
+          messages: [],
+        }),
+      })
+
+      expect(res.status).toBe(200)
+      expect(completionsMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          model: 'gpt-test',
+          stream: true,
+        }),
+        {
+          signal: expect.any(AbortSignal),
+        }
+      )
+    })
+
     it('必須 header がない場合は 400 を返す', async () => {
       const { chatRoutes } = await importSubject()
 


### PR DESCRIPTION
## Issues

- Close #919

## Why

`chat-compare` で特定モデルのストリームが止まったときに、比較全体が `isSubmitting` のまま固まる状態を避けるためです。

## Summary

モデル単位のアイドルタイムアウトと 1 回の自動リトライを追加し、タイムアウトしたモデルだけを停止・再試行できるようにしました。
あわせて、server 側で request abort signal を OpenAI SDK に伝播するようにしました。

## Changes

- `useCompareStream` をモデル単位の controller / timer 管理に変更
- 60 秒アイドルタイムアウトと 1 回自動リトライを追加
- `useCompareState` と `CompareColumn` に retrying 状態と表示を追加
- `/api/chat/stream` から OpenAI SDK request options に `signal` を伝播
- timeout / retry / cancel / UI / signal 伝播のテストを追加

## Verification

- `bun run test -- tests/client/hooks/use-compare-stream.test.tsx tests/client/hooks/use-compare-state.test.ts tests/client/components/compare-column.test.tsx tests/features/chat/chat.test.ts tests/routes/chat.test.ts` - passed
- `bun run lint` - passed
- `bun run test` - passed
