### PR TITLE
feat(portfolio): add SVG icon catalog debug page

### DIFF
--- a/projects/portfolio/DEVELOPMENT.md
+++ b/projects/portfolio/DEVELOPMENT.md
@@ -139,7 +139,7 @@ printf 'replace-with-password\n' | bun run db:user:add -- --email test@example.c
 `/debug/svg-catalog` は開発時専用のデバッグページです。`src/client/components/svg/` 以下の SVG アイコンコンポーネントを一覧で確認でき、ダークモード切り替えも可能です。
 
 - `bun run dev` でのみ有効です。本番ビルドには含まれません。
-- ナビゲーションの「SVG Catalog」リンク、または <http://localhost:3000/debug/svg-catalog> にアクセスしてください。
+- ナビゲーションの「SVGs」リンク、または <http://localhost:3000/debug/svg-catalog> にアクセスしてください。
 
 ## Authentication Notes
 

--- a/projects/portfolio/DEVELOPMENT.md
+++ b/projects/portfolio/DEVELOPMENT.md
@@ -132,6 +132,15 @@ printf 'replace-with-password\n' | bun run db:user:add -- --email test@example.c
 
 同じメールアドレスが既に存在する場合、このコマンドは失敗します。
 
+## Debug Pages
+
+### SVG Icon Catalog
+
+`/debug/svg-catalog` は開発時専用のデバッグページです。`src/client/components/svg/` 以下の SVG アイコンコンポーネントを一覧で確認でき、ダークモード切り替えも可能です。
+
+- `bun run dev` でのみ有効です。本番ビルドには含まれません。
+- ナビゲーションの「SVG Catalog」リンク、または <http://localhost:3000/debug/svg-catalog> にアクセスしてください。
+
 ## Authentication Notes
 
 - サインイン時は `users.password_hash` を使ってパスワードを検証します

--- a/projects/portfolio/src/client/main.tsx
+++ b/projects/portfolio/src/client/main.tsx
@@ -3,14 +3,16 @@ import { createRouter, RouterProvider } from '@tanstack/react-router'
 import { createRoot } from 'react-dom/client'
 import { routeTree } from './routeTree.gen'
 
-let augmentedRouteTree = routeTree
+const debugRoute = import.meta.env.DEV
+  ? (await import('./routes/_debug.svg-catalog')).Route
+  : null
 
-if (import.meta.env.DEV) {
-  const module = (await new Function(
-    "return import('./routes/_debug.svg-catalog')"
-  )()) as typeof import('./routes/_debug.svg-catalog')
-  augmentedRouteTree = routeTree.addChildren([module.Route]) as any
-}
+const augmentedRouteTree = debugRoute
+  ? routeTree.addChildren([
+      ...(Array.isArray(routeTree.children) ? routeTree.children : []),
+      debugRoute,
+    ])
+  : routeTree
 
 const router = createRouter({ routeTree: augmentedRouteTree })
 

--- a/projects/portfolio/src/client/main.tsx
+++ b/projects/portfolio/src/client/main.tsx
@@ -3,15 +3,10 @@ import { createRouter, RouterProvider } from '@tanstack/react-router'
 import { createRoot } from 'react-dom/client'
 import { routeTree } from './routeTree.gen'
 
-const debugRoute = import.meta.env.DEV
-  ? (await import('./routes/_debug.svg-catalog')).Route
-  : null
+const debugRoute = import.meta.env.DEV ? (await import('./routes/_debug.svg-catalog')).Route : null
 
 const augmentedRouteTree = debugRoute
-  ? routeTree.addChildren([
-      ...(Array.isArray(routeTree.children) ? routeTree.children : []),
-      debugRoute,
-    ])
+  ? routeTree.addChildren([...(Array.isArray(routeTree.children) ? routeTree.children : []), debugRoute])
   : routeTree
 
 const router = createRouter({ routeTree: augmentedRouteTree })

--- a/projects/portfolio/src/client/main.tsx
+++ b/projects/portfolio/src/client/main.tsx
@@ -3,7 +3,16 @@ import { createRouter, RouterProvider } from '@tanstack/react-router'
 import { createRoot } from 'react-dom/client'
 import { routeTree } from './routeTree.gen'
 
-const router = createRouter({ routeTree })
+let augmentedRouteTree = routeTree
+
+if (import.meta.env.DEV) {
+  const module = (await new Function(
+    "return import('./routes/_debug.svg-catalog')"
+  )()) as typeof import('./routes/_debug.svg-catalog')
+  augmentedRouteTree = routeTree.addChildren([module.Route]) as any
+}
+
+const router = createRouter({ routeTree: augmentedRouteTree })
 
 // Register the router instance for type safety
 declare module '@tanstack/react-router' {

--- a/projects/portfolio/src/client/routes/__root.tsx
+++ b/projects/portfolio/src/client/routes/__root.tsx
@@ -33,7 +33,7 @@ function Root() {
 
   if (import.meta.env.DEV) {
     menuItems.push({
-      label: 'SVG Catalog',
+      label: 'SVGs',
       icon: <SparkleIcon size={20} />,
       to: '/debug/svg-catalog' as any,
     })

--- a/projects/portfolio/src/client/routes/__root.tsx
+++ b/projects/portfolio/src/client/routes/__root.tsx
@@ -7,6 +7,7 @@ import { ChatbotIcon } from '#/client/components/svg/chatbot-icon'
 import { CompareIcon } from '#/client/components/svg/compare-icon'
 import { DashboardIcon } from '#/client/components/svg/dashboard-icon'
 import { DiffIcon } from '#/client/components/svg/diff-icon'
+import { SparkleIcon } from '#/client/components/svg/sparkle-icon'
 
 const TanStackRouterDevtoolsPanel = import.meta.env.PROD
   ? () => null // Render nothing in production
@@ -22,18 +23,25 @@ export const Route = createRootRoute({
 })
 
 function Root() {
+  const menuItems = [
+    { label: 'Home', icon: <DashboardIcon size={24} />, to: '/' },
+    { label: 'About', icon: <AboutIcon size={18} />, to: '/about' },
+    { label: 'Diff', icon: <DiffIcon size={20} />, to: '/diff' },
+    { label: 'Chat', icon: <ChatbotIcon size={26} />, to: '/chat' },
+    { label: 'Compare', icon: <CompareIcon size={22} />, to: '/chat-compare' },
+  ]
+
+  if (import.meta.env.DEV) {
+    menuItems.push({
+      label: 'SVG Catalog',
+      icon: <SparkleIcon size={20} />,
+      to: '/debug/svg-catalog' as any,
+    })
+  }
+
   return (
     <>
-      <AppLayout
-        version={import.meta.env.VITE_APP_VERSION || ''}
-        menuItems={[
-          { label: 'Home', icon: <DashboardIcon size={24} />, to: '/' },
-          { label: 'About', icon: <AboutIcon size={18} />, to: '/about' },
-          { label: 'Diff', icon: <DiffIcon size={20} />, to: '/diff' },
-          { label: 'Chat', icon: <ChatbotIcon size={26} />, to: '/chat' },
-          { label: 'Compare', icon: <CompareIcon size={22} />, to: '/chat-compare' },
-        ]}
-      >
+      <AppLayout version={import.meta.env.VITE_APP_VERSION || ''} menuItems={menuItems}>
         <Suspense fallback={<RouteLoading />}>
           <Outlet />
         </Suspense>

--- a/projects/portfolio/src/client/routes/_debug.svg-catalog.tsx
+++ b/projects/portfolio/src/client/routes/_debug.svg-catalog.tsx
@@ -85,7 +85,10 @@ function SvgCatalog() {
       </div>
       <div className='grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5'>
         {icons.map(({ fileName, componentName, Component }) => (
-          <div key={componentName} className='flex flex-col items-center gap-2 rounded border border-gray-200 p-4 text-gray-900 dark:border-gray-700 dark:text-white'>
+          <div
+            key={componentName}
+            className='flex flex-col items-center gap-2 rounded border border-gray-200 p-4 text-gray-900 dark:border-gray-700 dark:text-white'
+          >
             <Component size={32} />
             <span className='text-xs text-gray-500'>{componentName}</span>
             <span className='text-[10px] text-gray-400'>{fileName}</span>

--- a/projects/portfolio/src/client/routes/_debug.svg-catalog.tsx
+++ b/projects/portfolio/src/client/routes/_debug.svg-catalog.tsx
@@ -1,0 +1,97 @@
+import { createRoute } from '@tanstack/react-router'
+import { useEffect, useState } from 'react'
+import { Route as RootRoute } from './__root'
+
+const modules = import.meta.glob('../components/svg/*-icon.tsx', { eager: true })
+
+interface IconEntry {
+  fileName: string
+  componentName: string
+  Component: React.FC<{ size?: number }>
+}
+
+const icons: IconEntry[] = Object.entries(modules).map(([path, mod]) => {
+  const fileName = path.split('/').pop() ?? ''
+  const componentName = Object.keys(mod as Record<string, unknown>).find((k) => k.endsWith('Icon')) ?? ''
+  const Component = (mod as Record<string, unknown>)[componentName] as React.FC<{ size?: number }>
+  return { fileName, componentName, Component }
+})
+
+export const Route = createRoute({
+  getParentRoute: () => RootRoute,
+  path: '/debug/svg-catalog',
+  component: SvgCatalog,
+})
+
+function SvgCatalog() {
+  const [isDark, setIsDark] = useState(() => {
+    if (typeof window === 'undefined') {
+      return false
+    }
+    const saved = localStorage.getItem('theme')
+    if (saved === 'dark') {
+      return true
+    }
+    if (saved === 'light') {
+      return false
+    }
+    return document.documentElement.classList.contains('dark')
+  })
+
+  useEffect(() => {
+    const syncTheme = () => {
+      const saved = localStorage.getItem('theme')
+      if (saved === 'dark') {
+        setIsDark(true)
+        return
+      }
+      if (saved === 'light') {
+        setIsDark(false)
+        return
+      }
+      setIsDark(document.documentElement.classList.contains('dark'))
+    }
+
+    syncTheme()
+
+    const observer = new MutationObserver(syncTheme)
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] })
+    window.addEventListener('storage', syncTheme)
+
+    return () => {
+      observer.disconnect()
+      window.removeEventListener('storage', syncTheme)
+    }
+  }, [])
+
+  const toggleDark = () => {
+    const next = !isDark
+    setIsDark(next)
+    document.documentElement.classList.toggle('dark', next)
+    localStorage.setItem('theme', next ? 'dark' : 'light')
+  }
+
+  return (
+    <div className='p-4'>
+      <div className='mb-4 flex items-center justify-between'>
+        <h1 className='text-xl font-bold'>SVG Icon Catalog</h1>
+        <button
+          type='button'
+          onClick={toggleDark}
+          className='rounded border px-3 py-1.5 text-sm hover:bg-gray-100 dark:hover:bg-gray-800'
+        >
+          {isDark ? 'Light Mode' : 'Dark Mode'}
+        </button>
+      </div>
+      <div className='grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5'>
+        {icons.map(({ fileName, componentName, Component }) => (
+          <div key={componentName} className='flex flex-col items-center gap-2 rounded border p-4'>
+            <Component size={32} />
+            <span className='text-xs text-gray-500'>{componentName}</span>
+            <span className='text-[10px] text-gray-400'>{fileName}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/projects/portfolio/src/client/routes/_debug.svg-catalog.tsx
+++ b/projects/portfolio/src/client/routes/_debug.svg-catalog.tsx
@@ -74,18 +74,18 @@ function SvgCatalog() {
   return (
     <div className='p-4'>
       <div className='mb-4 flex items-center justify-between'>
-        <h1 className='text-xl font-bold'>SVG Icon Catalog</h1>
+        <h1 className='text-xl font-bold text-gray-900 dark:text-white'>SVG Icon Catalog</h1>
         <button
           type='button'
           onClick={toggleDark}
-          className='rounded border px-3 py-1.5 text-sm hover:bg-gray-100 dark:hover:bg-gray-800'
+          className='rounded border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-900 hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-900 dark:text-white dark:hover:bg-gray-800'
         >
           {isDark ? 'Light Mode' : 'Dark Mode'}
         </button>
       </div>
       <div className='grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5'>
         {icons.map(({ fileName, componentName, Component }) => (
-          <div key={componentName} className='flex flex-col items-center gap-2 rounded border p-4'>
+          <div key={componentName} className='flex flex-col items-center gap-2 rounded border border-gray-200 p-4 text-gray-900 dark:border-gray-700 dark:text-white'>
             <Component size={32} />
             <span className='text-xs text-gray-500'>{componentName}</span>
             <span className='text-[10px] text-gray-400'>{fileName}</span>

--- a/projects/portfolio/tsr.config.json
+++ b/projects/portfolio/tsr.config.json
@@ -1,4 +1,5 @@
 {
   "routesDirectory": "./src/client/routes",
-  "generatedRouteTree": "./src/client/routeTree.gen.ts"
+  "generatedRouteTree": "./src/client/routeTree.gen.ts",
+  "routeFileIgnorePrefix": "_debug"
 }


### PR DESCRIPTION
## Issues

- Close #947

## Why

`src/client/components/svg/` 以下に約30個のアイコンコンポーネントが散在しており、開発時にどのアイコンが存在し、ダークモード下でどう描画されるかを一目で確認できるデバッグページが必要です。

## Summary

開発サーバー起動時のみ有効な `/debug/svg-catalog` ページを追加します。`import.meta.glob` でアイコンを動的一覧し、グリッド表示とダークモード切り替えを備えています。本番ビルドには一切含まれません。

## Changes

- `src/client/routes/_debug.svg-catalog.tsx` を新規作成（アイコンカタログページ）
- `src/client/main.tsx` に dev 時のみ `addChildren` でルート追加するロジックを追加
- `src/client/routes/__root.tsx` に dev 時のみナビゲーションリンクを追加
- `tsr.config.json` に `routeFileIgnorePrefix` を追加して `_debug` ファイルを自動ルート生成から除外
- `DEVELOPMENT.md` に `/debug/svg-catalog` の存在と用途を追記

## ScreenShot
|Light |Dark|
|-|-|
|<img width="1354" height="962" alt="image" src="https://github.com/user-attachments/assets/da679c8b-1365-4bd0-9ac5-051f700f3471" />|<img width="1353" height="958" alt="image" src="https://github.com/user-attachments/assets/80310f09-ceff-428f-b40f-e3885f98a0bd" />|


## Checklist

- [x] `bun run lint` が通る
- [x] `bun run test` が通る
- [x] `bun run format` が通る
- [x] 本番ビルド後、`_debug.svg-catalog.tsx` のコードが含まれていないことを確認
