### PR TITLE
fix(portfolio): hide production error details

### DIFF
--- a/projects/portfolio/src/server/app.tsx
+++ b/projects/portfolio/src/server/app.tsx
@@ -3,6 +3,7 @@ import { Hono } from 'hono'
 import type { MiddlewareHandler } from 'hono'
 import { requestId } from 'hono/request-id'
 import type pino from 'pino'
+import { getErrorMessage } from './lib/error-message'
 import { logger } from './lib/logger'
 import { AuthenticationError, authRoutes } from './routes/auth'
 import { chatRoutes } from './routes/chat'
@@ -84,10 +85,10 @@ const app = new Hono<HonoEnv>()
   )
   .onError((err, c) => {
     if (err instanceof AuthenticationError) {
-      return c.json({ error: err.message }, 401)
+      return c.json({ error: getErrorMessage(err, 'Authentication error') }, 401)
     }
 
-    return c.json({ error: err.message }, 500)
+    return c.json({ error: getErrorMessage(err, 'Internal Server Error') }, 500)
   })
 const routes = app
   .route('/', authRoutes)

--- a/projects/portfolio/src/server/features/chat-sessions/session-manager.ts
+++ b/projects/portfolio/src/server/features/chat-sessions/session-manager.ts
@@ -3,6 +3,7 @@ import { chatConversationRepository } from '#/server/features/chat-conversations
 import { chat } from '#/server/features/chat/chat'
 import { convertStreamChunks } from '#/server/features/chat/converter'
 import type { ResponsesStreamChunk, StreamChunk } from '#/server/features/chat/transport'
+import { getErrorMessage } from '#/server/lib/error-message'
 import { logger } from '#/server/lib/logger'
 import type { ApiMode, AssistantMessage, Conversation } from '#/types'
 import type {
@@ -165,7 +166,7 @@ export class ChatSessionManager {
 
       logger.error({ err, sessionId }, 'Session chat generation failed')
       await this.finishSession(sessionId, 'error', {
-        message: err instanceof Error ? err.message : 'Upstream error',
+        message: getErrorMessage(err, 'Upstream error'),
       })
       await this.persistIfSignedIn(sessionId, params.databaseUrl, params.ttlSeconds)
     } finally {

--- a/projects/portfolio/src/server/lib/error-message.ts
+++ b/projects/portfolio/src/server/lib/error-message.ts
@@ -1,0 +1,7 @@
+export const isProduction = () => process.env.NODE_ENV === 'production'
+
+export const getErrorMessage = (err: unknown, fallback: string) => {
+  if (isProduction()) return fallback
+
+  return err instanceof Error ? err.message : fallback
+}

--- a/projects/portfolio/src/server/routes/chat.ts
+++ b/projects/portfolio/src/server/routes/chat.ts
@@ -10,6 +10,7 @@ import { chatStub } from '#/server/features/chat-stub/chat-stub'
 import { chat } from '#/server/features/chat/chat'
 import { convertCompletion, convertStreamChunks } from '#/server/features/chat/converter'
 import type { CompletionChunk, ResponsesStreamChunk, StreamChunk } from '#/server/features/chat/transport'
+import { getErrorMessage } from '#/server/lib/error-message'
 import { logger } from '#/server/lib/logger'
 import { ApiChatMessageSchema, type ApiMode } from '#/types'
 import {
@@ -258,10 +259,7 @@ const chatRoutes = new Hono<HonoEnv>()
       return c.json(response)
     } catch (err) {
       requestLogger.error({ err }, 'Upstream chat completion failed')
-      return c.json(
-        { error: err instanceof Error ? err.message : 'Upstream error', code: 'UPSTREAM_ERROR' as const },
-        502
-      )
+      return c.json({ error: getErrorMessage(err, 'Upstream error'), code: 'UPSTREAM_ERROR' as const }, 502)
     }
   })
   // SSE ストリーム専用
@@ -304,10 +302,7 @@ const chatRoutes = new Hono<HonoEnv>()
       )
     } catch (err) {
       requestLogger.error({ err }, 'Upstream stream chat failed')
-      return c.json(
-        { error: err instanceof Error ? err.message : 'Upstream error', code: 'UPSTREAM_ERROR' as const },
-        502
-      )
+      return c.json({ error: getErrorMessage(err, 'Upstream error'), code: 'UPSTREAM_ERROR' as const }, 502)
     }
 
     const streamCompletion = completion as StreamChunk | ResponsesStreamChunk

--- a/projects/portfolio/tests/app.test.tsx
+++ b/projects/portfolio/tests/app.test.tsx
@@ -80,6 +80,24 @@ describe('app', () => {
     expect(logger.error).toHaveBeenCalledTimes(1)
   })
 
+  it('production では AuthenticationError の詳細を隠す', async () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    const { app } = await importSubject()
+    const res = await app.request('/auth-error')
+
+    expect(res.status).toBe(401)
+    await expect(res.json()).resolves.toEqual({ error: 'Authentication error' })
+  })
+
+  it('production ではその他の Error の詳細を隠す', async () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    const { app } = await importSubject()
+    const res = await app.request('/unknown-error')
+
+    expect(res.status).toBe(500)
+    await expect(res.json()).resolves.toEqual({ error: 'Internal Server Error' })
+  })
+
   it('正常レスポンスにセキュリティヘッダーを付与する', async () => {
     const { app } = await importSubject()
     const res = await app.request('/auth-ok')

--- a/projects/portfolio/tests/features/chat-sessions/session-manager.test.ts
+++ b/projects/portfolio/tests/features/chat-sessions/session-manager.test.ts
@@ -174,6 +174,65 @@ describe('ChatSessionManager', () => {
     expect(isTerminalSessionEvent(events.at(-1)!)).toBe(true)
   })
 
+  it('production では upstream エラーの詳細を error event に出さない', async () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    const { manager, completionsMock } = await importSubject()
+    completionsMock.mockRejectedValue(new Error('Connection refused'))
+
+    const session = await manager.startSession({
+      header: {
+        'api-key': 'api-key',
+        'base-url': 'https://example.com',
+      },
+      req: request,
+      apiMode: 'chat_completions',
+      email: null,
+      databaseUrl: undefined,
+      ttlSeconds: 1800,
+      disconnectGraceMs: 30000,
+    })
+
+    await vi.waitFor(async () => {
+      await expect(manager.getSession(session.id)).resolves.toMatchObject({
+        status: 'error',
+        error: 'Upstream error',
+      })
+    })
+
+    const events = await manager.readEvents(session.id)
+    expect(events.at(-1)).toMatchObject({
+      type: 'error',
+      data: {
+        message: 'Upstream error',
+      },
+    })
+  })
+
+  it('development では upstream エラーの詳細を error event に残す', async () => {
+    const { manager, completionsMock } = await importSubject()
+    completionsMock.mockRejectedValue(new Error('Connection refused'))
+
+    const session = await manager.startSession({
+      header: {
+        'api-key': 'api-key',
+        'base-url': 'https://example.com',
+      },
+      req: request,
+      apiMode: 'chat_completions',
+      email: null,
+      databaseUrl: undefined,
+      ttlSeconds: 1800,
+      disconnectGraceMs: 30000,
+    })
+
+    await vi.waitFor(async () => {
+      await expect(manager.getSession(session.id)).resolves.toMatchObject({
+        status: 'error',
+        error: 'Connection refused',
+      })
+    })
+  })
+
   it('event log を assistant message へ fold する', async () => {
     const { foldSessionEvents } = await importSubject()
 

--- a/projects/portfolio/tests/routes/chat.test.ts
+++ b/projects/portfolio/tests/routes/chat.test.ts
@@ -382,6 +382,31 @@ describe('chatRoutes', () => {
         code: 'UPSTREAM_ERROR',
       })
     })
+
+    it('production の upstream エラー時は詳細を隠す', async () => {
+      vi.stubEnv('NODE_ENV', 'production')
+      const { chatRoutes, completionsMock } = await importSubject()
+      completionsMock.mockRejectedValue(new Error('Connection refused'))
+
+      const res = await chatRoutes.request('/api/chat', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'api-key': 'api-key',
+          'base-url': 'https://example.com',
+        },
+        body: JSON.stringify({
+          model: 'gpt-test',
+          messages: [],
+        }),
+      })
+
+      expect(res.status).toBe(502)
+      await expect(res.json()).resolves.toEqual({
+        error: 'Upstream error',
+        code: 'UPSTREAM_ERROR',
+      })
+    })
   })
 
   describe('POST /api/chat/stream', () => {
@@ -550,6 +575,31 @@ describe('chatRoutes', () => {
       await expect(res.json()).resolves.toEqual({
         error: "Invalid request body 'model'",
         code: 'VALIDATION_ERROR',
+      })
+    })
+
+    it('production の upstream エラー時は詳細を隠す', async () => {
+      vi.stubEnv('NODE_ENV', 'production')
+      const { chatRoutes, completionsMock } = await importSubject()
+      completionsMock.mockRejectedValue(new Error('Connection refused'))
+
+      const res = await chatRoutes.request('/api/chat/stream', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'api-key': 'api-key',
+          'base-url': 'https://example.com',
+        },
+        body: JSON.stringify({
+          model: 'gpt-test',
+          messages: [],
+        }),
+      })
+
+      expect(res.status).toBe(502)
+      await expect(res.json()).resolves.toEqual({
+        error: 'Upstream error',
+        code: 'UPSTREAM_ERROR',
       })
     })
   })


### PR DESCRIPTION
## Issues

- Close #957

## Why

本番環境の API レスポンスや SSE error event から、内部エラー詳細や upstream の生メッセージがクライアントへ露出するのを防ぐため。

## Summary

`NODE_ENV=production` のときだけ公開用の固定エラーメッセージを返すようにしました。開発環境では従来どおり詳細な `err.message` を返し、デバッグ性は維持しています。

## Changes

- 共通のエラーメッセージ出し分けヘルパーを追加
- グローバル `.onError` の 401 / 500 レスポンスを本番時に抽象化
- `/api/chat` と `/api/chat/stream` の upstream エラーを本番時に抽象化
- chat session の SSE error event と session error 保存値を本番時に抽象化
- production / development の挙動をテストで追加

## Verification

- `bun run format` - passed
- `bun run lint` - passed
- `bun run test` - passed
