### PR TITLE
feat(portfolio): add per-model stop and manual retry to chat-compare

### DIFF
--- a/projects/portfolio/src/client/components/chat-compare/compare-column.tsx
+++ b/projects/portfolio/src/client/components/chat-compare/compare-column.tsx
@@ -2,11 +2,15 @@ import { useCallback, useState } from 'react'
 import { copyToClipboard } from '#/client/components/chat/copy-to-clipboard'
 import { CheckIcon } from '#/client/components/svg/check-icon'
 import { CopyIcon } from '#/client/components/svg/copy-icon'
+import { RefreshIcon } from '#/client/components/svg/refresh-icon'
+import { StopIcon } from '#/client/components/svg/stop-icon'
 import type { ApiChatMessage, ImageContent, TextContent } from '#/types'
 import type { ModelStreamState } from './hooks/use-compare-state'
 
 interface CompareColumnProps {
   state: ModelStreamState
+  onCancelModel?: (model: string) => void
+  onRetryModel?: (model: string) => void
 }
 
 function formatResponseTime(ms: number): string {
@@ -102,7 +106,7 @@ function CompareMessage({ copied, message, onCopy }: { copied: boolean; message:
   )
 }
 
-export function CompareColumn({ state }: CompareColumnProps) {
+export function CompareColumn({ state, onCancelModel, onRetryModel }: CompareColumnProps) {
   const { model, status, messages, content, reasoningContent, usage, finishReason, responseTimeMs, error } = state
   const showMeta = status === 'done' && (finishReason || usage || responseTimeMs !== null)
   const [copiedId, setCopiedId] = useState('')
@@ -118,13 +122,40 @@ export function CompareColumn({ state }: CompareColumnProps) {
     setCopiedId('')
   }, [])
 
+  const isActive = status === 'streaming' || status === 'retrying'
+  const isStopped = status === 'error' || status === 'cancelled'
+
   return (
     <div className='flex min-w-0 flex-1 flex-col overflow-hidden border-r border-gray-200 last:border-r-0 dark:border-gray-700'>
-      <div className='shrink-0 overflow-hidden text-ellipsis whitespace-nowrap border-b border-gray-200 px-3 py-2 text-center font-medium text-sm dark:border-gray-700 dark:text-gray-200'>
-        {model}
-        {status === 'streaming' && (
-          <span className='ml-1 inline-block h-2 w-2 animate-pulse rounded-full bg-primary-600 align-middle' />
-        )}
+      <div className='flex shrink-0 items-center justify-between border-b border-gray-200 px-3 py-2 dark:border-gray-700'>
+        <span className='overflow-hidden text-ellipsis whitespace-nowrap font-medium text-sm dark:text-gray-200'>
+          {model}
+          {isActive && (
+            <span className='ml-1 inline-block h-2 w-2 animate-pulse rounded-full bg-primary-600 align-middle' />
+          )}
+        </span>
+        <span className='flex shrink-0 items-center gap-1'>
+          {isActive && onCancelModel && (
+            <button
+              type='button'
+              onClick={() => onCancelModel(model)}
+              aria-label={`Stop ${model}`}
+              className='flex h-7 w-7 cursor-pointer items-center justify-center rounded-md text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-700 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-white'
+            >
+              <StopIcon size={14} className='fill-current' />
+            </button>
+          )}
+          {isStopped && onRetryModel && (
+            <button
+              type='button'
+              onClick={() => onRetryModel(model)}
+              aria-label={`Retry ${model}`}
+              className='flex h-7 w-7 cursor-pointer items-center justify-center rounded-md text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-700 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-white'
+            >
+              <RefreshIcon size={14} className='fill-current' />
+            </button>
+          )}
+        </span>
       </div>
       <div className='min-h-0 flex-1 overflow-y-auto px-3 py-2'>
         {messages.map((message, index) => (
@@ -144,7 +175,7 @@ export function CompareColumn({ state }: CompareColumnProps) {
             {error}
           </div>
         )}
-        {status === 'streaming' && (
+        {isActive && (
           <>
             {reasoningContent && (
               <details className='mt-2 mb-2'>

--- a/projects/portfolio/src/client/components/chat-compare/hooks/use-compare-state.ts
+++ b/projects/portfolio/src/client/components/chat-compare/hooks/use-compare-state.ts
@@ -1,9 +1,11 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import type { ApiChatMessage, ChatUsage } from '#/types'
+
+export type ModelStreamStatus = 'idle' | 'streaming' | 'retrying' | 'done' | 'error' | 'cancelled'
 
 export interface ModelStreamState {
   model: string
-  status: 'idle' | 'streaming' | 'done' | 'error'
+  status: ModelStreamStatus
   messages: ApiChatMessage[]
   content: string
   reasoningContent: string
@@ -30,9 +32,16 @@ function createModelStreamState(model: string): ModelStreamState {
 export function useCompareState() {
   const [selectedModels, setSelectedModels] = useState<string[]>([])
   const [modelStates, setModelStates] = useState<Record<string, ModelStreamState>>({})
-  const [isSubmitting, setIsSubmitting] = useState(false)
 
   const hasConversation = selectedModels.some((model) => (modelStates[model]?.messages.length ?? 0) > 0)
+
+  const isSubmitting = useMemo(
+    () =>
+      selectedModels.some(
+        (model) => modelStates[model]?.status === 'streaming' || modelStates[model]?.status === 'retrying'
+      ),
+    [selectedModels, modelStates]
+  )
 
   const initModelStates = useCallback((models: string[]) => {
     setModelStates((prev) => {
@@ -88,6 +97,33 @@ export function useCompareState() {
         ...prev[model],
         status: 'error' as const,
         error,
+      },
+    }))
+  }, [])
+
+  const setModelCancelled = useCallback((model: string) => {
+    setModelStates((prev) => ({
+      ...prev,
+      [model]: {
+        ...prev[model],
+        status: 'cancelled' as const,
+        error: 'Cancelled by user',
+      },
+    }))
+  }, [])
+
+  const setModelRetrying = useCallback((model: string) => {
+    setModelStates((prev) => ({
+      ...prev,
+      [model]: {
+        ...prev[model],
+        status: 'retrying' as const,
+        content: '',
+        reasoningContent: '',
+        usage: null,
+        finishReason: null,
+        responseTimeMs: null,
+        error: null,
       },
     }))
   }, [])
@@ -167,12 +203,13 @@ export function useCompareState() {
     setSelectedModels,
     modelStates,
     isSubmitting,
-    setIsSubmitting,
     hasConversation,
     initModelStates,
     updateStreamingContent,
     setModelDone,
     setModelError,
+    setModelCancelled,
+    setModelRetrying,
     resetModelStream,
     appendAssistantMessage,
     setModelStreaming,

--- a/projects/portfolio/src/client/components/chat-compare/hooks/use-compare-stream.ts
+++ b/projects/portfolio/src/client/components/chat-compare/hooks/use-compare-stream.ts
@@ -99,6 +99,9 @@ export function useCompareStream() {
     const { settings, modelState, userMessage, callbacks } = args
     const { model } = modelState
 
+    controllerMapRef.current.get(model)?.abort()
+    controllerMapRef.current.delete(model)
+
     const controller = new AbortController()
     controllerMapRef.current.set(model, controller)
 
@@ -139,6 +142,15 @@ async function runModelStream(
   onError: (error: string) => void
 ): Promise<void> {
   const startTime = Date.now()
+  let timedOut = false
+  let idleTimer: ReturnType<typeof setTimeout> | undefined
+
+  const clearIdleTimer = () => {
+    if (idleTimer) {
+      clearTimeout(idleTimer)
+      idleTimer = undefined
+    }
+  }
 
   try {
     const res = await client.api.chat.stream.$post(
@@ -168,15 +180,6 @@ async function runModelStream(
     let usage: ChatUsage | null = null
     let receivedFinish = false
     let running = true
-    let timedOut = false
-    let idleTimer: ReturnType<typeof setTimeout> | undefined
-
-    const clearIdleTimer = () => {
-      if (idleTimer) {
-        clearTimeout(idleTimer)
-        idleTimer = undefined
-      }
-    }
 
     const startIdleTimer = () => {
       clearIdleTimer()
@@ -251,6 +254,7 @@ async function runModelStream(
       onError('Stream ended without finish reason')
     }
   } catch (error) {
+    clearIdleTimer()
     if (error instanceof Error && error.name === 'AbortError') return
     onError(error instanceof Error ? error.message : 'Unknown error')
   }

--- a/projects/portfolio/src/client/components/chat-compare/hooks/use-compare-stream.ts
+++ b/projects/portfolio/src/client/components/chat-compare/hooks/use-compare-stream.ts
@@ -8,6 +8,8 @@ import type { ModelStreamState } from './use-compare-state'
 
 const client = hc<AppType>('/')
 
+const IDLE_TIMEOUT_MS = 30_000
+
 interface StreamCallbacks {
   onStreamContent: (model: string, content: string, reasoningContent: string) => void
   onStreamDone: (
@@ -22,16 +24,42 @@ interface StreamCallbacks {
   onStreamError: (model: string, error: string) => void
 }
 
+interface ModelCallbacks {
+  onStreamContent: (content: string, reasoningContent: string) => void
+  onStreamDone: (result: {
+    finishReason: string
+    usage: ChatUsage | null
+    responseTimeMs: number
+    content: string
+  }) => void
+  onStreamError: (error: string) => void
+}
+
+interface SubmitModelArgs {
+  settings: CompareSettings
+  modelState: ModelStreamState
+  userMessage?: ApiChatMessage
+  callbacks: ModelCallbacks
+}
+
 export function useCompareStream() {
-  const abortControllerRef = useRef<AbortController | null>(null)
+  const controllerMapRef = useRef<Map<string, AbortController>>(new Map())
+
+  const cancelModel = useCallback((model: string) => {
+    const controller = controllerMapRef.current.get(model)
+    controllerMapRef.current.delete(model)
+    controller?.abort()
+  }, [])
 
   const cancelAll = useCallback(() => {
-    abortControllerRef.current?.abort()
-    abortControllerRef.current = null
+    for (const controller of controllerMapRef.current.values()) {
+      controller.abort()
+    }
+    controllerMapRef.current.clear()
   }, [])
 
   const submitCompare = useCallback(
-    async (
+    (
       settings: CompareSettings,
       modelStates: Record<string, ModelStreamState>,
       selectedModels: string[],
@@ -40,38 +68,61 @@ export function useCompareStream() {
     ) => {
       if (selectedModels.length === 0) return
 
-      const models = selectedModels
-
-      const controller = new AbortController()
-      abortControllerRef.current = controller
-
       const header = {
         'api-key': settings.apiKey,
         'base-url': settings.baseURL,
       }
 
-      const promises = models.map((model) =>
+      for (const model of selectedModels) {
+        const controller = new AbortController()
+        controllerMapRef.current.set(model, controller)
+
+        const messages = modelStates[model] ? [...modelStates[model].messages, userMessage] : [userMessage]
+
         runModelStream(
           model,
           header,
-          {
-            apiMode: settings.apiMode,
-            model,
-            messages: [...modelStates[model].messages, userMessage],
-          },
+          { apiMode: settings.apiMode, model, messages },
           controller.signal,
           (content, reasoningContent) => callbacks.onStreamContent(model, content, reasoningContent),
           (result) => callbacks.onStreamDone(model, result),
           (error) => callbacks.onStreamError(model, error)
-        )
-      )
-
-      await Promise.allSettled(promises)
+        ).finally(() => {
+          controllerMapRef.current.delete(model)
+        })
+      }
     },
     []
   )
 
-  return { submitCompare, cancelAll }
+  const submitModel = useCallback((args: SubmitModelArgs) => {
+    const { settings, modelState, userMessage, callbacks } = args
+    const { model } = modelState
+
+    const controller = new AbortController()
+    controllerMapRef.current.set(model, controller)
+
+    const header = {
+      'api-key': settings.apiKey,
+      'base-url': settings.baseURL,
+    }
+
+    const messages = userMessage ? [...modelState.messages, userMessage] : modelState.messages
+
+    return runModelStream(
+      model,
+      header,
+      { apiMode: settings.apiMode, model, messages },
+      controller.signal,
+      callbacks.onStreamContent,
+      callbacks.onStreamDone,
+      callbacks.onStreamError
+    ).finally(() => {
+      controllerMapRef.current.delete(model)
+    })
+  }, [])
+
+  return { submitCompare, submitModel, cancelModel, cancelAll }
 }
 
 async function runModelStream(
@@ -117,13 +168,36 @@ async function runModelStream(
     let usage: ChatUsage | null = null
     let receivedFinish = false
     let running = true
+    let timedOut = false
+    let idleTimer: ReturnType<typeof setTimeout> | undefined
+
+    const clearIdleTimer = () => {
+      if (idleTimer) {
+        clearTimeout(idleTimer)
+        idleTimer = undefined
+      }
+    }
+
+    const startIdleTimer = () => {
+      clearIdleTimer()
+      idleTimer = setTimeout(() => {
+        timedOut = true
+        running = false
+        reader.cancel().catch(() => {})
+      }, IDLE_TIMEOUT_MS)
+    }
+
+    startIdleTimer()
 
     while (running) {
       const { done, value } = await reader.read()
+
+      clearIdleTimer()
+
       if (done) break
 
       buffer += decoder.decode(value, { stream: true })
-      while (running) {
+      while (true) {
         const idx = buffer.indexOf('\n')
         if (idx === -1) break
 
@@ -155,9 +229,17 @@ async function runModelStream(
           // パース失敗は無視
         }
       }
+
+      if (running) {
+        startIdleTimer()
+      }
     }
 
-    if (receivedFinish) {
+    clearIdleTimer()
+
+    if (timedOut) {
+      onError('Response timed out')
+    } else if (receivedFinish) {
       const responseTimeMs = Date.now() - startTime
       onDone({
         finishReason,
@@ -165,6 +247,8 @@ async function runModelStream(
         responseTimeMs,
         content: accumulated.content,
       })
+    } else if (running) {
+      onError('Stream ended without finish reason')
     }
   } catch (error) {
     if (error instanceof Error && error.name === 'AbortError') return

--- a/projects/portfolio/src/client/components/svg/refresh-icon.tsx
+++ b/projects/portfolio/src/client/components/svg/refresh-icon.tsx
@@ -1,0 +1,14 @@
+import { type IconProps, SvgIcon } from './icon-base'
+
+export function RefreshIcon({ size = 24, className = 'fill-black dark:fill-white' }: IconProps) {
+  return (
+    <SvgIcon size={size} title='refresh-icon'>
+      <path
+        fillRule='evenodd'
+        clipRule='evenodd'
+        d='M4 12a8 8 0 0 1 12.93-6.146l-1.065 1.065A6 6 0 1 0 18 12h-3l3.707 3.707a1 1 0 0 0 1.414 0L23.83 12H19a10 10 0 1 1-15-7.071V1a1 1 0 0 1 2 0v4a1 1 0 0 1-1 1H1a1 1 0 0 1 0-2h3.343A8 8 0 0 1 4 12z'
+        className={className}
+      />
+    </SvgIcon>
+  )
+}

--- a/projects/portfolio/src/client/pages/chat-compare/index.tsx
+++ b/projects/portfolio/src/client/pages/chat-compare/index.tsx
@@ -24,19 +24,19 @@ export function ChatCompare() {
     setSelectedModels,
     modelStates,
     isSubmitting,
-    setIsSubmitting,
     hasConversation,
     initModelStates,
     updateStreamingContent,
     setModelDone,
     setModelError,
-    resetModelStream,
+    setModelCancelled,
+    setModelRetrying,
     appendAssistantMessage,
     setModelStreaming,
     appendUserMessageToAll,
     resetAllConversations,
   } = useCompareState()
-  const { submitCompare, cancelAll } = useCompareStream()
+  const { submitCompare, submitModel, cancelModel, cancelAll } = useCompareStream()
 
   const [input, setInput] = useState('')
   const [settingsOpen, setSettingsOpen] = useState(false)
@@ -103,7 +103,7 @@ export function ChatCompare() {
     setPendingModelChange(null)
   }, [])
 
-  const handleSubmit = useCallback(async () => {
+  const handleSubmit = useCallback(() => {
     const trimmed = input.trim()
     if (trimmed.length === 0 || selectedModels.length === 0 || isSubmitting) return
 
@@ -111,14 +111,12 @@ export function ChatCompare() {
     const userMessage = { role: 'user' as const, content: trimmed }
 
     setInput('')
-    setIsSubmitting(true)
-
     appendUserMessageToAll(models, userMessage)
     for (const model of models) {
       setModelStreaming(model)
     }
 
-    await submitCompare(settings, modelStates, models, userMessage, {
+    submitCompare(settings, modelStates, models, userMessage, {
       onStreamContent: (model, content, reasoningContent) => {
         updateStreamingContent(model, content, reasoningContent)
       },
@@ -136,8 +134,6 @@ export function ChatCompare() {
         setModelError(model, error)
       },
     })
-
-    setIsSubmitting(false)
   }, [
     appendAssistantMessage,
     appendUserMessageToAll,
@@ -148,7 +144,6 @@ export function ChatCompare() {
     setModelDone,
     setModelError,
     setModelStreaming,
-    setIsSubmitting,
     settings,
     submitCompare,
     updateStreamingContent,
@@ -156,11 +151,63 @@ export function ChatCompare() {
 
   const handleCancel = useCallback(() => {
     cancelAll()
-    setIsSubmitting(false)
     for (const model of selectedModels) {
-      resetModelStream(model)
+      const state = modelStates[model]
+      if (state && (state.status === 'streaming' || state.status === 'retrying')) {
+        setModelCancelled(model)
+      }
     }
-  }, [cancelAll, resetModelStream, selectedModels, setIsSubmitting])
+  }, [cancelAll, modelStates, selectedModels, setModelCancelled])
+
+  const handleCancelModel = useCallback(
+    (model: string) => {
+      cancelModel(model)
+      setModelCancelled(model)
+    },
+    [cancelModel, setModelCancelled]
+  )
+
+  const handleRetryModel = useCallback(
+    (model: string) => {
+      const state = modelStates[model]
+      if (!state) return
+
+      setModelRetrying(model)
+
+      void submitModel({
+        settings,
+        modelState: state,
+        callbacks: {
+          onStreamContent: (content, reasoningContent) => {
+            updateStreamingContent(model, content, reasoningContent)
+          },
+          onStreamDone: (result) => {
+            setModelDone(model, {
+              finishReason: result.finishReason,
+              usage: result.usage,
+              responseTimeMs: result.responseTimeMs,
+            })
+            if (result.content) {
+              appendAssistantMessage(model, { role: 'assistant', content: result.content })
+            }
+          },
+          onStreamError: (error) => {
+            setModelError(model, error)
+          },
+        },
+      })
+    },
+    [
+      modelStates,
+      setModelRetrying,
+      submitModel,
+      settings,
+      updateStreamingContent,
+      setModelDone,
+      appendAssistantMessage,
+      setModelError,
+    ]
+  )
 
   const handleChangeInput = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setInput(e.target.value)
@@ -269,6 +316,8 @@ export function ChatCompare() {
                     error: null,
                   }
                 }
+                onCancelModel={handleCancelModel}
+                onRetryModel={handleRetryModel}
               />
             ))
           )

--- a/projects/portfolio/tests/client/components/compare-column.test.tsx
+++ b/projects/portfolio/tests/client/components/compare-column.test.tsx
@@ -1,0 +1,160 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { CompareColumn } from '#/client/components/chat-compare/compare-column'
+import type { ModelStreamState } from '#/client/components/chat-compare/hooks/use-compare-state'
+
+function createModelState(overrides: Partial<ModelStreamState> = {}): ModelStreamState {
+  return {
+    model: 'test-model',
+    status: 'idle',
+    messages: [],
+    content: '',
+    reasoningContent: '',
+    usage: null,
+    finishReason: null,
+    responseTimeMs: null,
+    error: null,
+    ...overrides,
+  }
+}
+
+describe('CompareColumn', () => {
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  describe('停止ボタン', () => {
+    it('は status が streaming の場合に表示される', () => {
+      render(
+        <CompareColumn
+          state={createModelState({ status: 'streaming' })}
+          onCancelModel={vi.fn()}
+          onRetryModel={vi.fn()}
+        />
+      )
+
+      expect(screen.queryByLabelText('Stop test-model')).not.toBeNull()
+    })
+
+    it('は status が retrying の場合に表示される', () => {
+      render(
+        <CompareColumn
+          state={createModelState({ status: 'retrying' })}
+          onCancelModel={vi.fn()}
+          onRetryModel={vi.fn()}
+        />
+      )
+
+      expect(screen.queryByLabelText('Stop test-model')).not.toBeNull()
+    })
+
+    it('は status が idle / done / error / cancelled の場合は表示されない', () => {
+      const statuses: ModelStreamState['status'][] = ['idle', 'done', 'error', 'cancelled']
+      for (const status of statuses) {
+        const { unmount } = render(
+          <CompareColumn state={createModelState({ status })} onCancelModel={vi.fn()} onRetryModel={vi.fn()} />
+        )
+
+        expect(screen.queryByLabelText('Stop test-model')).toBeNull()
+        unmount()
+      }
+    })
+
+    it('は押下時に onCancelModel が model 名とともに呼ばれる', () => {
+      const onCancelModel = vi.fn()
+      render(
+        <CompareColumn
+          state={createModelState({ status: 'streaming', model: 'gpt-5' })}
+          onCancelModel={onCancelModel}
+        />
+      )
+
+      fireEvent.click(screen.getByLabelText('Stop gpt-5'))
+
+      expect(onCancelModel).toHaveBeenCalledOnce()
+      expect(onCancelModel).toHaveBeenCalledWith('gpt-5')
+    })
+  })
+
+  describe('再試行ボタン', () => {
+    it('は status が error の場合に表示される', () => {
+      render(
+        <CompareColumn
+          state={createModelState({ status: 'error', error: 'timeout' })}
+          onCancelModel={vi.fn()}
+          onRetryModel={vi.fn()}
+        />
+      )
+
+      expect(screen.queryByLabelText('Retry test-model')).not.toBeNull()
+    })
+
+    it('は status が cancelled の場合に表示される', () => {
+      render(
+        <CompareColumn
+          state={createModelState({ status: 'cancelled', error: 'Cancelled by user' })}
+          onCancelModel={vi.fn()}
+          onRetryModel={vi.fn()}
+        />
+      )
+
+      expect(screen.queryByLabelText('Retry test-model')).not.toBeNull()
+    })
+
+    it('は status が idle / streaming / retrying / done の場合は表示されない', () => {
+      const statuses: ModelStreamState['status'][] = ['idle', 'streaming', 'retrying', 'done']
+      for (const status of statuses) {
+        const { unmount } = render(
+          <CompareColumn state={createModelState({ status })} onCancelModel={vi.fn()} onRetryModel={vi.fn()} />
+        )
+
+        expect(screen.queryByLabelText('Retry test-model')).toBeNull()
+        unmount()
+      }
+    })
+
+    it('は押下時に onRetryModel が model 名とともに呼ばれる', () => {
+      const onRetryModel = vi.fn()
+      render(
+        <CompareColumn
+          state={createModelState({ status: 'error', error: 'timeout', model: 'claude-sonnet' })}
+          onRetryModel={onRetryModel}
+        />
+      )
+
+      fireEvent.click(screen.getByLabelText('Retry claude-sonnet'))
+
+      expect(onRetryModel).toHaveBeenCalledOnce()
+      expect(onRetryModel).toHaveBeenCalledWith('claude-sonnet')
+    })
+  })
+
+  describe('エラー表示', () => {
+    it('は error 文字列がある場合にエラーメッセージを表示する', () => {
+      render(
+        <CompareColumn
+          state={createModelState({ status: 'error', error: 'Response timed out' })}
+          onCancelModel={vi.fn()}
+          onRetryModel={vi.fn()}
+        />
+      )
+
+      expect(screen.getByText('Response timed out')).toBeTruthy()
+    })
+
+    it('は cancelled ステータスでも error 文字列を表示する', () => {
+      render(
+        <CompareColumn
+          state={createModelState({ status: 'cancelled', error: 'Cancelled by user' })}
+          onCancelModel={vi.fn()}
+          onRetryModel={vi.fn()}
+        />
+      )
+
+      expect(screen.getByText('Cancelled by user')).toBeTruthy()
+    })
+  })
+})

--- a/projects/portfolio/tests/client/hooks/use-compare-state.test.ts
+++ b/projects/portfolio/tests/client/hooks/use-compare-state.test.ts
@@ -1,0 +1,203 @@
+// @vitest-environment jsdom
+
+import { renderHook, act } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { useCompareState } from '#/client/components/chat-compare/hooks/use-compare-state'
+
+describe('useCompareState', () => {
+  describe('setModelCancelled', () => {
+    it('は部分出力を保持したまま status を cancelled に変更する', () => {
+      const { result } = renderHook(() => useCompareState())
+
+      act(() => {
+        result.current.setSelectedModels(['model-a'])
+        result.current.initModelStates(['model-a'])
+      })
+
+      const model = 'model-a'
+      act(() => {
+        result.current.updateStreamingContent(model, 'partial content', 'partial reasoning')
+      })
+      act(() => {
+        result.current.setModelCancelled(model)
+      })
+
+      const state = result.current.modelStates[model]
+      expect(state.status).toBe('cancelled')
+      expect(state.content).toBe('partial content')
+      expect(state.reasoningContent).toBe('partial reasoning')
+      expect(state.error).toBe('Cancelled by user')
+    })
+  })
+
+  describe('setModelRetrying', () => {
+    it('は streaming 関連データをクリアし status を retrying に変更する', () => {
+      const { result } = renderHook(() => useCompareState())
+
+      act(() => {
+        result.current.setSelectedModels(['model-a'])
+        result.current.initModelStates(['model-a'])
+      })
+
+      const model = 'model-a'
+      act(() => {
+        result.current.updateStreamingContent(model, 'partial', 'reasoning')
+      })
+      act(() => {
+        result.current.setModelError(model, 'some error')
+      })
+      act(() => {
+        result.current.setModelRetrying(model)
+      })
+
+      const state = result.current.modelStates[model]
+      expect(state.status).toBe('retrying')
+      expect(state.content).toBe('')
+      expect(state.reasoningContent).toBe('')
+      expect(state.usage).toBeNull()
+      expect(state.finishReason).toBeNull()
+      expect(state.responseTimeMs).toBeNull()
+      expect(state.error).toBeNull()
+    })
+  })
+
+  describe('setModelError', () => {
+    it('は部分出力を保持したまま status を error に変更する', () => {
+      const { result } = renderHook(() => useCompareState())
+
+      act(() => {
+        result.current.setSelectedModels(['model-a'])
+        result.current.initModelStates(['model-a'])
+      })
+
+      const model = 'model-a'
+      act(() => {
+        result.current.updateStreamingContent(model, 'partial content', '')
+      })
+      act(() => {
+        result.current.setModelError(model, 'Network error')
+      })
+
+      const state = result.current.modelStates[model]
+      expect(state.status).toBe('error')
+      expect(state.content).toBe('partial content')
+      expect(state.error).toBe('Network error')
+    })
+  })
+
+  describe('isSubmitting', () => {
+    it('は streaming または retrying のモデルが1つでもあれば true になる', () => {
+      const { result } = renderHook(() => useCompareState())
+
+      act(() => {
+        result.current.setSelectedModels(['model-a', 'model-b'])
+        result.current.initModelStates(['model-a', 'model-b'])
+      })
+
+      expect(result.current.isSubmitting).toBe(false)
+
+      act(() => {
+        result.current.setModelStreaming('model-a')
+      })
+
+      expect(result.current.isSubmitting).toBe(true)
+
+      act(() => {
+        result.current.setModelDone('model-a', {
+          finishReason: 'stop',
+          usage: null,
+          responseTimeMs: 100,
+        })
+      })
+
+      expect(result.current.isSubmitting).toBe(false)
+
+      act(() => {
+        result.current.setModelRetrying('model-b')
+      })
+
+      expect(result.current.isSubmitting).toBe(true)
+    })
+
+    it('は全モデルが idle/done/error/cancelled の場合は false になる', () => {
+      const { result } = renderHook(() => useCompareState())
+
+      act(() => {
+        result.current.setSelectedModels(['model-a', 'model-b'])
+        result.current.initModelStates(['model-a', 'model-b'])
+      })
+
+      expect(result.current.isSubmitting).toBe(false)
+
+      act(() => {
+        result.current.setModelDone('model-a', {
+          finishReason: 'stop',
+          usage: null,
+          responseTimeMs: 100,
+        })
+      })
+      act(() => {
+        result.current.setModelError('model-b', 'error')
+      })
+
+      expect(result.current.isSubmitting).toBe(false)
+
+      act(() => {
+        result.current.setModelCancelled('model-a')
+      })
+
+      expect(result.current.isSubmitting).toBe(false)
+    })
+  })
+
+  describe('appendAssistantMessage', () => {
+    it('は streaming データをキープしたまま assistant メッセージを messages に追加する', () => {
+      const { result } = renderHook(() => useCompareState())
+
+      act(() => {
+        result.current.setSelectedModels(['model-a'])
+        result.current.initModelStates(['model-a'])
+      })
+
+      const userMessage = { role: 'user' as const, content: 'hello' }
+      act(() => {
+        result.current.appendUserMessageToAll(['model-a'], userMessage)
+      })
+
+      const assistantMessage = { role: 'assistant' as const, content: 'hi there' }
+      act(() => {
+        result.current.appendAssistantMessage('model-a', assistantMessage)
+      })
+
+      const state = result.current.modelStates['model-a']
+      expect(state.messages).toHaveLength(2)
+      expect(state.messages[0]).toEqual(userMessage)
+      expect(state.messages[1]).toHaveProperty('role', 'assistant')
+      expect(state.messages[1]).toHaveProperty('content', 'hi there')
+    })
+  })
+
+  describe('resetModelStream', () => {
+    it('は全データをクリアし status を idle に戻す', () => {
+      const { result } = renderHook(() => useCompareState())
+
+      act(() => {
+        result.current.setSelectedModels(['model-a'])
+        result.current.initModelStates(['model-a'])
+      })
+
+      act(() => {
+        result.current.updateStreamingContent('model-a', 'content', 'reasoning')
+      })
+      act(() => {
+        result.current.resetModelStream('model-a')
+      })
+
+      const state = result.current.modelStates['model-a']
+      expect(state.status).toBe('idle')
+      expect(state.content).toBe('')
+      expect(state.reasoningContent).toBe('')
+      expect(state.messages).toHaveLength(0)
+    })
+  })
+})

--- a/projects/portfolio/tests/client/hooks/use-compare-stream.test.ts
+++ b/projects/portfolio/tests/client/hooks/use-compare-stream.test.ts
@@ -1,67 +1,69 @@
 // @vitest-environment jsdom
 
 import { renderHook, act } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-vi.mock('hono/client', () => {
-  const createMockClient = () => ({
-    api: {
-      chat: {
-        stream: {
-          $post: vi.fn(),
-        },
-      },
-    },
-  })
-  return {
-    hc: vi.fn(() => createMockClient()),
-  }
-})
+const mock$post = vi.fn()
+
+vi.mock('hono/client', () => ({
+  hc: vi.fn(() => ({
+    api: { chat: { stream: { $post: mock$post } } },
+  })),
+}))
 
 describe('useCompareStream', () => {
+  let abortSpy: ReturnType<typeof vi.spyOn>
+
   beforeEach(() => {
     vi.resetModules()
+    mock$post.mockReset()
+    mock$post.mockReturnValue(new Promise<{ ok: false; json: () => Promise<Record<string, unknown>> }>(() => {}))
+    abortSpy = vi.spyOn(AbortController.prototype, 'abort')
   })
+
+  afterEach(() => {
+    abortSpy.mockRestore()
+  })
+
+  const settings = {
+    schemaVersion: '1.0.0',
+    baseURL: 'http://localhost',
+    apiKey: 'test-key',
+    apiMode: 'chat_completions' as const,
+  }
 
   it('cancelModel は対象モデルの AbortController のみ abort する', async () => {
     const { useCompareStream } = await import('#/client/components/chat-compare/hooks/use-compare-stream')
 
     const { result } = renderHook(() => useCompareStream())
 
-    const settings = {
-      schemaVersion: '1.0.0',
-      baseURL: 'http://localhost',
-      apiKey: 'test-key',
-      apiMode: 'chat_completions' as const,
-    }
-
-    const modelState = {
-      model: 'model-a',
-      status: 'idle' as const,
-      messages: [],
-      content: '',
-      reasoningContent: '',
-      usage: null,
-      finishReason: null,
-      responseTimeMs: null,
-      error: null,
-    }
-
-    const userMessage = { role: 'user' as const, content: 'test' }
-
     act(() => {
-      result.current.submitCompare(settings, { 'model-a': modelState }, ['model-a'], userMessage, {
-        onStreamContent: vi.fn(),
-        onStreamDone: vi.fn(),
-        onStreamError: vi.fn(),
-      })
+      result.current.submitCompare(
+        settings,
+        {
+          'model-a': {
+            model: 'model-a',
+            status: 'idle' as const,
+            messages: [],
+            content: '',
+            reasoningContent: '',
+            usage: null,
+            finishReason: null,
+            responseTimeMs: null,
+            error: null,
+          },
+        },
+        ['model-a'],
+        { role: 'user' as const, content: 'test' },
+        { onStreamContent: vi.fn(), onStreamDone: vi.fn(), onStreamError: vi.fn() }
+      )
     })
 
     act(() => {
       result.current.cancelModel('model-a')
     })
 
-    expect(result.current).toBeDefined()
+    expect(abortSpy).toHaveBeenCalled()
   })
 
   it('cancelAll は全モデルの AbortController を abort する', async () => {
@@ -69,50 +71,36 @@ describe('useCompareStream', () => {
 
     const { result } = renderHook(() => useCompareStream())
 
-    const settings = {
-      schemaVersion: '1.0.0',
-      baseURL: 'http://localhost',
-      apiKey: 'test-key',
-      apiMode: 'chat_completions' as const,
-    }
-
-    const modelStateA = {
-      model: 'model-a',
-      status: 'idle' as const,
-      messages: [],
-      content: '',
-      reasoningContent: '',
-      usage: null,
-      finishReason: null,
-      responseTimeMs: null,
-      error: null,
-    }
-
-    const modelStateB = {
-      model: 'model-b',
-      status: 'idle' as const,
-      messages: [],
-      content: '',
-      reasoningContent: '',
-      usage: null,
-      finishReason: null,
-      responseTimeMs: null,
-      error: null,
-    }
-
-    const userMessage = { role: 'user' as const, content: 'test' }
-
     act(() => {
       result.current.submitCompare(
         settings,
-        { 'model-a': modelStateA, 'model-b': modelStateB },
-        ['model-a', 'model-b'],
-        userMessage,
         {
-          onStreamContent: vi.fn(),
-          onStreamDone: vi.fn(),
-          onStreamError: vi.fn(),
-        }
+          'model-a': {
+            model: 'model-a',
+            status: 'idle' as const,
+            messages: [],
+            content: '',
+            reasoningContent: '',
+            usage: null,
+            finishReason: null,
+            responseTimeMs: null,
+            error: null,
+          },
+          'model-b': {
+            model: 'model-b',
+            status: 'idle' as const,
+            messages: [],
+            content: '',
+            reasoningContent: '',
+            usage: null,
+            finishReason: null,
+            responseTimeMs: null,
+            error: null,
+          },
+        },
+        ['model-a', 'model-b'],
+        { role: 'user' as const, content: 'test' },
+        { onStreamContent: vi.fn(), onStreamDone: vi.fn(), onStreamError: vi.fn() }
       )
     })
 
@@ -120,20 +108,16 @@ describe('useCompareStream', () => {
       result.current.cancelAll()
     })
 
-    expect(result.current).toBeDefined()
+    expect(abortSpy).toHaveBeenCalledTimes(2)
   })
 
-  it('submitModel は指定モデルだけ stream を開始する', async () => {
+  it('submitModel は正しい引数で stream API を呼び出す', async () => {
+    mock$post.mockReset()
+    mock$post.mockReturnValue(new Promise(() => {}))
+
     const { useCompareStream } = await import('#/client/components/chat-compare/hooks/use-compare-stream')
 
     const { result } = renderHook(() => useCompareStream())
-
-    const settings = {
-      schemaVersion: '1.0.0',
-      baseURL: 'http://localhost',
-      apiKey: 'test-key',
-      apiMode: 'chat_completions' as const,
-    }
 
     const modelState = {
       model: 'model-a',
@@ -153,10 +137,58 @@ describe('useCompareStream', () => {
       onStreamError: vi.fn(),
     }
 
-    await act(async () => {
-      await result.current.submitModel({ settings, modelState, callbacks })
+    act(() => {
+      result.current.submitModel({ settings, modelState, callbacks })
     })
 
-    expect(result.current).toBeDefined()
+    expect(mock$post).toHaveBeenCalledOnce()
+    const callArgs = mock$post.mock.calls[0]
+
+    const requestArg = callArgs[0] as { json: { model: string; messages: typeof modelState.messages } }
+    expect(requestArg.json.model).toBe('model-a')
+    expect(requestArg.json.messages).toEqual([{ role: 'user', content: 'hello' }])
+
+    const headers = requestArg as unknown as { header: Record<string, string> }
+    expect(headers.header['api-key']).toBe('test-key')
+    expect(headers.header['base-url']).toBe('http://localhost')
+  })
+
+  it('submitModel は既存の controller がある場合に abort してから新しい controller をセットする', async () => {
+    mock$post.mockReset()
+    mock$post.mockReturnValue(new Promise(() => {}))
+
+    const { useCompareStream } = await import('#/client/components/chat-compare/hooks/use-compare-stream')
+
+    const { result } = renderHook(() => useCompareStream())
+
+    const modelState = {
+      model: 'model-a',
+      status: 'retrying' as const,
+      messages: [{ role: 'user' as const, content: 'hello' }],
+      content: '',
+      reasoningContent: '',
+      usage: null,
+      finishReason: null,
+      responseTimeMs: null,
+      error: null,
+    }
+
+    const callbacks = {
+      onStreamContent: vi.fn(),
+      onStreamDone: vi.fn(),
+      onStreamError: vi.fn(),
+    }
+
+    act(() => {
+      result.current.submitModel({ settings, modelState, callbacks })
+    })
+
+    const callsAfterFirst = abortSpy.mock.calls.length
+
+    act(() => {
+      result.current.submitModel({ settings, modelState, callbacks })
+    })
+
+    expect(abortSpy).toHaveBeenCalledTimes(callsAfterFirst + 1)
   })
 })

--- a/projects/portfolio/tests/client/hooks/use-compare-stream.test.ts
+++ b/projects/portfolio/tests/client/hooks/use-compare-stream.test.ts
@@ -1,0 +1,162 @@
+// @vitest-environment jsdom
+
+import { renderHook, act } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('hono/client', () => {
+  const createMockClient = () => ({
+    api: {
+      chat: {
+        stream: {
+          $post: vi.fn(),
+        },
+      },
+    },
+  })
+  return {
+    hc: vi.fn(() => createMockClient()),
+  }
+})
+
+describe('useCompareStream', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  it('cancelModel は対象モデルの AbortController のみ abort する', async () => {
+    const { useCompareStream } = await import('#/client/components/chat-compare/hooks/use-compare-stream')
+
+    const { result } = renderHook(() => useCompareStream())
+
+    const settings = {
+      schemaVersion: '1.0.0',
+      baseURL: 'http://localhost',
+      apiKey: 'test-key',
+      apiMode: 'chat_completions' as const,
+    }
+
+    const modelState = {
+      model: 'model-a',
+      status: 'idle' as const,
+      messages: [],
+      content: '',
+      reasoningContent: '',
+      usage: null,
+      finishReason: null,
+      responseTimeMs: null,
+      error: null,
+    }
+
+    const userMessage = { role: 'user' as const, content: 'test' }
+
+    act(() => {
+      result.current.submitCompare(settings, { 'model-a': modelState }, ['model-a'], userMessage, {
+        onStreamContent: vi.fn(),
+        onStreamDone: vi.fn(),
+        onStreamError: vi.fn(),
+      })
+    })
+
+    act(() => {
+      result.current.cancelModel('model-a')
+    })
+
+    expect(result.current).toBeDefined()
+  })
+
+  it('cancelAll は全モデルの AbortController を abort する', async () => {
+    const { useCompareStream } = await import('#/client/components/chat-compare/hooks/use-compare-stream')
+
+    const { result } = renderHook(() => useCompareStream())
+
+    const settings = {
+      schemaVersion: '1.0.0',
+      baseURL: 'http://localhost',
+      apiKey: 'test-key',
+      apiMode: 'chat_completions' as const,
+    }
+
+    const modelStateA = {
+      model: 'model-a',
+      status: 'idle' as const,
+      messages: [],
+      content: '',
+      reasoningContent: '',
+      usage: null,
+      finishReason: null,
+      responseTimeMs: null,
+      error: null,
+    }
+
+    const modelStateB = {
+      model: 'model-b',
+      status: 'idle' as const,
+      messages: [],
+      content: '',
+      reasoningContent: '',
+      usage: null,
+      finishReason: null,
+      responseTimeMs: null,
+      error: null,
+    }
+
+    const userMessage = { role: 'user' as const, content: 'test' }
+
+    act(() => {
+      result.current.submitCompare(
+        settings,
+        { 'model-a': modelStateA, 'model-b': modelStateB },
+        ['model-a', 'model-b'],
+        userMessage,
+        {
+          onStreamContent: vi.fn(),
+          onStreamDone: vi.fn(),
+          onStreamError: vi.fn(),
+        }
+      )
+    })
+
+    act(() => {
+      result.current.cancelAll()
+    })
+
+    expect(result.current).toBeDefined()
+  })
+
+  it('submitModel は指定モデルだけ stream を開始する', async () => {
+    const { useCompareStream } = await import('#/client/components/chat-compare/hooks/use-compare-stream')
+
+    const { result } = renderHook(() => useCompareStream())
+
+    const settings = {
+      schemaVersion: '1.0.0',
+      baseURL: 'http://localhost',
+      apiKey: 'test-key',
+      apiMode: 'chat_completions' as const,
+    }
+
+    const modelState = {
+      model: 'model-a',
+      status: 'retrying' as const,
+      messages: [{ role: 'user' as const, content: 'hello' }],
+      content: '',
+      reasoningContent: '',
+      usage: null,
+      finishReason: null,
+      responseTimeMs: null,
+      error: null,
+    }
+
+    const callbacks = {
+      onStreamContent: vi.fn(),
+      onStreamDone: vi.fn(),
+      onStreamError: vi.fn(),
+    }
+
+    await act(async () => {
+      await result.current.submitModel({ settings, modelState, callbacks })
+    })
+
+    expect(result.current).toBeDefined()
+  })
+})


### PR DESCRIPTION
## Issues

- Close #928

## Why

chat-compare の timeout/retry 方針を、自動リトライではなくモデル単位の手動停止・手動リトライへ変更する。SSE 接続後に LLM 応答が止まった場合も、対象モデルだけ timeout/error として扱い、ユーザーが明示的に再試行できる UI にする。

## Summary

`useCompareStream` をモデル単位の実行・停止 API に寄せ、アイドルタイムアウト時は自動リトライせず手動リトライ前提とした。`CompareColumn` に停止・再試行ボタンを追加し、全体停止は composer の停止ボタンで維持する。

<img width="368" height="150" alt="image" src="https://github.com/user-attachments/assets/c559ae04-0150-48a1-8d28-175db7ac635e" />

↓リトライ中

<img width="325" height="158" alt="image" src="https://github.com/user-attachments/assets/1cac6472-46cf-4e9f-9daa-6ff39b51765e" />

↓ストリームDONE

<img width="317" height="190" alt="image" src="https://github.com/user-attachments/assets/77680ab2-ca87-4d33-a26d-9f5af8dad0c1" />


## Changes

- `useCompareState`: `cancelled` / `retrying` ステータス追加、`setModelCancelled` / `setModelRetrying` 追加、`isSubmitting` をモデル状態からの派生値に変更
- `useCompareStream`: 単一 `AbortController` からモデル単位 `Map<string, AbortController>` に変更、`cancelModel` / `submitModel` 追加、アイドルタイムアウト（30秒）追加（自動リトライなし）
- `CompareColumn`: 停止ボタン（streaming/retrying 時）と再試行ボタン（error/cancelled 時）を追加
- `ChatCompare`: モデル単位停止・再試行・全体停止の配線、`submitCompare` を fire-and-forget に変更
- `RefreshIcon` SVG アイコンを新規追加
- テスト追加: `useCompareState`, `useCompareStream`, `CompareColumn`

## Verification

- `bun run lint` — 0 warnings, 0 errors
- `bun run format:check` — All matched files use the correct format
- `bun run test` — 49 test files, 270 tests passed
