### PR TITLE
feat(simple-agent-poc): add agent dropdown and remove sessionId caching in test page

### DIFF
--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/api.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/api.py
@@ -29,7 +29,11 @@ from simple_agent_poc.core.types import (
     ValidationError,
 )
 from simple_agent_poc.adapters.http.test_page import TEST_PAGE_HTML
-from simple_agent_poc.entrypoints.bootstrap import create_run_agent_use_case_factory
+from simple_agent_poc.core.agent_definition import AgentDefinitionRegistry
+from simple_agent_poc.entrypoints.bootstrap import (
+    create_agent_definition_registry,
+    create_run_agent_use_case_factory,
+)
 
 
 class ChatRequest(BaseModel):
@@ -148,10 +152,12 @@ def resolve_session_id(
 def create_app(
     *,
     use_case_factory: Callable[[], RunAgentUseCase] | None = None,
+    agent_definitions: AgentDefinitionRegistry | None = None,
 ) -> FastAPI:
     """Create the FastAPI application."""
     app = FastAPI(title="simple-agent-poc")
     factory = use_case_factory or create_run_agent_use_case_factory()
+    definitions = agent_definitions or create_agent_definition_registry()
 
     def get_run_agent_use_case() -> RunAgentUseCase:
         return factory()
@@ -309,6 +315,10 @@ def create_app(
                 yield f"event: error\ndata: {json.dumps({'detail': str(error)}, ensure_ascii=False)}\n\n"
 
         return StreamingResponse(event_stream(), media_type="text/event-stream")
+
+    @app.get("/api/agents")
+    def list_agents() -> dict[str, list[str]]:
+        return {"agents": definitions.list_ids()}
 
     @app.get("/", response_class=HTMLResponse)
     def test_page() -> HTMLResponse:

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/test_page.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/test_page.py
@@ -49,7 +49,8 @@ TEST_PAGE_HTML = """<!doctype html>
     </select>
   </label>
   <label>Agent
-    <input type="text" id="agent-id" value="default" size="10" onchange="onAgentIdChange()">
+    <select id="agent-id" onchange="onAgentIdChange()">
+    </select>
   </label>
   <label>Session
     <input type="text" id="session-id" size="24" placeholder="(new)" onchange="onSessionIdChange()">
@@ -102,7 +103,7 @@ function onModeChange() {
 }
 
 function onAgentIdChange() {
-  state.agentId = el("agent-id").value.trim() || "default";
+  state.agentId = el("agent-id").value;
   persist();
 }
 
@@ -122,7 +123,6 @@ function persist() {
     localStorage.setItem("sap_test_ui", JSON.stringify({
       mode: state.mode,
       agentId: state.agentId,
-      sessionId: state.sessionId,
     }));
   } catch (_) {}
 }
@@ -133,8 +133,29 @@ function restore() {
     if (!raw) return;
     const d = JSON.parse(raw);
     if (d.mode) { state.mode = d.mode; el("mode-select").value = d.mode; }
-    if (d.agentId) { state.agentId = d.agentId; el("agent-id").value = d.agentId; }
-    if (d.sessionId) { state.sessionId = d.sessionId; el("session-id").value = d.sessionId; }
+    if (d.agentId) { state.agentId = d.agentId; }
+  } catch (_) {}
+}
+
+async function fetchAgents() {
+  try {
+    const resp = await fetch("/api/agents");
+    if (!resp.ok) return;
+    const data = await resp.json();
+    const select = el("agent-id");
+    select.innerHTML = "";
+    for (const id of data.agents) {
+      const option = document.createElement("option");
+      option.value = id;
+      option.textContent = id;
+      select.appendChild(option);
+    }
+    if (state.agentId && data.agents.includes(state.agentId)) {
+      select.value = state.agentId;
+    } else if (data.agents.length > 0) {
+      select.value = data.agents[0];
+      state.agentId = data.agents[0];
+    }
   } catch (_) {}
 }
 
@@ -509,7 +530,7 @@ function truncate(s, max) {
 }
 
 restore();
-el("msg-input").focus();
+(async () => { await fetchAgents(); el("msg-input").focus(); })();
 </script>
 </body>
 </html>

--- a/projects/simple-agent-poc/src/simple_agent_poc/core/agent_definition.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/core/agent_definition.py
@@ -87,6 +87,10 @@ class AgentDefinitionRegistry:
         except KeyError as error:
             raise ValidationError(f"Unknown agent_id: {agent_id}") from error
 
+    def list_ids(self) -> list[str]:
+        """Return all registered agent ids."""
+        return list(self._definitions.keys())
+
 
 def _build_agent_definition(
     agent_id: object,


### PR DESCRIPTION
## Why

テスト用GUIのAgent指定をテキスト入力からプルダウン選択に変更し、ユーザビリティを向上させます。また、sessionIdがlocalStorageにキャッシュされて画面リロード時に前回値が残る問題を解消します。

## Summary

テストページのAgent選択を `<select>` ドロップダウンに変更し、`GET /api/agents` エンドポイントから動的にAgent一覧を取得するようにしました。合わせてsessionIdのlocalStorageキャッシュを廃止し、画面リロード時にクリアされるようにしました。

## Changes

- `AgentDefinitionRegistry` に `list_ids()` メソッドを追加
- `GET /api/agents` エンドポイントを追加
- テストページのAgent指定を `<input type="text">` から `<select>` ドロップダウンに変更
- テストページのlocalStorage永続化からsessionIdを除外（リロード時にクリア）

## Checklist

- [x] ruff format / lint パス
- [x] ty type check パス
- [x] pytest 全テストパス (179 passed)
