### PR TITLE
refactor(portfolio): replace relative imports with #/ alias

### DIFF
--- a/projects/portfolio/src/client/components/chat/chat-settings/hooks/use-chat-settings.ts
+++ b/projects/portfolio/src/client/components/chat/chat-settings/hooks/use-chat-settings.ts
@@ -1,6 +1,6 @@
+import type { ChatSettingsContextValue } from '#/client/components/chat/chat-settings/chat-settings-context'
 import { useLockBodyScroll } from '#/client/hooks/use-lock-body-scroll'
 import type { Settings } from '#/client/storage/remote-storage-settings'
-import type { ChatSettingsContextValue } from '#/client/components/chat/chat-settings/chat-settings-context'
 import { useLocalStorageSettings } from './use-local-storage-settings'
 import { useModelFetching } from './use-model-fetching'
 import { useSettingsHandlers } from './use-settings-handlers'

--- a/projects/portfolio/src/client/components/chat/chat-settings/hooks/use-chat-settings.ts
+++ b/projects/portfolio/src/client/components/chat/chat-settings/hooks/use-chat-settings.ts
@@ -1,6 +1,6 @@
 import { useLockBodyScroll } from '#/client/hooks/use-lock-body-scroll'
 import type { Settings } from '#/client/storage/remote-storage-settings'
-import type { ChatSettingsContextValue } from '../chat-settings-context'
+import type { ChatSettingsContextValue } from '#/client/components/chat/chat-settings/chat-settings-context'
 import { useLocalStorageSettings } from './use-local-storage-settings'
 import { useModelFetching } from './use-model-fetching'
 import { useSettingsHandlers } from './use-settings-handlers'

--- a/projects/portfolio/src/client/components/chat/chat-settings/settings/auto-model-toggle.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-settings/settings/auto-model-toggle.tsx
@@ -1,5 +1,5 @@
-import { ToggleInput } from '#/client/components/input/toggle-input'
 import { useChatSettingsContext } from '#/client/components/chat/chat-settings/chat-settings-context'
+import { ToggleInput } from '#/client/components/input/toggle-input'
 
 export function AutoModelToggle() {
   const { autoModel, handleToggleAutoModel } = useChatSettingsContext()

--- a/projects/portfolio/src/client/components/chat/chat-settings/settings/auto-model-toggle.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-settings/settings/auto-model-toggle.tsx
@@ -1,5 +1,5 @@
 import { ToggleInput } from '#/client/components/input/toggle-input'
-import { useChatSettingsContext } from '../chat-settings-context'
+import { useChatSettingsContext } from '#/client/components/chat/chat-settings/chat-settings-context'
 
 export function AutoModelToggle() {
   const { autoModel, handleToggleAutoModel } = useChatSettingsContext()

--- a/projects/portfolio/src/client/components/chat/chat-settings/settings/reasoning-effort.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-settings/settings/reasoning-effort.tsx
@@ -1,5 +1,5 @@
-import { ToggleInput } from '#/client/components/input/toggle-input'
 import { useChatSettingsContext } from '#/client/components/chat/chat-settings/chat-settings-context'
+import { ToggleInput } from '#/client/components/input/toggle-input'
 
 export function ReasoningEffort() {
   const { reasoningEffort, reasoningEffortEnabled, handleChangeReasoningEffort, handleToggleReasoningEffort } =

--- a/projects/portfolio/src/client/components/chat/chat-settings/settings/reasoning-effort.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-settings/settings/reasoning-effort.tsx
@@ -1,5 +1,5 @@
 import { ToggleInput } from '#/client/components/input/toggle-input'
-import { useChatSettingsContext } from '../chat-settings-context'
+import { useChatSettingsContext } from '#/client/components/chat/chat-settings/chat-settings-context'
 
 export function ReasoningEffort() {
   const { reasoningEffort, reasoningEffortEnabled, handleChangeReasoningEffort, handleToggleReasoningEffort } =

--- a/projects/portfolio/src/client/components/chat/chat-settings/settings/temperature-slider.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-settings/settings/temperature-slider.tsx
@@ -1,5 +1,5 @@
-import { ToggleInput } from '#/client/components/input/toggle-input'
 import { useChatSettingsContext } from '#/client/components/chat/chat-settings/chat-settings-context'
+import { ToggleInput } from '#/client/components/input/toggle-input'
 
 export function TemperatureSlider() {
   const { temperature, temperatureEnabled, handleChangeTemperature, handleToggleTemperature } = useChatSettingsContext()

--- a/projects/portfolio/src/client/components/chat/chat-settings/settings/temperature-slider.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-settings/settings/temperature-slider.tsx
@@ -1,5 +1,5 @@
 import { ToggleInput } from '#/client/components/input/toggle-input'
-import { useChatSettingsContext } from '../chat-settings-context'
+import { useChatSettingsContext } from '#/client/components/chat/chat-settings/chat-settings-context'
 
 export function TemperatureSlider() {
   const { temperature, temperatureEnabled, handleChangeTemperature, handleToggleTemperature } = useChatSettingsContext()

--- a/projects/portfolio/src/client/components/theme-toggle.tsx
+++ b/projects/portfolio/src/client/components/theme-toggle.tsx
@@ -1,4 +1,4 @@
-import { useTheme } from '../hooks/use-theme'
+import { useTheme } from '#/client/hooks/use-theme'
 import { MoonIcon } from './svg/moon-icon'
 import { SunIcon } from './svg/sun-icon'
 

--- a/projects/portfolio/src/client/pages/diff/index.tsx
+++ b/projects/portfolio/src/client/pages/diff/index.tsx
@@ -2,7 +2,7 @@ import Editor from '@monaco-editor/react'
 import type { ComponentType } from 'react'
 import { useEffect, useState } from 'react'
 import ReactDiffViewerModule from 'react-diff-viewer'
-import { loadDiffState, saveDiffState } from '../../storage/diff-state'
+import { loadDiffState, saveDiffState } from '#/client/storage/diff-state'
 
 const reactDiffViewerImport = ReactDiffViewerModule as ComponentType<any> | { default: ComponentType<any> }
 const ReactDiffViewer =

--- a/projects/portfolio/src/db/seeders/add-user-record.ts
+++ b/projects/portfolio/src/db/seeders/add-user-record.ts
@@ -1,7 +1,7 @@
 import { eq } from 'drizzle-orm'
 import { uuidv7 } from 'uuidv7'
-import { getDatabase } from '../'
-import { usersTable } from '../schema'
+import { getDatabase } from '#/db'
+import { usersTable } from '#/db/schema'
 
 export interface AddUserInput {
   databaseUrl: string

--- a/projects/portfolio/src/db/seeders/add-user.ts
+++ b/projects/portfolio/src/db/seeders/add-user.ts
@@ -1,4 +1,4 @@
-import { hashPassword } from '../../server/features/auth/password-hash'
+import { hashPassword } from '#/server/features/auth/password-hash'
 import { parseAddUserArgs } from './add-user-args'
 import { addUser, ensureUserDoesNotExist } from './add-user-record'
 import { readPassword } from './read-password'

--- a/projects/portfolio/src/db/seeders/upsert-user.ts
+++ b/projects/portfolio/src/db/seeders/upsert-user.ts
@@ -1,6 +1,6 @@
 import { uuidv7 } from 'uuidv7'
-import { getDatabase } from '../'
-import { usersTable } from '../schema'
+import { getDatabase } from '#/db'
+import { usersTable } from '#/db/schema'
 
 export interface UpsertUserInput {
   databaseUrl: string

--- a/projects/portfolio/src/server/middleware/auth.ts
+++ b/projects/portfolio/src/server/middleware/auth.ts
@@ -1,6 +1,6 @@
 import { createMiddleware } from 'hono/factory'
-import type { HonoEnv } from '../routes/shared'
-import { getSignedInEmail } from '../routes/shared'
+import type { HonoEnv } from '#/server/routes/shared'
+import { getSignedInEmail } from '#/server/routes/shared'
 
 export const requireAuth = createMiddleware<HonoEnv>(async (c, next) => {
   const email = await getSignedInEmail(c)

--- a/projects/portfolio/src/server/routes/html.tsx
+++ b/projects/portfolio/src/server/routes/html.tsx
@@ -1,6 +1,6 @@
 import { Hono } from 'hono'
 import { renderToString } from 'react-dom/server'
-import { formatDurationLabel } from '../features/cookie/cookie'
+import { formatDurationLabel } from '#/server/features/cookie/cookie'
 import type { HonoEnv } from './shared'
 import { getServerEnv, getSignedInEmail } from './shared'
 


### PR DESCRIPTION
## Why

プロジェクトでは `#/*` → `./src/*` のエイリアスが `tsconfig.json` / `vite.config.ts` に定義されており、多くのインポート既にエイリアス形式で統一されているが、一部のファイルに相対パス `../` が残っていたため、完全に統一する。

## Summary

11ファイル・14箇所の `../` 相対パスインポートを `#/` エイリアスインポートに変換する。

## Changes

- `src/client/pages/diff/index.tsx`: `../../storage/diff-state` → `#/client/storage/diff-state`
- `src/client/components/chat/chat-settings/hooks/use-chat-settings.ts`: `../chat-settings-context` → `#/client/components/chat/chat-settings/chat-settings-context`
- `src/server/routes/html.tsx`: `../features/cookie/cookie` → `#/server/features/cookie/cookie`
- `src/client/components/chat/chat-settings/settings/*.tsx` (3 files): `../chat-settings-context` → `#/client/components/chat/chat-settings/chat-settings-context`
- `src/server/middleware/auth.ts`: `../routes/shared` → `#/server/routes/shared`
- `src/client/components/theme-toggle.tsx`: `../hooks/use-theme` → `#/client/hooks/use-theme`
- `src/db/seeders/add-user-record.ts`, `upsert-user.ts`: `../` / `../schema` → `#/db` / `#/db/schema`
- `src/db/seeders/add-user.ts`: `../../server/features/auth/password-hash` → `#/server/features/auth/password-hash`

## Checklist

- [x] リント / 型チェック通過
- [x] 全271テスト通過
- [x] `../` 相対パスインポートの残存なし
