### PR TITLE
[portfolio] Move prompt templates to DB seed

### DIFF
--- a/projects/portfolio/DEVELOPMENT.md
+++ b/projects/portfolio/DEVELOPMENT.md
@@ -132,6 +132,20 @@ printf 'replace-with-password\n' | bun run db:user:add -- --email test@example.c
 
 同じメールアドレスが既に存在する場合、このコマンドは失敗します。
 
+### Seed Prompt Templates
+
+```sh
+bun run db:prompt-templates:seed
+```
+
+Seed結果はDB側から確認できます。
+
+```sql
+select id, display_order, enabled
+from prompt_templates
+order by display_order, id;
+```
+
 ## Debug Pages
 
 ### SVG Icon Catalog

--- a/projects/portfolio/drizzle/0004_tough_red_wolf.sql
+++ b/projects/portfolio/drizzle/0004_tough_red_wolf.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "prompt_templates" (
+	"id" text PRIMARY KEY NOT NULL,
+	"input_type" text NOT NULL,
+	"title" text NOT NULL,
+	"placeholder" text NOT NULL,
+	"prompt" text NOT NULL,
+	"display_order" integer NOT NULL,
+	"enabled" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp NOT NULL,
+	"updated_at" timestamp NOT NULL
+);

--- a/projects/portfolio/drizzle/meta/0004_snapshot.json
+++ b/projects/portfolio/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,252 @@
+{
+  "id": "6d40df4c-b0f9-4ca1-a3b5-e03f5eecf85e",
+  "prevId": "85c2cc6d-d7d1-422b-ae1f-c9f652f36ac4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversations_user_id_users_id_fk": {
+          "name": "conversations_user_id_users_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reasoning_content": {
+          "name": "reasoning_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_conversation_id_conversations_id_fk": {
+          "name": "messages_conversation_id_conversations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prompt_templates": {
+      "name": "prompt_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "input_type": {
+          "name": "input_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "placeholder": {
+          "name": "placeholder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/projects/portfolio/drizzle/meta/_journal.json
+++ b/projects/portfolio/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1775990886633,
       "tag": "0003_nappy_sage",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1780108159593,
+      "tag": "0004_tough_red_wolf",
+      "breakpoints": true
     }
   ]
 }

--- a/projects/portfolio/package.json
+++ b/projects/portfolio/package.json
@@ -15,7 +15,8 @@
     "format": "oxfmt",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
-    "db:user:add": "dotenv -- bun run src/db/seeders/add-user.ts"
+    "db:user:add": "dotenv -- bun run src/db/seeders/add-user.ts",
+    "db:prompt-templates:seed": "dotenv -- bun run src/db/seeders/seed-prompt-templates.ts"
   },
   "dependencies": {
     "@hono/node-server": "^2.0.4",

--- a/projects/portfolio/src/client/components/chat/prompt-template.tsx
+++ b/projects/portfolio/src/client/components/chat/prompt-template.tsx
@@ -1,7 +1,11 @@
+import { hc } from 'hono/client'
 import type { ChangeEvent, KeyboardEvent } from 'react'
-import { memo, useMemo, useState } from 'react'
+import { memo, useEffect, useMemo, useState } from 'react'
 import { useModelFetching } from '#/client/components/chat/chat-settings/hooks/use-model-fetching'
 import { readFromLocalStorage, saveToLocalStorage } from '#/client/storage/remote-storage-settings'
+import type { AppType } from '#/server/app'
+
+const client = hc<AppType>('/')
 
 interface PromptTemplate {
   id: string
@@ -10,53 +14,6 @@ interface PromptTemplate {
   placeholder: string
   prompt: string
 }
-
-const promptTemplates: PromptTemplate[] = [
-  {
-    id: 'translate_en',
-    inputType: 'textarea',
-    title: '🇺🇸 英語へ翻訳',
-    placeholder: '例: これを英語で言うと？',
-    prompt: `
-You are an English translation assistant.
-Please accurately and naturally translate the user's input text from Japanese into English.
-Use the very last user input in the system prompt.`.trim(),
-  },
-  {
-    id: 'translate_ja',
-    inputType: 'textarea',
-    title: '🇯🇵 日本語へ翻訳',
-    placeholder: '例: How do you say this in Japanese?',
-    prompt: `
-You are a Japanese translation assistant.
-Please accurately and naturally translate the user's input text into Japanese.
-Use the very last user input in the system prompt.`.trim(),
-  },
-  {
-    id: 'commit_message',
-    inputType: 'text',
-    title: '📝 コミットメッセージを作成',
-    placeholder: '例: ユーザー登録機能を追加',
-    prompt: `
-You are a Assistant to create commit messages.
-Summarizes the input and produces an English sentence of appropriate length for the commit message.
-Please enclose the English sentences in triple backtick code blocks when outputting.
-Be sure to translate the output English into Japanese again with a new line and output it in “Japanese”.
-Use the very last user input in the system prompt.`.trim(),
-  },
-  {
-    id: 'text_summarization',
-    inputType: 'textarea',
-    title: '✍️ 文章を校正',
-    placeholder: '例: 入力した文章を校正します',
-    prompt: `
-You are an expert proofreader.
-Please carefully edit the following text for spelling, grammar, punctuation, and sentence structure errors.
-Correct any awkward or unnatural phrasing and improve clarity while preserving the original meaning and intent.
-Provide the revised, polished version of the entire text.
-Use the very last user input in the system prompt.`.trim(),
-  },
-] as const
 
 export interface TemplateInput {
   model: string
@@ -85,12 +42,41 @@ interface Props {
 
 function PromptTemplateComponent({ autoModel, placeholder, onSubmit }: Props) {
   const [composing, setComposition] = useState(false)
+  const [promptTemplates, setPromptTemplates] = useState<PromptTemplate[]>([])
 
   const defaultSettings = useMemo(() => {
     return readFromLocalStorage()
   }, [])
   const [templateModels, setTemplateModels] = useState(defaultSettings.templateModels || {})
   const { fetchedModels, isLoadingModels, fetchError } = useModelFetching({ autoModel })
+
+  useEffect(() => {
+    let ignore = false
+
+    client.api['prompt-templates']
+      .$get()
+      .then(async (response) => {
+        if (!response.ok) {
+          return { data: [] }
+        }
+
+        return response.json()
+      })
+      .then(({ data }) => {
+        if (!ignore) {
+          setPromptTemplates(data)
+        }
+      })
+      .catch(() => {
+        if (!ignore) {
+          setPromptTemplates([])
+        }
+      })
+
+    return () => {
+      ignore = true
+    }
+  }, [])
 
   const handleChangeComposition = (composition: boolean) => {
     setComposition(composition)
@@ -176,12 +162,16 @@ function PromptTemplateComponent({ autoModel, placeholder, onSubmit }: Props) {
     )
   }
 
+  if (promptTemplates.length === 0) {
+    return null
+  }
+
   return (
     <div>
       <div className='grid grid-cols-1 gap-3 p-4 md:grid-cols-2'>
         {promptTemplates.map((template) => (
           <div
-            key={template.title}
+            key={template.id}
             className='rounded-xl border border-gray-200 bg-white p-4 dark:border-gray-600 dark:bg-gray-800'
           >
             <div className='mb-2 flex items-center justify-between'>

--- a/projects/portfolio/src/db/schema.ts
+++ b/projects/portfolio/src/db/schema.ts
@@ -1,5 +1,5 @@
 import { relations } from 'drizzle-orm'
-import { jsonb, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core'
+import { boolean, integer, jsonb, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core'
 
 // ユーザー
 export const usersTable = pgTable('users', {
@@ -31,6 +31,19 @@ export const messagesTable = pgTable('messages', {
   reasoningContent: text('reasoning_content').notNull(),
   metadata: jsonb('metadata').notNull().default({}),
   createdAt: timestamp('created_at', { mode: 'date' }).notNull(),
+})
+
+// 共通プロンプトテンプレート
+export const promptTemplatesTable = pgTable('prompt_templates', {
+  id: text('id').primaryKey(),
+  inputType: text('input_type').notNull(),
+  title: text('title').notNull(),
+  placeholder: text('placeholder').notNull(),
+  prompt: text('prompt').notNull(),
+  displayOrder: integer('display_order').notNull(),
+  enabled: boolean('enabled').notNull().default(true),
+  createdAt: timestamp('created_at', { mode: 'date' }).notNull(),
+  updatedAt: timestamp('updated_at', { mode: 'date' }).notNull(),
 })
 
 // リレーション

--- a/projects/portfolio/src/db/seeders/prompt-template-defaults.ts
+++ b/projects/portfolio/src/db/seeders/prompt-template-defaults.ts
@@ -1,0 +1,59 @@
+export interface DefaultPromptTemplate {
+  id: string
+  inputType: 'text' | 'textarea'
+  title: string
+  placeholder: string
+  prompt: string
+  displayOrder: number
+}
+
+export const defaultPromptTemplates = [
+  {
+    id: 'translate_en',
+    inputType: 'textarea',
+    title: '🇺🇸 英語へ翻訳',
+    placeholder: '例: これを英語で言うと？',
+    prompt: `
+You are an English translation assistant.
+Please accurately and naturally translate the user's input text from Japanese into English.
+Use the very last user input in the system prompt.`.trim(),
+    displayOrder: 10,
+  },
+  {
+    id: 'translate_ja',
+    inputType: 'textarea',
+    title: '🇯🇵 日本語へ翻訳',
+    placeholder: '例: How do you say this in Japanese?',
+    prompt: `
+You are a Japanese translation assistant.
+Please accurately and naturally translate the user's input text into Japanese.
+Use the very last user input in the system prompt.`.trim(),
+    displayOrder: 20,
+  },
+  {
+    id: 'commit_message',
+    inputType: 'text',
+    title: '📝 コミットメッセージを作成',
+    placeholder: '例: ユーザー登録機能を追加',
+    prompt: `
+You are a Assistant to create commit messages.
+Summarizes the input and produces an English sentence of appropriate length for the commit message.
+Please enclose the English sentences in triple backtick code blocks when outputting.
+Be sure to translate the output English into Japanese again with a new line and output it in “Japanese”.
+Use the very last user input in the system prompt.`.trim(),
+    displayOrder: 30,
+  },
+  {
+    id: 'text_summarization',
+    inputType: 'textarea',
+    title: '✍️ 文章を校正',
+    placeholder: '例: 入力した文章を校正します',
+    prompt: `
+You are an expert proofreader.
+Please carefully edit the following text for spelling, grammar, punctuation, and sentence structure errors.
+Correct any awkward or unnatural phrasing and improve clarity while preserving the original meaning and intent.
+Provide the revised, polished version of the entire text.
+Use the very last user input in the system prompt.`.trim(),
+    displayOrder: 40,
+  },
+] as const satisfies DefaultPromptTemplate[]

--- a/projects/portfolio/src/db/seeders/seed-prompt-templates.ts
+++ b/projects/portfolio/src/db/seeders/seed-prompt-templates.ts
@@ -1,0 +1,17 @@
+import { upsertPromptTemplates } from './upsert-prompt-templates'
+
+async function main() {
+  const databaseUrl = process.env.DATABASE_URL
+
+  if (!databaseUrl) {
+    throw new Error('DATABASE_URL is required')
+  }
+
+  const count = await upsertPromptTemplates({ databaseUrl })
+  console.log(`Upserted ${count} prompt templates`)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/projects/portfolio/src/db/seeders/upsert-prompt-templates.ts
+++ b/projects/portfolio/src/db/seeders/upsert-prompt-templates.ts
@@ -1,0 +1,37 @@
+import { getDatabase } from '#/db'
+import { promptTemplatesTable } from '#/db/schema'
+import { defaultPromptTemplates } from './prompt-template-defaults'
+
+export interface UpsertPromptTemplatesInput {
+  databaseUrl: string
+}
+
+export async function upsertPromptTemplates({ databaseUrl }: UpsertPromptTemplatesInput) {
+  const db = getDatabase(databaseUrl)
+  const now = new Date()
+
+  for (const template of defaultPromptTemplates) {
+    await db
+      .insert(promptTemplatesTable)
+      .values({
+        ...template,
+        enabled: true,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: promptTemplatesTable.id,
+        set: {
+          inputType: template.inputType,
+          title: template.title,
+          placeholder: template.placeholder,
+          prompt: template.prompt,
+          displayOrder: template.displayOrder,
+          enabled: true,
+          updatedAt: now,
+        },
+      })
+  }
+
+  return defaultPromptTemplates.length
+}

--- a/projects/portfolio/src/server/app.tsx
+++ b/projects/portfolio/src/server/app.tsx
@@ -10,6 +10,7 @@ import { chatRoutes } from './routes/chat'
 import { conversationsRoutes } from './routes/conversations'
 import { htmlRoutes } from './routes/html'
 import { modelsRoutes } from './routes/models'
+import { promptTemplatesRoutes } from './routes/prompt-templates'
 import type { HonoEnv } from './routes/shared'
 
 const securityHeaders = {
@@ -95,6 +96,7 @@ const routes = app
   .route('/', chatRoutes)
   .route('/', conversationsRoutes)
   .route('/', modelsRoutes)
+  .route('/', promptTemplatesRoutes)
   .route('/', htmlRoutes)
 
 export type AppType = typeof routes

--- a/projects/portfolio/src/server/features/prompt-templates/repository.ts
+++ b/projects/portfolio/src/server/features/prompt-templates/repository.ts
@@ -1,0 +1,35 @@
+import { asc, eq } from 'drizzle-orm'
+import { z } from 'zod'
+import { getDatabase } from '#/db'
+import { promptTemplatesTable } from '#/db/schema'
+
+export const PromptTemplateSchema = z.object({
+  id: z.string(),
+  inputType: z.enum(['text', 'textarea']),
+  title: z.string(),
+  placeholder: z.string(),
+  prompt: z.string(),
+})
+
+export type PromptTemplate = z.infer<typeof PromptTemplateSchema>
+
+export async function readPromptTemplates(databaseUrl: string): Promise<PromptTemplate[]> {
+  const db = getDatabase(databaseUrl)
+  const rows = await db
+    .select({
+      id: promptTemplatesTable.id,
+      inputType: promptTemplatesTable.inputType,
+      title: promptTemplatesTable.title,
+      placeholder: promptTemplatesTable.placeholder,
+      prompt: promptTemplatesTable.prompt,
+    })
+    .from(promptTemplatesTable)
+    .where(eq(promptTemplatesTable.enabled, true))
+    .orderBy(asc(promptTemplatesTable.displayOrder), asc(promptTemplatesTable.id))
+
+  return rows.map((row) => PromptTemplateSchema.parse(row))
+}
+
+export const promptTemplateRepository = {
+  read: readPromptTemplates,
+}

--- a/projects/portfolio/src/server/routes/prompt-templates.ts
+++ b/projects/portfolio/src/server/routes/prompt-templates.ts
@@ -1,0 +1,20 @@
+import { Hono } from 'hono'
+import { promptTemplateRepository } from '#/server/features/prompt-templates/repository'
+import { logger } from '#/server/lib/logger'
+import type { HonoEnv } from './shared'
+import { getServerEnv } from './shared'
+
+const promptTemplatesRoutes = new Hono<HonoEnv>().get('/api/prompt-templates', async (c) => {
+  const { DATABASE_URL = '' } = getServerEnv(c)
+  const requestLogger = c.var.logger ?? logger
+
+  try {
+    const templates = await promptTemplateRepository.read(DATABASE_URL)
+    return c.json({ data: templates })
+  } catch (error) {
+    requestLogger.error({ err: error }, 'Failed to read prompt templates')
+    return c.json({ data: [] }, 500)
+  }
+})
+
+export { promptTemplatesRoutes }

--- a/projects/portfolio/tests/client/components/prompt-template.test.tsx
+++ b/projects/portfolio/tests/client/components/prompt-template.test.tsx
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const STORAGE_KEY = 'portfolio.chat-settings'
+
+const promptTemplatesGetMock = vi.fn()
+
+vi.mock('hono/client', () => ({
+  hc: () => ({
+    api: {
+      'prompt-templates': {
+        $get: (...args: unknown[]) => promptTemplatesGetMock(...args),
+      },
+    },
+  }),
+}))
+
+vi.mock('#/client/components/chat/chat-settings/hooks/use-model-fetching', () => ({
+  useModelFetching: () => ({
+    fetchedModels: [],
+    isLoadingModels: false,
+    fetchError: null,
+  }),
+}))
+
+const defaultSettings = {
+  schemaVersion: '1.4.0',
+  model: 'gpt-4.1-mini',
+  baseURL: '',
+  apiKey: '',
+  apiMode: 'chat_completions',
+  temperature: 0.7,
+  temperatureEnabled: false,
+  maxTokens: undefined,
+  reasoningEffort: 'medium',
+  reasoningEffortEnabled: false,
+  fakeMode: false,
+  autoModel: false,
+  markdownPreview: true,
+  streamMode: true,
+  includeChatHistory: true,
+  sendImagesOnlyOnce: true,
+  sidebarOpen: true,
+  templateModels: {},
+}
+
+const createLocalStorageMock = (initialEntries: Record<string, string> = {}) => {
+  const store = new Map(Object.entries(initialEntries))
+
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value)
+    },
+    removeItem: (key: string) => {
+      store.delete(key)
+    },
+    clear: () => {
+      store.clear()
+    },
+  }
+}
+
+describe('PromptTemplate', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'localStorage',
+      createLocalStorageMock({
+        [STORAGE_KEY]: JSON.stringify(defaultSettings),
+      })
+    )
+    promptTemplatesGetMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [
+          {
+            id: 'commit_message',
+            inputType: 'text',
+            title: 'コミットメッセージを作成',
+            placeholder: '変更内容',
+            prompt: 'Create commit message',
+          },
+        ],
+      }),
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('APIから取得したテンプレートを表示して送信する', async () => {
+    const onSubmit = vi.fn()
+    const { PromptTemplate } = await import('#/client/components/chat/prompt-template')
+
+    render(<PromptTemplate autoModel={false} onSubmit={onSubmit} />)
+
+    const input = await screen.findByPlaceholderText('変更内容')
+    fireEvent.change(input, { target: { value: 'add prompt templates' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(promptTemplatesGetMock).toHaveBeenCalledTimes(1)
+    expect(onSubmit).toHaveBeenCalledWith({
+      model: '',
+      prompt: 'Create commit message',
+      content: 'add prompt templates',
+    })
+  })
+
+  it('有効テンプレートが0件の場合はテンプレート欄を表示しない', async () => {
+    promptTemplatesGetMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [] }),
+    })
+    const { PromptTemplate } = await import('#/client/components/chat/prompt-template')
+
+    render(<PromptTemplate autoModel={false} />)
+
+    await waitFor(() => {
+      expect(screen.queryByText('コミットメッセージを作成')).toBeNull()
+    })
+  })
+
+  it('取得失敗時はテンプレート欄を表示しない', async () => {
+    promptTemplatesGetMock.mockRejectedValue(new Error('network error'))
+    const { PromptTemplate } = await import('#/client/components/chat/prompt-template')
+
+    render(<PromptTemplate autoModel={false} />)
+
+    await waitFor(() => {
+      expect(screen.queryByText('コミットメッセージを作成')).toBeNull()
+    })
+  })
+})

--- a/projects/portfolio/tests/db/seeders/upsert-prompt-templates.test.ts
+++ b/projects/portfolio/tests/db/seeders/upsert-prompt-templates.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { getDatabase } from '#/db'
+import { promptTemplatesTable } from '#/db/schema'
+import { defaultPromptTemplates } from '#/db/seeders/prompt-template-defaults'
+import { upsertPromptTemplates } from '#/db/seeders/upsert-prompt-templates'
+
+vi.mock('#/db', () => ({
+  getDatabase: vi.fn(),
+}))
+
+const mockedGetDatabase = vi.mocked(getDatabase)
+
+function createDbStub() {
+  const onConflictDoUpdate = vi.fn().mockResolvedValue(undefined)
+  const values = vi.fn(() => ({ onConflictDoUpdate }))
+  const insert = vi.fn(() => ({ values }))
+
+  return {
+    db: { insert },
+    insert,
+    values,
+    onConflictDoUpdate,
+  }
+}
+
+describe('upsertPromptTemplates', () => {
+  beforeEach(() => {
+    mockedGetDatabase.mockReset()
+  })
+
+  it('既定テンプレートを安定IDで upsert する', async () => {
+    const { db, insert, values, onConflictDoUpdate } = createDbStub()
+    mockedGetDatabase.mockReturnValue(db as never)
+
+    await expect(upsertPromptTemplates({ databaseUrl: 'postgres://db' })).resolves.toBe(defaultPromptTemplates.length)
+
+    expect(mockedGetDatabase).toHaveBeenCalledWith('postgres://db')
+    expect(insert).toHaveBeenCalledTimes(defaultPromptTemplates.length)
+    expect(values).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'translate_en',
+        enabled: true,
+        displayOrder: 10,
+      })
+    )
+    expect(onConflictDoUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: promptTemplatesTable.id,
+        set: expect.objectContaining({
+          enabled: true,
+          title: '🇺🇸 英語へ翻訳',
+        }),
+      })
+    )
+  })
+})

--- a/projects/portfolio/tests/routes/prompt-templates.test.ts
+++ b/projects/portfolio/tests/routes/prompt-templates.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const { repositoryMock } = vi.hoisted(() => ({
+  repositoryMock: {
+    read: vi.fn(),
+  },
+}))
+
+vi.mock('#/server/features/prompt-templates/repository', () => ({
+  promptTemplateRepository: repositoryMock,
+}))
+
+import { promptTemplatesRoutes } from '#/server/routes/prompt-templates'
+
+describe('promptTemplatesRoutes', () => {
+  it('未認証でも有効なテンプレート一覧を返す', async () => {
+    vi.stubEnv('DATABASE_URL', 'postgres://db')
+    repositoryMock.read.mockResolvedValue([
+      {
+        id: 'translate_en',
+        inputType: 'textarea',
+        title: '英語へ翻訳',
+        placeholder: '入力',
+        prompt: 'Translate',
+      },
+    ])
+
+    const res = await promptTemplatesRoutes.request('/api/prompt-templates')
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({
+      data: [
+        {
+          id: 'translate_en',
+          inputType: 'textarea',
+          title: '英語へ翻訳',
+          placeholder: '入力',
+          prompt: 'Translate',
+        },
+      ],
+    })
+    expect(repositoryMock.read).toHaveBeenCalledWith('postgres://db')
+  })
+
+  it('取得失敗時は空配列と 500 を返す', async () => {
+    vi.stubEnv('DATABASE_URL', 'postgres://db')
+    repositoryMock.read.mockRejectedValue(new Error('database unavailable'))
+
+    const res = await promptTemplatesRoutes.request('/api/prompt-templates')
+
+    expect(res.status).toBe(500)
+    await expect(res.json()).resolves.toEqual({ data: [] })
+  })
+})


### PR DESCRIPTION
## Issues

- Close #966

## Why

Chat画面のテンプレート定義をフロントコード固定からDB管理へ移し、将来の管理画面編集やテンプレート拡張に進める土台を作るためです。

## Summary

`prompt_templates` テーブル、既定テンプレートSeed、未認証の取得APIを追加しました。Chat画面はAPI取得結果を表示し、取得失敗または0件の場合はテンプレート欄を非表示にします。

## Changes

- `prompt_templates` テーブルと Drizzle migration を追加
- 既定4件を安定IDでupsertする `bun run db:prompt-templates:seed` を追加
- `GET /api/prompt-templates` を追加し、`enabled = true` のみ `displayOrder ASC`, `id ASC` で返却
- `PromptTemplate` の固定配列を削除し、API取得ベースへ変更
- Seed手順とDB参照確認を `DEVELOPMENT.md` に追記
- route / Seed / client component のテストを追加

## Verification

- `bun run format` - passed
- `bun run test -- tests/routes/prompt-templates.test.ts tests/db/seeders/upsert-prompt-templates.test.ts tests/client/components/prompt-template.test.tsx` - passed
- `bun run lint` - passed
- `bun run test` - passed
- `bun run typegen` - passed
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/portfolio bun run db:migrate` - passed
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/portfolio bun run db:prompt-templates:seed` - passed
- Seed再実行後、`select count(*) from prompt_templates;` が `4` のままであることを確認

## Seed Verification

```sh
bun run db:migrate
bun run db:prompt-templates:seed
```

DB側からSeed結果を確認できます。

```sql
select id, display_order, enabled
from prompt_templates
order by display_order, id;
```

ローカル確認結果:

```text
         id         | display_order | enabled
--------------------+---------------+---------
 translate_en       |            10 | t
 translate_ja       |            20 | t
 commit_message     |            30 | t
 text_summarization |            40 | t
```
