### PR TITLE
fix: align dark mode toggle on-state color

### DIFF
--- a/projects/portfolio/src/client/components/input/toggle-input.tsx
+++ b/projects/portfolio/src/client/components/input/toggle-input.tsx
@@ -12,7 +12,7 @@ export function ToggleInput({ label, labelClassName, value, disabled, onClick }:
       ? 'cursor-not-allowed bg-primary-200 dark:bg-primary-900/40'
       : 'cursor-not-allowed bg-gray-200 dark:bg-gray-700'
     : value
-      ? 'cursor-pointer bg-primary-800 dark:bg-primary-600'
+      ? 'cursor-pointer bg-primary-800 dark:bg-primary-500'
       : 'cursor-pointer bg-gray-400 dark:bg-gray-600'
 
   const thumbClassName = disabled ? 'bg-gray-50 shadow-sm dark:bg-gray-300' : 'bg-white shadow-md dark:bg-gray-200'


### PR DESCRIPTION
## Why

ダークモード時の `ToggleInput` の On 状態が周囲のフォーム要素より明るく見え、Chat Settings 内で配色の一貫性が崩れていました。既存の dark theme に合わせて、On 状態の視認性を保ちながら浮きを抑える必要がありました。

## Summary

ToggleInput のダークモード時の On 背景色を `primary-600` から `primary-500` に調整しました。Off 状態との差は維持しつつ、周囲の入力欄やスライダーで使っている色調に寄せています。

## Changes

- `ToggleInput` の On 状態のダークモード色を `dark:bg-primary-500` に変更
- ライトモード、Off 状態、disabled 状態の見た目は維持

## Checklist

- [x] フォーマット
- [x] リント / 型チェック
- [x] テスト
