### PR TITLE
chore: harden checkout credentials in workflows

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.ref || github.ref }}
+          persist-credentials: false
           # プッシュイベントでは直前のコミットとの差分で十分
           # 2コミット分の履歴で変更検出が可能
           fetch-depth: 2

--- a/.github/workflows/old/detect-changed-directories.yml.disabled
+++ b/.github/workflows/old/detect-changed-directories.yml.disabled
@@ -11,8 +11,9 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 2 # 最新の2つのコミットをフェッチ
 
       - name: Get changed directories

--- a/.github/workflows/pullrequest-check.yml
+++ b/.github/workflows/pullrequest-check.yml
@@ -32,6 +32,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
+
           auth_header="$(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 -w0)"
           git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic $auth_header" \
             fetch origin ${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}

--- a/.github/workflows/pullrequest-check.yml
+++ b/.github/workflows/pullrequest-check.yml
@@ -23,14 +23,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           # PRのベースブランチとの差分取得に必要な履歴深度
           # 50コミットあれば通常のPRの変更はカバーできる
           fetch-depth: 50
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Fetch base branch for comparison
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
-          git fetch origin ${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
+          auth_header="$(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 -w0)"
+          git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic $auth_header" \
+            fetch origin ${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
 
       - name: Get Changed Directories
         uses: ./.github/actions/get-changed-directories


### PR DESCRIPTION
## Issues

- Refs GitHub Actions checkout credential hardening

## Why

GitHub Actions の通常 CI / CD では後続ステップから Git 認証情報を使う必要がないため、checkout 後に credentials を永続化しない設定へ寄せます。

## Summary

workflow の `actions/checkout` を `@v6` に統一し、`persist-credentials: false` を明示しました。PR CI で必要な base branch の追加 fetch は、一時的な auth header を使って認証情報を git config に残さない形に変更しています。

## Changes

- `docker-build.yml` の checkout に `persist-credentials: false` を追加
- `pullrequest-check.yml` の checkout に `persist-credentials: false` を追加
- PR CI の base branch fetch を一時 auth header 経由に変更
- 無効化済みサンプル workflow の checkout を `@v6` に更新し、`persist-credentials: false` を追加

## Checklist

- [x] `git diff --check`
- [x] YAML parse
- [x] checkout 設定の確認
- [ ] actionlint

## Details

`actionlint` はローカル環境に未インストールだったため未実行です。
