### PR TITLE
feat(portfolio): add security headers and markdown sanitization

### DIFF
--- a/projects/portfolio/bun.lock
+++ b/projects/portfolio/bun.lock
@@ -23,6 +23,7 @@
         "react-dom": "^19.2.6",
         "react-markdown": "^10.1.0",
         "react-syntax-highlighter": "^16.1.1",
+        "rehype-sanitize": "^6.0.0",
         "remark-cjk-friendly": "^2.0.1",
         "remark-cjk-friendly-gfm-strikethrough": "^2.0.1",
         "remark-gfm": "^4.0.1",
@@ -697,6 +698,8 @@
 
     "hast-util-parse-selector": ["hast-util-parse-selector@4.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A=="],
 
+    "hast-util-sanitize": ["hast-util-sanitize@5.0.2", "", { "dependencies": { "@types/hast": "^3.0.0", "@ungap/structured-clone": "^1.0.0", "unist-util-position": "^5.0.0" } }, "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg=="],
+
     "hast-util-to-jsx-runtime": ["hast-util-to-jsx-runtime@2.3.2", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "hast-util-whitespace": "^3.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "property-information": "^6.0.0", "space-separated-tokens": "^2.0.0", "style-to-object": "^1.0.0", "unist-util-position": "^5.0.0", "vfile-message": "^4.0.0" } }, "sha512-1ngXYb+V9UT5h+PxNRa1O1FYguZK/XL+gkeqvp7EdHlB9oHUG0eYRo/vY5inBdcqo3RkPMC58/H94HvkbfGdyg=="],
 
     "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
@@ -1032,6 +1035,8 @@
     "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
 
     "refractor": ["refractor@5.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/prismjs": "^1.0.0", "hastscript": "^9.0.0", "parse-entities": "^4.0.0" } }, "sha512-QXOrHQF5jOpjjLfiNk5GFnWhRXvxjUVnlFxkeDmewR5sXkr3iM46Zo+CnRR8B+MDVqkULW4EcLVcRBNOPXHosw=="],
+
+    "rehype-sanitize": ["rehype-sanitize@6.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-sanitize": "^5.0.0" } }, "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg=="],
 
     "remark-cjk-friendly": ["remark-cjk-friendly@2.0.1", "", { "dependencies": { "micromark-extension-cjk-friendly": "2.0.1" }, "peerDependencies": { "@types/mdast": "^4.0.0", "unified": "^11.0.0" }, "optionalPeers": ["@types/mdast"] }, "sha512-6WwkoQyZf/4j5k53zdFYrR8Ca+UVn992jXdLUSBDZR4eBpFhKyVxmA4gUHra/5fesjGIxrDhHesNr/sVoiiysA=="],
 

--- a/projects/portfolio/package.json
+++ b/projects/portfolio/package.json
@@ -36,6 +36,7 @@
     "react-dom": "^19.2.6",
     "react-markdown": "^10.1.0",
     "react-syntax-highlighter": "^16.1.1",
+    "rehype-sanitize": "^6.0.0",
     "remark-cjk-friendly": "^2.0.1",
     "remark-cjk-friendly-gfm-strikethrough": "^2.0.1",
     "remark-gfm": "^4.0.1",

--- a/projects/portfolio/src/client/components/chat/chat-message-list.tsx
+++ b/projects/portfolio/src/client/components/chat/chat-message-list.tsx
@@ -1,5 +1,6 @@
 import { memo, type ReactNode, type RefObject, useCallback, useRef, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
+import rehypeSanitize from 'rehype-sanitize'
 import remarkGfm from 'remark-gfm'
 import type { SaveGeneratedFileRequest } from '#/client/components/chat/assistant-code-block'
 import {
@@ -18,6 +19,7 @@ import { SpinnerIcon } from '#/client/components/svg/spinner-icon'
 import type { GeneratedCodeFile, Message } from '#/types'
 
 const markdownRemarkPlugins = [remarkGfm]
+const markdownRehypePlugins = [rehypeSanitize]
 const markdownComponents = {
   a: MarkdownLink,
   code: CodeBlockRenderer,
@@ -126,7 +128,11 @@ export function ChatMessageList({
                       }
                     >
                       <StreamingCodeBlockContext.Provider value={true}>
-                        <ReactMarkdown remarkPlugins={markdownRemarkPlugins} components={markdownComponents}>
+                        <ReactMarkdown
+                          remarkPlugins={markdownRemarkPlugins}
+                          rehypePlugins={markdownRehypePlugins}
+                          components={markdownComponents}
+                        >
                           {stream.content}
                         </ReactMarkdown>
                       </StreamingCodeBlockContext.Provider>

--- a/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
+++ b/projects/portfolio/src/client/components/chat/code-block-renderer.tsx
@@ -37,21 +37,27 @@ const CUSTOM_STYLE: CSSProperties = {
 
 type MarkdownLinkProps = AnchorHTMLAttributes<HTMLAnchorElement>
 
-export function MarkdownLink({ href, children }: MarkdownLinkProps) {
+export function MarkdownLink({ href, children, ...props }: MarkdownLinkProps) {
   const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
     event.preventDefault()
     if (!href) {
       return
     }
     if (href.startsWith('http')) {
-      window.open(href, '_blank')
+      window.open(href, '_blank', 'noopener,noreferrer')
     } else {
       window.location.href = href
     }
   }
 
   return (
-    <a href={href} onClick={handleClick} className='text-primary-800 underline dark:text-primary-400'>
+    <a
+      {...props}
+      href={href}
+      rel='noopener noreferrer'
+      onClick={handleClick}
+      className='text-primary-800 underline dark:text-primary-400'
+    >
       {children}
     </a>
   )

--- a/projects/portfolio/src/client/components/chat/message-renderer.tsx
+++ b/projects/portfolio/src/client/components/chat/message-renderer.tsx
@@ -1,5 +1,6 @@
 import { Fragment, memo, type ReactNode, useEffect, useRef, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
+import rehypeSanitize from 'rehype-sanitize'
 import remarkCjkFriendly from 'remark-cjk-friendly'
 import remarkCjkFriendlyGfmStrikethrough from 'remark-cjk-friendly-gfm-strikethrough'
 import remarkGfm from 'remark-gfm'
@@ -27,6 +28,7 @@ import type { GeneratedCodeFile, Message } from '#/types'
 import { isImageContentArray } from '#/types'
 
 const markdownRemarkPlugins = [remarkGfm, remarkCjkFriendly, remarkCjkFriendlyGfmStrikethrough]
+const markdownRehypePlugins = [rehypeSanitize]
 const markdownComponents = {
   a: MarkdownLink,
   code: AssistantAwareCodeBlock,
@@ -305,7 +307,11 @@ function MessageRendererComponent({
           : null
       }
     >
-      <ReactMarkdown remarkPlugins={markdownRemarkPlugins} components={markdownComponents}>
+      <ReactMarkdown
+        remarkPlugins={markdownRemarkPlugins}
+        rehypePlugins={markdownRehypePlugins}
+        components={markdownComponents}
+      >
         {message.content}
       </ReactMarkdown>
     </CodeBlockOpenStateContext.Provider>

--- a/projects/portfolio/src/client/pages/about/index.tsx
+++ b/projects/portfolio/src/client/pages/about/index.tsx
@@ -1,4 +1,5 @@
 import Markdown from 'react-markdown'
+import rehypeSanitize from 'rehype-sanitize'
 import remarkGfm from 'remark-gfm'
 
 const source = `
@@ -48,7 +49,9 @@ export function About() {
     <div className='min-h-full bg-white px-4 py-6 dark:bg-gray-900 md:px-8 md:py-8'>
       <div className='mx-auto max-w-3xl'>
         <div className='prose prose-sm max-w-none text-gray-700 prose-headings:text-gray-900 prose-strong:text-gray-900 prose-a:text-blue-700 prose-code:text-gray-800 prose-pre:bg-gray-950 md:prose-base dark:prose-invert dark:text-gray-200 dark:prose-headings:text-white dark:prose-strong:text-white dark:prose-a:text-blue-300 dark:prose-code:text-gray-100'>
-          <Markdown remarkPlugins={[remarkGfm]}>{source}</Markdown>
+          <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeSanitize]}>
+            {source}
+          </Markdown>
         </div>
       </div>
     </div>

--- a/projects/portfolio/src/server/app.tsx
+++ b/projects/portfolio/src/server/app.tsx
@@ -13,11 +13,11 @@ import type { HonoEnv } from './routes/shared'
 
 const securityHeaders = {
   'Content-Security-Policy':
-    "default-src 'self'; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; script-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self'; frame-src 'self'",
+    "base-uri 'self'; default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self'; frame-src 'self'",
   'X-Content-Type-Options': 'nosniff',
   'X-Frame-Options': 'DENY',
   'Referrer-Policy': 'strict-origin-when-cross-origin',
-  'Permissions-Policy': 'camera=(), microphone=(), geolocation=()',
+  'Permissions-Policy': 'camera=(), microphone=(), geolocation=(), payment=(), usb=(), display-capture=()',
 } as const
 
 const applySecurityHeaders: MiddlewareHandler<HonoEnv> = async (c, next) => {

--- a/projects/portfolio/src/server/app.tsx
+++ b/projects/portfolio/src/server/app.tsx
@@ -1,5 +1,6 @@
 import { structuredLogger } from '@hono/structured-logger'
 import { Hono } from 'hono'
+import type { MiddlewareHandler } from 'hono'
 import { requestId } from 'hono/request-id'
 import type pino from 'pino'
 import { logger } from './lib/logger'
@@ -10,8 +11,26 @@ import { htmlRoutes } from './routes/html'
 import { modelsRoutes } from './routes/models'
 import type { HonoEnv } from './routes/shared'
 
+const securityHeaders = {
+  'Content-Security-Policy':
+    "default-src 'self'; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; script-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self'; frame-src 'self'",
+  'X-Content-Type-Options': 'nosniff',
+  'X-Frame-Options': 'DENY',
+  'Referrer-Policy': 'strict-origin-when-cross-origin',
+  'Permissions-Policy': 'camera=(), microphone=(), geolocation=()',
+} as const
+
+const applySecurityHeaders: MiddlewareHandler<HonoEnv> = async (c, next) => {
+  await next()
+
+  for (const [name, value] of Object.entries(securityHeaders)) {
+    c.header(name, value)
+  }
+}
+
 const app = new Hono<HonoEnv>()
   .use(requestId())
+  .use(applySecurityHeaders)
   .use(
     structuredLogger<pino.Logger>({
       createLogger: (c) => logger.child({ requestId: c.var.requestId }),

--- a/projects/portfolio/src/server/features/cookie/cookie.ts
+++ b/projects/portfolio/src/server/features/cookie/cookie.ts
@@ -15,7 +15,7 @@ export const cookie: Cookie = {
     const cookieExpiresSec = parseDurationToSeconds(duration)
     return {
       path: '/',
-      secure: false, // httpのため
+      secure: process.env.NODE_ENV === 'production',
       httpOnly: true,
       maxAge: cookieExpiresSec,
       expires: new Date(Date.now() + cookieExpiresSec * 1000),

--- a/projects/portfolio/tests/app.test.tsx
+++ b/projects/portfolio/tests/app.test.tsx
@@ -42,12 +42,14 @@ const importSubject = async () => {
 
 const expectSecurityHeaders = (res: Response) => {
   expect(res.headers.get('Content-Security-Policy')).toBe(
-    "default-src 'self'; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; script-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self'; frame-src 'self'"
+    "base-uri 'self'; default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self'; frame-src 'self'"
   )
   expect(res.headers.get('X-Content-Type-Options')).toBe('nosniff')
   expect(res.headers.get('X-Frame-Options')).toBe('DENY')
   expect(res.headers.get('Referrer-Policy')).toBe('strict-origin-when-cross-origin')
-  expect(res.headers.get('Permissions-Policy')).toBe('camera=(), microphone=(), geolocation=()')
+  expect(res.headers.get('Permissions-Policy')).toBe(
+    'camera=(), microphone=(), geolocation=(), payment=(), usb=(), display-capture=()'
+  )
 }
 
 describe('app', () => {

--- a/projects/portfolio/tests/app.test.tsx
+++ b/projects/portfolio/tests/app.test.tsx
@@ -40,6 +40,16 @@ const importSubject = async () => {
   }
 }
 
+const expectSecurityHeaders = (res: Response) => {
+  expect(res.headers.get('Content-Security-Policy')).toBe(
+    "default-src 'self'; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; script-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self'; frame-src 'self'"
+  )
+  expect(res.headers.get('X-Content-Type-Options')).toBe('nosniff')
+  expect(res.headers.get('X-Frame-Options')).toBe('DENY')
+  expect(res.headers.get('Referrer-Policy')).toBe('strict-origin-when-cross-origin')
+  expect(res.headers.get('Permissions-Policy')).toBe('camera=(), microphone=(), geolocation=()')
+}
+
 describe('app', () => {
   beforeEach(() => {
     vi.resetModules()
@@ -53,6 +63,7 @@ describe('app', () => {
     expect(res.status).toBe(401)
     expect(requestId).toEqual(expect.any(String))
     await expect(res.json()).resolves.toEqual({ error: 'auth failed' })
+    expectSecurityHeaders(res)
     expect(logger.child).toHaveBeenCalledWith({ requestId })
     expect(logger.warn).toHaveBeenCalledTimes(1)
   })
@@ -63,6 +74,15 @@ describe('app', () => {
 
     expect(res.status).toBe(500)
     await expect(res.json()).resolves.toEqual({ error: 'boom' })
+    expectSecurityHeaders(res)
     expect(logger.error).toHaveBeenCalledTimes(1)
+  })
+
+  it('正常レスポンスにセキュリティヘッダーを付与する', async () => {
+    const { app } = await importSubject()
+    const res = await app.request('/auth-ok')
+
+    expect(res.status).toBe(200)
+    expectSecurityHeaders(res)
   })
 })

--- a/projects/portfolio/tests/client/components/message-renderer.test.tsx
+++ b/projects/portfolio/tests/client/components/message-renderer.test.tsx
@@ -35,41 +35,6 @@ function createAssistantMessage(
 }
 
 describe('MessageRenderer', () => {
-  describe('Markdown セキュリティ', () => {
-    it('危険な HTML を DOM として描画しない', () => {
-      const { container } = render(
-        <MessageRenderer
-          message={createAssistantMessage('<script>alert("xss")</script><img src=x onerror=alert(1)>')}
-          index={0}
-          messages={[]}
-          conversationId='conversation-1'
-          markdownPreview={true}
-          copied={false}
-          onCopyMessage={vi.fn()}
-        />
-      )
-
-      expect(container.querySelector('script')).toBeNull()
-      expect(container.querySelector('img')).toBeNull()
-    })
-
-    it('Markdown link に rel を付与する', () => {
-      render(
-        <MessageRenderer
-          message={createAssistantMessage('[example](https://example.com)')}
-          index={0}
-          messages={[]}
-          conversationId='conversation-1'
-          markdownPreview={true}
-          copied={false}
-          onCopyMessage={vi.fn()}
-        />
-      )
-
-      expect(screen.getByRole('link', { name: 'example' }).getAttribute('rel')).toBe('noopener noreferrer')
-    })
-  })
-
   describe('ユーザーメッセージ編集', () => {
     const userMessage: UserMessage = {
       id: 'user-1',
@@ -334,6 +299,41 @@ describe('MessageRenderer', () => {
         'http://files.example.com/public/portfolio/c1/message-1-block-0.html'
       )
       expect(screen.queryByRole('button', { name: 'Generate preview' })).toBeNull()
+    })
+  })
+
+  describe('Markdown セキュリティ', () => {
+    it('危険な HTML を DOM として描画しない', () => {
+      const { container } = render(
+        <MessageRenderer
+          message={createAssistantMessage('<script>alert("xss")</script><img src=x onerror=alert(1)>')}
+          index={0}
+          messages={[]}
+          conversationId='conversation-1'
+          markdownPreview={true}
+          copied={false}
+          onCopyMessage={vi.fn()}
+        />
+      )
+
+      expect(container.querySelector('script')).toBeNull()
+      expect(container.querySelector('img')).toBeNull()
+    })
+
+    it('Markdown link に rel を付与する', () => {
+      render(
+        <MessageRenderer
+          message={createAssistantMessage('[example](https://example.com)')}
+          index={0}
+          messages={[]}
+          conversationId='conversation-1'
+          markdownPreview={true}
+          copied={false}
+          onCopyMessage={vi.fn()}
+        />
+      )
+
+      expect(screen.getByRole('link', { name: 'example' }).getAttribute('rel')).toBe('noopener noreferrer')
     })
   })
 })

--- a/projects/portfolio/tests/client/components/message-renderer.test.tsx
+++ b/projects/portfolio/tests/client/components/message-renderer.test.tsx
@@ -35,6 +35,41 @@ function createAssistantMessage(
 }
 
 describe('MessageRenderer', () => {
+  describe('Markdown セキュリティ', () => {
+    it('危険な HTML を DOM として描画しない', () => {
+      const { container } = render(
+        <MessageRenderer
+          message={createAssistantMessage('<script>alert("xss")</script><img src=x onerror=alert(1)>')}
+          index={0}
+          messages={[]}
+          conversationId='conversation-1'
+          markdownPreview={true}
+          copied={false}
+          onCopyMessage={vi.fn()}
+        />
+      )
+
+      expect(container.querySelector('script')).toBeNull()
+      expect(container.querySelector('img')).toBeNull()
+    })
+
+    it('Markdown link に rel を付与する', () => {
+      render(
+        <MessageRenderer
+          message={createAssistantMessage('[example](https://example.com)')}
+          index={0}
+          messages={[]}
+          conversationId='conversation-1'
+          markdownPreview={true}
+          copied={false}
+          onCopyMessage={vi.fn()}
+        />
+      )
+
+      expect(screen.getByRole('link', { name: 'example' }).getAttribute('rel')).toBe('noopener noreferrer')
+    })
+  })
+
   describe('ユーザーメッセージ編集', () => {
     const userMessage: UserMessage = {
       id: 'user-1',

--- a/projects/portfolio/tests/features/cookie/cookie.test.ts
+++ b/projects/portfolio/tests/features/cookie/cookie.test.ts
@@ -34,6 +34,7 @@ describe('formatDurationLabel', () => {
 describe('cookie.createOptions', () => {
   afterEach(() => {
     vi.useRealTimers()
+    vi.unstubAllEnvs()
   })
 
   it('cookie 用の options を作成する', () => {
@@ -50,5 +51,13 @@ describe('cookie.createOptions', () => {
       sameSite: 'Strict',
     })
     expect(options.expires.toISOString()).toBe('2026-03-17T00:00:00.000Z')
+  })
+
+  it('production では secure を有効にする', () => {
+    vi.stubEnv('NODE_ENV', 'production')
+
+    const options = cookie.createOptions('1d')
+
+    expect(options.secure).toBe(true)
   })
 })


### PR DESCRIPTION
## Issues

- Close #955

## Why

LLM 応答の Markdown レンダリングにおける XSS リスクを下げ、ブラウザ側のセキュリティヘッダーによる多層防御を有効にするため。

## Summary

portfolio アプリ全体にセキュリティヘッダーを付与し、ReactMarkdown の描画経路へ `rehype-sanitize` を追加しました。あわせて Markdown link の reverse tabnabbing 対策と、production 環境での Cookie secure フラグ有効化を行いました。

## Changes

- app 共通ミドルウェアで CSP / nosniff / frame deny / referrer policy / permissions policy を設定
- チャット、ストリーミング、about ページの Markdown レンダリングに `rehype-sanitize` を追加
- Markdown link に `rel="noopener noreferrer"` と `window.open` の `noopener,noreferrer` 指定を追加
- `NODE_ENV=production` のとき Cookie `secure` を有効化
- セキュリティヘッダー、Markdown HTML 抑止、リンク属性、Cookie secure 切替のテストを追加

## Verification

- [x] `bun run lint` - passed
- [x] `bun run test` - passed
- [x] `bun run format:check` - passed
