### PR TITLE
fix(simple-agent-poc): indent multi-line tool results in CLI renderer

### DIFF
--- a/projects/simple-agent-poc/src/simple_agent_poc/adapters/cli/renderer.py
+++ b/projects/simple-agent-poc/src/simple_agent_poc/adapters/cli/renderer.py
@@ -135,8 +135,9 @@ def show_agent_response(response: RunAgentResponse) -> None:
     if response.tool_call_history:
         print("Agent: ")
         for tc in response.tool_call_history:
+            result_text = tc.result.replace("\n", "\n     → ")
             print(f"  🔧 {tc.name}({tc.arguments})")
-            print(f"     → {tc.result}")
+            print(f"     → {result_text}")
         if response.message:
             print(f"       {response.message}")
     else:
@@ -225,7 +226,8 @@ def show_streaming_response(
                     except StopIteration:
                         break
                     if isinstance(next_event, ToolResultEvent):
-                        sys.stdout.write(f"\n     → {next_event.result}")
+                        result_text = next_event.result.replace("\n", "\n     → ")
+                        sys.stdout.write(f"\n     → {result_text}")
                         sys.stdout.flush()
                     continue
             elif isinstance(event, ToolResultEvent):
@@ -233,7 +235,8 @@ def show_streaming_response(
                     indicator.stop()
                     sys.stdout.write("Agent: ")
                     started = True
-                sys.stdout.write(f"\n     → {event.result}")
+                result_text = event.result.replace("\n", "\n     → ")
+                sys.stdout.write(f"\n     → {result_text}")
                 sys.stdout.flush()
             elif isinstance(event, SessionPaused):
                 indicator.stop()


### PR DESCRIPTION
## Why

CLI表示で ask_user のツール結果が複数行テキストの場合、1行目しかインデントが適用されず、2行目以降が左端から表示される不具合を修正。

## Summary

ツール結果の複数行テキスト全体に `     → ` プレフィックスを適用するよう `renderer.py` を修正。

## Changes

- `renderer.py:139` - 同期モードの `show_agent_response` 内ツール履歴表示
- `renderer.py:228` - ストリーミングモード ask_user 結果表示
- `renderer.py:237` - ストリーミングモード一般ツール結果表示

## Before

```
     → --- ユーザーからの回答 ---
- あなたのお名前を教えてください。 → あ
```

## After

```
     → --- ユーザーからの回答 ---
     → - あなたのお名前を教えてください。 → あ
```
