### PR TITLE
fix(portfolio): regenerate missing code previews

### DIFF
--- a/projects/portfolio/src/client/features/chat/components/assistant-code-block.tsx
+++ b/projects/portfolio/src/client/features/chat/components/assistant-code-block.tsx
@@ -2,6 +2,7 @@ import { createContext, type HTMLAttributes, type ReactNode, useContext, useEffe
 import {
   CodeBlockGenerateButton,
   CodeBlockPreviewButton,
+  CodeBlockPreviewLink,
   CodeBlockRenderer,
 } from '#/client/features/chat/components/code-block-renderer'
 import type { GeneratedCodeFile } from '#/types'
@@ -10,6 +11,7 @@ export type SaveGeneratedFileRequest = {
   blockIndex: number
   language: string
   content: string
+  force?: boolean
 }
 
 export interface AssistantCodeBlockContextValue {
@@ -112,6 +114,34 @@ function AssistantSavableCodeBlock({
     }
   }
 
+  const handlePreview = async () => {
+    const previewWindow = window.open('', '_blank', 'noopener,noreferrer')
+    if (!previewWindow) {
+      return
+    }
+
+    setSaving(true)
+    setError(null)
+    try {
+      const file = await ctx.onSave({
+        blockIndex,
+        language: detectedLanguage ?? '',
+        content: code,
+        force: true,
+      })
+      if (file?.previewUrl) {
+        previewWindow.location.href = file.previewUrl
+      } else {
+        previewWindow.close()
+      }
+    } catch (err) {
+      previewWindow.close()
+      setError(err instanceof Error ? err.message : 'Failed to preview')
+    } finally {
+      setSaving(false)
+    }
+  }
+
   useEffect(() => {
     if (previewHref && awaitingPreviewRef.current) {
       window.open(previewHref, '_blank', 'noopener,noreferrer')
@@ -120,7 +150,11 @@ function AssistantSavableCodeBlock({
   }, [previewHref])
 
   const actions = previewHref ? (
-    <CodeBlockPreviewButton href={previewHref} />
+    ctx.canSaveGeneratedFile ? (
+      <CodeBlockPreviewButton onClick={handlePreview} pending={saving} disabled={ctx.disabled} />
+    ) : (
+      <CodeBlockPreviewLink href={previewHref} />
+    )
   ) : canShowSaveAction ? (
     <CodeBlockGenerateButton onClick={handleSave} pending={saving} disabled={ctx.disabled} />
   ) : undefined

--- a/projects/portfolio/src/client/features/chat/components/assistant-code-block.tsx
+++ b/projects/portfolio/src/client/features/chat/components/assistant-code-block.tsx
@@ -115,10 +115,11 @@ function AssistantSavableCodeBlock({
   }
 
   const handlePreview = async () => {
-    const previewWindow = window.open('', '_blank', 'noopener,noreferrer')
+    const previewWindow = window.open('about:blank', '_blank')
     if (!previewWindow) {
       return
     }
+    previewWindow.opener = null
 
     setSaving(true)
     setError(null)

--- a/projects/portfolio/src/client/features/chat/components/code-block-renderer.tsx
+++ b/projects/portfolio/src/client/features/chat/components/code-block-renderer.tsx
@@ -114,10 +114,37 @@ type CodeBlockRendererProps = HTMLAttributes<HTMLElement> & {
 }
 
 export interface CodeBlockPreviewButtonProps {
+  onClick: () => void
+  pending?: boolean
+  disabled?: boolean
+}
+
+export function CodeBlockPreviewButton({ onClick, pending, disabled }: CodeBlockPreviewButtonProps) {
+  return (
+    <button
+      type='button'
+      onClick={onClick}
+      disabled={pending || disabled}
+      aria-label={pending ? 'Checking preview' : 'Preview code block'}
+      className='relative inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-md text-gray-600 transition-[background-color,color] duration-200 ease-out hover:bg-gray-200 hover:text-gray-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 disabled:cursor-default disabled:opacity-60 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white dark:focus-visible:ring-gray-500'
+    >
+      {pending ? (
+        <svg viewBox='0 0 24 24' aria-hidden='true' fill='none' className='h-[18px] w-[18px] animate-spin'>
+          <circle cx='12' cy='12' r='9' strokeWidth='2.5' className='stroke-current opacity-25' />
+          <path d='M21 12a9 9 0 0 0-9-9' strokeWidth='2.5' strokeLinecap='round' className='stroke-current' />
+        </svg>
+      ) : (
+        <EyeIcon size={18} className='stroke-current' />
+      )}
+    </button>
+  )
+}
+
+export interface CodeBlockPreviewLinkProps {
   href: string
 }
 
-export function CodeBlockPreviewButton({ href }: CodeBlockPreviewButtonProps) {
+export function CodeBlockPreviewLink({ href }: CodeBlockPreviewLinkProps) {
   return (
     <a
       href={href}

--- a/projects/portfolio/src/client/features/chat/hooks/use-chat-actions.ts
+++ b/projects/portfolio/src/client/features/chat/hooks/use-chat-actions.ts
@@ -183,6 +183,7 @@ export function useChatActions({
           blockIndex: params.blockIndex,
           language: params.language,
           content: params.content,
+          force: params.force,
         }),
       })
       if (!res.ok) {

--- a/projects/portfolio/src/server/features/chat-conversations/file-server-client.ts
+++ b/projects/portfolio/src/server/features/chat-conversations/file-server-client.ts
@@ -42,6 +42,16 @@ export function buildFileServerPreviewUrl(publicBaseUrl: string, publicPath: str
   return `${publicBaseUrl}${publicPath}`
 }
 
+export async function checkFileExists(publicBaseUrl: string, publicPath: string): Promise<boolean> {
+  try {
+    const res = await fetch(buildFileServerPreviewUrl(publicBaseUrl, publicPath), { method: 'HEAD' })
+    return res.ok
+  } catch (error) {
+    logger.warn({ err: error, publicPath }, 'file-server file existence check failed')
+    return false
+  }
+}
+
 /**
  * file-server の設定を env から解決する。
  * 現時点では固定 admin credentials を使うが、将来 portfolio user と

--- a/projects/portfolio/src/server/features/chat-conversations/file-server-client.ts
+++ b/projects/portfolio/src/server/features/chat-conversations/file-server-client.ts
@@ -43,13 +43,8 @@ export function buildFileServerPreviewUrl(publicBaseUrl: string, publicPath: str
 }
 
 export async function checkFileExists(publicBaseUrl: string, publicPath: string): Promise<boolean> {
-  try {
-    const res = await fetch(buildFileServerPreviewUrl(publicBaseUrl, publicPath), { method: 'HEAD' })
-    return res.ok
-  } catch (error) {
-    logger.warn({ err: error, publicPath }, 'file-server file existence check failed')
-    return false
-  }
+  const res = await fetch(buildFileServerPreviewUrl(publicBaseUrl, publicPath), { method: 'HEAD' })
+  return res.ok
 }
 
 /**

--- a/projects/portfolio/src/server/features/chat-conversations/repository.ts
+++ b/projects/portfolio/src/server/features/chat-conversations/repository.ts
@@ -49,6 +49,7 @@ interface ChatConversationRepository {
       blockIndex: number
       language: string
       content: string
+      force?: boolean
     },
     fileServerConfig: FileServerConfig | null
   ): Promise<SaveGeneratedFileResult>

--- a/projects/portfolio/src/server/features/chat-conversations/save-generated-file.ts
+++ b/projects/portfolio/src/server/features/chat-conversations/save-generated-file.ts
@@ -3,6 +3,7 @@ import { getDatabase } from '#/db'
 import { conversationsTable, messagesTable, usersTable } from '#/db/schema'
 import {
   buildFileServerPreviewUrl,
+  checkFileExists,
   type FileServerConfig,
   loginToFileServer,
   uploadFileToFileServer,
@@ -29,6 +30,7 @@ interface SaveGeneratedFileParams {
   blockIndex: number
   language: string
   content: string
+  force?: boolean
 }
 
 const LANGUAGE_EXTENSION_MAP: Record<string, { ext: string; contentType: string }> = {
@@ -110,10 +112,16 @@ export async function saveGeneratedFile(
     ? (existingMetadata.generatedFiles as GeneratedCodeFile[])
     : []
 
-  // 既に同じ blockIndex で保存済みなら再 upload せずそのまま返す
+  // force 指定時は file-server 側の実体が残っている場合だけ既存 file を返す
   const existing = existingFiles.find((f) => f.blockIndex === params.blockIndex)
-  if (existing) {
+  if (existing && !params.force) {
     return { ok: true, file: existing, alreadyExisted: true }
+  }
+  if (existing && params.force) {
+    const exists = await checkFileExists(fileServerConfig.publicBaseUrl, existing.publicPath)
+    if (exists) {
+      return { ok: true, file: existing, alreadyExisted: true }
+    }
   }
 
   const fileName = `${params.messageId}-block-${params.blockIndex}.${extension.ext}`
@@ -145,7 +153,8 @@ export async function saveGeneratedFile(
     createdAt,
   }
 
-  const mergedFiles = [...existingFiles, file]
+  const otherFiles = existingFiles.filter((f) => f.blockIndex !== params.blockIndex)
+  const mergedFiles = [...otherFiles, file]
   const mergedMetadata: Record<string, unknown> = {
     ...existingMetadata,
     generatedFiles: mergedFiles,

--- a/projects/portfolio/src/server/features/chat-conversations/save-generated-file.ts
+++ b/projects/portfolio/src/server/features/chat-conversations/save-generated-file.ts
@@ -118,9 +118,12 @@ export async function saveGeneratedFile(
     return { ok: true, file: existing, alreadyExisted: true }
   }
   if (existing && params.force) {
-    const exists = await checkFileExists(fileServerConfig.publicBaseUrl, existing.publicPath)
+    const exists = await checkExistingFileExists(fileServerConfig, existing)
     if (exists) {
       return { ok: true, file: existing, alreadyExisted: true }
+    }
+    if (exists === null) {
+      return { ok: false, reason: 'file-server-unavailable' }
     }
   }
 
@@ -163,6 +166,18 @@ export async function saveGeneratedFile(
   await db.update(messagesTable).set({ metadata: mergedMetadata }).where(eq(messagesTable.id, params.messageId))
 
   return { ok: true, file, alreadyExisted: false }
+}
+
+async function checkExistingFileExists(
+  fileServerConfig: FileServerConfig,
+  existing: GeneratedCodeFile
+): Promise<boolean | null> {
+  try {
+    return await checkFileExists(fileServerConfig.publicBaseUrl, existing.publicPath)
+  } catch (error) {
+    logger.warn({ err: error, publicPath: existing.publicPath }, 'file-server file existence check failed')
+    return null
+  }
 }
 
 export type { AssistantMetadata }

--- a/projects/portfolio/src/server/routes/conversations.ts
+++ b/projects/portfolio/src/server/routes/conversations.ts
@@ -45,6 +45,7 @@ const SaveGeneratedFileBodySchema = z.object({
   blockIndex: z.number().int().nonnegative(),
   language: z.string().min(1),
   content: z.string().min(1),
+  force: z.boolean().optional(),
 })
 
 const conversationsRoutes = new Hono<HonoEnv>()
@@ -132,6 +133,7 @@ const conversationsRoutes = new Hono<HonoEnv>()
           blockIndex: body.blockIndex,
           language: body.language,
           content: body.content,
+          force: body.force,
         },
         fileServerConfig
       )

--- a/projects/portfolio/tests/client/components/message-renderer.test.tsx
+++ b/projects/portfolio/tests/client/components/message-renderer.test.tsx
@@ -300,6 +300,65 @@ describe('MessageRenderer', () => {
       )
       expect(screen.queryByRole('button', { name: 'Generate preview' })).toBeNull()
     })
+
+    it('認証済みの既存プレビューは force 指定で保存し直して戻り値の URL を開く', async () => {
+      const previewWindow = {
+        location: { href: '' },
+        close: vi.fn(),
+      }
+      const openMock = vi.spyOn(window, 'open').mockReturnValue(previewWindow as unknown as Window)
+      const onSaveGeneratedFile = vi.fn().mockResolvedValue({
+        blockIndex: 0,
+        language: 'html',
+        fileName: 'message-1-block-0.html',
+        publicPath: '/public/portfolio/c1/message-1-block-0.html',
+        previewUrl: 'http://files.example.com/public/portfolio/c1/message-1-block-0.html',
+        contentType: 'text/html; charset=utf-8',
+        createdAt: '2026-04-19T00:00:00.000Z',
+      })
+
+      render(
+        <MessageRenderer
+          message={createAssistantMessage('```html\n<div>Hello</div>\n```', [
+            {
+              blockIndex: 0,
+              language: 'html',
+              fileName: 'message-1-block-0.html',
+              publicPath: '/public/portfolio/c1/message-1-block-0.html',
+              previewUrl: 'http://files.example.com/public/portfolio/c1/message-1-block-0.html',
+              contentType: 'text/html; charset=utf-8',
+              createdAt: '2026-04-19T00:00:00.000Z',
+            },
+          ])}
+          index={0}
+          messages={[]}
+          conversationId='conversation-1'
+          canSaveGeneratedFile={true}
+          markdownPreview={true}
+          copied={false}
+          onCopyMessage={vi.fn()}
+          onSaveGeneratedFile={onSaveGeneratedFile}
+        />
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: 'Preview code block' }))
+
+      await waitFor(() => {
+        expect(onSaveGeneratedFile).toHaveBeenCalledWith(
+          0,
+          expect.objectContaining({
+            blockIndex: 0,
+            language: 'html',
+            force: true,
+          })
+        )
+      })
+      expect(openMock).toHaveBeenCalledWith('', '_blank', 'noopener,noreferrer')
+      expect(previewWindow.location.href).toBe('http://files.example.com/public/portfolio/c1/message-1-block-0.html')
+      expect(previewWindow.close).not.toHaveBeenCalled()
+
+      openMock.mockRestore()
+    })
   })
 
   describe('Markdown セキュリティ', () => {

--- a/projects/portfolio/tests/client/components/message-renderer.test.tsx
+++ b/projects/portfolio/tests/client/components/message-renderer.test.tsx
@@ -304,6 +304,7 @@ describe('MessageRenderer', () => {
     it('認証済みの既存プレビューは force 指定で保存し直して戻り値の URL を開く', async () => {
       const previewWindow = {
         location: { href: '' },
+        opener: window,
         close: vi.fn(),
       }
       const openMock = vi.spyOn(window, 'open').mockReturnValue(previewWindow as unknown as Window)
@@ -353,7 +354,8 @@ describe('MessageRenderer', () => {
           })
         )
       })
-      expect(openMock).toHaveBeenCalledWith('', '_blank', 'noopener,noreferrer')
+      expect(openMock).toHaveBeenCalledWith('about:blank', '_blank')
+      expect(previewWindow.opener).toBeNull()
       expect(previewWindow.location.href).toBe('http://files.example.com/public/portfolio/c1/message-1-block-0.html')
       expect(previewWindow.close).not.toHaveBeenCalled()
 

--- a/projects/portfolio/tests/features/chat-conversations/save-generated-file.test.ts
+++ b/projects/portfolio/tests/features/chat-conversations/save-generated-file.test.ts
@@ -10,6 +10,7 @@ const importSubject = async (params: {
     conversationUserId: string
   }
   fileExists?: boolean
+  fileExistsError?: Error
 }) => {
   mockLogger()
   const updateSets: unknown[] = []
@@ -47,7 +48,9 @@ const importSubject = async (params: {
 
   const loginToFileServer = vi.fn().mockResolvedValue('session-value')
   const uploadFileToFileServer = vi.fn().mockResolvedValue(undefined)
-  const checkFileExists = vi.fn().mockResolvedValue(params.fileExists ?? true)
+  const checkFileExists = params.fileExistsError
+    ? vi.fn().mockRejectedValue(params.fileExistsError)
+    : vi.fn().mockResolvedValue(params.fileExists ?? true)
   vi.doMock('#/server/features/chat-conversations/file-server-client', () => ({
     buildFileServerPreviewUrl: vi.fn((publicBaseUrl: string, publicPath: string) => `${publicBaseUrl}${publicPath}`),
     checkFileExists,
@@ -270,6 +273,43 @@ describe('saveGeneratedFile', () => {
         ],
       },
     })
+  })
+
+  it('force 指定の存在確認に失敗したら upload せず file-server-unavailable を返す', async () => {
+    const existing = {
+      blockIndex: 0,
+      language: 'html',
+      fileName: 'm1-block-0.html',
+      publicPath: '/public/portfolio/c1/m1-block-0.html',
+      previewUrl: 'http://files.example.com/public/portfolio/c1/m1-block-0.html',
+      contentType: 'text/html; charset=utf-8',
+      createdAt: '2026-04-19T00:00:00.000Z',
+    }
+    const { saveGeneratedFile, checkFileExists, uploadFileToFileServer } = await importSubject({
+      users: [{ id: 'u1', email: 'x@example.com' }],
+      ownedRow: {
+        messageId: 'm1',
+        role: 'assistant',
+        metadata: { generatedFiles: [existing] },
+        conversationUserId: 'u1',
+      },
+      fileExistsError: new Error('connection refused'),
+    })
+
+    const result = await saveGeneratedFile(
+      'postgres://db',
+      'x@example.com',
+      { conversationId: 'c1', messageId: 'm1', blockIndex: 0, language: 'html', content: '<p/>', force: true },
+      {
+        baseUrl: 'http://fs',
+        publicBaseUrl: 'http://files.example.com',
+        credentials: { username: 'admin', password: 'p' },
+      }
+    )
+
+    expect(result).toEqual({ ok: false, reason: 'file-server-unavailable' })
+    expect(checkFileExists).toHaveBeenCalledWith('http://files.example.com', existing.publicPath)
+    expect(uploadFileToFileServer).not.toHaveBeenCalled()
   })
 
   it('新規保存時は login+upload して metadata.generatedFiles を更新する', async () => {

--- a/projects/portfolio/tests/features/chat-conversations/save-generated-file.test.ts
+++ b/projects/portfolio/tests/features/chat-conversations/save-generated-file.test.ts
@@ -9,6 +9,7 @@ const importSubject = async (params: {
     metadata: unknown
     conversationUserId: string
   }
+  fileExists?: boolean
 }) => {
   mockLogger()
   const updateSets: unknown[] = []
@@ -46,15 +47,17 @@ const importSubject = async (params: {
 
   const loginToFileServer = vi.fn().mockResolvedValue('session-value')
   const uploadFileToFileServer = vi.fn().mockResolvedValue(undefined)
+  const checkFileExists = vi.fn().mockResolvedValue(params.fileExists ?? true)
   vi.doMock('#/server/features/chat-conversations/file-server-client', () => ({
     buildFileServerPreviewUrl: vi.fn((publicBaseUrl: string, publicPath: string) => `${publicBaseUrl}${publicPath}`),
+    checkFileExists,
     loginToFileServer,
     uploadFileToFileServer,
   }))
 
   const { saveGeneratedFile, resolveExtension } =
     await import('#/server/features/chat-conversations/save-generated-file')
-  return { saveGeneratedFile, resolveExtension, updateSets, loginToFileServer, uploadFileToFileServer }
+  return { saveGeneratedFile, resolveExtension, updateSets, checkFileExists, loginToFileServer, uploadFileToFileServer }
 }
 
 describe('saveGeneratedFile', () => {
@@ -170,6 +173,103 @@ describe('saveGeneratedFile', () => {
 
     expect(result).toEqual({ ok: true, file: existing, alreadyExisted: true })
     expect(uploadFileToFileServer).not.toHaveBeenCalled()
+  })
+
+  it('force 指定でも既存ファイルが存在すれば upload しない', async () => {
+    const existing = {
+      blockIndex: 0,
+      language: 'html',
+      fileName: 'm1-block-0.html',
+      publicPath: '/public/portfolio/c1/m1-block-0.html',
+      previewUrl: 'http://files.example.com/public/portfolio/c1/m1-block-0.html',
+      contentType: 'text/html; charset=utf-8',
+      createdAt: '2026-04-19T00:00:00.000Z',
+    }
+    const { saveGeneratedFile, checkFileExists, uploadFileToFileServer } = await importSubject({
+      users: [{ id: 'u1', email: 'x@example.com' }],
+      ownedRow: {
+        messageId: 'm1',
+        role: 'assistant',
+        metadata: { generatedFiles: [existing] },
+        conversationUserId: 'u1',
+      },
+      fileExists: true,
+    })
+
+    const result = await saveGeneratedFile(
+      'postgres://db',
+      'x@example.com',
+      { conversationId: 'c1', messageId: 'm1', blockIndex: 0, language: 'html', content: '<p/>', force: true },
+      {
+        baseUrl: 'http://fs',
+        publicBaseUrl: 'http://files.example.com',
+        credentials: { username: 'admin', password: 'p' },
+      }
+    )
+
+    expect(result).toEqual({ ok: true, file: existing, alreadyExisted: true })
+    expect(checkFileExists).toHaveBeenCalledWith('http://files.example.com', existing.publicPath)
+    expect(uploadFileToFileServer).not.toHaveBeenCalled()
+  })
+
+  it('force 指定で既存ファイルが不在なら再 upload して同一 blockIndex を置換する', async () => {
+    const existing = {
+      blockIndex: 0,
+      language: 'html',
+      fileName: 'm1-block-0.html',
+      publicPath: '/public/portfolio/c1/m1-block-0.html',
+      previewUrl: 'http://files.example.com/public/portfolio/c1/m1-block-0.html',
+      contentType: 'text/html; charset=utf-8',
+      createdAt: '2026-04-19T00:00:00.000Z',
+    }
+    const other = {
+      blockIndex: 1,
+      language: 'svg',
+      fileName: 'm1-block-1.svg',
+      publicPath: '/public/portfolio/c1/m1-block-1.svg',
+      previewUrl: 'http://files.example.com/public/portfolio/c1/m1-block-1.svg',
+      contentType: 'image/svg+xml; charset=utf-8',
+      createdAt: '2026-04-19T00:00:00.000Z',
+    }
+    const { saveGeneratedFile, updateSets, uploadFileToFileServer } = await importSubject({
+      users: [{ id: 'u1', email: 'x@example.com' }],
+      ownedRow: {
+        messageId: 'm1',
+        role: 'assistant',
+        metadata: { generatedFiles: [existing, other] },
+        conversationUserId: 'u1',
+      },
+      fileExists: false,
+    })
+
+    const result = await saveGeneratedFile(
+      'postgres://db',
+      'x@example.com',
+      { conversationId: 'c1', messageId: 'm1', blockIndex: 0, language: 'html', content: '<p>new</p>', force: true },
+      {
+        baseUrl: 'http://fs',
+        publicBaseUrl: 'http://files.example.com',
+        credentials: { username: 'admin', password: 'p' },
+      }
+    )
+
+    expect(result).toMatchObject({ ok: true, alreadyExisted: false })
+    expect(uploadFileToFileServer).toHaveBeenCalledWith(
+      expect.anything(),
+      'session-value',
+      expect.objectContaining({ fileName: 'm1-block-0.html', content: '<p>new</p>' })
+    )
+    expect(updateSets[0]).toMatchObject({
+      metadata: {
+        generatedFiles: [
+          other,
+          expect.objectContaining({
+            blockIndex: 0,
+            publicPath: '/public/portfolio/c1/m1-block-0.html',
+          }),
+        ],
+      },
+    })
   })
 
   it('新規保存時は login+upload して metadata.generatedFiles を更新する', async () => {

--- a/projects/portfolio/tests/routes/conversations.test.ts
+++ b/projects/portfolio/tests/routes/conversations.test.ts
@@ -237,11 +237,16 @@ describe('conversationsRoutes', () => {
         blockIndex: 0,
         language: 'html',
         content: '<p/>',
+        force: true,
       }),
     })
 
     expect(res.status).toBe(200)
     await expect(res.json()).resolves.toEqual({ file, alreadyExisted: false })
+    const lastSaveCall = repositoryMock.saveGeneratedFile.mock.calls.at(-1)
+    expect(lastSaveCall?.[0]).toBe('postgres://db')
+    expect(lastSaveCall?.[1]).toBe('test@example.com')
+    expect(lastSaveCall?.[2]).toEqual(expect.objectContaining({ force: true }))
   })
 
   it('DELETE /messages は複数 query を repository.deleteMessages に渡す', async () => {


### PR DESCRIPTION
## Issues

- Close #975

## Why

コードブロックプレビューの file-server 実体が削除されても DB メタデータが残るため、eye アイコンから NotFound が開かれる状態を解消するため。

## Summary

認証済みユーザーの既存プレビュークリック時に保存 API を `force: true` で呼び、サーバー側で file-server 上の存在確認を行うようにしました。実体がなければ再アップロードし、返却された previewUrl を直接新規タブへ反映します。

## Changes

- file-server の HEAD 存在確認 helper を追加
- generated file 保存 API と repository に `force` を伝播
- `force` 時に既存実体がなければ再アップロードし、同一 blockIndex の metadata を置換
- 認証済みの preview UI を button 化し、未認証は従来どおり direct link を維持
- サーバー・ルート・クライアントの関連テストを追加

## Verification

- `bun run format` - passed
- `bun run lint` - passed
- `bun run test tests/features/chat-conversations/save-generated-file.test.ts tests/routes/conversations.test.ts tests/client/components/message-renderer.test.tsx` - passed
- `bun run test` - passed
