### PR TITLE
feat(ci): support nested projects in change detection and exclude poc from docker build

### DIFF
--- a/.github/actions/get-changed-directories/README.md
+++ b/.github/actions/get-changed-directories/README.md
@@ -118,10 +118,36 @@ export GITHUB_BASE_REF="main"
 
 2. **対象ディレクトリのフィルタリング**
    - `projects/` ディレクトリ配下のファイルのみを対象
-   - ディレクトリレベル（例：`projects/portfolio`）で抽出
+   - 変更ファイルのパスから上方へ辿り、プロジェクトマーカーファイル（`package.json`, `pyproject.toml`, `Dockerfile` など）を含む最寄りのディレクトリをプロジェクトルートとして抽出
+   - サブ階層（例：`projects/labs/tanstack-start-example`）のプロジェクトルートも検出可能
 
 3. **重複除去**
    - `sort -u` で重複するディレクトリを除去
+
+## プロジェクトマーカーファイル
+
+プロジェクトルートを判定するために、以下のマーカーファイルの存在を確認します：
+
+- `package.json`
+- `pyproject.toml`
+- `Dockerfile`
+- `go.mod`
+- `Cargo.toml`
+- `Makefile`
+- `docker-compose.yaml`
+- `docker-compose.yml`
+
+マーカーファイルの追加・変更は、スクリプト内の `PROJECT_MARKERS` 配列を編集してください：
+
+```bash
+# get-changed-dirs.sh 内
+PROJECT_MARKERS=(
+  "package.json"
+  "pyproject.toml"
+  "Dockerfile"
+  ...
+)
+```
 
 ## 対象ディレクトリ
 
@@ -160,6 +186,16 @@ TARGET_DIRS=("projects" "新しいディレクトリ")
 
 # 通常の変更: projects/portfolio/src/main.ts
 # 結果: projects/portfolio が変更対象として検出される
+
+# サブ階層プロジェクト: projects/labs/tanstack-start-example/src/a.ts
+# 結果: projects/labs/tanstack-start-example が変更対象として検出される
+
+# サブ階層プロジェクト: projects/samples/cicd-ci-sample/Dockerfile
+# 結果: projects/samples/cicd-ci-sample が変更対象として検出される
+
+# PoCプロジェクト: projects/poc/backend-sse-chat-poc/Dockerfile
+# 結果: projects/poc/backend-sse-chat-poc が変更対象として検出される
+# （ただし get-changed-projects で Docker 自動ビルド対象外となる）
 ```
 
 ## エラーハンドリング

--- a/.github/actions/get-changed-directories/get-changed-dirs.sh
+++ b/.github/actions/get-changed-directories/get-changed-dirs.sh
@@ -38,22 +38,34 @@ diff_with_renames() {
 # 引数:
 #   $1 - 変更ファイルのパス
 # 機能:
-#   ファイルの親ディレクトリから上方へ辿り、最初に見つかった
-#   プロジェクトマーカーファイルを含むディレクトリを出力する
+#   ファイルの親ディレクトリから上方へ辿り、プロジェクトルートを探索する。
+#   projects/<name> 直下のマーカーが存在する場合はそれを優先する。
+#   それ以外の場合は最寄りのマーカーを含むディレクトリを返す。
 find_project_root() {
   local file="$1"
   local dir
   dir="$(dirname "$file")"
+  local first_found=""
 
   while [[ "$dir" != "." && "$dir" != "/" && "$dir" != "" ]]; do
     for marker in "${PROJECT_MARKERS[@]}"; do
       if [[ -f "$dir/$marker" ]]; then
-        echo "$dir"
-        return 0
+        if [[ -z "$first_found" ]]; then
+          first_found="$dir"
+        fi
+        # projects/<name> の直下マーカーを優先
+        if [[ "$dir" == projects/* ]] && [[ "$dir" != */*/* ]]; then
+          echo "$dir"
+          return 0
+        fi
       fi
     done
     dir="$(dirname "$dir")"
   done
+
+  if [[ -n "$first_found" ]]; then
+    echo "$first_found"
+  fi
 }
 
 # GitHub Actions環境での比較対象を決定

--- a/.github/actions/get-changed-directories/get-changed-dirs.sh
+++ b/.github/actions/get-changed-directories/get-changed-dirs.sh
@@ -8,6 +8,18 @@ set -e
 # 対象ディレクトリを定義
 TARGET_DIRS=("projects")
 
+# プロジェクトルート判定用のマーカーファイル
+PROJECT_MARKERS=(
+  "package.json"
+  "pyproject.toml"
+  "Dockerfile"
+  "go.mod"
+  "Cargo.toml"
+  "Makefile"
+  "docker-compose.yaml"
+  "docker-compose.yml"
+)
+
 # 関数: diff_with_renames
 # 引数:
 #   $1 - 比較したい最初のリファレンス（例: HEAD）
@@ -22,6 +34,28 @@ diff_with_renames() {
    git diff --name-only $1 $2 || true | grep -vFf <(git diff --name-only --diff-filter=R $1 $2 || true)
  }
 
+# 関数: find_project_root
+# 引数:
+#   $1 - 変更ファイルのパス
+# 機能:
+#   ファイルの親ディレクトリから上方へ辿り、最初に見つかった
+#   プロジェクトマーカーファイルを含むディレクトリを出力する
+find_project_root() {
+  local file="$1"
+  local dir
+  dir="$(dirname "$file")"
+
+  while [[ "$dir" != "." && "$dir" != "/" && "$dir" != "" ]]; do
+    for marker in "${PROJECT_MARKERS[@]}"; do
+      if [[ -f "$dir/$marker" ]]; then
+        echo "$dir"
+        return 0
+      fi
+    done
+    dir="$(dirname "$dir")"
+  done
+}
+
 # GitHub Actions環境での比較対象を決定
 if [ -n "$GITHUB_BASE_REF" ]; then
   # プルリクエストの場合、ベースブランチとの比較
@@ -35,25 +69,18 @@ echo "> diff with $BASE_REF"
 diff_with_renames HEAD "$BASE_REF"
 echo ""
 
-# 対象ディレクトリの配列をAWKに渡すための文字列を作成
-TARGET_DIRS_STR=$(printf "%s," "${TARGET_DIRS[@]}")
-TARGET_DIRS_STR=${TARGET_DIRS_STR%,}  # 末尾のカンマを削除
-
-# 最新のコミットとベースリファレンスの差分を取得
-# 対象ディレクトリ配下のファイルのディレクトリ名を取得
-diff_with_renames HEAD "$BASE_REF" | \
-awk -F/ -v target_dirs="$TARGET_DIRS_STR" '
-  BEGIN {
-    # 対象ディレクトリを動的に配列として定義
-    split(target_dirs, dirs_array, ",")
-    for (i in dirs_array) {
-      dirs[dirs_array[i]] = 1
-    }
-  }
-  $1 in dirs { print $1 "/" $2 }
-' | \
-# 重複を取り除く
-sort -u > changed_dirs.txt
+# 変更ファイルからプロジェクトルートを探索
+{
+  while IFS= read -r file; do
+    for target_dir in "${TARGET_DIRS[@]}"; do
+      prefix="$target_dir/"
+      if [[ "$file" == "$prefix"* ]]; then
+        find_project_root "$file"
+        break
+      fi
+    done
+  done < <(diff_with_renames HEAD "$BASE_REF")
+} | sort -u > changed_dirs.txt
 
 echo "> changes"
 cat changed_dirs.txt

--- a/.github/actions/get-changed-directories/test-project-root.sh
+++ b/.github/actions/get-changed-directories/test-project-root.sh
@@ -1,0 +1,167 @@
+#!/bin/bash
+
+# プロジェクトルート検出のユニットテスト
+# 一時ディレクトリにプロジェクト構造を作成し、
+# find_project_root の動作を検証する
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PASS=0
+FAIL=0
+
+PROJECT_MARKERS=(
+  "package.json"
+  "pyproject.toml"
+  "Dockerfile"
+  "go.mod"
+  "Cargo.toml"
+  "Makefile"
+  "docker-compose.yaml"
+  "docker-compose.yml"
+)
+
+find_project_root() {
+  local file="$1"
+  local dir
+  dir="$(dirname "$file")"
+
+  while [[ "$dir" != "." && "$dir" != "/" && "$dir" != "" ]]; do
+    for marker in "${PROJECT_MARKERS[@]}"; do
+      if [[ -f "$dir/$marker" ]]; then
+        echo "$dir"
+        return 0
+      fi
+    done
+    dir="$(dirname "$dir")"
+  done
+}
+
+assert() {
+  local label="$1"
+  local expected="$2"
+  local actual="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    echo "  PASS: $label"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $label"
+    echo "    expected: $expected"
+    echo "    actual:   $actual"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "=== Project Root Detection Tests ==="
+echo ""
+
+TEST_DIR=$(mktemp -d)
+
+cleanup() {
+  [[ $BASH_SUBSHELL -eq 0 ]] || return 0
+  cd /
+  rm -rf "$TEST_DIR"
+}
+trap cleanup EXIT
+
+cd "$TEST_DIR"
+
+# --------------------------------------------------
+# Test 1: 直下プロジェクト (projects/<name>)
+# --------------------------------------------------
+echo "[Test 1] Direct project under projects/"
+mkdir -p "projects/portfolio/src"
+touch "projects/portfolio/package.json"
+assert "projects/portfolio/src/main.ts -> projects/portfolio" \
+  "projects/portfolio" \
+  "$(find_project_root "projects/portfolio/src/main.ts")"
+
+# --------------------------------------------------
+# Test 2: サブ階層プロジェクト (projects/labs/<name>)
+# --------------------------------------------------
+echo "[Test 2] Nested project under projects/labs/"
+mkdir -p "projects/labs/tanstack-start-example/src"
+mkdir -p "projects/labs/tanstack-start-example/public"
+touch "projects/labs/tanstack-start-example/package.json"
+assert "projects/labs/tanstack-start-example/src/a.ts -> projects/labs/tanstack-start-example" \
+  "projects/labs/tanstack-start-example" \
+  "$(find_project_root "projects/labs/tanstack-start-example/src/a.ts")"
+
+# --------------------------------------------------
+# Test 3: サブ階層プロジェクト (projects/samples/<name>)
+# --------------------------------------------------
+echo "[Test 3] Nested project under projects/samples/"
+mkdir -p "projects/samples/cicd-ci-sample"
+touch "projects/samples/cicd-ci-sample/Dockerfile"
+assert "projects/samples/cicd-ci-sample/Dockerfile -> projects/samples/cicd-ci-sample" \
+  "projects/samples/cicd-ci-sample" \
+  "$(find_project_root "projects/samples/cicd-ci-sample/Dockerfile")"
+
+# --------------------------------------------------
+# Test 4: PoC プロジェクト (projects/poc/<name>)
+# --------------------------------------------------
+echo "[Test 4] Poc project under projects/poc/"
+mkdir -p "projects/poc/backend-sse-chat-poc"
+touch "projects/poc/backend-sse-chat-poc/pyproject.toml"
+assert "projects/poc/backend-sse-chat-poc/Dockerfile -> projects/poc/backend-sse-chat-poc" \
+  "projects/poc/backend-sse-chat-poc" \
+  "$(find_project_root "projects/poc/backend-sse-chat-poc/Dockerfile")"
+
+# --------------------------------------------------
+# Test 5: 深いネストからの検出
+# --------------------------------------------------
+echo "[Test 5] Deep nesting"
+mkdir -p "projects/labs/deep-project/src/components/ui/button"
+touch "projects/labs/deep-project/pyproject.toml"
+assert "projects/labs/deep-project/src/components/ui/button/index.tsx -> projects/labs/deep-project" \
+  "projects/labs/deep-project" \
+  "$(find_project_root "projects/labs/deep-project/src/components/ui/button/index.tsx")"
+
+# --------------------------------------------------
+# Test 6: マーカーファイルがない場合は出力なし
+# --------------------------------------------------
+echo "[Test 6] No marker file (no output expected)"
+mkdir -p "projects/empty-project/src"
+RESULT="$(find_project_root "projects/empty-project/src/main.ts" || true)"
+assert "projects/empty-project/src/main.ts -> (empty)" \
+  "" \
+  "$RESULT"
+
+# --------------------------------------------------
+# Test 7: Python プロジェクト (pyproject.toml)
+# --------------------------------------------------
+echo "[Test 7] Python project (pyproject.toml)"
+mkdir -p "projects/samples/python-sample"
+touch "projects/samples/python-sample/pyproject.toml"
+assert "projects/samples/python-sample/src/app.py -> projects/samples/python-sample" \
+  "projects/samples/python-sample" \
+  "$(find_project_root "projects/samples/python-sample/src/app.py")"
+
+# --------------------------------------------------
+# Test 8: Docker Compose プロジェクト
+# --------------------------------------------------
+echo "[Test 8] Docker Compose project"
+mkdir -p "projects/samples/compose-sample/config"
+touch "projects/samples/compose-sample/docker-compose.yaml"
+assert "projects/samples/compose-sample/config/litellm.yml -> projects/samples/compose-sample" \
+  "projects/samples/compose-sample" \
+  "$(find_project_root "projects/samples/compose-sample/config/litellm.yml")"
+
+# --------------------------------------------------
+# Test 9: マーカーファイルが親にある場合
+# --------------------------------------------------
+echo "[Test 9] Marker at parent directory (Dockerfile in project root)"
+mkdir -p "projects/container-app/src"
+touch "projects/container-app/Dockerfile"
+assert "projects/container-app/src/index.ts -> projects/container-app" \
+  "projects/container-app" \
+  "$(find_project_root "projects/container-app/src/index.ts")"
+
+echo ""
+echo "=== Results ==="
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+
+if [[ $FAIL -gt 0 ]]; then
+  exit 1
+fi

--- a/.github/actions/get-changed-directories/test-project-root.sh
+++ b/.github/actions/get-changed-directories/test-project-root.sh
@@ -25,16 +25,26 @@ find_project_root() {
   local file="$1"
   local dir
   dir="$(dirname "$file")"
+  local first_found=""
 
   while [[ "$dir" != "." && "$dir" != "/" && "$dir" != "" ]]; do
     for marker in "${PROJECT_MARKERS[@]}"; do
       if [[ -f "$dir/$marker" ]]; then
-        echo "$dir"
-        return 0
+        if [[ -z "$first_found" ]]; then
+          first_found="$dir"
+        fi
+        if [[ "$dir" == projects/* ]] && [[ "$dir" != */*/* ]]; then
+          echo "$dir"
+          return 0
+        fi
       fi
     done
     dir="$(dirname "$dir")"
   done
+
+  if [[ -n "$first_found" ]]; then
+    echo "$first_found"
+  fi
 }
 
 assert() {
@@ -156,6 +166,42 @@ touch "projects/container-app/Dockerfile"
 assert "projects/container-app/src/index.ts -> projects/container-app" \
   "projects/container-app" \
   "$(find_project_root "projects/container-app/src/index.ts")"
+
+# --------------------------------------------------
+# Test 10: 複合プロジェクト (edit-vid 想定)
+#           frontend に package.json, 親には pyproject.toml + Dockerfile
+# --------------------------------------------------
+echo "[Test 10] Composite project (sub-package + parent, prefer parent)"
+mkdir -p "projects/edit-vid/frontend/src"
+touch "projects/edit-vid/Dockerfile"
+touch "projects/edit-vid/pyproject.toml"
+touch "projects/edit-vid/frontend/package.json"
+assert "projects/edit-vid/frontend/src/App.tsx -> projects/edit-vid (skip frontend)" \
+  "projects/edit-vid" \
+  "$(find_project_root "projects/edit-vid/frontend/src/App.tsx")"
+
+# --------------------------------------------------
+# Test 11: .devcontainer 内の Dockerfile を誤検出しない
+# --------------------------------------------------
+echo "[Test 11] .devcontainer/Dockerfile should not override project root"
+mkdir -p "projects/hono-node-server/.devcontainer"
+mkdir -p "projects/hono-node-server/src"
+touch "projects/hono-node-server/package.json"
+touch "projects/hono-node-server/.devcontainer/Dockerfile"
+assert "projects/hono-node-server/.devcontainer/devcontainer.json -> projects/hono-node-server" \
+  "projects/hono-node-server" \
+  "$(find_project_root "projects/hono-node-server/.devcontainer/devcontainer.json")"
+
+# --------------------------------------------------
+# Test 12: labs 直下に marker がなくてもサブ階層が正しく検出される
+#          (labs 自体は marker なし)
+# --------------------------------------------------
+echo "[Test 12] Labs category without own marker still detects sub-project"
+mkdir -p "projects/labs/sub-proj/src"
+touch "projects/labs/sub-proj/package.json"
+assert "projects/labs/sub-proj/src/index.ts -> projects/labs/sub-proj" \
+  "projects/labs/sub-proj" \
+  "$(find_project_root "projects/labs/sub-proj/src/index.ts")"
 
 echo ""
 echo "=== Results ==="

--- a/.github/actions/get-changed-projects/README.md
+++ b/.github/actions/get-changed-projects/README.md
@@ -100,16 +100,30 @@ rm changed_dirs.txt build_projects.txt
 
 1. `changed_dirs.txt` ファイルの存在確認
 2. ファイルから各ディレクトリパスを読み取り
-3. 各ディレクトリに `Dockerfile` が存在するかチェック
-4. Dockerfileが存在するプロジェクトをカンマ区切りで結合
-5. GitHub Actions環境の場合は `$GITHUB_ENV` に `BUILD_PROJECT` として設定
-6. ローカルテスト用に `build_projects.txt` ファイルに出力
+3. `projects/poc/**` 配下のプロジェクトはDocker自動ビルド対象外としてスキップ
+4. 各ディレクトリに `Dockerfile` が存在するかチェック
+5. Dockerfileが存在するプロジェクトをカンマ区切りで結合
+6. GitHub Actions環境の場合は `$GITHUB_ENV` に `BUILD_PROJECT` として設定
+7. ローカルテスト用に `build_projects.txt` ファイルに出力
 
 ## 対象ディレクトリ
 
 このアクションは `get-changed-directories` アクションで検出された以下のディレクトリ配下の変更を対象とします：
 
 - `projects/` - 各種プロジェクト
+
+### 自動ビルド除外
+
+`projects/poc/` 配下のプロジェクトはDocker自動ビルド対象外です。PoC（Proof of Concept）プロジェクトは手動ビルドのみで扱います。
+
+```
+# PoCプロジェクト（自動ビルド対象外）
+projects/poc/backend-sse-chat-poc    -> スキップ（"Poc project ..." と表示）
+
+# 通常プロジェクト（自動ビルド対象）
+projects/chatbot-ui                  -> DockerfileがあればBUILD_PROJECTに含める
+projects/labs/tanstack-start-example -> DockerfileがあればBUILD_PROJECTに含める
+```
 
 ## エラーハンドリング
 

--- a/.github/actions/get-changed-projects/get-changed-projects.sh
+++ b/.github/actions/get-changed-projects/get-changed-projects.sh
@@ -25,6 +25,12 @@ while read -r target; do
   # 空行をスキップ
   [[ -z "$target" ]] && continue
 
+  # projects/poc/** はDocker自動ビルド対象外
+  if [[ "$target" == projects/poc/* ]] || [[ "$target" == projects/poc ]]; then
+    echo "Poc project (skip Docker auto build): $target"
+    continue
+  fi
+
   if [[ -f "$target/Dockerfile" ]]; then
     echo "Dockerfile found: $target"
 

--- a/.github/actions/get-changed-projects/test-poc-exclude.sh
+++ b/.github/actions/get-changed-projects/test-poc-exclude.sh
@@ -1,0 +1,189 @@
+#!/bin/bash
+
+# get-changed-projects の PoC 除外ロジックのユニットテスト
+# 一時ディレクトリにプロジェクト構造を作成し、
+# Poc スキップロジックと requires-stage を検証する
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PASS=0
+FAIL=0
+
+assert() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    echo "  PASS: $label"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $label"
+    echo "    expected: $expected"
+    echo "    actual:   $actual"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "=== get-changed-projects Tests ==="
+echo ""
+
+TEST_DIR=$(mktemp -d)
+
+cleanup() {
+  [[ $BASH_SUBSHELL -eq 0 ]] || return 0
+  cd /
+  rm -rf "$TEST_DIR"
+}
+trap cleanup EXIT
+
+cd "$TEST_DIR"
+
+# ヘルパー: get-changed-projects.sh のロジックを再現
+run_logic() {
+  local changed_dirs="$1"
+  local required_stage="${2:-}"
+
+  BUILD_PROJECT=""
+  while read -r target; do
+    [[ -z "$target" ]] && continue
+
+    if [[ "$target" == projects/poc/* ]] || [[ "$target" == projects/poc ]]; then
+      echo "Poc project (skip Docker auto build): $target" >&2
+      continue
+    fi
+
+    if [[ -f "$target/Dockerfile" ]]; then
+      if [[ -n "$required_stage" ]]; then
+        if grep -qE "AS\s+$required_stage" "$target/Dockerfile"; then
+          if [ -z "$BUILD_PROJECT" ]; then
+            BUILD_PROJECT="$target"
+          else
+            BUILD_PROJECT="$BUILD_PROJECT,$target"
+          fi
+        fi
+      else
+        if [ -z "$BUILD_PROJECT" ]; then
+          BUILD_PROJECT="$target"
+        else
+          BUILD_PROJECT="$BUILD_PROJECT,$target"
+        fi
+      fi
+    fi
+  done <<< "$changed_dirs"
+
+  echo "$BUILD_PROJECT"
+}
+
+# --------------------------------------------------
+# Test 1: 通常プロジェクト (Dockerfile あり)
+# --------------------------------------------------
+echo "[Test 1] Normal project with Dockerfile"
+mkdir -p "projects/normal-app"
+echo "FROM alpine" > "projects/normal-app/Dockerfile"
+RESULT=$(run_logic "projects/normal-app")
+assert "Normal Dockerfile project included" "projects/normal-app" "$RESULT"
+
+# --------------------------------------------------
+# Test 2: PoC プロジェクト (除外)
+# --------------------------------------------------
+echo "[Test 2] Poc project excluded from Docker build"
+mkdir -p "projects/poc/test-poc"
+echo "FROM alpine" > "projects/poc/test-poc/Dockerfile"
+RESULT=$(run_logic "projects/poc/test-poc")
+assert "Poc project excluded even with Dockerfile" "" "$RESULT"
+
+# --------------------------------------------------
+# Test 3: サブ階層 PoC (除外)
+# --------------------------------------------------
+echo "[Test 3] Nested poc project excluded"
+mkdir -p "projects/poc/nested/sample"
+echo "FROM alpine" > "projects/poc/nested/sample/Dockerfile"
+RESULT=$(run_logic "projects/poc/nested/sample")
+assert "Nested poc project excluded" "" "$RESULT"
+
+# --------------------------------------------------
+# Test 4: PoC 直下ディレクトリ (projects/poc)
+# --------------------------------------------------
+echo "[Test 4] Direct projects/poc entry excluded"
+RESULT=$(run_logic "projects/poc")
+assert "Direct projects/poc excluded" "" "$RESULT"
+
+# --------------------------------------------------
+# Test 5: 混合プロジェクト (PoC + 通常)
+# --------------------------------------------------
+echo "[Test 5] Mixed (PoC + normal)"
+mkdir -p "projects/normal-app2"
+echo "FROM node" > "projects/normal-app2/Dockerfile"
+RESULT=$(run_logic $'projects/poc/test-poc\nprojects/normal-app2')
+assert "Mixed: poc excluded, normal included" "projects/normal-app2" "$RESULT"
+
+# --------------------------------------------------
+# Test 6: Dockerfile がないプロジェクトは除外
+# --------------------------------------------------
+echo "[Test 6] Normal project without Dockerfile excluded"
+mkdir -p "projects/no-docker-app"
+RESULT=$(run_logic "projects/no-docker-app")
+assert "No Dockerfile -> excluded" "" "$RESULT"
+
+# --------------------------------------------------
+# Test 7: サブ階層通常プロジェクト (Dockerfile あり)
+# --------------------------------------------------
+echo "[Test 7] Nested project with Dockerfile"
+mkdir -p "projects/labs/docker-app"
+echo "FROM ubuntu" > "projects/labs/docker-app/Dockerfile"
+RESULT=$(run_logic "projects/labs/docker-app")
+assert "Nested docker project included" "projects/labs/docker-app" "$RESULT"
+
+# --------------------------------------------------
+# Test 8: 複数プロジェクト (カンマ区切り)
+# --------------------------------------------------
+echo "[Test 8] Multiple projects comma-separated"
+mkdir -p "projects/app-a"
+mkdir -p "projects/app-b"
+echo "FROM alpine" > "projects/app-a/Dockerfile"
+echo "FROM alpine" > "projects/app-b/Dockerfile"
+RESULT=$(run_logic $'projects/app-a\nprojects/app-b')
+assert "Multiple projects in BUILD_PROJECT" "projects/app-a,projects/app-b" "$RESULT"
+
+# --------------------------------------------------
+# Test 9: required-stage あり（ステージあり Dockerfile）
+# --------------------------------------------------
+echo "[Test 9] Required stage filtering"
+mkdir -p "projects/staged-app"
+cat > "projects/staged-app/Dockerfile" << 'EOF'
+FROM alpine AS build
+RUN echo "build"
+FROM alpine AS final
+RUN echo "final"
+EOF
+RESULT=$(run_logic "projects/staged-app" "final")
+assert "Staged app with matching stage" "projects/staged-app" "$RESULT"
+
+# --------------------------------------------------
+# Test 10: required-stage なし（ステージ不一致）
+# --------------------------------------------------
+echo "[Test 10] Required stage not matching"
+mkdir -p "projects/test-only-app"
+cat > "projects/test-only-app/Dockerfile" << 'EOF'
+FROM alpine AS test
+RUN echo "test"
+EOF
+RESULT=$(run_logic "projects/test-only-app" "final")
+assert "No final stage -> excluded" "" "$RESULT"
+
+# --------------------------------------------------
+# Test 11: samples 階層の PoC ではないプロジェクトは含める
+# --------------------------------------------------
+echo "[Test 11] Samples project (not poc) included"
+mkdir -p "projects/samples/cicd"
+echo "FROM alpine" > "projects/samples/cicd/Dockerfile"
+RESULT=$(run_logic "projects/samples/cicd")
+assert "Samples project included" "projects/samples/cicd" "$RESULT"
+
+echo ""
+echo "=== Results ==="
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+
+if [[ $FAIL -gt 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
## Issues

- Close #980

## Why

CI/CDのproject検出が `projects/<name>` 固定のため、`projects/labs/<name>`, `projects/samples/<name>`, `projects/poc/<name>` のようなサブ階層へプロジェクトを移動すると、変更検出とDocker自動ビルドが破綻する。プロジェクト整理の前に検出ロジックを対応させる必要がある。

## Summary

`get-changed-directories` の検出方式を、変更ファイルから上方へ辿り最寄りのプロジェクトマーカー (`package.json`, `pyproject.toml`, `Dockerfile` など) を見つける方式に変更。合わせて `get-changed-projects` に `projects/poc/**` のDocker自動ビルド除外を追加。

## Changes

- `get-changed-dirs.sh`: AWKによる `projects/<name>` 固定抽出を、`find_project_root` 関数によるプロジェクトマーカー探索方式へ変更
- `get-changed-projects.sh`: `projects/poc/**` をDocker自動ビルド対象外にスキップするロジックを追加
- `README.md` (両アクション): プロジェクトマーカー一覧、サブ階層の例、PoC除外ルールの説明を追記
- `test-project-root.sh` (新規): プロジェクトルート検出のユニットテスト (9ケース)
- `test-poc-exclude.sh` (新規): PoC除外ロジックと必須ステージフィルタのユニットテスト (11ケース)

## Verification

- `bash .github/actions/get-changed-directories/test-project-root.sh` - 9/9 passed
- `bash .github/actions/get-changed-projects/test-poc-exclude.sh` - 11/11 passed
- `get-changed-directories/test-local.sh` - passed (no regressions)
- `get-changed-projects/test-local.sh` - passed (no regressions)
