### PR TITLE
feat(portfolio): add signin rate limit

### DIFF
--- a/projects/portfolio/src/server/middleware/rate-limit.ts
+++ b/projects/portfolio/src/server/middleware/rate-limit.ts
@@ -1,3 +1,5 @@
+import { getConnInfo } from '@hono/node-server/conninfo'
+import type { Context } from 'hono'
 import { createMiddleware } from 'hono/factory'
 import { AuthenticationError } from '#/server/features/auth/auth'
 import type { HonoEnv } from '#/server/routes/shared'
@@ -21,8 +23,8 @@ const isUnrefableTimer = (
   return typeof timer === 'object' && timer !== null && 'unref' in timer
 }
 
-const getClientIp = (headers: { header(name: string): string | undefined }) => {
-  return headers.header('x-forwarded-for') ?? headers.header('x-real-ip') ?? 'unknown'
+const getClientIp = (c: Context<HonoEnv>) => {
+  return getConnInfo(c).remote.address ?? 'unknown'
 }
 
 const isBlocked = (entry: RateLimitEntry | undefined, now: number) => {
@@ -75,7 +77,7 @@ export const resetSigninRateLimit = () => {
 }
 
 export const signinRateLimit = createMiddleware<HonoEnv>(async (c, next) => {
-  const ip = getClientIp(c.req)
+  const ip = getClientIp(c)
   const now = Date.now()
   const entry = store.get(ip)
 

--- a/projects/portfolio/src/server/middleware/rate-limit.ts
+++ b/projects/portfolio/src/server/middleware/rate-limit.ts
@@ -1,0 +1,101 @@
+import { createMiddleware } from 'hono/factory'
+import { AuthenticationError } from '#/server/features/auth/auth'
+import type { HonoEnv } from '#/server/routes/shared'
+
+type RateLimitEntry = {
+  failures: number
+  firstFailureAt: number
+  blockedUntil: number
+}
+
+const store = new Map<string, RateLimitEntry>()
+
+const MAX_FAILURES = 5
+const FAILURE_WINDOW_MS = 60_000
+const BLOCK_DURATION_MS = 60_000
+const CLEANUP_INTERVAL_MS = 60_000
+
+const isUnrefableTimer = (
+  timer: ReturnType<typeof setInterval>
+): timer is ReturnType<typeof setInterval> & { unref(): void } => {
+  return typeof timer === 'object' && timer !== null && 'unref' in timer
+}
+
+const getClientIp = (headers: { header(name: string): string | undefined }) => {
+  return headers.header('x-forwarded-for') ?? headers.header('x-real-ip') ?? 'unknown'
+}
+
+const isBlocked = (entry: RateLimitEntry | undefined, now: number) => {
+  return entry !== undefined && now < entry.blockedUntil
+}
+
+const recordFailure = (ip: string, now: number) => {
+  const current = store.get(ip)
+  const entry =
+    current && current.blockedUntil === 0 && now - current.firstFailureAt < FAILURE_WINDOW_MS
+      ? current
+      : {
+          failures: 0,
+          firstFailureAt: now,
+          blockedUntil: 0,
+        }
+
+  entry.failures += 1
+  if (entry.failures >= MAX_FAILURES) {
+    entry.blockedUntil = now + BLOCK_DURATION_MS
+  }
+
+  store.set(ip, entry)
+}
+
+const resetFailures = (ip: string) => {
+  store.delete(ip)
+}
+
+const cleanupExpiredEntries = () => {
+  const now = Date.now()
+
+  for (const [ip, entry] of store) {
+    const blockExpired = entry.blockedUntil > 0 && now >= entry.blockedUntil
+    const failureWindowExpired = entry.blockedUntil === 0 && now - entry.firstFailureAt > FAILURE_WINDOW_MS
+
+    if (blockExpired || failureWindowExpired) {
+      store.delete(ip)
+    }
+  }
+}
+
+const cleanupInterval = setInterval(cleanupExpiredEntries, CLEANUP_INTERVAL_MS)
+if (isUnrefableTimer(cleanupInterval)) {
+  cleanupInterval.unref()
+}
+
+export const resetSigninRateLimit = () => {
+  store.clear()
+}
+
+export const signinRateLimit = createMiddleware<HonoEnv>(async (c, next) => {
+  const ip = getClientIp(c.req)
+  const now = Date.now()
+  const entry = store.get(ip)
+
+  if (isBlocked(entry, now)) {
+    return c.json({ error: 'Too many login attempts. Please try again later.' }, 429)
+  }
+
+  try {
+    await next()
+  } catch (error) {
+    if (error instanceof AuthenticationError) {
+      recordFailure(ip, Date.now())
+    }
+    throw error
+  }
+
+  if (c.res.status === 401) {
+    recordFailure(ip, Date.now())
+    return
+  }
+
+  resetFailures(ip)
+})

--- a/projects/portfolio/src/server/routes/auth.ts
+++ b/projects/portfolio/src/server/routes/auth.ts
@@ -4,6 +4,7 @@ import { deleteCookie, setSignedCookie } from 'hono/cookie'
 import { z } from 'zod'
 import { AuthenticationError, auth } from '#/server/features/auth/auth'
 import { cookie } from '#/server/features/cookie/cookie'
+import { signinRateLimit } from '#/server/middleware/rate-limit'
 import type { HonoEnv } from './shared'
 import { getServerEnv } from './shared'
 
@@ -13,7 +14,7 @@ const SignInBodySchema = z.object({
 })
 
 const authRoutes = new Hono<HonoEnv>()
-  .post('/api/signin', sValidator('json', SignInBodySchema), async (c) => {
+  .post('/api/signin', sValidator('json', SignInBodySchema), signinRateLimit, async (c) => {
     const { email, password } = c.req.valid('json')
     const { DATABASE_URL = '', COOKIE_SECRET = '', COOKIE_NAME = '', COOKIE_EXPIRES = '1d' } = getServerEnv(c)
 

--- a/projects/portfolio/src/server/routes/shared.ts
+++ b/projects/portfolio/src/server/routes/shared.ts
@@ -1,3 +1,4 @@
+import type { HttpBindings } from '@hono/node-server'
 import type { Context } from 'hono'
 import { env } from 'hono/adapter'
 import { deleteCookie, getSignedCookie } from 'hono/cookie'
@@ -22,7 +23,7 @@ export type Env = Partial<{
 }>
 
 export type HonoEnv = {
-  Bindings: Env
+  Bindings: Env & Partial<HttpBindings> & { server?: Partial<HttpBindings> }
   Variables: {
     email: string
     logger: pino.Logger

--- a/projects/portfolio/tests/routes/auth.test.ts
+++ b/projects/portfolio/tests/routes/auth.test.ts
@@ -1,3 +1,4 @@
+import type { HttpBindings } from '@hono/node-server'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { loginMock, logoutMock, setSignedCookieMock, deleteCookieMock } = vi.hoisted(() => ({
@@ -44,16 +45,20 @@ describe('authRoutes', () => {
     vi.stubEnv('COOKIE_NAME', 'session')
     vi.stubEnv('COOKIE_EXPIRES', '1d')
 
-    const res = await authRoutes.request('/api/signin', {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json',
+    const res = await authRoutes.request(
+      '/api/signin',
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          email: 'test@example.com',
+          password: 'testexample',
+        }),
       },
-      body: JSON.stringify({
-        email: 'test@example.com',
-        password: 'testexample',
-      }),
-    })
+      createNodeEnv('192.0.2.10')
+    )
 
     expect(res.status).toBe(200)
     expect(loginMock).toHaveBeenCalledWith('postgres://db', 'test@example.com', 'testexample')
@@ -128,6 +133,20 @@ describe('authRoutes', () => {
       }
     })
 
+    it('x-forwarded-for が変わっても接続元 IP でブロックする', async () => {
+      loginMock.mockRejectedValue(new AuthenticationError('認証に失敗しました'))
+
+      for (let i = 0; i < 5; i += 1) {
+        const res = await requestSignin('192.0.2.5', `198.51.100.${i}`)
+
+        expect(res.status).toBe(401)
+      }
+
+      const res = await requestSignin('192.0.2.5', '198.51.100.99')
+
+      expect(res.status).toBe(429)
+    })
+
     it('ブロックは IP ごとに独立し、1 分経過後に解除される', async () => {
       vi.useFakeTimers()
       vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
@@ -151,16 +170,32 @@ describe('authRoutes', () => {
   })
 })
 
-const requestSignin = (ip: string) => {
-  return app.request('/api/signin', {
-    method: 'POST',
-    headers: {
-      'content-type': 'application/json',
-      'x-forwarded-for': ip,
+const requestSignin = (ip: string, forwardedFor?: string) => {
+  return app.request(
+    '/api/signin',
+    {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        ...(forwardedFor ? { 'x-forwarded-for': forwardedFor } : {}),
+      },
+      body: JSON.stringify({
+        email: 'test@example.com',
+        password: 'testexample',
+      }),
     },
-    body: JSON.stringify({
-      email: 'test@example.com',
-      password: 'testexample',
-    }),
-  })
+    createNodeEnv(ip)
+  )
+}
+
+const createNodeEnv = (remoteAddress: string): Partial<HttpBindings> => {
+  return {
+    incoming: {
+      socket: {
+        remoteAddress,
+        remotePort: 12345,
+        remoteFamily: 'IPv4',
+      },
+    } as HttpBindings['incoming'],
+  }
 }

--- a/projects/portfolio/tests/routes/auth.test.ts
+++ b/projects/portfolio/tests/routes/auth.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { loginMock, logoutMock, setSignedCookieMock, deleteCookieMock } = vi.hoisted(() => ({
   loginMock: vi.fn(),
@@ -25,9 +25,19 @@ vi.mock('hono/cookie', async () => {
   }
 })
 
-import { authRoutes } from '#/server/routes/auth'
+import app from '#/server/app'
+import { resetSigninRateLimit } from '#/server/middleware/rate-limit'
+import { AuthenticationError, authRoutes } from '#/server/routes/auth'
 
 describe('authRoutes', () => {
+  beforeEach(() => {
+    resetSigninRateLimit()
+    loginMock.mockReset()
+    logoutMock.mockReset()
+    setSignedCookieMock.mockReset()
+    deleteCookieMock.mockReset()
+  })
+
   it('認証成功時に cookie を設定する', async () => {
     vi.stubEnv('DATABASE_URL', 'postgres://db')
     vi.stubEnv('COOKIE_SECRET', 'secret')
@@ -83,4 +93,74 @@ describe('authRoutes', () => {
 
     expect(res.status).toBe(400)
   })
+
+  describe('signin rate limit', () => {
+    it('同一 IP から 5 回連続で認証失敗すると 429 を返す', async () => {
+      loginMock.mockRejectedValue(new AuthenticationError('認証に失敗しました'))
+
+      for (let i = 0; i < 5; i += 1) {
+        const res = await requestSignin('192.0.2.1')
+
+        expect(res.status).toBe(401)
+      }
+
+      const res = await requestSignin('192.0.2.1')
+
+      expect(res.status).toBe(429)
+      await expect(res.json()).resolves.toEqual({ error: 'Too many login attempts. Please try again later.' })
+    })
+
+    it('認証成功時にカウンタをリセットする', async () => {
+      loginMock.mockRejectedValueOnce(new AuthenticationError('認証に失敗しました'))
+
+      const failedRes = await requestSignin('192.0.2.2')
+      expect(failedRes.status).toBe(401)
+
+      loginMock.mockResolvedValue(undefined)
+      const successRes = await requestSignin('192.0.2.2')
+      expect(successRes.status).toBe(200)
+
+      loginMock.mockRejectedValue(new AuthenticationError('認証に失敗しました'))
+      for (let i = 0; i < 4; i += 1) {
+        const res = await requestSignin('192.0.2.2')
+
+        expect(res.status).toBe(401)
+      }
+    })
+
+    it('ブロックは IP ごとに独立し、1 分経過後に解除される', async () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
+      loginMock.mockRejectedValue(new AuthenticationError('認証に失敗しました'))
+
+      for (let i = 0; i < 5; i += 1) {
+        await requestSignin('192.0.2.3')
+      }
+
+      const blockedRes = await requestSignin('192.0.2.3')
+      expect(blockedRes.status).toBe(429)
+
+      const otherIpRes = await requestSignin('192.0.2.4')
+      expect(otherIpRes.status).toBe(401)
+
+      vi.advanceTimersByTime(60_000)
+
+      const expiredRes = await requestSignin('192.0.2.3')
+      expect(expiredRes.status).toBe(401)
+    })
+  })
 })
+
+const requestSignin = (ip: string) => {
+  return app.request('/api/signin', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-forwarded-for': ip,
+    },
+    body: JSON.stringify({
+      email: 'test@example.com',
+      password: 'testexample',
+    }),
+  })
+}


### PR DESCRIPTION
## Issues

- Close #956

## Why

`/api/signin` has no attempt limit, so repeated password guesses can continue without server-side throttling. This adds a small in-memory guard for the current single-instance deployment to reduce brute-force risk before broader exposure.

## Summary

This PR adds IP-based signin failure tracking and blocks repeated failed attempts for one minute. Successful signin clears the tracked failures for that IP.

## Changes

- Add `signinRateLimit` middleware with a 5-failure-per-minute threshold and one-minute block duration.
- Apply the middleware to `POST /api/signin` after request body validation.
- Add route tests for blocking, reset on success, per-IP isolation, and block expiry.

## Verification

- `bun run format:check` - passed
- `bun run lint` - passed
- `bun run test` - passed
