### PR TITLE
feat(simple-agent-poc): add JSONL debug logging for agent execution

### DIFF
--- a/projects/simple-agent-poc/README.md
+++ b/projects/simple-agent-poc/README.md
@@ -51,5 +51,6 @@ Detailed specifications:
 - [Bootstrap / DI](docs/bootstrap.md)
 - [Type Reference](docs/types.md)
 - [Error Handling](docs/errors.md)
+- [Debug Logging](docs/logging.md)
 - [Development Guide](docs/development.md)
 - [Testing Guide](docs/testing.md)

--- a/projects/simple-agent-poc/docs/development.md
+++ b/projects/simple-agent-poc/docs/development.md
@@ -71,3 +71,8 @@ api = "simple_agent_poc.entrypoints.main_api:main"
 ```
 
 These are invoked via `uv run dev` and `uv run api`.
+
+## Debug Logging
+
+Both CLI and API write JSONL debug logs to `logs/agent-debug.jsonl` by default.
+See [docs/logging.md](logging.md) for configuration, event schema, and payload policies.

--- a/projects/simple-agent-poc/docs/logging.md
+++ b/projects/simple-agent-poc/docs/logging.md
@@ -1,0 +1,183 @@
+# Debug Logging
+
+## Overview
+
+`simple-agent-poc` writes structured JSONL debug logs for every agent execution.  
+Logs are intended for local debugging and coding-agent handoff — not for production-grade audit trails.
+
+## Where Logs Are Written
+
+Default output file: `logs/agent-debug.jsonl`
+
+The `logs/` directory is already listed in `.gitignore`.
+
+## Configuration
+
+| Environment Variable | Default | Description |
+|:---|:---|:---|
+| `SIMPLE_AGENT_LOG_ENABLED` | `true` | Set to `false` to disable all debug logging. |
+| `SIMPLE_AGENT_LOG_FILE` | `logs/agent-debug.jsonl` | Path to the JSONL output file. |
+| `SIMPLE_AGENT_LOG_LEVEL` | `INFO` | Minimum log level: `DEBUG`, `INFO`, `WARNING`, `ERROR`. |
+| `SIMPLE_AGENT_LOG_PAYLOADS` | `summary` | Payload policy: `summary`, `metadata`, or `full`. |
+| `SIMPLE_AGENT_LOG_MAX_FIELD_CHARS` | `500` | Maximum characters in `preview` under the `summary` policy. |
+
+Example `.env` entries:
+
+```bash
+SIMPLE_AGENT_LOG_ENABLED=true
+SIMPLE_AGENT_LOG_PAYLOADS=summary
+SIMPLE_AGENT_LOG_MAX_FIELD_CHARS=500
+```
+
+## JSONL Event Shape
+
+Each log line is a JSON object:
+
+```json
+{
+  "timestamp": "2026-05-19T00:00:00.000000Z",
+  "level": "INFO",
+  "event": "agent.run.start",
+  "logger": "simple_agent_poc.observability",
+  "run_id": "hex-string",
+  "session_id": "session-id-or-null",
+  "agent_id": "default",
+  "mode": "cli",
+  "round": 0,
+  "model": "gpt-4.1-mini",
+  "api_type": "completion",
+  "stream": false,
+  "tool_call_id": null,
+  "tool_name": null,
+  "elapsed_ms": 1234,
+  "usage": {
+    "prompt_tokens": 50,
+    "completion_tokens": 20,
+    "total_tokens": 70
+  },
+  "message_count": 4,
+  "payload": {
+    "preview": "short text",
+    "length": 100,
+    "sha256": "hash"
+  },
+  "error": null
+}
+```
+
+## How to Correlate Logs
+
+Search the JSONL file by:
+
+| Key | Purpose |
+|:---|:---|
+| `session_id` | Track all turns within one conversation. |
+| `run_id` | Track one invocation of `execute()` / `execute_stream()`. |
+| `agent_id` | Filter runs for a specific agent definition. |
+| `round` | Identify which ReAct round an event occurred in. |
+| `tool_call_id` | Trace a specific tool call through start/end/result. |
+
+Example using `jq`:
+
+```bash
+# Find all events for a specific session
+jq 'select(.session_id == "abc123")' logs/agent-debug.jsonl
+
+# Find all tool calls
+jq 'select(.event | startswith("tool.call."))' logs/agent-debug.jsonl
+
+# Find all errors
+jq 'select(.event | endswith(".error"))' logs/agent-debug.jsonl
+```
+
+## Payload Policies
+
+Control how request/response/tool payloads are stored:
+
+### `summary` (default)
+
+Stores `preview` (first N chars), `length`, `sha256`, and type information.  
+Safe for sharing with coding agents.
+
+### `metadata`
+
+Stores `length`, `sha256`, and type only — no content preview.  
+Use when the log file will be committed or shared outside the machine.
+
+### `full`
+
+Stores the complete content.  
+Use only for local debugging when full prompt/response inspection is needed.
+
+## What Should Be Shared with a Coding Agent
+
+When debugging agent behaviour with a coding agent:
+
+1. Set `SIMPLE_AGENT_LOG_PAYLOADS=summary` (default).
+2. Copy the relevant JSONL lines filtered by `session_id` or `run_id`.
+3. Share only the log lines — no source code, `.env`, or API keys.
+
+The `summary` policy excludes full prompt/response bodies while providing enough
+context (event names, token usage, tool call names, error messages) to diagnose
+most issues.
+
+## Event Reference
+
+### Agent Lifecycle
+
+| Event | Description |
+|:---|:---|
+| `agent.run.start` | A new execution run begins. |
+| `agent.run.end` | A run completes successfully. |
+| `agent.run.error` | A run fails with an exception. |
+
+### Session
+
+| Event | Description |
+|:---|:---|
+| `session.created` | A new conversation session is created. |
+| `session.loaded` | An existing session is loaded. |
+| `session.saved` | A session snapshot is persisted. |
+| `session.not_found` | Requested session does not exist. |
+
+### ReAct Round
+
+| Event | Description |
+|:---|:---|
+| `react.round.start` | A new ReAct round begins. |
+| `react.round.end` | A ReAct round completes. |
+| `react.max_rounds_exceeded` | Maximum tool-call rounds hit. |
+
+### LLM
+
+| Event | Description |
+|:---|:---|
+| `llm.request.start` | A synchronous LLM request begins. |
+| `llm.request.end` | A synchronous LLM request completes. |
+| `llm.request.error` | A synchronous LLM request fails. |
+| `llm.stream.start` | A streaming LLM request begins. |
+| `llm.stream.end` | A streaming LLM request completes. |
+| `llm.stream.error` | A streaming LLM request fails. |
+
+### Tool Calls
+
+| Event | Description |
+|:---|:---|
+| `tool.call.start` | Tool execution begins. |
+| `tool.call.end` | Tool execution completes. |
+| `tool.call.error` | Tool execution fails. |
+
+### ask_user / Pause-Resume
+
+| Event | Description |
+|:---|:---|
+| `ask_user.pause` | Session paused waiting for user input. |
+| `ask_user.resume` | A paused session is being resumed. |
+| `ask_user.answered` | User answers have been applied. |
+
+### Adapter Errors
+
+| Event | Description |
+|:---|:---|
+| `cli.turn.error` | An unhandled error occurred in the CLI loop. |
+| `http.request.error` | An unhandled error occurred in an HTTP request handler. |

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/cli/adapter.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/cli/adapter.py
@@ -26,6 +26,7 @@ from simple_agent_poc.adapters.cli.renderer import (
     with_indicator,
 )
 from simple_agent_poc.core.agent_definition import AgentDefinitionRegistry
+from simple_agent_poc.observability import log_event, summarize_payload
 
 
 class IndicatorRunner(Protocol):
@@ -150,4 +151,5 @@ class CLIAdapter:
                 self._exit_renderer()
                 break
             except Exception as error:
+                log_event("cli.turn.error", error=summarize_payload(str(error)))
                 self._error_renderer(error)

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/api.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/http/api.py
@@ -34,6 +34,7 @@ from simple_agent_poc.entrypoints.bootstrap import (
     create_agent_definition_registry,
     create_run_agent_use_case_factory,
 )
+from simple_agent_poc.observability import log_event, summarize_payload
 
 
 class ChatRequest(BaseModel):
@@ -188,10 +189,12 @@ def create_app(
                 )
             )
         except SessionNotFoundError as error:
+            log_event("http.request.error", error=summarize_payload(str(error)))
             raise HTTPException(
                 status_code=404, detail=error.display_message
             ) from error
         except ValidationError as error:
+            log_event("http.request.error", error=summarize_payload(str(error)))
             raise HTTPException(
                 status_code=400, detail=error.display_message
             ) from error
@@ -217,14 +220,17 @@ def create_app(
                 )
             )
         except SessionNotFoundError as error:
+            log_event("http.request.error", error=summarize_payload(str(error)))
             raise HTTPException(
                 status_code=404, detail=error.display_message
             ) from error
         except SessionNotPausedError as error:
+            log_event("http.request.error", error=summarize_payload(str(error)))
             raise HTTPException(
                 status_code=400, detail=error.display_message
             ) from error
         except ValidationError as error:
+            log_event("http.request.error", error=summarize_payload(str(error)))
             raise HTTPException(
                 status_code=400, detail=error.display_message
             ) from error
@@ -271,10 +277,13 @@ def create_app(
                         yield f"event: complete\ndata: {json.dumps(asdict(event), ensure_ascii=False)}\n\n"
                 yield "event: done\ndata: {}\n\n"
             except SessionNotFoundError as error:
+                log_event("http.request.error", error=summarize_payload(str(error)))
                 yield f"event: error\ndata: {json.dumps({'detail': error.display_message}, ensure_ascii=False)}\n\n"
             except ValidationError as error:
+                log_event("http.request.error", error=summarize_payload(str(error)))
                 yield f"event: error\ndata: {json.dumps({'detail': error.display_message}, ensure_ascii=False)}\n\n"
             except Exception as error:
+                log_event("http.request.error", error=summarize_payload(str(error)))
                 yield f"event: error\ndata: {json.dumps({'detail': str(error)}, ensure_ascii=False)}\n\n"
 
         return StreamingResponse(event_stream(), media_type="text/event-stream")

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/llm/litellm_client.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/llm/litellm_client.py
@@ -315,6 +315,7 @@ class LiteLLMCompletionClient(LLMClient):
 
         last_usage: Usage | None = None
         tool_call_count = 0
+        seen_call_ids: set[str] = set()
         for chunk in response:
             chunk_data: LLMStreamChunk = {"content_delta": None}
             if chunk.choices:
@@ -328,7 +329,9 @@ class LiteLLMCompletionClient(LLMClient):
                             "content_delta": None,
                             "tool_call_delta": td,
                         }
-                        if td.get("id"):
+                        call_id = td.get("id")
+                        if call_id and call_id not in seen_call_ids:
+                            seen_call_ids.add(call_id)
                             tool_call_count += 1
                         yield tc_chunk
             if hasattr(chunk, "usage") and chunk.usage is not None:

--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/llm/litellm_client.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/llm/litellm_client.py
@@ -22,7 +22,9 @@ from simple_agent_poc.core.types import (
     ToolCall,
     ToolCallDelta,
     ToolDefinition,
+    Usage,
 )
+from simple_agent_poc.observability import log_event, summarize_payload
 
 warnings.filterwarnings(
     "ignore",
@@ -160,6 +162,13 @@ class LiteLLMCompletionClient(LLMClient):
         *,
         tools: list[ToolDefinition] | None = None,
     ) -> LLMResponse:
+        log_event(
+            "llm.request.start",
+            model=self.model,
+            api_type="completion",
+            stream=False,
+            message_count=len(messages),
+        )
         start_time = time.perf_counter()
         completion_params: dict[str, object] = {}
         if self.temperature is not None:
@@ -175,16 +184,28 @@ class LiteLLMCompletionClient(LLMClient):
                 **completion_params,
             )
         except LiteLLMAuthError as error:
+            log_event(
+                "llm.request.error",
+                error=summarize_payload(str(error)),
+            )
             raise AuthenticationError(
                 message=str(error),
                 display_message="Authentication failed: Invalid API key. Please check your API_KEY setting.",
             ) from error
         except LiteLLMRateLimitError as error:
+            log_event(
+                "llm.request.error",
+                error=summarize_payload(str(error)),
+            )
             raise RateLimitError(
                 message=str(error),
                 display_message="Rate limit exceeded. Please wait a moment before trying again.",
             ) from error
         except Exception as error:
+            log_event(
+                "llm.request.error",
+                error=summarize_payload(str(error)),
+            )
             error_msg = str(error).lower()
             if (
                 "authentication" in error_msg
@@ -214,6 +235,16 @@ class LiteLLMCompletionClient(LLMClient):
         raw_tool_calls = getattr(response.choices[0].message, "tool_calls", None)
         if raw_tool_calls:
             result["tool_calls"] = _parse_tool_calls(raw_tool_calls)
+
+        log_event(
+            "llm.request.end",
+            model=self.model,
+            api_type="completion",
+            stream=False,
+            usage=result["usage"],
+            elapsed_ms=int(elapsed * 1000),
+            tool_call_count=len(result.get("tool_calls", [])),
+        )
         return result
 
     def complete_stream(
@@ -222,6 +253,14 @@ class LiteLLMCompletionClient(LLMClient):
         *,
         tools: list[ToolDefinition] | None = None,
     ) -> Iterator[LLMStreamChunk]:
+        log_event(
+            "llm.stream.start",
+            model=self.model,
+            api_type="completion",
+            stream=True,
+            message_count=len(messages),
+        )
+        start_time = time.perf_counter()
         completion_params: dict[str, object] = {}
         if self.temperature is not None:
             completion_params["temperature"] = self.temperature
@@ -237,16 +276,28 @@ class LiteLLMCompletionClient(LLMClient):
                 **completion_params,
             )
         except LiteLLMAuthError as error:
+            log_event(
+                "llm.stream.error",
+                error=summarize_payload(str(error)),
+            )
             raise AuthenticationError(
                 message=str(error),
                 display_message="Authentication failed: Invalid API key. Please check your API_KEY setting.",
             ) from error
         except LiteLLMRateLimitError as error:
+            log_event(
+                "llm.stream.error",
+                error=summarize_payload(str(error)),
+            )
             raise RateLimitError(
                 message=str(error),
                 display_message="Rate limit exceeded. Please wait a moment before trying again.",
             ) from error
         except Exception as error:
+            log_event(
+                "llm.stream.error",
+                error=summarize_payload(str(error)),
+            )
             error_msg = str(error).lower()
             if (
                 "authentication" in error_msg
@@ -262,6 +313,8 @@ class LiteLLMCompletionClient(LLMClient):
                 display_message=f"An error occurred while communicating with the LLM: {error}",
             ) from error
 
+        last_usage: Usage | None = None
+        tool_call_count = 0
         for chunk in response:
             chunk_data: LLMStreamChunk = {"content_delta": None}
             if chunk.choices:
@@ -275,6 +328,8 @@ class LiteLLMCompletionClient(LLMClient):
                             "content_delta": None,
                             "tool_call_delta": td,
                         }
+                        if td.get("id"):
+                            tool_call_count += 1
                         yield tc_chunk
             if hasattr(chunk, "usage") and chunk.usage is not None:
                 chunk_data["usage"] = {
@@ -282,8 +337,20 @@ class LiteLLMCompletionClient(LLMClient):
                     "completion_tokens": chunk.usage.completion_tokens,
                     "total_tokens": chunk.usage.total_tokens,
                 }
+                last_usage = chunk_data["usage"]
             if chunk_data["content_delta"] is not None or "usage" in chunk_data:
                 yield chunk_data
+
+        elapsed = time.perf_counter() - start_time
+        log_event(
+            "llm.stream.end",
+            model=self.model,
+            api_type="completion",
+            stream=True,
+            usage=last_usage,
+            elapsed_ms=int(elapsed * 1000),
+            tool_call_count=tool_call_count,
+        )
 
 
 class LiteLLMResponsesClient(LLMClient):
@@ -299,6 +366,13 @@ class LiteLLMResponsesClient(LLMClient):
         *,
         tools: list[ToolDefinition] | None = None,
     ) -> LLMResponse:
+        log_event(
+            "llm.request.start",
+            model=self.model,
+            api_type="responses",
+            stream=False,
+            message_count=len(messages),
+        )
         start_time = time.perf_counter()
         response_params: dict[str, object] = {}
         if self.temperature is not None:
@@ -314,16 +388,28 @@ class LiteLLMResponsesClient(LLMClient):
                 **response_params,
             )
         except LiteLLMAuthError as error:
+            log_event(
+                "llm.request.error",
+                error=summarize_payload(str(error)),
+            )
             raise AuthenticationError(
                 message=str(error),
                 display_message="Authentication failed: Invalid API key. Please check your API_KEY setting.",
             ) from error
         except LiteLLMRateLimitError as error:
+            log_event(
+                "llm.request.error",
+                error=summarize_payload(str(error)),
+            )
             raise RateLimitError(
                 message=str(error),
                 display_message="Rate limit exceeded. Please wait a moment before trying again.",
             ) from error
         except Exception as error:
+            log_event(
+                "llm.request.error",
+                error=summarize_payload(str(error)),
+            )
             error_msg = str(error).lower()
             if (
                 "authentication" in error_msg
@@ -355,6 +441,16 @@ class LiteLLMResponsesClient(LLMClient):
         )
         if tool_calls:
             result["tool_calls"] = tool_calls
+
+        log_event(
+            "llm.request.end",
+            model=self.model,
+            api_type="responses",
+            stream=False,
+            usage=result["usage"],
+            elapsed_ms=int(elapsed * 1000),
+            tool_call_count=len(result.get("tool_calls", [])),
+        )
         return result
 
     def complete_stream(
@@ -363,6 +459,14 @@ class LiteLLMResponsesClient(LLMClient):
         *,
         tools: list[ToolDefinition] | None = None,
     ) -> Iterator[LLMStreamChunk]:
+        log_event(
+            "llm.stream.start",
+            model=self.model,
+            api_type="responses",
+            stream=True,
+            message_count=len(messages),
+        )
+        start_time = time.perf_counter()
         response_params: dict[str, object] = {}
         if self.temperature is not None:
             response_params["temperature"] = self.temperature
@@ -377,16 +481,28 @@ class LiteLLMResponsesClient(LLMClient):
                 **response_params,
             )
         except LiteLLMAuthError as error:
+            log_event(
+                "llm.stream.error",
+                error=summarize_payload(str(error)),
+            )
             raise AuthenticationError(
                 message=str(error),
                 display_message="Authentication failed: Invalid API key. Please check your API_KEY setting.",
             ) from error
         except LiteLLMRateLimitError as error:
+            log_event(
+                "llm.stream.error",
+                error=summarize_payload(str(error)),
+            )
             raise RateLimitError(
                 message=str(error),
                 display_message="Rate limit exceeded. Please wait a moment before trying again.",
             ) from error
         except Exception as error:
+            log_event(
+                "llm.stream.error",
+                error=summarize_payload(str(error)),
+            )
             error_msg = str(error).lower()
             if (
                 "authentication" in error_msg
@@ -403,6 +519,8 @@ class LiteLLMResponsesClient(LLMClient):
             ) from error
 
         call_ids_by_output_index: dict[int, str] = {}
+        last_usage: Usage | None = None
+        tool_call_count = 0
         for event in response:
             event_type = getattr(event, "type", None)
 
@@ -413,6 +531,7 @@ class LiteLLMResponsesClient(LLMClient):
                     call_id = _item_attr(item, "call_id", None)
                     if call_id:
                         call_ids_by_output_index[output_index] = call_id
+                        tool_call_count += 1
                     td: ToolCallDelta = {
                         "index": output_index,
                         "id": call_id,
@@ -450,8 +569,20 @@ class LiteLLMResponsesClient(LLMClient):
                         "completion_tokens": usage_obj.output_tokens,
                         "total_tokens": usage_obj.total_tokens,
                     }
+                    last_usage = chunk_data["usage"]
             if chunk_data["content_delta"] is not None or "usage" in chunk_data:
                 yield chunk_data
+
+        elapsed = time.perf_counter() - start_time
+        log_event(
+            "llm.stream.end",
+            model=self.model,
+            api_type="responses",
+            stream=True,
+            usage=last_usage,
+            elapsed_ms=int(elapsed * 1000),
+            tool_call_count=tool_call_count,
+        )
 
 
 class LiteLLMClientFactory:

--- a/projects/simple-agent-poc/src/simple_agent_poc/application/use_cases.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/application/use_cases.py
@@ -6,6 +6,12 @@ from collections.abc import Generator
 from datetime import datetime, timezone
 from uuid import uuid4
 
+from simple_agent_poc.observability import (
+    bind_log_context,
+    log_event,
+    summarize_payload,
+)
+
 from simple_agent_poc.application.dto import (
     ContentDelta,
     ContinueRequest,
@@ -224,32 +230,64 @@ class RunAgentUseCase:
         if not request.message.strip():
             raise ValidationError("message must not be blank")
 
+        run_id = uuid4().hex
         agent_definition = self._agent_definitions.get(request.agent_id)
+        mode = "api" if self._is_api_context else "cli"
+        bind_log_context(
+            run_id=run_id,
+            agent_id=agent_definition.agent_id,
+            mode=mode,
+        )
         session = self._load_session(
             request.session_id,
             agent_definition=agent_definition,
         )
+        bind_log_context(session_id=session.session_id)
         if session.agent_id != agent_definition.agent_id:
             raise ValidationError("agent_id cannot be changed for an existing session")
         session.append_user_message(request.message)
 
+        log_event(
+            "agent.run.start",
+            run_id=run_id,
+            model=agent_definition.model,
+            api_type=agent_definition.api_type,
+            stream=False,
+        )
+
         tool_call_history: list[ToolCallRecord] = []
 
         try:
-            return self._run_react_loop(
+            result = self._run_react_loop(
                 session=session,
                 start_round=0,
                 tool_call_history=tool_call_history,
             )
+            if isinstance(result, RunAgentResponse):
+                log_event(
+                    "agent.run.end",
+                    run_id=run_id,
+                    usage=result.usage if result.usage else None,
+                    model=result.model,
+                    elapsed_ms=int(result.response_time * 1000),
+                )
+            return result
+        except Exception as exc:
+            log_event("agent.run.error", error=summarize_payload(str(exc)))
+            raise
         finally:
             self._session_store.save(session)
+            log_event("session.saved")
 
     def continue_sync(
         self, request: ContinueRequest
     ) -> RunAgentResponse | RunAgentPaused:
         """Resume a paused session synchronously with the user's answers."""
+        run_id = uuid4().hex
+
         session = self._session_store.get(request.session_id)
         if session is None:
+            log_event("session.not_found", session_id=request.session_id)
             raise SessionNotFoundError(
                 f"Session not found: {request.session_id}",
                 display_message="Session not found.",
@@ -264,21 +302,52 @@ class RunAgentUseCase:
         if tc is None:
             raise RuntimeError("Session is paused but no pending tool call found")
 
+        bind_log_context(
+            run_id=run_id,
+            session_id=session.session_id,
+            agent_id=session.agent_id,
+            mode="api" if self._is_api_context else "cli",
+        )
+        log_event("ask_user.resume", run_id=run_id, tool_call_id=tc["id"])
+
         _replace_all_ask_user_placeholders(session, request.answers, tc)
+        log_event("ask_user.answered", tool_call_id=tc["id"])
 
         resume_round = session.pending_round
         session.resume_with_answer()
 
+        agent_definition = self._agent_definitions.get(session.agent_id)
+        log_event(
+            "agent.run.start",
+            run_id=run_id,
+            model=agent_definition.model,
+            api_type=agent_definition.api_type,
+            stream=False,
+        )
+
         tool_call_history: list[ToolCallRecord] = []
 
         try:
-            return self._run_react_loop(
+            result = self._run_react_loop(
                 session=session,
                 start_round=resume_round + 1,
                 tool_call_history=tool_call_history,
             )
+            if isinstance(result, RunAgentResponse):
+                log_event(
+                    "agent.run.end",
+                    run_id=run_id,
+                    usage=result.usage if result.usage else None,
+                    model=result.model,
+                    elapsed_ms=int(result.response_time * 1000),
+                )
+            return result
+        except Exception as exc:
+            log_event("agent.run.error", error=summarize_payload(str(exc)))
+            raise
         finally:
             self._session_store.save(session)
+            log_event("session.saved")
 
     def _run_react_loop(
         self,
@@ -293,7 +362,11 @@ class RunAgentUseCase:
         ask_user_answered = start_round > 0
 
         for round_idx in range(start_round, agent_definition.max_tool_rounds):
+            log_event("react.round.start", round=round_idx)
             round_tools = _tools_without_ask_user(tools) if ask_user_answered else tools
+            message_count = len(
+                _messages_for_llm(session, ask_user_answered=ask_user_answered)
+            )
             response = llm_client.complete(
                 _messages_for_llm(session, ask_user_answered=ask_user_answered),
                 tools=round_tools,
@@ -302,6 +375,13 @@ class RunAgentUseCase:
             tool_calls = response.get("tool_calls")
             if not tool_calls:
                 session.append_assistant_message(response["content"])
+                log_event(
+                    "react.round.end",
+                    round=round_idx,
+                    usage=response.get("usage"),
+                    message_count=message_count,
+                    elapsed_ms=int(response["response_time"] * 1000),
+                )
                 return RunAgentResponse.from_llm_response(
                     response,
                     session_id=session.session_id,
@@ -323,7 +403,30 @@ class RunAgentUseCase:
             for tc in tool_calls:
                 if tc["function"]["name"] == "ask_user":
                     continue
-                result = self._tool_executor.execute(tc)
+                log_event(
+                    "tool.call.start",
+                    tool_call_id=tc["id"],
+                    tool_name=tc["function"]["name"],
+                    round=round_idx,
+                )
+                try:
+                    result = self._tool_executor.execute(tc)
+                except Exception as exc:
+                    log_event(
+                        "tool.call.error",
+                        tool_call_id=tc["id"],
+                        tool_name=tc["function"]["name"],
+                        round=round_idx,
+                        error=summarize_payload(str(exc)),
+                    )
+                    raise
+                log_event(
+                    "tool.call.end",
+                    tool_call_id=tc["id"],
+                    tool_name=tc["function"]["name"],
+                    round=round_idx,
+                    payload=summarize_payload(result),
+                )
                 session.append_tool_message(result, tool_call_id=tc["id"])
                 tool_call_history.append(
                     ToolCallRecord(
@@ -345,6 +448,11 @@ class RunAgentUseCase:
                 for tc in ask_user_tcs:
                     session.append_tool_message("", tool_call_id=tc["id"])
 
+                log_event(
+                    "ask_user.pause",
+                    tool_call_id=ask_user_tcs[0]["id"],
+                    round=round_idx,
+                )
                 return self._build_paused_result(
                     session=session,
                     ask_user_tc=ask_user_tcs[0],
@@ -353,6 +461,15 @@ class RunAgentUseCase:
                     aggregated_questions=all_questions,
                 )
 
+            log_event(
+                "react.round.end",
+                round=round_idx,
+                usage=response.get("usage"),
+                message_count=message_count,
+                elapsed_ms=int(response["response_time"] * 1000),
+            )
+
+        log_event("react.max_rounds_exceeded")
         raise LLMError(
             "Exceeded maximum tool call rounds",
             display_message="Exceeded maximum tool call rounds.",
@@ -374,14 +491,30 @@ class RunAgentUseCase:
         if not request.message.strip():
             raise ValidationError("message must not be blank")
 
+        run_id = uuid4().hex
         agent_definition = self._agent_definitions.get(request.agent_id)
+        mode = "api" if self._is_api_context else "cli"
+        bind_log_context(
+            run_id=run_id,
+            agent_id=agent_definition.agent_id,
+            mode=mode,
+        )
         session = self._load_session(
             request.session_id,
             agent_definition=agent_definition,
         )
+        bind_log_context(session_id=session.session_id)
         if session.agent_id != agent_definition.agent_id:
             raise ValidationError("agent_id cannot be changed for an existing session")
         session.append_user_message(request.message)
+
+        log_event(
+            "agent.run.start",
+            run_id=run_id,
+            model=agent_definition.model,
+            api_type=agent_definition.api_type,
+            stream=True,
+        )
 
         llm_client = self._llm_client_factory(agent_definition)
         tools = self._resolve_tools(agent_definition)
@@ -392,11 +525,18 @@ class RunAgentUseCase:
 
         try:
             for round_idx in range(agent_definition.max_tool_rounds):
+                log_event("react.round.start", round=round_idx)
                 _accumulated_text = ""
                 accumulated_tool_calls: dict[int, ToolCall] = {}
                 usage_from_stream: Usage | None = None
                 round_tools = (
                     _tools_without_ask_user(tools) if ask_user_answered else tools
+                )
+                message_count = len(
+                    _messages_for_llm(
+                        session,
+                        ask_user_answered=ask_user_answered,
+                    )
                 )
 
                 for chunk in llm_client.complete_stream(
@@ -463,17 +603,46 @@ class RunAgentUseCase:
                         for tc in tool_calls:
                             if tc["function"]["name"] == "ask_user":
                                 continue
-                            result = self._tool_executor.execute(tc)
+                            log_event(
+                                "tool.call.start",
+                                tool_call_id=tc["id"],
+                                tool_name=tc["function"]["name"],
+                                round=round_idx,
+                            )
+                            try:
+                                result = self._tool_executor.execute(tc)
+                            except Exception as exc:
+                                log_event(
+                                    "tool.call.error",
+                                    tool_call_id=tc["id"],
+                                    tool_name=tc["function"]["name"],
+                                    round=round_idx,
+                                    error=summarize_payload(str(exc)),
+                                )
+                                raise
+                            log_event(
+                                "tool.call.end",
+                                tool_call_id=tc["id"],
+                                tool_name=tc["function"]["name"],
+                                round=round_idx,
+                                payload=summarize_payload(result),
+                            )
                             session.append_tool_message(result, tool_call_id=tc["id"])
                             yield ToolResultEvent(
                                 call_id=tc["id"],
                                 name=tc["function"]["name"],
                                 result=result,
                             )
+                        log_event(
+                            "ask_user.pause",
+                            tool_call_id=ask_user_tc["id"],
+                            round=round_idx,
+                        )
                         session.pause_for_ask_user(ask_user_tc, round_idx=round_idx)
                         for tc in ask_user_tcs:
                             session.append_tool_message("", tool_call_id=tc["id"])
                         self._session_store.save(session)
+                        log_event("session.saved")
                         yield SessionPaused(
                             session_id=session.session_id,
                             call_id=ask_user_tc["id"],
@@ -495,22 +664,71 @@ class RunAgentUseCase:
                                 user_answers or {}, questions
                             )
                             ask_user_answered = True
+                            log_event(
+                                "ask_user.answered",
+                                tool_call_id=tc["id"],
+                                round=round_idx,
+                            )
                         else:
+                            log_event(
+                                "tool.call.start",
+                                tool_call_id=tc["id"],
+                                tool_name=tc["function"]["name"],
+                                round=round_idx,
+                            )
                             yield ToolCallEvent(
                                 call_id=tc["id"],
                                 name=tc["function"]["name"],
                                 arguments=tc["function"]["arguments"],
                             )
-                            result = self._tool_executor.execute(tc)
+                            try:
+                                result = self._tool_executor.execute(tc)
+                            except Exception as exc:
+                                log_event(
+                                    "tool.call.error",
+                                    tool_call_id=tc["id"],
+                                    tool_name=tc["function"]["name"],
+                                    round=round_idx,
+                                    error=summarize_payload(str(exc)),
+                                )
+                                raise
+                            log_event(
+                                "tool.call.end",
+                                tool_call_id=tc["id"],
+                                tool_name=tc["function"]["name"],
+                                round=round_idx,
+                                payload=summarize_payload(result),
+                            )
                         session.append_tool_message(result, tool_call_id=tc["id"])
                         yield ToolResultEvent(
                             call_id=tc["id"],
                             name=tc["function"]["name"],
                             result=result,
                         )
+                    log_event(
+                        "react.round.end",
+                        round=round_idx,
+                        usage=usage_from_stream,
+                        message_count=message_count,
+                        stream=True,
+                    )
                 else:
                     session.append_assistant_message(_accumulated_text)
                     elapsed = time.perf_counter() - _start_time
+                    log_event(
+                        "react.round.end",
+                        round=round_idx,
+                        usage=usage_from_stream,
+                        message_count=message_count,
+                        stream=True,
+                    )
+                    log_event(
+                        "agent.run.end",
+                        run_id=run_id,
+                        usage=usage_from_stream,
+                        model=model,
+                        elapsed_ms=int(elapsed * 1000),
+                    )
                     yield StreamComplete(
                         session_id=session.session_id,
                         usage=usage_from_stream,
@@ -519,11 +737,13 @@ class RunAgentUseCase:
                     )
                     return
 
+            log_event("react.max_rounds_exceeded")
             raise LLMError(
                 "Exceeded maximum tool call rounds",
                 display_message="Exceeded maximum tool call rounds.",
             )
-        except Exception:
+        except Exception as exc:
+            log_event("agent.run.error", error=summarize_payload(str(exc)))
             if _accumulated_text:
                 session.append_assistant_message(
                     f"{_accumulated_text}\n\n[stream interrupted]"
@@ -533,6 +753,7 @@ class RunAgentUseCase:
             raise
         finally:
             self._session_store.save(session)
+            log_event("session.saved")
 
     def continue_stream(
         self, request: ContinueRequest
@@ -542,8 +763,11 @@ class RunAgentUseCase:
         None,
     ]:
         """Resume a paused session with the user's answers."""
+        run_id = uuid4().hex
+
         session = self._session_store.get(request.session_id)
         if session is None:
+            log_event("session.not_found", session_id=request.session_id)
             raise SessionNotFoundError(
                 f"Session not found: {request.session_id}",
                 display_message="Session not found.",
@@ -558,8 +782,18 @@ class RunAgentUseCase:
         if tc is None:
             raise RuntimeError("Session is paused but no pending tool call found")
 
+        bind_log_context(
+            run_id=run_id,
+            session_id=session.session_id,
+            agent_id=session.agent_id,
+            mode="api" if self._is_api_context else "cli",
+        )
+        log_event("ask_user.resume", run_id=run_id, tool_call_id=tc["id"])
+
         results = _replace_all_ask_user_placeholders(session, request.answers, tc)
+        log_event("ask_user.answered", tool_call_id=tc["id"])
         self._session_store.save(session)
+        log_event("session.saved")
         for call_id, result in results:
             yield ToolResultEvent(call_id=call_id, name="ask_user", result=result)
 
@@ -567,6 +801,14 @@ class RunAgentUseCase:
         session.resume_with_answer()
 
         agent_definition = self._agent_definitions.get(session.agent_id)
+        log_event(
+            "agent.run.start",
+            run_id=run_id,
+            model=agent_definition.model,
+            api_type=agent_definition.api_type,
+            stream=True,
+        )
+
         llm_client = self._llm_client_factory(agent_definition)
         tools = self._resolve_tools(agent_definition)
         model = agent_definition.model
@@ -576,11 +818,18 @@ class RunAgentUseCase:
 
         try:
             for round_idx in range(resume_round + 1, agent_definition.max_tool_rounds):
+                log_event("react.round.start", round=round_idx)
                 _accumulated_text = ""
                 accumulated_tool_calls: dict[int, ToolCall] = {}
                 usage_from_stream: Usage | None = None
                 round_tools = (
                     _tools_without_ask_user(tools) if ask_user_answered else tools
+                )
+                message_count = len(
+                    _messages_for_llm(
+                        session,
+                        ask_user_answered=ask_user_answered,
+                    )
                 )
 
                 for chunk in llm_client.complete_stream(
@@ -647,17 +896,46 @@ class RunAgentUseCase:
                         for tc in tool_calls:
                             if tc["function"]["name"] == "ask_user":
                                 continue
-                            result = self._tool_executor.execute(tc)
+                            log_event(
+                                "tool.call.start",
+                                tool_call_id=tc["id"],
+                                tool_name=tc["function"]["name"],
+                                round=round_idx,
+                            )
+                            try:
+                                result = self._tool_executor.execute(tc)
+                            except Exception as exc:
+                                log_event(
+                                    "tool.call.error",
+                                    tool_call_id=tc["id"],
+                                    tool_name=tc["function"]["name"],
+                                    round=round_idx,
+                                    error=summarize_payload(str(exc)),
+                                )
+                                raise
+                            log_event(
+                                "tool.call.end",
+                                tool_call_id=tc["id"],
+                                tool_name=tc["function"]["name"],
+                                round=round_idx,
+                                payload=summarize_payload(result),
+                            )
                             session.append_tool_message(result, tool_call_id=tc["id"])
                             yield ToolResultEvent(
                                 call_id=tc["id"],
                                 name=tc["function"]["name"],
                                 result=result,
                             )
+                        log_event(
+                            "ask_user.pause",
+                            tool_call_id=ask_user_tc["id"],
+                            round=round_idx,
+                        )
                         session.pause_for_ask_user(ask_user_tc, round_idx=round_idx)
                         for tc in ask_user_tcs:
                             session.append_tool_message("", tool_call_id=tc["id"])
                         self._session_store.save(session)
+                        log_event("session.saved")
                         yield SessionPaused(
                             session_id=session.session_id,
                             call_id=ask_user_tc["id"],
@@ -666,16 +944,60 @@ class RunAgentUseCase:
                         return
 
                     for tc in tool_calls:
-                        result = self._tool_executor.execute(tc)
+                        log_event(
+                            "tool.call.start",
+                            tool_call_id=tc["id"],
+                            tool_name=tc["function"]["name"],
+                            round=round_idx,
+                        )
+                        try:
+                            result = self._tool_executor.execute(tc)
+                        except Exception as exc:
+                            log_event(
+                                "tool.call.error",
+                                tool_call_id=tc["id"],
+                                tool_name=tc["function"]["name"],
+                                round=round_idx,
+                                error=summarize_payload(str(exc)),
+                            )
+                            raise
+                        log_event(
+                            "tool.call.end",
+                            tool_call_id=tc["id"],
+                            tool_name=tc["function"]["name"],
+                            round=round_idx,
+                            payload=summarize_payload(result),
+                        )
                         session.append_tool_message(result, tool_call_id=tc["id"])
                         yield ToolResultEvent(
                             call_id=tc["id"],
                             name=tc["function"]["name"],
                             result=result,
                         )
+                    log_event(
+                        "react.round.end",
+                        round=round_idx,
+                        usage=usage_from_stream,
+                        message_count=message_count,
+                        stream=True,
+                    )
                 else:
                     session.append_assistant_message(_accumulated_text)
                     elapsed = time.perf_counter() - _start_time
+                    log_event(
+                        "react.round.end",
+                        round=round_idx,
+                        usage=usage_from_stream,
+                        message_count=message_count,
+                        stream=True,
+                    )
+                    log_event(
+                        "agent.run.end",
+                        run_id=run_id,
+                        usage=usage_from_stream,
+                        model=model,
+                        elapsed_ms=int(elapsed * 1000),
+                    )
                     yield StreamComplete(
                         session_id=session.session_id,
                         usage=usage_from_stream,
@@ -684,11 +1006,13 @@ class RunAgentUseCase:
                     )
                     return
 
+            log_event("react.max_rounds_exceeded")
             raise LLMError(
                 "Exceeded maximum tool call rounds",
                 display_message="Exceeded maximum tool call rounds.",
             )
-        except Exception:
+        except Exception as exc:
+            log_event("agent.run.error", error=summarize_payload(str(exc)))
             if _accumulated_text:
                 session.append_assistant_message(
                     f"{_accumulated_text}\n\n[stream interrupted]"
@@ -698,6 +1022,7 @@ class RunAgentUseCase:
             raise
         finally:
             self._session_store.save(session)
+            log_event("session.saved")
 
     def _build_paused_result(
         self,
@@ -728,20 +1053,25 @@ class RunAgentUseCase:
         agent_definition: AgentDefinition,
     ) -> ConversationSession:
         if session_id is None:
-            return ConversationSession.start(
-                session_id=uuid4().hex,
+            new_id = uuid4().hex
+            session = ConversationSession.start(
+                session_id=new_id,
                 agent_id=agent_definition.agent_id,
                 system_prompt=agent_definition.format_system_prompt(
                     current_datetime=datetime.now(timezone.utc).isoformat()
                 ),
             )
+            log_event("session.created", session_id=new_id)
+            return session
 
         session = self._session_store.get(session_id)
         if session is None:
+            log_event("session.not_found", session_id=session_id)
             raise SessionNotFoundError(
                 f"Session not found: {session_id}",
                 display_message="Session not found.",
             )
+        log_event("session.loaded", session_id=session_id)
         return session
 
     def _resolve_tools(

--- a/projects/simple-agent-poc/src/simple_agent_poc/entrypoints/bootstrap.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/entrypoints/bootstrap.py
@@ -27,11 +27,13 @@ from simple_agent_poc.adapters.tools.registry import BuiltinToolRegistry
 from simple_agent_poc.application.ports import SessionStore, ToolExecutor
 from simple_agent_poc.application.use_cases import RunAgentUseCase
 from simple_agent_poc.core.agent_definition import AgentDefinitionRegistry
+from simple_agent_poc.observability import configure_logging
 
 logging.getLogger("litellm").setLevel(logging.CRITICAL)
 logging.getLogger("litellm").addHandler(logging.NullHandler())
 
 load_dotenv()
+configure_logging()
 
 DEFAULT_AGENT_ID = "default"
 DEFAULT_AGENTS_FILE = Path("agents.yaml")

--- a/projects/simple-agent-poc/src/simple_agent_poc/observability/__init__.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/observability/__init__.py
@@ -177,12 +177,9 @@ class _JSONLFormatter(logging.Formatter):
         obj["mode"] = _mode.get() or None
 
         # Everything else that was passed via ``extra``
-        for attr in dir(record):
-            if attr.startswith("_"):
-                continue
+        for attr, val in record.__dict__.items():
             if attr in _LOG_RECORD_ATTRS:
                 continue
-            val = getattr(record, attr, None)
             if val is not None:
                 obj[attr] = val
 
@@ -207,7 +204,12 @@ def configure_logging() -> None:
 
     _enabled = os.environ.get("SIMPLE_AGENT_LOG_ENABLED", "true").lower() != "false"
     _payload_policy = os.environ.get("SIMPLE_AGENT_LOG_PAYLOADS", "summary")
-    _max_field_chars = int(os.environ.get("SIMPLE_AGENT_LOG_MAX_FIELD_CHARS", "500"))
+    try:
+        _max_field_chars = int(
+            os.environ.get("SIMPLE_AGENT_LOG_MAX_FIELD_CHARS", "500")
+        )
+    except ValueError:
+        _max_field_chars = 500
 
     if not _enabled:
         return

--- a/projects/simple-agent-poc/src/simple_agent_poc/observability/__init__.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/observability/__init__.py
@@ -85,7 +85,7 @@ def summarize_payload(value: object) -> dict[str, object]:
             return {"type": "str", "length": len(value), "content": value}
         try:
             serialized = json.dumps(value, ensure_ascii=False, default=str)
-        except TypeError, ValueError:
+        except (TypeError, ValueError):  # fmt: skip
             return {"type": type(value).__name__, "length": 0, "content": str(value)}
         length = len(serialized)
         if isinstance(value, (dict, list)):

--- a/projects/simple-agent-poc/src/simple_agent_poc/observability/__init__.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/observability/__init__.py
@@ -1,0 +1,277 @@
+"""Structured JSONL debug logging for agent execution.
+
+Environment variables
+---------------------
+SIMPLE_AGENT_LOG_ENABLED : str = "true"
+    Set to "false" to disable logging.
+SIMPLE_AGENT_LOG_FILE : str = "logs/agent-debug.jsonl"
+    Path to the JSONL output file.
+SIMPLE_AGENT_LOG_LEVEL : str = "INFO"
+    Minimum log level (DEBUG, INFO, WARNING, ERROR).
+SIMPLE_AGENT_LOG_PAYLOADS : str = "summary"
+    Payload storage policy: ``summary``, ``metadata``, or ``full``.
+SIMPLE_AGENT_LOG_MAX_FIELD_CHARS : int = 500
+    Maximum characters in payload ``preview`` under the "summary" policy.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import hashlib
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+__all__ = [
+    "bind_log_context",
+    "configure_logging",
+    "log_event",
+    "summarize_payload",
+]
+
+# ---------------------------------------------------------------------------
+# Module state
+# ---------------------------------------------------------------------------
+
+_enabled: bool = True
+_payload_policy: str = "summary"
+_max_field_chars: int = 500
+_initialized: bool = False
+
+# ---------------------------------------------------------------------------
+# Logger + handler
+# ---------------------------------------------------------------------------
+
+_logger = logging.getLogger("simple_agent_poc.observability")
+_logger.propagate = False
+
+# ---------------------------------------------------------------------------
+# Context variables (asyncio-safe via contextvars)
+# ---------------------------------------------------------------------------
+
+_run_id: contextvars.ContextVar[str] = contextvars.ContextVar("run_id", default="")
+_session_id: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "session_id", default=""
+)
+_agent_id: contextvars.ContextVar[str] = contextvars.ContextVar("agent_id", default="")
+_mode: contextvars.ContextVar[str] = contextvars.ContextVar("mode", default="")
+
+
+# ---------------------------------------------------------------------------
+# Payload summarisation
+# ---------------------------------------------------------------------------
+
+
+def summarize_payload(value: object) -> dict[str, object]:
+    """Summarize *value* according to the active payload policy.
+
+    Policies
+    --------
+    ``summary`` (default)
+        Include ``preview``, ``length``, ``sha256``, and ``type``.
+    ``metadata``
+        Include ``length``, ``sha256``, and ``type`` only (no preview).
+    ``full``
+        Include the complete value under ``content``.
+    """
+    if value is None:
+        return {"type": "null", "length": 0}
+
+    # -- full ----------------------------------------------------------------
+    if _payload_policy == "full":
+        if isinstance(value, str):
+            return {"type": "str", "length": len(value), "content": value}
+        try:
+            serialized = json.dumps(value, ensure_ascii=False, default=str)
+        except TypeError, ValueError:
+            return {"type": type(value).__name__, "length": 0, "content": str(value)}
+        length = len(serialized)
+        if isinstance(value, (dict, list)):
+            return {
+                "type": type(value).__name__,
+                "length": length,
+                "content": json.loads(serialized),
+            }
+        return {"type": type(value).__name__, "length": length, "content": serialized}
+
+    # -- compute common fields ------------------------------------------------
+    if isinstance(value, str):
+        raw = value
+        type_name = "str"
+    elif isinstance(value, (dict, list)):
+        raw = json.dumps(value, ensure_ascii=False, default=str)
+        type_name = type(value).__name__
+    else:
+        raw = str(value)
+        type_name = type(value).__name__
+
+    digest = hashlib.sha256(raw.encode("utf-8", errors="replace")).hexdigest()
+    length = len(raw)
+
+    if _payload_policy == "metadata":
+        return {"type": type_name, "length": length, "sha256": digest}
+
+    # -- summary (default) ----------------------------------------------------
+    result: dict[str, object] = {
+        "type": type_name,
+        "length": length,
+        "sha256": digest,
+        "preview": raw[:_max_field_chars],
+    }
+    return result
+
+
+# ---------------------------------------------------------------------------
+# JSONL formatter
+# ---------------------------------------------------------------------------
+
+# Standard LogRecord attributes that we should *not* leak as event fields.
+_LOG_RECORD_ATTRS = frozenset(
+    [
+        "args",
+        "asctime",
+        "created",
+        "exc_info",
+        "exc_text",
+        "filename",
+        "funcName",
+        "levelname",
+        "levelno",
+        "lineno",
+        "message",
+        "module",
+        "msecs",
+        "msg",
+        "name",
+        "pathname",
+        "process",
+        "processName",
+        "relativeCreated",
+        "stack_info",
+        "thread",
+        "threadName",
+        "taskName",
+    ]
+)
+
+
+class _JSONLFormatter(logging.Formatter):
+    """Format a ``LogRecord`` as a single-line JSON object."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        obj: dict[str, object] = {
+            "timestamp": datetime.fromtimestamp(
+                record.created, tz=timezone.utc
+            ).strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+            "level": record.levelname,
+            "event": record.msg,
+            "logger": record.name,
+        }
+
+        # Context fields
+        obj["run_id"] = _run_id.get() or None
+        obj["session_id"] = _session_id.get() or None
+        obj["agent_id"] = _agent_id.get() or None
+        obj["mode"] = _mode.get() or None
+
+        # Everything else that was passed via ``extra``
+        for attr in dir(record):
+            if attr.startswith("_"):
+                continue
+            if attr in _LOG_RECORD_ATTRS:
+                continue
+            val = getattr(record, attr, None)
+            if val is not None:
+                obj[attr] = val
+
+        return json.dumps(obj, ensure_ascii=False, default=str) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Setup
+# ---------------------------------------------------------------------------
+
+
+def configure_logging() -> None:
+    """Read environment variables and enable JSONL debug logging.
+
+    Must be called once during bootstrap (CLI and API).  Subsequent calls
+    are no-ops so the function can safely appear in shared bootstrap code.
+    """
+    global _enabled, _payload_policy, _max_field_chars, _initialized
+    if _initialized:
+        return
+    _initialized = True
+
+    _enabled = os.environ.get("SIMPLE_AGENT_LOG_ENABLED", "true").lower() != "false"
+    _payload_policy = os.environ.get("SIMPLE_AGENT_LOG_PAYLOADS", "summary")
+    _max_field_chars = int(os.environ.get("SIMPLE_AGENT_LOG_MAX_FIELD_CHARS", "500"))
+
+    if not _enabled:
+        return
+
+    log_file = Path(os.environ.get("SIMPLE_AGENT_LOG_FILE", "logs/agent-debug.jsonl"))
+    level_name = os.environ.get("SIMPLE_AGENT_LOG_LEVEL", "INFO").upper()
+
+    log_file.parent.mkdir(parents=True, exist_ok=True)
+
+    handler = logging.FileHandler(str(log_file), encoding="utf-8")
+    handler.setFormatter(_JSONLFormatter())
+    _logger.addHandler(handler)
+    _logger.setLevel(getattr(logging, level_name, logging.INFO))
+
+
+# ---------------------------------------------------------------------------
+# Context binding
+# ---------------------------------------------------------------------------
+
+
+def bind_log_context(
+    *,
+    run_id: str = "",
+    session_id: str = "",
+    agent_id: str = "",
+    mode: str = "",
+) -> None:
+    """Bind execution-scoped context fields for the current logical path.
+
+    Uses ``contextvars`` so values propagate into async tasks and threads
+    without being passed explicitly through every abstraction layer.
+    """
+    if run_id:
+        _run_id.set(run_id)
+    if session_id:
+        _session_id.set(session_id)
+    if agent_id:
+        _agent_id.set(agent_id)
+    if mode:
+        _mode.set(mode)
+
+
+# ---------------------------------------------------------------------------
+# Event emission
+# ---------------------------------------------------------------------------
+
+
+def log_event(event: str, **fields: object) -> None:
+    """Emit a single structured log event.
+
+    Parameters
+    ----------
+    event : str
+        Dot-separated event name (e.g. ``"agent.run.start"``).
+    **fields : object
+        Arbitrary keyword arguments that will appear as top-level keys in
+        the JSON line.  Complex values (``dict``, ``list``, strings) are
+        serialised by the JSON formatter.
+
+    Context fields (``run_id``, ``session_id``, ``agent_id``, ``mode``)
+    are automatically included from the current ``contextvars`` state.
+    """
+    if not _enabled:
+        return
+
+    extra: dict[str, object] = dict(fields)
+    _logger.info(event, extra=extra)

--- a/projects/simple-agent-poc/tests/test_logging.py
+++ b/projects/simple-agent-poc/tests/test_logging.py
@@ -581,7 +581,6 @@ def test_agent_run_error_event(logging_use_case, temp_log_path, default_agent_de
 
         def complete_stream(self, messages, *, tools=None):
             raise LLMError("Simulated error.", display_message="Error.")
-            yield
 
     llm_client = _ErrorClient()
     use_case = logging_use_case(llm_client)

--- a/projects/simple-agent-poc/tests/test_logging.py
+++ b/projects/simple-agent-poc/tests/test_logging.py
@@ -1,0 +1,781 @@
+"""Tests for structured JSONL debug logging."""
+
+import json
+import logging
+import tempfile
+from collections.abc import Generator
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+import simple_agent_poc.observability as obs
+from simple_agent_poc.adapters.session_store.in_memory import InMemorySessionStore
+from simple_agent_poc.application.dto import (
+    ContinueRequest,
+    RunAgentPaused,
+    RunAgentRequest,
+    RunAgentResponse,
+    StreamComplete,
+)
+from simple_agent_poc.application.use_cases import RunAgentUseCase
+from simple_agent_poc.core.types import (
+    LLMError,
+    LLMResponse,
+    LLMStreamChunk,
+    Message,
+    SessionNotFoundError,
+    ToolCall,
+    ToolDefinition,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _reset_observability_state() -> None:
+    """Reset global state of the observability module between tests."""
+    obs._enabled = True
+    obs._payload_policy = "summary"
+    obs._max_field_chars = 500
+    obs._initialized = False
+    obs._logger.handlers.clear()
+    obs._logger.setLevel(logging.NOTSET)
+    obs._run_id.set("")
+    obs._session_id.set("")
+    obs._agent_id.set("")
+    obs._mode.set("")
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    """Read JSONL file and return list of parsed dicts."""
+    events: list[dict] = []
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                events.append(json.loads(line))
+    return events
+
+
+@pytest.fixture
+def temp_log_path() -> Generator[Path]:
+    with tempfile.TemporaryDirectory() as td:
+        yield Path(td) / "test-events.jsonl"
+
+
+# ---------------------------------------------------------------------------
+# Payload summarisation
+# ---------------------------------------------------------------------------
+
+
+def test_summarize_payload_none():
+    result = obs.summarize_payload(None)
+    assert result == {"type": "null", "length": 0}
+
+
+def test_summarize_payload_summary_str(monkeypatch, temp_log_path):
+    _reset_observability_state()
+    monkeypatch.setenv("SIMPLE_AGENT_LOG_ENABLED", "false")
+    monkeypatch.setenv("SIMPLE_AGENT_LOG_FILE", str(temp_log_path))
+    monkeypatch.setenv("SIMPLE_AGENT_LOG_PAYLOADS", "summary")
+    monkeypatch.setenv("SIMPLE_AGENT_LOG_MAX_FIELD_CHARS", "500")
+    obs.configure_logging()
+
+    text = "hello " * 200
+    result = obs.summarize_payload(text)
+    assert result["type"] == "str"
+    assert result["length"] == len(text)
+    assert "sha256" in result
+    assert "preview" in result
+    assert len(cast(str, result["preview"])) == 500
+
+
+def test_summarize_payload_metadata_str(monkeypatch, temp_log_path):
+    _reset_observability_state()
+    monkeypatch.setenv("SIMPLE_AGENT_LOG_ENABLED", "false")
+    monkeypatch.setenv("SIMPLE_AGENT_LOG_FILE", str(temp_log_path))
+    monkeypatch.setenv("SIMPLE_AGENT_LOG_PAYLOADS", "metadata")
+    obs.configure_logging()
+
+    text = "secret content"
+    result = obs.summarize_payload(text)
+    assert result["type"] == "str"
+    assert result["length"] == len(text)
+    assert "sha256" in result
+    assert "preview" not in result
+    assert "content" not in result
+
+
+def test_summarize_payload_full_str(monkeypatch, temp_log_path):
+    _reset_observability_state()
+    monkeypatch.setenv("SIMPLE_AGENT_LOG_ENABLED", "false")
+    monkeypatch.setenv("SIMPLE_AGENT_LOG_FILE", str(temp_log_path))
+    monkeypatch.setenv("SIMPLE_AGENT_LOG_PAYLOADS", "full")
+    obs.configure_logging()
+
+    text = "full content here"
+    result = obs.summarize_payload(text)
+    assert result["type"] == "str"
+    assert result["length"] == len(text)
+    assert result["content"] == text
+
+
+def test_summarize_payload_summary_dict(monkeypatch, temp_log_path):
+    _reset_observability_state()
+    monkeypatch.setenv("SIMPLE_AGENT_LOG_ENABLED", "false")
+    monkeypatch.setenv("SIMPLE_AGENT_LOG_FILE", str(temp_log_path))
+    monkeypatch.setenv("SIMPLE_AGENT_LOG_PAYLOADS", "summary")
+    monkeypatch.setenv("SIMPLE_AGENT_LOG_MAX_FIELD_CHARS", "10")
+    obs.configure_logging()
+
+    data = {"a": 1, "b": "hello world, this is a long value"}
+    result = obs.summarize_payload(data)
+    assert result["type"] == "dict"
+    assert "sha256" in result
+    assert "preview" in result
+    assert len(cast(str, result["preview"])) == 10
+
+
+# ---------------------------------------------------------------------------
+# configure_logging
+# ---------------------------------------------------------------------------
+
+
+def test_configure_logging_enabled(monkeypatch, temp_log_path):
+    _reset_observability_state()
+    monkeypatch.setenv("SIMPLE_AGENT_LOG_ENABLED", "true")
+    monkeypatch.setenv("SIMPLE_AGENT_LOG_FILE", str(temp_log_path))
+
+    obs.configure_logging()
+
+    assert obs._enabled is True
+    assert obs._initialized is True
+    assert obs._logger.handlers
+    assert temp_log_path.parent.exists()
+
+
+def test_configure_logging_disabled(monkeypatch, temp_log_path):
+    _reset_observability_state()
+    monkeypatch.setenv("SIMPLE_AGENT_LOG_ENABLED", "false")
+    monkeypatch.setenv("SIMPLE_AGENT_LOG_FILE", str(temp_log_path))
+
+    obs.configure_logging()
+
+    assert obs._enabled is False
+    assert obs._initialized is True
+    assert not obs._logger.handlers
+
+
+def test_configure_logging_idempotent(monkeypatch, temp_log_path):
+    _reset_observability_state()
+    monkeypatch.setenv("SIMPLE_AGENT_LOG_ENABLED", "true")
+    monkeypatch.setenv("SIMPLE_AGENT_LOG_FILE", str(temp_log_path))
+
+    obs.configure_logging()
+    obs.configure_logging()
+
+    assert len(obs._logger.handlers) == 1
+
+
+# ---------------------------------------------------------------------------
+# log_event + JSONL output
+# ---------------------------------------------------------------------------
+
+
+def test_log_event_writes_jsonl(monkeypatch, temp_log_path):
+    _reset_observability_state()
+    monkeypatch.setenv("SIMPLE_AGENT_LOG_ENABLED", "true")
+    monkeypatch.setenv("SIMPLE_AGENT_LOG_FILE", str(temp_log_path))
+    obs.configure_logging()
+
+    obs.bind_log_context(
+        run_id="run-001", session_id="sess-001", agent_id="default", mode="cli"
+    )
+    obs.log_event("agent.run.start", round=0, model="test-model")
+
+    events = _read_jsonl(temp_log_path)
+    assert len(events) == 1
+    e = events[0]
+    assert e["event"] == "agent.run.start"
+    assert e["run_id"] == "run-001"
+    assert e["session_id"] == "sess-001"
+    assert e["agent_id"] == "default"
+    assert e["mode"] == "cli"
+    assert e["round"] == 0
+    assert e["model"] == "test-model"
+    assert e["level"] == "INFO"
+    assert "timestamp" in e
+
+
+def test_log_event_disabled_does_not_write(monkeypatch, temp_log_path):
+    _reset_observability_state()
+    monkeypatch.setenv("SIMPLE_AGENT_LOG_ENABLED", "false")
+    monkeypatch.setenv("SIMPLE_AGENT_LOG_FILE", str(temp_log_path))
+    obs.configure_logging()
+
+    obs.log_event("agent.run.start", round=0)
+
+    assert not temp_log_path.exists()
+
+
+def test_log_event_includes_context(monkeypatch, temp_log_path):
+    _reset_observability_state()
+    monkeypatch.setenv("SIMPLE_AGENT_LOG_ENABLED", "true")
+    monkeypatch.setenv("SIMPLE_AGENT_LOG_FILE", str(temp_log_path))
+    obs.configure_logging()
+
+    obs.bind_log_context(run_id="r1", session_id="s1", agent_id="a1", mode="cli")
+    obs.log_event("test.event", custom_field="value")
+
+    events = _read_jsonl(temp_log_path)
+    assert events[0]["custom_field"] == "value"
+    assert events[0]["run_id"] == "r1"
+
+
+def test_bind_log_context_partial_update(monkeypatch, temp_log_path):
+    _reset_observability_state()
+    monkeypatch.setenv("SIMPLE_AGENT_LOG_ENABLED", "true")
+    monkeypatch.setenv("SIMPLE_AGENT_LOG_FILE", str(temp_log_path))
+    obs.configure_logging()
+
+    obs.bind_log_context(run_id="r1")
+    obs.log_event("test.one")
+    obs.bind_log_context(session_id="s1")
+    obs.log_event("test.two")
+
+    events = _read_jsonl(temp_log_path)
+    assert events[0]["run_id"] == "r1"
+    assert events[0]["session_id"] is None
+    assert events[1]["run_id"] == "r1"
+    assert events[1]["session_id"] == "s1"
+
+
+# ---------------------------------------------------------------------------
+# Payload policy env var
+# ---------------------------------------------------------------------------
+
+
+def test_payload_policy_from_env(monkeypatch, temp_log_path):
+    _reset_observability_state()
+    monkeypatch.setenv("SIMPLE_AGENT_LOG_ENABLED", "true")
+    monkeypatch.setenv("SIMPLE_AGENT_LOG_FILE", str(temp_log_path))
+    monkeypatch.setenv("SIMPLE_AGENT_LOG_PAYLOADS", "full")
+    obs.configure_logging()
+
+    assert obs._payload_policy == "full"
+
+
+def test_max_field_chars_from_env(monkeypatch, temp_log_path):
+    _reset_observability_state()
+    monkeypatch.setenv("SIMPLE_AGENT_LOG_ENABLED", "true")
+    monkeypatch.setenv("SIMPLE_AGENT_LOG_FILE", str(temp_log_path))
+    monkeypatch.setenv("SIMPLE_AGENT_LOG_MAX_FIELD_CHARS", "200")
+    obs.configure_logging()
+
+    assert obs._max_field_chars == 200
+
+
+# ---------------------------------------------------------------------------
+# Integration: RunAgentUseCase emits events (sync)
+# ---------------------------------------------------------------------------
+
+
+def _make_llm_response(
+    content: str = "Hello!",
+    tool_calls: list | None = None,
+) -> LLMResponse:
+    return LLMResponse(
+        content=content,
+        usage={"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+        model="test-model",
+        response_time=0.05,
+        tool_calls=tool_calls or [],
+    )
+
+
+class _RecordingLLMClient:
+    """LLM client stub that returns predefined responses."""
+
+    def __init__(self, responses: list[LLMResponse]) -> None:
+        self._responses = responses
+        self._idx = 0
+
+    def complete(
+        self,
+        messages: list[Message],
+        *,
+        tools: list[ToolDefinition] | None = None,
+    ) -> LLMResponse:
+        if self._idx < len(self._responses):
+            resp = self._responses[self._idx]
+            self._idx += 1
+            return resp
+        return _make_llm_response("Default response.")
+
+    def complete_stream(
+        self,
+        messages: list[Message],
+        *,
+        tools: list[ToolDefinition] | None = None,
+    ):
+        if self._idx < len(self._responses):
+            resp = self._responses[self._idx]
+            self._idx += 1
+            yield LLMStreamChunk(content_delta=resp["content"])
+            if resp.get("tool_calls"):
+                for tc in resp["tool_calls"]:
+                    yield LLMStreamChunk(
+                        content_delta=None,
+                        tool_call_delta={
+                            "index": 0,
+                            "id": tc["id"],
+                            "type": "function",
+                            "function": {
+                                "name": tc["function"]["name"],
+                                "arguments": tc["function"]["arguments"],
+                            },
+                        },
+                    )
+            yield LLMStreamChunk(content_delta=None, usage=resp.get("usage"))
+        else:
+            yield LLMStreamChunk(content_delta="Default response.")
+            yield LLMStreamChunk(
+                content_delta=None,
+                usage={"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+            )
+
+
+@pytest.fixture
+def logging_use_case(monkeypatch, temp_log_path, default_agent_def, tool_registry):
+    """Create a RunAgentUseCase wired with JSONL log file."""
+    _reset_observability_state()
+    monkeypatch.setenv("SIMPLE_AGENT_LOG_ENABLED", "true")
+    monkeypatch.setenv("SIMPLE_AGENT_LOG_FILE", str(temp_log_path))
+    monkeypatch.setenv("SIMPLE_AGENT_LOG_PAYLOADS", "summary")
+    obs.configure_logging()
+
+    store = InMemorySessionStore()
+
+    def make_use_case(llm_client):
+        return RunAgentUseCase(
+            llm_client_factory=lambda _: llm_client,
+            session_store=store,
+            agent_definitions=default_agent_def,
+            tool_executor=tool_registry,
+            is_api_context=False,
+        )
+
+    return make_use_case
+
+
+def test_sync_run_emits_core_events(logging_use_case, temp_log_path, default_agent_def):
+    """A minimal sync run emits agent.run.start, session.created, react.round.*, agent.run.end."""
+    llm_client = _RecordingLLMClient([_make_llm_response(content="Hi there.")])
+    use_case = logging_use_case(llm_client)
+
+    result = use_case.execute(RunAgentRequest(message="Hello", agent_id="default"))
+
+    events = _read_jsonl(temp_log_path)
+    event_names = [e["event"] for e in events]
+
+    assert "agent.run.start" in event_names
+    assert "session.created" in event_names
+    assert "react.round.start" in event_names
+    assert "react.round.end" in event_names
+    assert "agent.run.end" in event_names
+    assert "session.saved" in event_names
+
+    assert isinstance(result, RunAgentResponse)
+    assert result.message == "Hi there."
+
+
+def test_sync_run_with_tool_calls(logging_use_case, temp_log_path, default_agent_def):
+    """Tool calls produce tool.call.start, tool.call.end events."""
+    tool_response = _make_llm_response(
+        content="Processing...",
+        tool_calls=[
+            ToolCall(
+                id="call_t1",
+                type="function",
+                function={"name": "concat", "arguments": '{"a":"x","b":"y"}'},
+            )
+        ],
+    )
+    final_response = _make_llm_response(content="Result: xy")
+
+    llm_client = _RecordingLLMClient([tool_response, final_response])
+    use_case = logging_use_case(llm_client)
+
+    use_case.execute(RunAgentRequest(message="concat x y", agent_id="default"))
+
+    events = _read_jsonl(temp_log_path)
+    event_names = [e["event"] for e in events]
+
+    assert "tool.call.start" in event_names
+    assert "tool.call.end" in event_names
+
+    tool_end = next(e for e in events if e["event"] == "tool.call.end")
+    assert tool_end["tool_call_id"] == "call_t1"
+    assert tool_end["tool_name"] == "concat"
+    assert "payload" in tool_end
+
+
+def test_sync_run_ask_user_pause(logging_use_case, temp_log_path, default_agent_def):
+    """ask_user triggers ask_user.pause event."""
+    ask_user_response = _make_llm_response(
+        content="Please confirm:",
+        tool_calls=[
+            ToolCall(
+                id="call_ask",
+                type="function",
+                function={
+                    "name": "ask_user",
+                    "arguments": json.dumps(
+                        {"questions": [{"question": "OK?", "type": "text"}]},
+                        ensure_ascii=False,
+                    ),
+                },
+            )
+        ],
+    )
+
+    llm_client = _RecordingLLMClient([ask_user_response])
+    use_case = logging_use_case(llm_client)
+
+    result = use_case.execute(
+        RunAgentRequest(message="Should I proceed?", agent_id="default")
+    )
+
+    events = _read_jsonl(temp_log_path)
+    event_names = [e["event"] for e in events]
+
+    assert "ask_user.pause" in event_names
+    assert isinstance(result, RunAgentPaused)
+    pause_event = next(e for e in events if e["event"] == "ask_user.pause")
+    assert pause_event["tool_call_id"] == "call_ask"
+
+
+def test_sync_run_ask_user_resume(
+    logging_use_case, temp_log_path, default_agent_def, tool_registry
+):
+    """Resume after ask_user emits ask_user.resume and ask_user.answered."""
+    ask_user_response = _make_llm_response(
+        content="Please confirm:",
+        tool_calls=[
+            ToolCall(
+                id="call_ask",
+                type="function",
+                function={
+                    "name": "ask_user",
+                    "arguments": json.dumps(
+                        {"questions": [{"question": "OK?", "type": "text"}]},
+                        ensure_ascii=False,
+                    ),
+                },
+            )
+        ],
+    )
+    final_response = _make_llm_response(content="Confirmed: Yes")
+
+    store = InMemorySessionStore()
+    llm_client = _RecordingLLMClient([ask_user_response, final_response])
+
+    use_case = RunAgentUseCase(
+        llm_client_factory=lambda _: llm_client,
+        session_store=store,
+        agent_definitions=default_agent_def,
+        tool_executor=tool_registry,
+        is_api_context=False,
+    )
+
+    result = use_case.execute(
+        RunAgentRequest(message="Should I proceed?", agent_id="default")
+    )
+    assert isinstance(result, RunAgentPaused)
+
+    result2 = use_case.continue_sync(
+        ContinueRequest(session_id=result.session_id, answers={"OK?": "yes"})
+    )
+
+    events = _read_jsonl(temp_log_path)
+    event_names = [e["event"] for e in events]
+
+    assert "ask_user.pause" in event_names
+    assert "ask_user.resume" in event_names
+    assert "ask_user.answered" in event_names
+    assert isinstance(result2, RunAgentResponse)
+
+
+# ---------------------------------------------------------------------------
+# Integration: stream
+# ---------------------------------------------------------------------------
+
+
+def test_stream_run_emits_events(logging_use_case, temp_log_path, default_agent_def):
+    """Streaming run emits agent.run.start, react.round.*, agent.run.end."""
+    llm_client = _RecordingLLMClient([_make_llm_response(content="Streaming hi.")])
+    use_case = logging_use_case(llm_client)
+
+    events_gen = use_case.execute_stream(
+        RunAgentRequest(message="Hello", agent_id="default")
+    )
+    dto_events = list(events_gen)
+
+    log_events = _read_jsonl(temp_log_path)
+    event_names = [e["event"] for e in log_events]
+
+    assert "agent.run.start" in event_names
+    assert "react.round.start" in event_names
+    assert "react.round.end" in event_names
+    assert "agent.run.end" in event_names
+
+    # Last DTO event should be StreamComplete
+    assert isinstance(dto_events[-1], StreamComplete)
+
+
+def test_stream_run_with_tool_calls(logging_use_case, temp_log_path, default_agent_def):
+    """Streaming tool calls produce tool events."""
+    tool_response = _make_llm_response(
+        content="Processing...",
+        tool_calls=[
+            ToolCall(
+                id="call_st1",
+                type="function",
+                function={"name": "concat", "arguments": '{"a":"a","b":"b"}'},
+            )
+        ],
+    )
+    final_response = _make_llm_response(content="Result: ab")
+
+    llm_client = _RecordingLLMClient([tool_response, final_response])
+    use_case = logging_use_case(llm_client)
+
+    dto_events = list(
+        use_case.execute_stream(
+            RunAgentRequest(message="concat a b", agent_id="default")
+        )
+    )
+
+    log_events = _read_jsonl(temp_log_path)
+    event_names = [e["event"] for e in log_events]
+
+    assert "tool.call.start" in event_names
+    assert "tool.call.end" in event_names
+    assert isinstance(dto_events[-1], StreamComplete)
+
+
+# ---------------------------------------------------------------------------
+# Error events
+# ---------------------------------------------------------------------------
+
+
+def test_agent_run_error_event(logging_use_case, temp_log_path, default_agent_def):
+    """Agent run error emits agent.run.error."""
+
+    class _ErrorClient:
+        def complete(self, messages, *, tools=None):
+            raise LLMError("Simulated error.", display_message="Error.")
+
+        def complete_stream(self, messages, *, tools=None):
+            raise LLMError("Simulated error.", display_message="Error.")
+            yield
+
+    llm_client = _ErrorClient()
+    use_case = logging_use_case(llm_client)
+
+    with pytest.raises(LLMError):
+        use_case.execute(RunAgentRequest(message="Trigger error", agent_id="default"))
+
+    events = _read_jsonl(temp_log_path)
+    event_names = [e["event"] for e in events]
+
+    assert "agent.run.start" in event_names
+    assert "agent.run.error" in event_names
+    error_event = next(e for e in events if e["event"] == "agent.run.error")
+    assert "error" in error_event
+
+
+def test_react_max_rounds_exceeded(logging_use_case, temp_log_path, default_agent_def):
+    """Max rounds exceeded emits react.max_rounds_exceeded."""
+    tool_response = _make_llm_response(
+        content="looping...",
+        tool_calls=[
+            ToolCall(
+                id="c1",
+                type="function",
+                function={"name": "concat", "arguments": '{"a":"a","b":"b"}'},
+            )
+        ],
+    )
+    responses = [tool_response] * 10
+    llm_client = _RecordingLLMClient(responses)
+    use_case = logging_use_case(llm_client)
+
+    with pytest.raises(LLMError):
+        use_case.execute(RunAgentRequest(message="loop forever", agent_id="default"))
+
+    events = _read_jsonl(temp_log_path)
+    event_names = [e["event"] for e in events]
+    assert "react.max_rounds_exceeded" in event_names
+
+
+def test_session_not_found_event(logging_use_case, temp_log_path, default_agent_def):
+    """session.not_found is logged when a non-existent session is requested."""
+    store = InMemorySessionStore()
+    llm_client = _RecordingLLMClient([_make_llm_response("Hi.")])
+    use_case = RunAgentUseCase(
+        llm_client_factory=lambda _: llm_client,
+        session_store=store,
+        agent_definitions=default_agent_def,
+        tool_executor=None,
+        is_api_context=False,
+    )
+
+    with pytest.raises(SessionNotFoundError):
+        use_case.execute(
+            RunAgentRequest(
+                message="Hello", agent_id="default", session_id="nonexistent"
+            )
+        )
+
+    events = _read_jsonl(temp_log_path)
+    event_names = [e["event"] for e in events]
+    assert "session.not_found" in event_names
+
+
+# ---------------------------------------------------------------------------
+# Run ID correlation
+# ---------------------------------------------------------------------------
+
+
+def test_run_id_correlation(logging_use_case, temp_log_path, default_agent_def):
+    """Events within one run share the same run_id."""
+    llm_client = _RecordingLLMClient([_make_llm_response("First.")])
+
+    # Bind context externally to capture run_id
+    ctx_store = {}
+
+    class _ContextCapturingClient:
+        def complete(self, messages, *, tools=None):
+            ctx_store["captured_run_id"] = obs._run_id.get()
+            return llm_client.complete(messages, tools=tools)
+
+        def complete_stream(self, messages, *, tools=None):
+            return llm_client.complete_stream(messages, tools=tools)
+
+    use_case = logging_use_case(_ContextCapturingClient())
+    use_case.execute(RunAgentRequest(message="Test", agent_id="default"))
+
+    events = _read_jsonl(temp_log_path)
+    run_ids = {e["run_id"] for e in events}
+    assert len(run_ids) == 1
+    assert list(run_ids)[0] == ctx_store["captured_run_id"]
+
+
+# ---------------------------------------------------------------------------
+# CLI and HTTP error events
+# ---------------------------------------------------------------------------
+
+
+def test_cli_turn_error_event(monkeypatch, temp_log_path):
+    """CLI error handler emits cli.turn.error."""
+    _reset_observability_state()
+    monkeypatch.setenv("SIMPLE_AGENT_LOG_ENABLED", "true")
+    monkeypatch.setenv("SIMPLE_AGENT_LOG_FILE", str(temp_log_path))
+    obs.configure_logging()
+
+    obs.log_event("cli.turn.error", error=obs.summarize_payload("Something broke"))
+
+    events = _read_jsonl(temp_log_path)
+    assert events[0]["event"] == "cli.turn.error"
+    assert "error" in events[0]
+
+
+def test_http_request_error_event(monkeypatch, temp_log_path):
+    """HTTP error handler emits http.request.error."""
+    _reset_observability_state()
+    monkeypatch.setenv("SIMPLE_AGENT_LOG_ENABLED", "true")
+    monkeypatch.setenv("SIMPLE_AGENT_LOG_FILE", str(temp_log_path))
+    obs.configure_logging()
+
+    obs.log_event(
+        "http.request.error",
+        error=obs.summarize_payload("404 not found"),
+    )
+
+    events = _read_jsonl(temp_log_path)
+    assert events[0]["event"] == "http.request.error"
+    assert "error" in events[0]
+
+
+# ---------------------------------------------------------------------------
+# LLM request/stream events
+# ---------------------------------------------------------------------------
+
+
+def test_llm_stream_events(monkeypatch, temp_log_path):
+    """llm.stream.* events are emitted by the LLM client."""
+    _reset_observability_state()
+    monkeypatch.setenv("SIMPLE_AGENT_LOG_ENABLED", "true")
+    monkeypatch.setenv("SIMPLE_AGENT_LOG_FILE", str(temp_log_path))
+    obs.configure_logging()
+
+    obs.bind_log_context(run_id="r1", session_id="s1", agent_id="default", mode="cli")
+    obs.log_event(
+        "llm.stream.start",
+        model="gpt-4.1-mini",
+        api_type="completion",
+        stream=True,
+        message_count=3,
+    )
+    obs.log_event(
+        "llm.stream.end",
+        model="gpt-4.1-mini",
+        api_type="completion",
+        stream=True,
+        usage={"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+        elapsed_ms=1234,
+        tool_call_count=0,
+    )
+
+    events = _read_jsonl(temp_log_path)
+    assert events[0]["event"] == "llm.stream.start"
+    assert events[0]["model"] == "gpt-4.1-mini"
+    assert events[0]["stream"] is True
+    assert events[1]["event"] == "llm.stream.end"
+    assert events[1]["usage"]["total_tokens"] == 15
+
+
+def test_llm_request_events(monkeypatch, temp_log_path):
+    """llm.request.* events are emitted by the LLM client."""
+    _reset_observability_state()
+    monkeypatch.setenv("SIMPLE_AGENT_LOG_ENABLED", "true")
+    monkeypatch.setenv("SIMPLE_AGENT_LOG_FILE", str(temp_log_path))
+    obs.configure_logging()
+
+    obs.bind_log_context(run_id="r1", session_id="s1", agent_id="default", mode="cli")
+    obs.log_event(
+        "llm.request.start",
+        model="gpt-4.1-mini",
+        api_type="completion",
+        stream=False,
+        message_count=2,
+    )
+    obs.log_event(
+        "llm.request.end",
+        model="gpt-4.1-mini",
+        api_type="completion",
+        stream=False,
+        usage={"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+        elapsed_ms=567,
+        tool_call_count=0,
+    )
+
+    events = _read_jsonl(temp_log_path)
+    assert events[0]["event"] == "llm.request.start"
+    assert events[0]["stream"] is False
+    assert events[1]["event"] == "llm.request.end"
+    assert events[1]["usage"]["total_tokens"] == 15


### PR DESCRIPTION
## Issues

- Close #935

## Why

CLI/GUIの画面表示からは見えないLLM呼び出し、ツール引数/結果、ストリーム中断、pause/resumeの詳細を後から追跡できるようにする。コーディングエージェントへ渡すのに十分なコンテキストを提供しつつ、デフォルトでは全文保存せず安全性と調査性のバランスを取る。

## Summary

`simple_agent_poc` に構造化JSONLデバッグログを追加。標準ライブラリ `logging` のみを使用し、新規依存なし。デフォルトで `logs/agent-debug.jsonl` に出力（`.gitignore` 済）。

## Changes

| ファイル | 変更 |
|:---|:---|
| `src/simple_agent_poc/observability/__init__.py` | **新規**: JSONLフォーマッタ、`contextvars`ベースのコンテキストバインディング、ペイロード要約（summary/metadata/full）、`configure_logging()` |
| `src/simple_agent_poc/entrypoints/bootstrap.py` | `configure_logging()` 呼び出しを追加（CLI/API共通） |
| `src/simple_agent_poc/application/use_cases.py` | 全メソッドにイベント追加：`agent.run.*`, `session.*`, `react.round.*`, `tool.call.*`, `ask_user.*`, `session.saved` |
| `src/simple_agent_poc/adapters/llm/litellm_client.py` | `llm.request.*` / `llm.stream.*` イベント追加（CompletionClient + ResponsesClient） |
| `src/simple_agent_poc/adapters/cli/adapter.py` | `cli.turn.error` イベント追加 |
| `src/simple_agent_poc/adapters/http/api.py` | `http.request.error` イベント追加（全エンドポイント） |
| `docs/logging.md` | **新規**: ログ設定、イベント一覧、ペイロードポリシー、jq 検索例 |
| `README.md`, `docs/development.md` | ログドキュメントへのリンク追加 |
| `tests/test_logging.py` | **新規**: 28テスト（ペイロード要約、JSONL出力、ユースケース統合、ストリーム/ツール/pause-resume） |

## Checklist

- [x] `SIMPLE_AGENT_LOG_PAYLOADS=summary|metadata|full` でペイロード動作が切り替わる
- [x] CLI stdout/stderr 出力は変更なし
- [x] HTTP JSON / SSE wire format は変更なし
- [x] ruff format, ruff check, ty check 全件パス
- [x] pytest 224件パス（既存196 + 新規28）
