### PR TITLE
chore(portfolio): upgrade hono vite dev server

### DIFF
--- a/projects/portfolio/bun.lock
+++ b/projects/portfolio/bun.lock
@@ -32,7 +32,7 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
-        "@hono/vite-dev-server": "^0.25.3",
+        "@hono/vite-dev-server": "^0.26.0",
         "@tailwindcss/postcss": "^4.3.0",
         "@tanstack/react-router-devtools": "^1.167.0",
         "@tanstack/router-plugin": "^1.168.11",
@@ -216,7 +216,7 @@
 
     "@hono/structured-logger": ["@hono/structured-logger@0.1.0", "", { "peerDependencies": { "hono": ">=4.0.0" } }, "sha512-06QUXbNnvb6lSJz/79WcC8yhGCbWT4EO2Zq3rodzQLwUT40OVXNerCKXUcwv4KgVZGKhVebzv1Vr84w/GKEl6Q=="],
 
-    "@hono/vite-dev-server": ["@hono/vite-dev-server@0.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.11", "minimatch": "^9.0.3" }, "peerDependencies": { "hono": "*", "miniflare": "*", "wrangler": "*" }, "optionalPeers": ["miniflare", "wrangler"] }, "sha512-w3uQ0KQF0i/SDcJ6+d5njEFTr6pbolajrt/GxV0pliYL+4ywiBqiOFRWSpwW3mTuZ80boww7+ZxJTGTBIzyBQg=="],
+    "@hono/vite-dev-server": ["@hono/vite-dev-server@0.26.0", "", { "dependencies": { "@hono/node-server": "^1.19.11", "minimatch": "^9.0.3" }, "peerDependencies": { "hono": "*", "miniflare": "*", "wrangler": "*" }, "optionalPeers": ["miniflare", "wrangler"] }, "sha512-DYHht1lge/SRGd1dpOgwhS6DpamSaDtxAOlwl2RkcYyLFy769DZPEX6CeRaUzeDNgClO9JAuT83VptxB5mH5jA=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.8", "", { "dependencies": { "@jridgewell/set-array": "^1.2.1", "@jridgewell/sourcemap-codec": "^1.4.10", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA=="],
 

--- a/projects/portfolio/package.json
+++ b/projects/portfolio/package.json
@@ -45,7 +45,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@hono/vite-dev-server": "^0.25.3",
+    "@hono/vite-dev-server": "^0.26.0",
     "@tailwindcss/postcss": "^4.3.0",
     "@tanstack/react-router-devtools": "^1.167.0",
     "@tanstack/router-plugin": "^1.168.11",


### PR DESCRIPTION
## Why

minor / patch 更新を取り込んだ後に残っていた `@hono/vite-dev-server` を更新し、依存関係の状態を揃えるためです。変更内容は ESM-only 化ですが、このリポジトリは既に ESM の Vite 設定を使っているため、影響を限定して取り込めます。

## Summary

`@hono/vite-dev-server` を `0.25.3` から `0.26.0` に更新しました。ローカル利用箇所を確認し、依存更新のみで対応可能であることを確認した上で、dev 起動を含む検証を実施しています。

## Changes

- `@hono/vite-dev-server` を `^0.26.0` に更新
- `bun.lock` を更新
- ESM-only 化の upstream 変更を確認
- `bun run dev` の起動確認を追加で実施

## Checklist

- [x] フォーマット
- [x] リント / 型チェック
- [x] テスト
- [x] dev サーバー起動確認

## Details

upstream の `@hono/vite-dev-server@0.26.0` は CommonJS を廃止して ESM-only になっています。\
このリポジトリでは `vite.config.ts` で ESM import を使っており、`require()` ベースの利用はありません。
