### PR TITLE
refactor(portfolio): useEffect起点のサーバー状態取得をuseQueryへ移行

### DIFF
--- a/projects/portfolio/src/client/components/chat/chat-settings/hooks/use-model-fetching.ts
+++ b/projects/portfolio/src/client/components/chat/chat-settings/hooks/use-model-fetching.ts
@@ -1,5 +1,5 @@
+import { useQuery } from '@tanstack/react-query'
 import { hc } from 'hono/client'
-import { useCallback, useEffect, useState } from 'react'
 import { readFromLocalStorage } from '#/client/storage/remote-storage-settings'
 import type { AppType } from '#/server/app'
 
@@ -51,35 +51,20 @@ interface UseModelFetchingReturn {
 export function useModelFetching(options: UseModelFetchingOptions): UseModelFetchingReturn {
   const { autoModel } = options
 
-  const [fetchedModels, setFetchedModels] = useState<string[]>([])
-  const [isLoadingModels, setIsLoadingModels] = useState(false)
-  const [fetchError, setFetchError] = useState<string | null>(null)
-
-  useEffect(() => {
-    if (autoModel) {
-      setIsLoadingModels(true)
-      setFetchError(null)
+  const query = useQuery({
+    queryKey: ['chat-models'],
+    queryFn: async () => {
       const { baseURL, apiKey } = readFromLocalStorage()
-      fetchModelsWithTimeout(baseURL, apiKey).then(({ models, error }) => {
-        setFetchedModels(models)
-        setFetchError(error)
-        setIsLoadingModels(false)
-      })
-    }
-  }, [autoModel])
+      return fetchModelsWithTimeout(baseURL, apiKey)
+    },
+    enabled: autoModel,
+    staleTime: 5 * 60 * 1000,
+  })
 
-  const refetchModels = useCallback(() => {
-    if (autoModel) {
-      setIsLoadingModels(true)
-      setFetchError(null)
-      const { baseURL, apiKey } = readFromLocalStorage()
-      fetchModelsWithTimeout(baseURL, apiKey).then(({ models, error }) => {
-        setFetchedModels(models)
-        setFetchError(error)
-        setIsLoadingModels(false)
-      })
-    }
-  }, [autoModel])
-
-  return { fetchedModels, isLoadingModels, fetchError, refetchModels }
+  return {
+    fetchedModels: query.data?.models ?? [],
+    isLoadingModels: query.isLoading,
+    fetchError: query.data?.error ?? null,
+    refetchModels: query.refetch,
+  }
 }

--- a/projects/portfolio/src/client/components/chat/chat-settings/hooks/use-model-fetching.ts
+++ b/projects/portfolio/src/client/components/chat/chat-settings/hooks/use-model-fetching.ts
@@ -51,10 +51,11 @@ interface UseModelFetchingReturn {
 export function useModelFetching(options: UseModelFetchingOptions): UseModelFetchingReturn {
   const { autoModel } = options
 
+  const { baseURL, apiKey } = readFromLocalStorage()
+
   const query = useQuery({
-    queryKey: ['chat-models'],
+    queryKey: ['chat-models', baseURL, apiKey],
     queryFn: async () => {
-      const { baseURL, apiKey } = readFromLocalStorage()
       return fetchModelsWithTimeout(baseURL, apiKey)
     },
     enabled: autoModel,

--- a/projects/portfolio/src/client/components/chat/prompt-template.tsx
+++ b/projects/portfolio/src/client/components/chat/prompt-template.tsx
@@ -1,6 +1,7 @@
+import { useQuery } from '@tanstack/react-query'
 import { hc } from 'hono/client'
 import type { ChangeEvent, KeyboardEvent } from 'react'
-import { memo, useEffect, useMemo, useState } from 'react'
+import { memo, useMemo, useState } from 'react'
 import { useModelFetching } from '#/client/components/chat/chat-settings/hooks/use-model-fetching'
 import { readFromLocalStorage, saveToLocalStorage } from '#/client/storage/remote-storage-settings'
 import type { AppType } from '#/server/app'
@@ -42,41 +43,26 @@ interface Props {
 
 function PromptTemplateComponent({ autoModel, placeholder, onSubmit }: Props) {
   const [composing, setComposition] = useState(false)
-  const [promptTemplates, setPromptTemplates] = useState<PromptTemplate[]>([])
+
+  const promptTemplatesQuery = useQuery({
+    queryKey: ['prompt-templates'],
+    queryFn: async () => {
+      const response = await client.api['prompt-templates'].$get()
+      if (!response.ok) {
+        return []
+      }
+      const { data } = await response.json()
+      return data
+    },
+    staleTime: 5 * 60 * 1000,
+  })
+  const promptTemplates = promptTemplatesQuery.data ?? []
 
   const defaultSettings = useMemo(() => {
     return readFromLocalStorage()
   }, [])
   const [templateModels, setTemplateModels] = useState(defaultSettings.templateModels || {})
   const { fetchedModels, isLoadingModels, fetchError } = useModelFetching({ autoModel })
-
-  useEffect(() => {
-    let ignore = false
-
-    client.api['prompt-templates']
-      .$get()
-      .then(async (response) => {
-        if (!response.ok) {
-          return { data: [] }
-        }
-
-        return response.json()
-      })
-      .then(({ data }) => {
-        if (!ignore) {
-          setPromptTemplates(data)
-        }
-      })
-      .catch(() => {
-        if (!ignore) {
-          setPromptTemplates([])
-        }
-      })
-
-    return () => {
-      ignore = true
-    }
-  }, [])
 
   const handleChangeComposition = (composition: boolean) => {
     setComposition(composition)

--- a/projects/portfolio/tests/client/components/prompt-template.test.tsx
+++ b/projects/portfolio/tests/client/components/prompt-template.test.tsx
@@ -1,6 +1,8 @@
 // @vitest-environment jsdom
 
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { type ReactNode, createElement } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const STORAGE_KEY = 'portfolio.chat-settings'
@@ -63,6 +65,18 @@ const createLocalStorageMock = (initialEntries: Record<string, string> = {}) => 
   }
 }
 
+const createQueryClientWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  })
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children)
+}
+
 describe('PromptTemplate', () => {
   beforeEach(() => {
     vi.stubGlobal(
@@ -96,7 +110,7 @@ describe('PromptTemplate', () => {
     const onSubmit = vi.fn()
     const { PromptTemplate } = await import('#/client/components/chat/prompt-template')
 
-    render(<PromptTemplate autoModel={false} onSubmit={onSubmit} />)
+    render(<PromptTemplate autoModel={false} onSubmit={onSubmit} />, { wrapper: createQueryClientWrapper() })
 
     const input = await screen.findByPlaceholderText('変更内容')
     fireEvent.change(input, { target: { value: 'add prompt templates' } })
@@ -117,7 +131,7 @@ describe('PromptTemplate', () => {
     })
     const { PromptTemplate } = await import('#/client/components/chat/prompt-template')
 
-    render(<PromptTemplate autoModel={false} />)
+    render(<PromptTemplate autoModel={false} />, { wrapper: createQueryClientWrapper() })
 
     await waitFor(() => {
       expect(screen.queryByText('コミットメッセージを作成')).toBeNull()
@@ -128,7 +142,7 @@ describe('PromptTemplate', () => {
     promptTemplatesGetMock.mockRejectedValue(new Error('network error'))
     const { PromptTemplate } = await import('#/client/components/chat/prompt-template')
 
-    render(<PromptTemplate autoModel={false} />)
+    render(<PromptTemplate autoModel={false} />, { wrapper: createQueryClientWrapper() })
 
     await waitFor(() => {
       expect(screen.queryByText('コミットメッセージを作成')).toBeNull()


### PR DESCRIPTION
## Issues

- Close #971

## Why

手動の `useEffect` / `useState` / mounted フラグによるデータ取得を減らし、キャッシュ・再取得・ローディング・エラー状態の扱いを TanStack Query の `useQuery` に寄せる。

## Summary

`prompt-templates` と `fetch-models` の2箇所で使われていた `useEffect` 起点のサーバー状態取得を TanStack Query の `useQuery` に移行。

## Changes

- `prompt-template.tsx`: `promptTemplates` 取得を `useState` + `useEffect` から `useQuery` に置き換え
- `use-model-fetching.ts`: モデル取得を `useState` + `useEffect` + `useCallback` から `useQuery` に置き換え
- `use-model-fetching.ts`: 戻り値インターフェース `UseModelFetchingReturn` を維持して呼び出し元との互換性を確保
- `prompt-template.test.tsx`: `QueryClientProvider` ラッパーを追加して `useQuery` 対応

## Verification

- `bun run lint` - passed
- `bun run format:check` - passed
- `bun run test` - passed
