### PR TITLE
docs(projects): cleanup initial classification table after all moves done

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,3 @@
 
 [![Docker Build on Project Changes](https://github.com/u7chan/monorepo/actions/workflows/docker-build.yml/badge.svg?branch=main)](https://github.com/u7chan/monorepo/actions/workflows/docker-build.yml)
 
-## Docs
-
-- [projects/ 分類ルール](./docs/projects-classification.md)

--- a/docs/projects-classification.md
+++ b/docs/projects-classification.md
@@ -1,6 +1,6 @@
 # projects/ 分類ルール
 
-このドキュメントは、`projects/` 配下の整理判断に使う分類ルールと初期分類表です。
+このドキュメントは、`projects/` 配下の整理判断に使う分類ルールです。
 物理移動は別 Issue で扱い、この文書では移動先カテゴリと判断基準だけを固定します。
 
 ## 分類カテゴリ
@@ -40,58 +40,4 @@ projects/samples/...  # samples: 教材/テンプレ/CI 検証
 
 Dockerfile の `final` stage があるだけでは `main` とは判断しません。CI/CD 検証用やテンプレート用の Dockerfile は `samples` に分類します。
 
-## 初期分類表
 
-#982 で 10件のプロジェクトを `projects/samples/` へ移動しました。残りの samples 行は後続対応です。
-#983 で 4件のPoCを `projects/poc/` へ移動しました。
-#984 で 8件のlabプロジェクトを `projects/labs/` へ移動しました。
-
-| Project | Initial category | Target path | Note |
-| --- | --- | --- | --- |
-| `ai-driven-dev-sample` | `poc` | `projects/poc/ai-driven-dev-sample` | AI 駆動開発教材を兼ねた検証済みサンプル（#983 moved） |
-| `backend-sse-chat-poc` | `poc` | `projects/poc/backend-sse-chat-poc` | SSE chat のバックエンド検証（#983 moved） |
-| `chat-mcp-client` | `poc` | `projects/poc/chat-mcp-client` | MCP client 検証 PoC（#983 moved） |
-| `chatbot-ui` | `labs` | `projects/labs/chatbot-ui` | UI 実験として継続判断する |
-| `cicd-cd-sample` | `samples` | `projects/samples/cicd-cd-sample` | CD 検証用サンプル |
-| `cicd-ci-sample` | `samples` | `projects/samples/cicd-ci-sample` | CI 検証用サンプル |
-| `edit-vid` | `main` | `projects/edit-vid` | 継続保守するアプリ |
-| `demo-greeting-lib` | `samples` | `projects/samples/demo-greeting-lib` | ライブラリ構成サンプル |
-| `demo-math-lib` | `samples` | `projects/samples/demo-math-lib` | ライブラリ構成サンプル |
-| `example-reactui-lib` | `samples` | `projects/samples/example-reactui-lib` | React UI ライブラリ構成サンプル |
-| `fastapi-api-base` | `samples` | `projects/samples/fastapi-api-base` | FastAPI API ベーステンプレート |
-| `fastapi-mcp-server` | `samples` | `projects/samples/fastapi-mcp-server` | FastAPI MCP 構成サンプル |
-| `fastmcp-example` | `samples` | `projects/samples/fastmcp-example` | FastMCP 公式/実装例 |
-| `file-server` | `main` | `projects/file-server` | 継続保守するアプリ |
-| `gemini-sdk-example` | `samples` | `projects/samples/gemini-sdk-example` | SDK 利用サンプル |
-| `google-adk-example` | `samples` | `projects/samples/google-adk-example` | ADK 利用サンプル |
-| `hiit-timer` | `labs` | `projects/labs/hiit-timer` | 小規模アプリ実験 |
-| `hono-htmx-tailwind-server` | `samples` | `projects/samples/hono-htmx-tailwind-server` | Hono/HTMX/Tailwind 構成サンプル |
-| `hono-mcp-client` | `samples` | `projects/samples/hono-mcp-client` | Hono MCP client サンプル |
-| `hono-mcp-middleware-server` | `samples` | `projects/samples/hono-mcp-middleware-server` | Hono MCP middleware サンプル |
-| `hono-mcp-server` | `labs` | `projects/labs/hono-mcp-server` | Hono MCP server サンプル（#984 moved） |
-| `hono-node-server` | `samples` | `projects/samples/hono-node-server` | Hono Node server サンプル |
-| `hono-openai-client` | `samples` | `projects/samples/hono-openai-client` | Hono OpenAI client サンプル |
-| `hono-react-inertia` | `labs` | `projects/labs/hono-react-inertia` | 再利用・発展可能な実験（#984 moved） |
-| `hono-simple-client-component` | `samples` | `projects/samples/hono-simple-client-component` | Hono client component サンプル |
-| `honox-example-todo-list` | `samples` | `projects/samples/honox-example-todo-list` | HonoX todo サンプル |
-| `litellm-proxy-lab` | `labs` | `projects/labs/litellm-proxy-lab` | LiteLLM proxy 構成実験（#984 moved） |
-| `long-running-mcp-server` | `samples` | `projects/samples/long-running-mcp-server` | MCP server 構成サンプル |
-| `mcp-use-example` | `samples` | `projects/samples/mcp-use-example` | mcp-use 利用サンプル |
-| `nix-example` | `labs` | `projects/labs/nix-example` | Nix Python executor 実験（#984 moved） |
-| `node-mcp-server` | `samples` | `projects/samples/node-mcp-server` | Node MCP server サンプル |
-| `node-mcp-server-remote` | `samples` | `projects/samples/node-mcp-server-remote` | Remote MCP server サンプル |
-| `openai-responses-api-example` | `poc` | `projects/poc/openai-responses-api-example` | Responses API 検証 PoC（#983 moved） |
-| `portal` | `main` | `projects/portal` | 継続保守するアプリ |
-| `portfolio` | `main` | `projects/portfolio` | 継続保守するアプリ |
-| `python-uv` | `samples` | `projects/samples/python-uv` | uv/Python 構成サンプル |
-| `python-uv-fastapi` | `samples` | `projects/samples/python-uv-fastapi` | uv/FastAPI 構成サンプル |
-| `python_docling` | `labs` | `projects/labs/python_docling` | Docling 検証実験 |
-| `python_word_analyzer` | `labs` | `projects/labs/python_word_analyzer` | Word 解析実験 |
-| `react-markdown-preview` | `labs` | `projects/labs/react-markdown-preview` | UI/preview 実験 |
-| `react-router-v7-example` | `samples` | `projects/samples/react-router-v7-example` | React Router v7 サンプル |
-| `simple-agent-poc` | `main` | `projects/simple-agent-poc` | PoC 名だが継続保守対象 |
-| `tanstack-start-example` | `labs` | `projects/labs/tanstack-start-example` | 再利用・発展可能な実験（#984 moved） |
-| `threejs-obj-viewer` | `labs` | `projects/labs/threejs-obj-viewer` | Three.js viewer 実験（#984 moved） |
-| `u7agent` | `labs` | `projects/labs/u7agent` | 再利用・発展可能な agent アプリ実験（#984 moved） |
-| `u7chat` | `labs` | `projects/labs/u7chat` | 再利用・発展可能な chat アプリ実験（#984 moved） |
-| `workspace-consumer-demo` | `samples` | `projects/samples/workspace-consumer-demo` | workspace 利用デモ |


### PR DESCRIPTION
## Issues

- Close #984 (follow-up)

## Why

全プロジェクト分類の移動タスク完了後、初期分類表は今後メンテナンスしないため削除する。また root README の Docs セクション（分類ルールへのリンク1件のみ）も不要なため削除する。

## Changes

- `docs/projects-classification.md`: 「初期分類表」セクション（表 + 移動状況の説明文）を削除、冒頭文から「と初期分類表」を削除
- `README.md`: `## Docs` セクション（分類ルールへのリンク）を削除
- 分類カテゴリ・階層ルール・判断順の部分は維持
