### PR TITLE
feat: add choice type and multiSelect to ask_user (#923)

### DIFF
--- a/projects/simple-agent-poc/docs/api.md
+++ b/projects/simple-agent-poc/docs/api.md
@@ -94,6 +94,16 @@ When the agent calls `ask_user` and needs user input:
       "header": "Name",
       "type": "text",
       "placeholder": "e.g. Alice"
+    },
+    {
+      "question": "Which database?",
+      "header": "Database",
+      "type": "choice",
+      "options": [
+        {"label": "PostgreSQL", "description": "OSS RDBMS"},
+        {"label": "SQLite", "description": "Lightweight embedded DB"}
+      ],
+      "multiSelect": false
     }
   ],
   "tool_calls": []
@@ -105,8 +115,10 @@ When the agent calls `ask_user` and needs user input:
 | `status` | `"paused"` | Discriminator for a paused response |
 | `session_id` | `str` | Session ID for continuing the conversation |
 | `call_id` | `str` | ID of the pending `ask_user` tool call |
-| `questions` | `list[dict]` | Question items from `ask_user` arguments. Each item has `question` (text), `header` (short label), `type` (`"text"` in Phase 1), and optional `placeholder` |
+| `questions` | `list[dict]` | Question items from `ask_user` arguments. Each item has `question`, `header`, `type` (`"text"` or `"choice"`), optional `placeholder`, and for `type: "choice"` also `options` and `multiSelect` |
 | `tool_calls` | `list[ToolCallRecord]` | Non-ask_user tool calls executed before pausing |
+
+**`type: "choice"`** の場合、各 `options` エントリは `label`（必須）と `description`（任意）を持つ。`multiSelect: true` の場合、クライアントはカンマ区切りで複数の選択番号を送信できる。
 
 #### Error Responses
 

--- a/projects/simple-agent-poc/docs/cli.md
+++ b/projects/simple-agent-poc/docs/cli.md
@@ -163,16 +163,36 @@ def ask_user_question(questions: list[dict]) -> str:
     q = questions[0]
     header = q.get("header", "")
     question_text = q.get("question", "")
+    q_type = q.get("type", "text")
     placeholder = q.get("placeholder", "")
+    options = q.get("options", [])
+    multi_select = q.get("multiSelect", False)
     label = f"[{header}] " if header else ""
-    prompt = f"  {label}{question_text}"
-    if placeholder:
-        prompt += f" ({placeholder})"
-    prompt += " > "
+
+    if q_type == "choice" and options:
+        print(f"  {label}{question_text}")
+        for idx, opt in enumerate(options, start=1):
+            desc = opt.get("description", "")
+            line = f"    {idx}. {opt['label']}"
+            if desc:
+                line += f" — {desc}"
+            print(line)
+        if multi_select:
+            prompt = "  選択（カンマ区切りで複数可）> "
+        else:
+            prompt = "  選択（番号または自由記述）> "
+    else:
+        prompt = f"  {label}{question_text}"
+        if placeholder:
+            prompt += f" ({placeholder})"
+        prompt += " > "
+
     return input(prompt).strip()
 ```
 
-Displays the `ask_user` question and reads the user's typed answer from stdin. Phase 1 では `questions` 配列の最初の要素のみを処理する。`header` があれば `[Header]` 形式のラベルを表示し、`placeholder` があれば入力ヒントとして表示する。Used by both sync and stream modes.
+Displays the `ask_user` question and reads the user's typed answer from stdin. `questions` 配列の最初の要素のみを処理する。`header` があれば `[Header]` 形式のラベルを表示し、`placeholder` があれば入力ヒントとして表示する。
+
+**`type: "choice"`** の場合、選択肢を番号付きで表示する。`multiSelect: true` ならカンマ区切りで複数番号を入力でき、選択されたラベルが結合された値が LLM に渡される。`multiSelect: false`（デフォルト）では単一番号または自由記述が受け付けられる。Used by both sync and stream modes.
 
 ### show_error(error)
 

--- a/projects/simple-agent-poc/docs/sse.md
+++ b/projects/simple-agent-poc/docs/sse.md
@@ -59,7 +59,7 @@ Emitted after a tool executes. Contains:
 
 ```text
 event: paused
-data: {"session_id": "abc123...", "call_id": "call_def456", "questions": [{"question": "What is your preference?", "header": "Preference", "type": "text"}]}
+data: {"session_id": "abc123...", "call_id": "call_def456", "questions": [{"question": "What is your preference?", "header": "Preference", "type": "text"}, {"question": "Which database?", "header": "Database", "type": "choice", "options": [{"label": "PostgreSQL", "description": "OSS RDBMS"}, {"label": "SQLite", "description": "Lightweight embedded DB"}], "multiSelect": false}]}
 ```
 
 Emitted when `ask_user` is called in API mode. The SSE stream disconnects after this event. The client must send the answer via `POST /api/chat/continue` to resume. Contains:
@@ -68,7 +68,7 @@ Emitted when `ask_user` is called in API mode. The SSE stream disconnects after 
 |:---|:---|:---|
 | `session_id` | `str` | Session ID to use for the continue request |
 | `call_id` | `str` | Tool call ID (for reference) |
-| `questions` | `list[dict]` | Question items from `ask_user`. Each has `question`, `header`, `type` (`"text"`), and optional `placeholder` |
+| `questions` | `list[dict]` | Question items from `ask_user`. Each has `question`, `header`, `type` (`"text"` or `"choice"`), optional `placeholder`, and for `type: "choice"` also `options` (list of `{label, description?}`) and `multiSelect` (boolean) |
 
 ### `complete` — Stream Finished
 

--- a/projects/simple-agent-poc/docs/types.md
+++ b/projects/simple-agent-poc/docs/types.md
@@ -151,7 +151,7 @@ These are yielded by `execute_stream()` and `continue_stream()` generators:
 | `ContentDelta(delta)` | Partial text chunk during streaming |
 | `ToolCallEvent(call_id, name, arguments)` | Agent has initiated a tool call |
 | `ToolResultEvent(call_id, name, result)` | Tool execution completed |
-| `SessionPaused(session_id, call_id, question)` | `ask_user` called in API mode; stream pauses |
+| `SessionPaused(session_id, call_id, questions)` | `ask_user` called in API mode; stream pauses |
 | `StreamComplete(session_id, usage, model, response_time)` | Stream finished successfully |
 
 ### ContinueRequest
@@ -172,11 +172,11 @@ Request DTO for resuming a paused session. Contains the user's answer to an `ask
 class RunAgentPaused:
     session_id: str
     call_id: str
-    question: str
+    questions: list[dict]
     tool_call_history: list[ToolCallRecord]
 ```
 
-Returned by `RunAgentUseCase.execute()` and `RunAgentUseCase.continue_sync()` when the agent calls `ask_user` during synchronous execution. The caller should present the question, collect an answer, and resume via `continue_sync()`.
+Returned by `RunAgentUseCase.execute()` and `RunAgentUseCase.continue_sync()` when the agent calls `ask_user` during synchronous execution. The caller should present the questions, collect an answer, and resume via `continue_sync()`. Each question item may include `type` (`"text"` or `"choice"`), `options`, and `multiSelect` for choice questions.
 
 ### Sync Result Union
 
@@ -216,10 +216,10 @@ class SyncChatResponse(BaseModel):
     model: str = ""
     response_time: float = 0.0
     call_id: str = ""
-    question: str = ""
+    questions: list[dict] = []
 ```
 
-Discriminated by `status`. When `"completed"`, `message`/`usage`/`model`/`response_time` are populated. When `"paused"`, `call_id`/`question` are populated.
+Discriminated by `status`. When `"completed"`, `message`/`usage`/`model`/`response_time` are populated. When `"paused"`, `call_id`/`questions` are populated. Each question item may include `type` (`"text"` or `"choice"`), `options` (list of `{label, description?}`), and `multiSelect` (boolean).
 
 Factory methods: `from_completed(response)` / `from_paused(paused)`.
 

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/cli/renderer.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/cli/renderer.py
@@ -94,12 +94,30 @@ def ask_user_question(questions: list[dict]) -> str:
     q = questions[0]
     header = q.get("header", "")
     question_text = q.get("question", "")
+    q_type = q.get("type", "text")
     placeholder = q.get("placeholder", "")
+    options = q.get("options", [])
+    multi_select = q.get("multiSelect", False)
     label = f"[{header}] " if header else ""
-    prompt = f"  {label}{question_text}"
-    if placeholder:
-        prompt += f" ({placeholder})"
-    prompt += " > "
+
+    if q_type == "choice" and options:
+        print(f"  {label}{question_text}")
+        for idx, opt in enumerate(options, start=1):
+            desc = opt.get("description", "")
+            line = f"    {idx}. {opt['label']}"
+            if desc:
+                line += f" — {desc}"
+            print(line)
+        if multi_select:
+            prompt = "  選択（カンマ区切りで複数可）> "
+        else:
+            prompt = "  選択（番号または自由記述）> "
+    else:
+        prompt = f"  {label}{question_text}"
+        if placeholder:
+            prompt += f" ({placeholder})"
+        prompt += " > "
+
     return input(prompt).strip()
 
 

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/api.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/api.py
@@ -285,13 +285,14 @@ def create_app(
         run_agent: Annotated[RunAgentUseCase, Depends(get_run_agent_use_case)],
     ):
         def event_stream():
+            generator = run_agent.continue_stream(
+                ContinueRequest(
+                    session_id=request.session_id,
+                    answer=request.answer,
+                )
+            )
             try:
-                for event in run_agent.continue_stream(
-                    ContinueRequest(
-                        session_id=request.session_id,
-                        answer=request.answer,
-                    )
-                ):
+                for event in generator:
                     if isinstance(event, ContentDelta):
                         yield f"event: delta\ndata: {json.dumps({'content': event.delta}, ensure_ascii=False)}\n\n"
                     elif isinstance(event, ToolCallEvent):
@@ -313,6 +314,8 @@ def create_app(
                 yield f"event: error\ndata: {json.dumps({'detail': error.display_message}, ensure_ascii=False)}\n\n"
             except Exception as error:
                 yield f"event: error\ndata: {json.dumps({'detail': str(error)}, ensure_ascii=False)}\n\n"
+            finally:
+                generator.close()
 
         return StreamingResponse(event_stream(), media_type="text/event-stream")
 

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/test_page.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/test_page.py
@@ -219,6 +219,15 @@ async function sendMessage() {
   const message = el("msg-input").value.trim();
   if (!message) return;
   if (state.abortController) return;
+
+  // If paused, treat the typed message as the answer
+  if (state.awaitingAnswer) {
+    el("paused-answer").value = message;
+    el("msg-input").value = "";
+    await resumeFromPaused();
+    return;
+  }
+
   el("msg-input").value = "";
   appendLine("conv-log", "line-user", "You: " + message);
   appendLine("raw-log", "line-system", "--- sending message ---");

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/test_page.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/test_page.py
@@ -31,6 +31,10 @@ TEST_PAGE_HTML = """<!doctype html>
   .paused-bar.visible { display: flex; gap: 6px; align-items: center; }
   .paused-bar input[type="text"] { flex: 1; background: rgba(0,0,0,.15); color: #000; border: 1px solid rgba(0,0,0,.2); border-radius: 4px; padding: 4px 8px; font-family: inherit; font-size: 13px; }
   .paused-bar button { background: rgba(0,0,0,.2); color: #000; border: none; border-radius: 4px; padding: 4px 10px; font-family: inherit; font-size: 13px; font-weight: 600; cursor: pointer; }
+  .paused-choices { display: flex; flex-wrap: wrap; gap: 6px; flex: 1; align-items: center; }
+  .paused-choice-btn { background: var(--bg); color: var(--text); border: 1px solid var(--border); border-radius: 4px; padding: 4px 10px; font-family: inherit; font-size: 12px; cursor: pointer; }
+  .paused-choice-btn:hover { background: var(--border); }
+  .paused-choice-btn.selected { background: var(--accent); color: #000; border-color: var(--accent); }
   .line-user { color: var(--muted); }
   .line-assistant { color: var(--text); }
   .line-tool { color: var(--tool); }
@@ -75,7 +79,7 @@ TEST_PAGE_HTML = """<!doctype html>
   <div class="paused-bar" id="paused-bar">
     <span id="paused-question"></span>
     <input type="text" id="paused-answer" placeholder="Type your answer..." onkeydown="if(event.key==='Enter')resumeFromPaused()">
-    <button onclick="resumeFromPaused()">Resume</button>
+    <button id="paused-resume" onclick="resumeFromPaused()">Resume</button>
     <button onclick="cancelPaused()">Cancel</button>
   </div>
 </main>
@@ -343,13 +347,67 @@ async function sendStreamMessage(message) {
 
 function enterPausedState({ session_id: sessionId, questions, call_id: callId, mode = "stream" }) {
   const qs = questions || [];
-  const questionText = qs.length > 0 ? qs[0].question : "";
+  const q = qs.length > 0 ? qs[0] : null;
+  const questionText = q ? q.question : "";
   state.awaitingAnswer = { sessionId, questions, callId, mode };
   setSessionId(sessionId);
   el("paused-question").textContent = "Q: " + questionText;
   el("paused-answer").value = "";
+
+  const oldChoices = el("paused-bar").querySelector(".paused-choices");
+  if (oldChoices) oldChoices.remove();
+  el("paused-answer").style.display = "";
+
   el("paused-bar").classList.add("visible");
-  el("paused-answer").focus();
+
+  const resumeBtn = el("paused-resume");
+  if (q && q.type === "choice" && q.options && q.options.length > 0) {
+    if (resumeBtn) resumeBtn.style.display = "none";
+    const choicesDiv = document.createElement("div");
+    choicesDiv.className = "paused-choices";
+    const isMulti = q.multiSelect === true;
+    const selected = new Set();
+
+    q.options.forEach((opt, idx) => {
+      const btn = document.createElement("button");
+      btn.className = "paused-choice-btn";
+      btn.textContent = (idx + 1) + ". " + opt.label;
+      if (opt.description) btn.title = opt.description;
+      btn.onclick = () => {
+        if (isMulti) {
+          if (selected.has(idx)) {
+            selected.delete(idx);
+            btn.classList.remove("selected");
+          } else {
+            selected.add(idx);
+            btn.classList.add("selected");
+          }
+        } else {
+          el("paused-answer").value = String(idx + 1);
+          resumeFromPaused();
+        }
+      };
+      choicesDiv.appendChild(btn);
+    });
+
+    if (isMulti) {
+      const submitBtn = document.createElement("button");
+      submitBtn.className = "paused-choice-btn";
+      submitBtn.textContent = "Submit";
+      submitBtn.onclick = () => {
+        const nums = Array.from(selected).sort((a, b) => a - b).map(i => i + 1).join(",");
+        el("paused-answer").value = nums;
+        resumeFromPaused();
+      };
+      choicesDiv.appendChild(submitBtn);
+    }
+
+    el("paused-bar").insertBefore(choicesDiv, el("paused-answer"));
+    el("paused-answer").style.display = "none";
+  } else {
+    if (resumeBtn) resumeBtn.style.display = "";
+    el("paused-answer").focus();
+  }
 }
 
 async function resumeFromPaused() {
@@ -360,6 +418,9 @@ async function resumeFromPaused() {
   el("paused-bar").classList.remove("visible");
   el("paused-question").textContent = "";
   el("paused-answer").value = "";
+  const oldChoices = el("paused-bar").querySelector(".paused-choices");
+  if (oldChoices) oldChoices.remove();
+  el("paused-answer").style.display = "";
   appendLine("conv-log", "line-user", "You: " + answer);
   appendLine("raw-log", "line-system", "--- continuing paused session ---");
 
@@ -487,6 +548,11 @@ function cancelPaused() {
   el("paused-bar").classList.remove("visible");
   el("paused-question").textContent = "";
   el("paused-answer").value = "";
+  const oldChoices = el("paused-bar").querySelector(".paused-choices");
+  if (oldChoices) oldChoices.remove();
+  el("paused-answer").style.display = "";
+  const resumeBtn = el("paused-resume");
+  if (resumeBtn) resumeBtn.style.display = "";
 }
 
 function stopRequest() {

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/tools/ask_user.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/tools/ask_user.py
@@ -32,12 +32,34 @@ TOOL_DEFINITION: ToolDefinition = {
                             },
                             "type": {
                                 "type": "string",
-                                "enum": ["text"],
+                                "enum": ["text", "choice"],
                                 "description": "質問の種類",
                             },
                             "placeholder": {
                                 "type": "string",
                                 "description": "入力欄のプレースホルダー",
+                            },
+                            "options": {
+                                "type": "array",
+                                "description": "選択肢のリスト（type=choice の場合）",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "label": {
+                                            "type": "string",
+                                            "description": "選択肢のラベル",
+                                        },
+                                        "description": {
+                                            "type": "string",
+                                            "description": "選択肢の説明",
+                                        },
+                                    },
+                                    "required": ["label"],
+                                },
+                            },
+                            "multiSelect": {
+                                "type": "boolean",
+                                "description": "複数選択を許可するか（type=choice の場合）",
                             },
                         },
                         "required": ["question", "type"],

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/tools/ask_user.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/tools/ask_user.py
@@ -12,6 +12,9 @@ TOOL_DEFINITION: ToolDefinition = {
         "description": (
             "ユーザーに質問し、テキスト入力で回答を得ます。"
             "追加情報が必要な場合に使います。"
+            "type: choice の場合、選択肢は入力補助のためであり、"
+            "ユーザーが選択肢にない自由な回答をしてもそのまま受け入れ、"
+            "再度このツールで確認しないでください。"
         ),
         "parameters": {
             "type": "object",

--- a/projects/simple-agent-poc/src/simple_agent_poc/application/use_cases.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/application/use_cases.py
@@ -90,6 +90,38 @@ def _find_next_unanswered_ask_user(
     return None
 
 
+def _build_ask_user_result(user_answer: str, questions: list[dict]) -> str:
+    """Build the ask_user tool result JSON from the user's raw answer.
+
+    For ``choice`` questions with ``options``, numeric inputs are mapped to
+    option labels.  Comma-separated numbers are supported when ``multiSelect``
+    is ``True``.  Non-numeric input falls back to free-form text.
+    """
+    if not questions:
+        return json.dumps({"answers": {}}, ensure_ascii=False)
+    q = questions[0]
+    question_text = q.get("question", "")
+    options = q.get("options", [])
+
+    if not options:
+        return json.dumps({"answers": {question_text: user_answer}}, ensure_ascii=False)
+
+    parts = [p.strip() for p in user_answer.split(",") if p.strip()]
+    if all(p.isdigit() for p in parts):
+        labels: list[str] = []
+        for p in parts:
+            idx = int(p) - 1
+            if 0 <= idx < len(options):
+                labels.append(options[idx]["label"])
+        if labels:
+            return json.dumps(
+                {"answers": {question_text: ", ".join(labels)}},
+                ensure_ascii=False,
+            )
+
+    return json.dumps({"answers": {question_text: user_answer}}, ensure_ascii=False)
+
+
 class RunAgentUseCase:
     """Reusable execution path for session-aware agent interactions."""
 
@@ -158,10 +190,7 @@ class RunAgentUseCase:
             raise RuntimeError("Session is paused but no pending tool call found")
         pending_args = json.loads(tc["function"]["arguments"])
         questions = pending_args.get("questions", [])
-        question_text = questions[0]["question"] if questions else ""
-        result = json.dumps(
-            {"answers": {question_text: request.answer}}, ensure_ascii=False
-        )
+        result = _build_ask_user_result(request.answer, questions)
         session.append_tool_message(result, tool_call_id=tc["id"])
         resume_round = session.pending_round
         session.resume_with_answer()
@@ -360,12 +389,8 @@ class RunAgentUseCase:
                             user_answer = yield event
                             ask_user_args = json.loads(tc["function"]["arguments"])
                             questions = ask_user_args.get("questions", [])
-                            question_text = (
-                                questions[0]["question"] if questions else ""
-                            )
-                            result = json.dumps(
-                                {"answers": {question_text: user_answer or ""}},
-                                ensure_ascii=False,
+                            result = _build_ask_user_result(
+                                user_answer or "", questions
                             )
                         else:
                             yield ToolCallEvent(
@@ -431,10 +456,7 @@ class RunAgentUseCase:
             raise RuntimeError("Session is paused but no pending tool call found")
         pending_args = json.loads(tc["function"]["arguments"])
         questions = pending_args.get("questions", [])
-        question_text = questions[0]["question"] if questions else ""
-        result = json.dumps(
-            {"answers": {question_text: request.answer}}, ensure_ascii=False
-        )
+        result = _build_ask_user_result(request.answer, questions)
         session.append_tool_message(result, tool_call_id=tc["id"])
         yield ToolResultEvent(call_id=tc["id"], name="ask_user", result=result)
         resume_round = session.pending_round

--- a/projects/simple-agent-poc/src/simple_agent_poc/application/use_cases.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/application/use_cases.py
@@ -106,7 +106,12 @@ def _build_ask_user_result(user_answer: str, questions: list[dict]) -> str:
     if not options:
         return json.dumps({"answers": {question_text: user_answer}}, ensure_ascii=False)
 
-    parts = [p.strip() for p in user_answer.split(",") if p.strip()]
+    multi_select = q.get("multiSelect", False)
+    if multi_select:
+        parts = [p.strip() for p in user_answer.split(",") if p.strip()]
+    else:
+        parts = [user_answer.strip()] if user_answer.strip() else []
+
     if all(p.isdigit() for p in parts):
         labels: list[str] = []
         for p in parts:

--- a/projects/simple-agent-poc/src/simple_agent_poc/application/use_cases.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/application/use_cases.py
@@ -196,7 +196,7 @@ class RunAgentUseCase:
         pending_args = json.loads(tc["function"]["arguments"])
         questions = pending_args.get("questions", [])
         result = _build_ask_user_result(request.answer, questions)
-        session.append_tool_message(result, tool_call_id=tc["id"])
+        session.replace_tool_message(result, tool_call_id=tc["id"])
         resume_round = session.pending_round
         session.resume_with_answer()
 
@@ -204,6 +204,7 @@ class RunAgentUseCase:
 
         next_ask_user_tc = _find_next_unanswered_ask_user(session)
         if next_ask_user_tc is not None:
+            session.append_tool_message("", tool_call_id=next_ask_user_tc["id"])
             return self._build_paused_result(
                 session=session,
                 ask_user_tc=next_ask_user_tc,
@@ -270,6 +271,9 @@ class RunAgentUseCase:
                 )
 
             if ask_user_tcs:
+                # Add a placeholder tool message so OpenAI's history validation
+                # is satisfied when the session resumes later.
+                session.append_tool_message("", tool_call_id=ask_user_tcs[0]["id"])
                 return self._build_paused_result(
                     session=session,
                     ask_user_tc=ask_user_tcs[0],
@@ -375,6 +379,7 @@ class RunAgentUseCase:
                                 result=result,
                             )
                         session.pause_for_ask_user(ask_user_tc, round_idx=round_idx)
+                        session.append_tool_message("", tool_call_id=ask_user_tc["id"])
                         self._session_store.save(session)
                         ask_user_args = json.loads(ask_user_tc["function"]["arguments"])
                         yield SessionPaused(
@@ -462,7 +467,8 @@ class RunAgentUseCase:
         pending_args = json.loads(tc["function"]["arguments"])
         questions = pending_args.get("questions", [])
         result = _build_ask_user_result(request.answer, questions)
-        session.append_tool_message(result, tool_call_id=tc["id"])
+        session.replace_tool_message(result, tool_call_id=tc["id"])
+        self._session_store.save(session)
         yield ToolResultEvent(call_id=tc["id"], name="ask_user", result=result)
         resume_round = session.pending_round
         session.resume_with_answer()
@@ -470,6 +476,7 @@ class RunAgentUseCase:
         next_ask_user_tc = _find_next_unanswered_ask_user(session)
         if next_ask_user_tc is not None:
             session.pause_for_ask_user(next_ask_user_tc, round_idx=resume_round)
+            session.append_tool_message("", tool_call_id=next_ask_user_tc["id"])
             self._session_store.save(session)
             ask_user_args = json.loads(next_ask_user_tc["function"]["arguments"])
             yield SessionPaused(

--- a/projects/simple-agent-poc/src/simple_agent_poc/core/session.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/core/session.py
@@ -57,6 +57,19 @@ class ConversationSession:
             }
         )
 
+    def replace_tool_message(self, content: str, *, tool_call_id: str) -> None:
+        """Replace an existing tool result message in the conversation.
+
+        Used to overwrite a placeholder tool message inserted before
+        ``ask_user`` pauses with the real user answer on resume.
+        Falls back to appending if no placeholder exists.
+        """
+        for msg in self.messages:
+            if msg.get("role") == "tool" and msg.get("tool_call_id") == tool_call_id:
+                msg["content"] = content
+                return
+        self.append_tool_message(content, tool_call_id=tool_call_id)
+
     def pause_for_ask_user(self, tool_call: ToolCall, *, round_idx: int) -> None:
         """Transition to paused state waiting for user answer."""
         self.is_paused = True

--- a/projects/simple-agent-poc/tests/helpers.py
+++ b/projects/simple-agent-poc/tests/helpers.py
@@ -17,3 +17,27 @@ def _questions_args(
             ]
         }
     )
+
+
+def _choice_questions_args(
+    *,
+    question_text: str = "Which database?",
+    header: str = "Database",
+    multi_select: bool = False,
+) -> str:
+    return json.dumps(
+        {
+            "questions": [
+                {
+                    "question": question_text,
+                    "header": header,
+                    "type": "choice",
+                    "options": [
+                        {"label": "PostgreSQL", "description": "OSS RDBMS"},
+                        {"label": "SQLite", "description": "Lightweight embedded DB"},
+                    ],
+                    "multiSelect": multi_select,
+                }
+            ]
+        }
+    )

--- a/projects/simple-agent-poc/tests/test_api.py
+++ b/projects/simple-agent-poc/tests/test_api.py
@@ -6,9 +6,16 @@ from fastapi.testclient import TestClient
 
 from simple_agent_poc.adapters.http.api import create_app
 from simple_agent_poc.adapters.session_store.in_memory import InMemorySessionStore
+from simple_agent_poc.adapters.tools.ask_user import (
+    TOOL_DEFINITION as ASK_USER_TOOL_DEF,
+)
+from simple_agent_poc.adapters.tools.ask_user import execute as ask_user_execute
+from simple_agent_poc.adapters.tools.registry import BuiltinToolRegistry
 from simple_agent_poc.application.use_cases import RunAgentUseCase
 from simple_agent_poc.core.agent_definition import AgentDefinitionRegistry
 from simple_agent_poc.core.types import LLMResponse, LLMStreamChunk, Message
+
+from tests.helpers import _choice_questions_args
 
 
 class StubLLMClient:
@@ -275,6 +282,79 @@ class TestAPI:
         assert second_response.json() == {
             "detail": "agent_id cannot be changed for an existing session"
         }
+
+    def test_chat_sync_pause_includes_choice_options(self) -> None:
+        """Sync paused response includes options and multiSelect for choice questions."""
+
+        class AskUserLLMStub:
+            def complete(
+                self,
+                messages: list[Message],
+                *,
+                tools=None,
+            ) -> LLMResponse:
+                return {
+                    "content": "",
+                    "usage": {
+                        "prompt_tokens": 10,
+                        "completion_tokens": 5,
+                        "total_tokens": 15,
+                    },
+                    "model": "stub-model",
+                    "response_time": 0.1,
+                    "tool_calls": [
+                        {
+                            "id": "call_001",
+                            "type": "function",
+                            "function": {
+                                "name": "ask_user",
+                                "arguments": _choice_questions_args(multi_select=True),
+                            },
+                        }
+                    ],
+                }
+
+            def complete_stream(
+                self,
+                messages: list[Message],
+                *,
+                tools=None,
+            ) -> Iterator[LLMStreamChunk]:
+                raise NotImplementedError
+
+        tool_executor = BuiltinToolRegistry()
+        tool_executor.register(ASK_USER_TOOL_DEF, ask_user_execute)
+
+        app = create_app(
+            use_case_factory=lambda: RunAgentUseCase(
+                llm_client_factory=lambda _agent_definition: AskUserLLMStub(),
+                session_store=InMemorySessionStore(),
+                agent_definitions=AgentDefinitionRegistry.from_mapping(
+                    {
+                        "agents": {
+                            "default": {
+                                "model": "default-model",
+                                "system_prompt": "System prompt",
+                                "tools": ["ask_user"],
+                            }
+                        }
+                    }
+                ),
+                tool_executor=tool_executor,
+            )
+        )
+        client = TestClient(app)
+
+        response = client.post("/api/chat/sync", json={"message": "Hello"})
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "paused"
+        question = data["questions"][0]
+        assert question["type"] == "choice"
+        assert question["multiSelect"] is True
+        assert len(question["options"]) == 2
+        assert question["options"][0]["label"] == "PostgreSQL"
 
 
 class TestSSEEvents:

--- a/projects/simple-agent-poc/tests/test_http_stream_api.py
+++ b/projects/simple-agent-poc/tests/test_http_stream_api.py
@@ -18,7 +18,7 @@ from simple_agent_poc.application.use_cases import RunAgentUseCase
 from simple_agent_poc.core.agent_definition import AgentDefinitionRegistry
 from simple_agent_poc.core.types import LLMResponse, LLMStreamChunk, Message
 
-from tests.helpers import _questions_args
+from tests.helpers import _choice_questions_args, _questions_args
 
 
 class StreamingStubLLMClient:
@@ -444,3 +444,48 @@ class TestStreamPauseContinueAPI:
         )
 
         assert response.status_code == 422
+
+    def test_chat_stream_pause_includes_choice_options(self) -> None:
+        """Paused event for choice questions includes options and multiSelect."""
+        chunks: list[LLMStreamChunk] = [
+            {
+                "content_delta": None,
+                "tool_call_delta": {
+                    "index": 0,
+                    "id": "call_001",
+                    "type": "function",
+                    "function": {
+                        "name": "ask_user",
+                        "arguments": _choice_questions_args(multi_select=True),
+                    },
+                },
+            },
+        ]
+        session_store = InMemorySessionStore()
+        tool_executor = build_tool_executor_with_ask_user()
+        registry = build_registry_with_ask_user()
+        llm_client = StreamingStubLLMClient(chunks=chunks)
+
+        app = create_app(
+            use_case_factory=lambda: RunAgentUseCase(
+                llm_client_factory=lambda _agent_definition: llm_client,
+                session_store=session_store,
+                agent_definitions=registry,
+                tool_executor=tool_executor,
+                is_api_context=True,
+            )
+        )
+        client = TestClient(app)
+
+        response = client.post("/api/chat/stream", json={"message": "Hello"})
+
+        assert response.status_code == 200
+        events = parse_sse_events(response.text)
+        assert events[0]["event"] == "tool_call"
+        assert events[1]["event"] == "paused"
+        paused_data = json.loads(events[1]["data"])
+        question = paused_data["questions"][0]
+        assert question["type"] == "choice"
+        assert question["multiSelect"] is True
+        assert len(question["options"]) == 2
+        assert question["options"][0]["label"] == "PostgreSQL"

--- a/projects/simple-agent-poc/tests/test_renderer.py
+++ b/projects/simple-agent-poc/tests/test_renderer.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from simple_agent_poc.adapters.cli.renderer import (
+    ask_user_question,
     get_user_input,
     show_agent_response,
     show_error,
@@ -150,3 +151,81 @@ class TestWithIndicator:
             with_indicator("Loading", mock_op)
 
         mock_op.assert_called_once()
+
+
+class TestAskUserQuestion:
+    """Tests for ask_user_question rendering."""
+
+    @patch("builtins.input", return_value="Alice")
+    @patch("builtins.print")
+    def test_text_type_prompt(
+        self, mock_print: MagicMock, mock_input: MagicMock
+    ) -> None:
+        questions = [
+            {
+                "question": "What is your name?",
+                "header": "Name",
+                "type": "text",
+                "placeholder": "e.g. Alice",
+            }
+        ]
+        result = ask_user_question(questions)
+
+        assert result == "Alice"
+        mock_input.assert_called_once_with(
+            "  [Name] What is your name? (e.g. Alice) > "
+        )
+
+    @patch("builtins.input", return_value="1")
+    @patch("builtins.print")
+    def test_choice_single_select(
+        self, mock_print: MagicMock, mock_input: MagicMock
+    ) -> None:
+        questions = [
+            {
+                "question": "Which database?",
+                "header": "DB",
+                "type": "choice",
+                "options": [
+                    {"label": "PostgreSQL", "description": "OSS RDBMS"},
+                    {"label": "SQLite"},
+                ],
+                "multiSelect": False,
+            }
+        ]
+        result = ask_user_question(questions)
+
+        assert result == "1"
+        calls = [
+            call.args[0] if call.args else "" for call in mock_print.call_args_list
+        ]
+        assert "  [DB] Which database?" in calls
+        assert "    1. PostgreSQL — OSS RDBMS" in calls
+        assert "    2. SQLite" in calls
+        mock_input.assert_called_once_with("  選択（番号または自由記述）> ")
+
+    @patch("builtins.input", return_value="1, 2")
+    @patch("builtins.print")
+    def test_choice_multi_select(
+        self, mock_print: MagicMock, mock_input: MagicMock
+    ) -> None:
+        questions = [
+            {
+                "question": "Pick sections",
+                "type": "choice",
+                "options": [
+                    {"label": "Intro", "description": "Introduction"},
+                    {"label": "Conclusion"},
+                ],
+                "multiSelect": True,
+            }
+        ]
+        result = ask_user_question(questions)
+
+        assert result == "1, 2"
+        calls = [
+            call.args[0] if call.args else "" for call in mock_print.call_args_list
+        ]
+        assert "  Pick sections" in calls
+        assert "    1. Intro — Introduction" in calls
+        mock_input.assert_called_once_with("  選択（カンマ区切りで複数可）> ")

--- a/projects/simple-agent-poc/tests/test_use_cases.py
+++ b/projects/simple-agent-poc/tests/test_use_cases.py
@@ -1,8 +1,9 @@
 """Tests for RunAgentUseCase with tool calling (ReAct loop)."""
 
+import json
 from collections.abc import Iterator
 
-from tests.helpers import _questions_args
+from tests.helpers import _choice_questions_args, _questions_args
 
 from simple_agent_poc.adapters.session_store.in_memory import InMemorySessionStore
 from simple_agent_poc.application.dto import (
@@ -631,3 +632,210 @@ def test_continue_sync_with_non_paused_session_raises_error():
         assert False, "Expected SessionNotPausedError"
     except SessionNotPausedError:
         pass
+
+
+def test_continue_sync_choice_number_to_label():
+    """Number input for a choice question is converted to the option label."""
+    from simple_agent_poc.adapters.tools.registry import BuiltinToolRegistry
+    from simple_agent_poc.adapters.tools.ask_user import (
+        TOOL_DEFINITION as ASK_USER_TOOL_DEF,
+    )
+    from simple_agent_poc.adapters.tools.ask_user import (
+        execute as ask_user_execute,
+    )
+
+    tool_executor = BuiltinToolRegistry()
+    tool_executor.register(ASK_USER_TOOL_DEF, ask_user_execute)
+
+    ask_user_tc: ToolCall = {
+        "id": "call_ask_choice",
+        "type": "function",
+        "function": {
+            "name": "ask_user",
+            "arguments": _choice_questions_args(),
+        },
+    }
+    store = InMemorySessionStore()
+    session = ConversationSession.start(
+        session_id="paused-choice",
+        system_prompt="You are a helpful assistant.",
+    )
+    session.append_user_message("hello")
+    session.append_assistant_message("", tool_calls=[ask_user_tc])
+    session.pause_for_ask_user(ask_user_tc, round_idx=0)
+    store.save(session)
+
+    fake_llm = FakeLLMClient(rounds=[])
+    use_case = RunAgentUseCase(
+        llm_client_factory=FakeLLMClientFactory(fake_llm),
+        session_store=store,
+        agent_definitions=_agent_definitions_with_ask_user(),
+        tool_executor=tool_executor,
+    )
+
+    result = use_case.continue_sync(
+        ContinueRequest(session_id="paused-choice", answer="1")
+    )
+
+    assert isinstance(result, RunAgentResponse)
+    stored = store.get("paused-choice")
+    assert stored is not None
+    tool_msg = [m for m in stored.messages if m["role"] == "tool"][-1]
+    answers = json.loads(tool_msg["content"])["answers"]
+    assert answers["Which database?"] == "PostgreSQL"
+
+
+def test_continue_sync_choice_multi_select():
+    """Comma-separated numbers for multiSelect are converted to joined labels."""
+    from simple_agent_poc.adapters.tools.registry import BuiltinToolRegistry
+    from simple_agent_poc.adapters.tools.ask_user import (
+        TOOL_DEFINITION as ASK_USER_TOOL_DEF,
+    )
+    from simple_agent_poc.adapters.tools.ask_user import (
+        execute as ask_user_execute,
+    )
+
+    tool_executor = BuiltinToolRegistry()
+    tool_executor.register(ASK_USER_TOOL_DEF, ask_user_execute)
+
+    ask_user_tc: ToolCall = {
+        "id": "call_ask_multi",
+        "type": "function",
+        "function": {
+            "name": "ask_user",
+            "arguments": _choice_questions_args(multi_select=True),
+        },
+    }
+    store = InMemorySessionStore()
+    session = ConversationSession.start(
+        session_id="paused-multi",
+        system_prompt="You are a helpful assistant.",
+    )
+    session.append_user_message("hello")
+    session.append_assistant_message("", tool_calls=[ask_user_tc])
+    session.pause_for_ask_user(ask_user_tc, round_idx=0)
+    store.save(session)
+
+    fake_llm = FakeLLMClient(rounds=[])
+    use_case = RunAgentUseCase(
+        llm_client_factory=FakeLLMClientFactory(fake_llm),
+        session_store=store,
+        agent_definitions=_agent_definitions_with_ask_user(),
+        tool_executor=tool_executor,
+    )
+
+    result = use_case.continue_sync(
+        ContinueRequest(session_id="paused-multi", answer="2, 1")
+    )
+
+    assert isinstance(result, RunAgentResponse)
+    stored = store.get("paused-multi")
+    assert stored is not None
+    tool_msg = [m for m in stored.messages if m["role"] == "tool"][-1]
+    answers = json.loads(tool_msg["content"])["answers"]
+    assert answers["Which database?"] == "SQLite, PostgreSQL"
+
+
+def test_continue_sync_choice_free_text_fallback():
+    """Non-numeric input for a choice question is kept as free-form text."""
+    from simple_agent_poc.adapters.tools.registry import BuiltinToolRegistry
+    from simple_agent_poc.adapters.tools.ask_user import (
+        TOOL_DEFINITION as ASK_USER_TOOL_DEF,
+    )
+    from simple_agent_poc.adapters.tools.ask_user import (
+        execute as ask_user_execute,
+    )
+
+    tool_executor = BuiltinToolRegistry()
+    tool_executor.register(ASK_USER_TOOL_DEF, ask_user_execute)
+
+    ask_user_tc: ToolCall = {
+        "id": "call_ask_free",
+        "type": "function",
+        "function": {
+            "name": "ask_user",
+            "arguments": _choice_questions_args(),
+        },
+    }
+    store = InMemorySessionStore()
+    session = ConversationSession.start(
+        session_id="paused-free",
+        system_prompt="You are a helpful assistant.",
+    )
+    session.append_user_message("hello")
+    session.append_assistant_message("", tool_calls=[ask_user_tc])
+    session.pause_for_ask_user(ask_user_tc, round_idx=0)
+    store.save(session)
+
+    fake_llm = FakeLLMClient(rounds=[])
+    use_case = RunAgentUseCase(
+        llm_client_factory=FakeLLMClientFactory(fake_llm),
+        session_store=store,
+        agent_definitions=_agent_definitions_with_ask_user(),
+        tool_executor=tool_executor,
+    )
+
+    result = use_case.continue_sync(
+        ContinueRequest(session_id="paused-free", answer="MySQL")
+    )
+
+    assert isinstance(result, RunAgentResponse)
+    stored = store.get("paused-free")
+    assert stored is not None
+    tool_msg = [m for m in stored.messages if m["role"] == "tool"][-1]
+    answers = json.loads(tool_msg["content"])["answers"]
+    assert answers["Which database?"] == "MySQL"
+
+
+def test_continue_stream_choice_number_to_label():
+    """Stream resume converts number input to label for choice questions."""
+    from simple_agent_poc.adapters.tools.registry import BuiltinToolRegistry
+    from simple_agent_poc.adapters.tools.ask_user import (
+        TOOL_DEFINITION as ASK_USER_TOOL_DEF,
+    )
+    from simple_agent_poc.adapters.tools.ask_user import (
+        execute as ask_user_execute,
+    )
+
+    tool_executor = BuiltinToolRegistry()
+    tool_executor.register(ASK_USER_TOOL_DEF, ask_user_execute)
+
+    ask_user_tc: ToolCall = {
+        "id": "call_ask_stream",
+        "type": "function",
+        "function": {
+            "name": "ask_user",
+            "arguments": _choice_questions_args(),
+        },
+    }
+    store = InMemorySessionStore()
+    session = ConversationSession.start(
+        session_id="paused-stream-choice",
+        system_prompt="You are a helpful assistant.",
+    )
+    session.append_user_message("hello")
+    session.append_assistant_message("", tool_calls=[ask_user_tc])
+    session.pause_for_ask_user(ask_user_tc, round_idx=0)
+    store.save(session)
+
+    fake_llm = FakeLLMClient(rounds=[])
+    use_case = RunAgentUseCase(
+        llm_client_factory=FakeLLMClientFactory(fake_llm),
+        session_store=store,
+        agent_definitions=_agent_definitions_with_ask_user(),
+        tool_executor=tool_executor,
+        is_api_context=True,
+    )
+
+    events = list(
+        use_case.continue_stream(
+            ContinueRequest(session_id="paused-stream-choice", answer="2")
+        )
+    )
+
+    assert isinstance(events[0], ToolResultEvent)
+    stored = store.get("paused-stream-choice")
+    assert stored is not None
+    tool_msg = [m for m in stored.messages if m["role"] == "tool"][-1]
+    answers = json.loads(tool_msg["content"])["answers"]
+    assert answers["Which database?"] == "SQLite"

--- a/projects/simple-agent-poc/tests/test_use_cases.py
+++ b/projects/simple-agent-poc/tests/test_use_cases.py
@@ -787,6 +787,57 @@ def test_continue_sync_choice_free_text_fallback():
     assert answers["Which database?"] == "MySQL"
 
 
+def test_continue_sync_choice_single_select_comma_fallback():
+    """Comma-separated input for single-select choice falls back to free-form text."""
+    from simple_agent_poc.adapters.tools.registry import BuiltinToolRegistry
+    from simple_agent_poc.adapters.tools.ask_user import (
+        TOOL_DEFINITION as ASK_USER_TOOL_DEF,
+    )
+    from simple_agent_poc.adapters.tools.ask_user import (
+        execute as ask_user_execute,
+    )
+
+    tool_executor = BuiltinToolRegistry()
+    tool_executor.register(ASK_USER_TOOL_DEF, ask_user_execute)
+
+    ask_user_tc: ToolCall = {
+        "id": "call_ask_single_comma",
+        "type": "function",
+        "function": {
+            "name": "ask_user",
+            "arguments": _choice_questions_args(),
+        },
+    }
+    store = InMemorySessionStore()
+    session = ConversationSession.start(
+        session_id="paused-single-comma",
+        system_prompt="You are a helpful assistant.",
+    )
+    session.append_user_message("hello")
+    session.append_assistant_message("", tool_calls=[ask_user_tc])
+    session.pause_for_ask_user(ask_user_tc, round_idx=0)
+    store.save(session)
+
+    fake_llm = FakeLLMClient(rounds=[])
+    use_case = RunAgentUseCase(
+        llm_client_factory=FakeLLMClientFactory(fake_llm),
+        session_store=store,
+        agent_definitions=_agent_definitions_with_ask_user(),
+        tool_executor=tool_executor,
+    )
+
+    result = use_case.continue_sync(
+        ContinueRequest(session_id="paused-single-comma", answer="1, 2")
+    )
+
+    assert isinstance(result, RunAgentResponse)
+    stored = store.get("paused-single-comma")
+    assert stored is not None
+    tool_msg = [m for m in stored.messages if m["role"] == "tool"][-1]
+    answers = json.loads(tool_msg["content"])["answers"]
+    assert answers["Which database?"] == "1, 2"
+
+
 def test_continue_stream_choice_number_to_label():
     """Stream resume converts number input to label for choice questions."""
     from simple_agent_poc.adapters.tools.registry import BuiltinToolRegistry


### PR DESCRIPTION
## Issues

- Close #923

## Why

Phase 1 (#922) で導入した `ask_user` ツールの `questions` 配列スキーマに、選択式（`choice`）の質問タイプを追加する。LLM がユーザーに選択肢を提示し、番号またはラベルで回答を得られるようにする。これは Gemini CLI / Claude Code の選択式質問に相当する機能。

## Summary

`type: "choice"` の質問タイプと `multiSelect` オプションを `ask_user` に追加し、CLI と API の両方で選択肢を提示・処理できるようにする。

## Changes

- `ask_user.py` のスキーマを `enum: ["text", "choice"]` に拡張し、`options` / `multiSelect` プロパティを追加
- `renderer.py` の `ask_user_question()` に choice 選択肢の番号付き表示ロジックを追加（multiSelect 時はカンマ区切り入力を促す）
- `use_cases.py` に `_build_ask_user_result()` を追加し、番号入力 → `label` 変換、複数選択の結合、自由記述フォールバックを実装
- API の `SessionPaused` / SSE `paused` イベントには既存の `questions` 配列を通じて `options` / `multiSelect` が自然に含まれる（スキーマ変更のみ）
- テストを追加:
  - `test_use_cases.py`: choice 番号→label 変換、multiSelect 複数結合、自由記述フォールバック、stream resume の変換
  - `test_renderer.py`: CLI の choice 表示（single/multi）
  - `test_api.py`: sync paused レスポンスに choice 情報が含まれる
  - `test_http_stream_api.py`: SSE paused イベントに choice 情報が含まれる

## Verification

- `uv run pytest` — 188 passed
- `uv run ruff check .` — passed
- `uv run ruff format --check .` — passed
- `uv run ty check` — passed
