### PR TITLE
feat: show LLM model name next to agent selector in test page

### DIFF
--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/api.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/api.py
@@ -320,8 +320,8 @@ def create_app(
         return StreamingResponse(event_stream(), media_type="text/event-stream")
 
     @app.get("/api/agents")
-    def list_agents() -> dict[str, list[str]]:
-        return {"agents": definitions.list_ids()}
+    def list_agents() -> dict[str, list[dict[str, str]]]:
+        return {"agents": definitions.list_agents()}
 
     @app.get("/", response_class=HTMLResponse)
     def test_page() -> HTMLResponse:

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/test_page.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/test_page.py
@@ -41,6 +41,7 @@ TEST_PAGE_HTML = """<!doctype html>
   .line-paused { color: var(--pause); }
   .line-error { color: var(--error); }
   .line-system { color: var(--muted); font-style: italic; }
+  .model-badge { font-size: 11px; font-family: ui-monospace, 'Cascadia Code', monospace; color: var(--text); background: var(--bg); border: 1px solid var(--border); border-radius: 4px; padding: 3px 8px; margin: 0 10px 0 4px; white-space: nowrap; }
 </style>
 </head>
 <body>
@@ -56,7 +57,7 @@ TEST_PAGE_HTML = """<!doctype html>
     <select id="agent-id" onchange="onAgentIdChange()">
     </select>
   </label>
-  <span id="agent-model" style="font-size:12px;color:var(--muted);margin-left:4px;"></span>
+  <span id="agent-model" class="model-badge"></span>
   <label>Session
     <input type="text" id="session-id" size="24" placeholder="(new)" onchange="onSessionIdChange()">
   </label>

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/test_page.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/test_page.py
@@ -56,6 +56,7 @@ TEST_PAGE_HTML = """<!doctype html>
     <select id="agent-id" onchange="onAgentIdChange()">
     </select>
   </label>
+  <span id="agent-model" style="font-size:12px;color:var(--muted);margin-left:4px;"></span>
   <label>Session
     <input type="text" id="session-id" size="24" placeholder="(new)" onchange="onSessionIdChange()">
   </label>
@@ -108,6 +109,12 @@ function onModeChange() {
 
 function onAgentIdChange() {
   state.agentId = el("agent-id").value;
+  const option = el("agent-id").selectedOptions[0];
+  if (option && option.dataset.model) {
+    el("agent-model").textContent = option.dataset.model;
+  } else {
+    el("agent-model").textContent = "";
+  }
   persist();
 }
 
@@ -148,18 +155,22 @@ async function fetchAgents() {
     const data = await resp.json();
     const select = el("agent-id");
     select.innerHTML = "";
-    for (const id of data.agents) {
+    const agentIds = [];
+    for (const agent of data.agents) {
       const option = document.createElement("option");
-      option.value = id;
-      option.textContent = id;
+      option.value = agent.id;
+      option.textContent = agent.id;
+      option.dataset.model = agent.model;
       select.appendChild(option);
+      agentIds.push(agent.id);
     }
-    if (state.agentId && data.agents.includes(state.agentId)) {
+    if (state.agentId && agentIds.includes(state.agentId)) {
       select.value = state.agentId;
-    } else if (data.agents.length > 0) {
-      select.value = data.agents[0];
-      state.agentId = data.agents[0];
+    } else if (agentIds.length > 0) {
+      select.value = agentIds[0];
+      state.agentId = agentIds[0];
     }
+    onAgentIdChange();
   } catch (_) {}
 }
 

--- a/projects/simple-agent-poc/src/simple_agent_poc/core/agent_definition.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/core/agent_definition.py
@@ -91,6 +91,13 @@ class AgentDefinitionRegistry:
         """Return all registered agent ids."""
         return list(self._definitions.keys())
 
+    def list_agents(self) -> list[dict[str, str]]:
+        """Return all registered agents with their model names."""
+        return [
+            {"id": agent.agent_id, "model": agent.model}
+            for agent in self._definitions.values()
+        ]
+
 
 def _build_agent_definition(
     agent_id: object,


### PR DESCRIPTION
## Summary

テストページのAgent選択ドロップダウンの横に、選択中のAgentが使用するLLMモデル名を表示するようにしました。

## Changes

- `/api/agents` エンドポイントのレスポンスを拡張し、各Agentの `id` と `model` を返すように変更
- `AgentDefinitionRegistry` に `list_agents()` メソッドを追加
- テストページのJSでAgent選択時にモデル名を更新する処理を追加
- テストページのHTMLにモデル名表示用の `<span>` を追加

## Checklist

- [x] テストが全て通過 (`uv run pytest`)
- [x] リンターを通過 (`uv run ruff check .`)
