### PR TITLE
Add execution sandbox runtime selection spike

### DIFF
--- a/projects/poc/execution-sandbox/.gitignore
+++ b/projects/poc/execution-sandbox/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/projects/poc/execution-sandbox/README.md
+++ b/projects/poc/execution-sandbox/README.md
@@ -1,0 +1,12 @@
+# Execution Sandbox PoC
+
+Spike for selecting the JavaScript runtime path for the AI Agent Execution Sandbox.
+
+```bash
+bun install
+bun test
+bun run typecheck
+bun run dev
+```
+
+The runtime selection notes and spike results live in `docs/runtime-selection.md`.

--- a/projects/poc/execution-sandbox/bun.lock
+++ b/projects/poc/execution-sandbox/bun.lock
@@ -1,0 +1,44 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "execution-sandbox-poc",
+      "dependencies": {
+        "hono": "^4.8.5",
+        "quickjs-emscripten": "^0.32.0",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.2.18",
+        "typescript": "^5.8.3",
+      },
+    },
+  },
+  "packages": {
+    "@jitl/quickjs-ffi-types": ["@jitl/quickjs-ffi-types@0.32.0", "", {}, "sha512-v9T+GQpmk43VDJ7d72sf0Nexhk+ArvtUihW27dy7lqAl0zBObFKtSBBIm5RBjwIhE8VwsPPm9PNuvPvNqLWUEg=="],
+
+    "@jitl/quickjs-wasmfile-debug-asyncify": ["@jitl/quickjs-wasmfile-debug-asyncify@0.32.0", "", { "dependencies": { "@jitl/quickjs-ffi-types": "0.32.0" } }, "sha512-EX8zbXwGqCgAE764M+qvkHtyXDi/FUoMBea0JnES7vCM3P7a2+EOZOjGv85wtZ2sJhI1oJ+nekmqpOODFDY+hw=="],
+
+    "@jitl/quickjs-wasmfile-debug-sync": ["@jitl/quickjs-wasmfile-debug-sync@0.32.0", "", { "dependencies": { "@jitl/quickjs-ffi-types": "0.32.0" } }, "sha512-LeYWrPGC1uNCTBWvibo3ZLJj0CSVNYUXvJpXMCmuQ5Sap2cCACc3uvGvYV4homHHBAzfw5akoTqMMS4YFRtw+Q=="],
+
+    "@jitl/quickjs-wasmfile-release-asyncify": ["@jitl/quickjs-wasmfile-release-asyncify@0.32.0", "", { "dependencies": { "@jitl/quickjs-ffi-types": "0.32.0" } }, "sha512-3oSwPfja12ICz4aIblB58cuY8JlEq5Txt8Cut4VLo+LH47QN+mzCnSgnbB03hWzg1LBcc+VyyI9UOag7a1NF+Q=="],
+
+    "@jitl/quickjs-wasmfile-release-sync": ["@jitl/quickjs-wasmfile-release-sync@0.32.0", "", { "dependencies": { "@jitl/quickjs-ffi-types": "0.32.0" } }, "sha512-BKNDI/TPBfGlLNGYpLrhcDGXmIk4xHm4MRAisOBnOzpXVn9HZWsfmMAc9WMBrAHjvvds6HOikKeaOBKdPdpVrg=="],
+
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "hono": ["hono@4.12.23", "", {}, "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA=="],
+
+    "quickjs-emscripten": ["quickjs-emscripten@0.32.0", "", { "dependencies": { "@jitl/quickjs-wasmfile-debug-asyncify": "0.32.0", "@jitl/quickjs-wasmfile-debug-sync": "0.32.0", "@jitl/quickjs-wasmfile-release-asyncify": "0.32.0", "@jitl/quickjs-wasmfile-release-sync": "0.32.0", "quickjs-emscripten-core": "0.32.0" } }, "sha512-So0Sqw869y/S2oE3Nuc0uT3Dhqgvsj8FSrwBdsuTosVsG8ME5/OcudU1GxsrIFdFABgy17GHnTVO9TYV/bLQcA=="],
+
+    "quickjs-emscripten-core": ["quickjs-emscripten-core@0.32.0", "", { "dependencies": { "@jitl/quickjs-ffi-types": "0.32.0" } }, "sha512-QFnPfjFey8EqknSrSxe1hZrf1/8z7/6s1QzGOmKo6++02r7QRRX7ZoyNaZh7JuVjWsVW87KnQrbZqnHkOAzUyg=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+  }
+}

--- a/projects/poc/execution-sandbox/docs/runtime-selection.md
+++ b/projects/poc/execution-sandbox/docs/runtime-selection.md
@@ -74,10 +74,11 @@ The host flow is:
 5. Install only `console.log`, `console.error`, and `console.warn`.
 6. Set the request input as a QuickJS global.
 7. Evaluate user code and require `main` to be a function.
-8. Call `main(input)`, execute QuickJS pending jobs, and await the returned promise.
-9. Serialize the result with `JSON.stringify` inside QuickJS.
-10. Dispose the result handles, context, and runtime.
-11. Release the concurrency slot in `finally`.
+8. Require `main.constructor.name` to be `AsyncFunction`.
+9. Call `main(input)`, execute QuickJS pending jobs, and await the returned promise.
+10. Serialize the result with `JSON.stringify` inside QuickJS.
+11. Dispose the result handles, context, and runtime.
+12. Release the concurrency slot in `finally`.
 
 ## Spike Results
 
@@ -87,9 +88,11 @@ The host flow is:
 | HTTP E2E timeout response | Passed. `POST /execute` returns HTTP 200 with `status: "error"` and `error.code: "TIMEOUT"`. |
 | Runtime/context cleanup | Passed. The test confirms the active slot count returns to 0 after timeout and a following request succeeds. |
 | `async function main(input)` invocation | Passed. The test defines, calls, awaits, and serializes the returned value. |
+| Non-async `main` rejection | Passed. Synchronous `function main()` returns `MAIN_FUNCTION_NOT_ASYNC`. |
 | stdout/stderr capture | Passed. `console.log` maps to stdout; `console.error` and `console.warn` map to stderr. |
 | stdout + stderr 64KB limit | Passed. Exceeding the combined limit returns `OUTPUT_LIMIT_EXCEEDED`. |
 | Result serialization error | Passed. Circular results return `RESULT_SERIALIZATION_ERROR`. Functions and `undefined` are also treated as non-serializable. |
+| Input serialization validation | Passed. Circular and `BigInt` inputs are rejected as `VALIDATION_ERROR` before execution. |
 | State reset between executions | Passed. A global set by one request is absent in the next request. |
 | Host API exposure | Passed. `Bun`, `process`, `require`, `fetch`, and `WebSocket` are not exposed. |
 | `MAX_CONCURRENCY=2` | Passed. The third concurrent HTTP request returns 429 with no `Retry-After` header. |
@@ -215,7 +218,7 @@ Observed result:
 
 ```text
 bun --version -> 1.3.10
-bun test -> 8 pass, 0 fail
+bun test -> 10 pass, 0 fail
 bun run typecheck -> passed
 ```
 

--- a/projects/poc/execution-sandbox/docs/runtime-selection.md
+++ b/projects/poc/execution-sandbox/docs/runtime-selection.md
@@ -1,0 +1,293 @@
+# Execution Sandbox Runtime Selection
+
+Parent: #986
+Issue: #993
+
+## Decision
+
+Phase 1 should use TypeScript + Bun + Hono with `quickjs-emscripten` for
+JavaScript execution.
+
+The spike gate passed on the local environment:
+
+```text
+Bun: 1.3.10
+hono: 4.12.23
+quickjs-emscripten: 0.32.0
+```
+
+`quickjs-emscripten` can stop a synchronous `while (true) {}` on Bun by using
+the official `QuickJSRuntime#setInterruptHandler` mechanism. The HTTP spike
+returns a timeout response, disposes the per-request runtime/context, and
+releases the concurrency slot.
+
+This is not a production security boundary. It is viable for the Phase 1 PoC
+shape in #986: short algorithmic JavaScript, no host filesystem, no network, no
+subprocess, no package install, and no long-running jobs.
+
+## Runtime Comparison
+
+| Runtime | Fit for Phase 1 | Notes | Decision |
+| --- | --- | --- | --- |
+| `quickjs-emscripten` | High | Runs JavaScript directly from TypeScript/Bun, exposes no Node/Bun APIs by default, supports per-runtime interrupt and memory/stack limits, and works with a Hono worker shape. | Adopt for Phase 1 JavaScript PoC. |
+| Wasmtime | Medium for WASM, low for direct JavaScript | Strong embeddable WASM runtime, but its documented embedding path is Rust/C/C++/other native APIs. A TypeScript+Bun worker would need a binding layer and a JavaScript language runtime compiled to WASM before it can run user JS. | Do not use as first Phase 1 host runtime. Revisit for language runtimes compiled to WASM. |
+| Wasmer | Medium for WASM packages, low for direct JavaScript | Wasmer has a JavaScript SDK and package ecosystem, but it is oriented around running WASM/Wasmer packages. It does not reduce the Phase 1 task of embedding a JS interpreter and shaping `async function main(input)`. | Do not use as first Phase 1 host runtime. Revisit for packaged WASM language runtimes. |
+
+References used during selection:
+
+- `quickjs-emscripten` README and API docs: https://github.com/justjake/quickjs-emscripten
+- Wasmtime embedding docs: https://docs.wasmtime.dev/lang.html
+- Wasmer JavaScript SDK docs: https://docs.wasmer.io/sdk/wasmer-js
+
+## Spike Artifacts
+
+```text
+projects/poc/execution-sandbox/
+  package.json
+  src/sandbox.ts
+  src/server.ts
+  tests/execution.test.ts
+  docs/runtime-selection.md
+```
+
+The spike keeps the future production implementation separate. `src/sandbox.ts`
+contains the reusable QuickJS execution pattern, while `src/server.ts` contains
+the minimal Hono `POST /execute` host.
+
+## Execution Pattern
+
+Phase 1 JavaScript requires:
+
+```js
+async function main(input) {
+  console.log("received", input.values.length);
+  return input.values.reduce((sum, value) => sum + value, 0);
+}
+```
+
+The host flow is:
+
+1. Validate `language`, `code`, `input`, and `timeoutMs`.
+2. Acquire a concurrency slot.
+3. Reuse the process-level QuickJS WASM module.
+4. Create a fresh QuickJS runtime and context for the request.
+5. Install only `console.log`, `console.error`, and `console.warn`.
+6. Set the request input as a QuickJS global.
+7. Evaluate user code and require `main` to be a function.
+8. Call `main(input)`, execute QuickJS pending jobs, and await the returned promise.
+9. Serialize the result with `JSON.stringify` inside QuickJS.
+10. Dispose the result handles, context, and runtime.
+11. Release the concurrency slot in `finally`.
+
+## Spike Results
+
+| Case | Result |
+| --- | --- |
+| Stop `while (true) {}` via interrupt handler | Passed. `QuickJSRuntime#setInterruptHandler` interrupts synchronous code and returns `TIMEOUT`. |
+| HTTP E2E timeout response | Passed. `POST /execute` returns HTTP 200 with `status: "error"` and `error.code: "TIMEOUT"`. |
+| Runtime/context cleanup | Passed. The test confirms the active slot count returns to 0 after timeout and a following request succeeds. |
+| `async function main(input)` invocation | Passed. The test defines, calls, awaits, and serializes the returned value. |
+| stdout/stderr capture | Passed. `console.log` maps to stdout; `console.error` and `console.warn` map to stderr. |
+| stdout + stderr 64KB limit | Passed. Exceeding the combined limit returns `OUTPUT_LIMIT_EXCEEDED`. |
+| Result serialization error | Passed. Circular results return `RESULT_SERIALIZATION_ERROR`. Functions and `undefined` are also treated as non-serializable. |
+| State reset between executions | Passed. A global set by one request is absent in the next request. |
+| Host API exposure | Passed. `Bun`, `process`, `require`, `fetch`, and `WebSocket` are not exposed. |
+| `MAX_CONCURRENCY=2` | Passed. The third concurrent HTTP request returns 429 with no `Retry-After` header. |
+
+The concurrency test uses a spike-only `beforeExecute` hook to hold two slots
+after validation and before execution. This isolates the HTTP slot behavior from
+QuickJS CPU execution and confirms the no-queue 429 policy.
+
+## Initial Limits
+
+```text
+timeout default: 1000ms
+timeout max: 3000ms
+code size max: 32KB
+input size max: 1MB
+stdout + stderr combined max: 64KB
+MAX_CONCURRENCY: 2
+network: disabled by omission
+host filesystem access: disabled by omission
+subprocess: disabled by omission
+thread/background execution from sandbox: disabled by omission
+```
+
+`timeoutMs` is accepted from the request and clamped to 3000ms. The response
+always includes `appliedTimeoutMs` for execution results.
+
+## API Contract Draft
+
+Request:
+
+```json
+{
+  "language": "javascript",
+  "code": "async function main(input) { console.log('run'); return input.values.reduce((a, b) => a + b, 0); }",
+  "input": {
+    "values": [1, 2, 3]
+  },
+  "timeoutMs": 5000
+}
+```
+
+Success response: HTTP 200
+
+```json
+{
+  "status": "success",
+  "stdout": "run\n",
+  "stderr": "",
+  "result": 6,
+  "durationMs": 42,
+  "appliedTimeoutMs": 3000
+}
+```
+
+Timeout response: HTTP 200
+
+```json
+{
+  "status": "error",
+  "stdout": "",
+  "stderr": "Execution timed out",
+  "result": null,
+  "durationMs": 50,
+  "appliedTimeoutMs": 50,
+  "error": {
+    "code": "TIMEOUT",
+    "message": "Execution timed out"
+  }
+}
+```
+
+Validation error response: HTTP 400
+
+```json
+{
+  "status": "error",
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "Invalid request",
+    "details": ["timeoutMs must be a positive number"]
+  }
+}
+```
+
+Payload limit response: HTTP 413
+
+```json
+{
+  "status": "error",
+  "error": {
+    "code": "PAYLOAD_TOO_LARGE",
+    "message": "code or input exceeds the configured size limit"
+  }
+}
+```
+
+Concurrency limit response: HTTP 429
+
+```json
+{
+  "status": "error",
+  "error": {
+    "code": "CONCURRENCY_LIMIT_EXCEEDED",
+    "message": "Too many concurrent executions",
+    "limit": 2
+  }
+}
+```
+
+Phase 1 does not include `Retry-After` because there is no queue.
+
+## Verification Commands
+
+From `projects/poc/execution-sandbox/`:
+
+```bash
+bun --version
+bun test
+bun run typecheck
+```
+
+Observed result:
+
+```text
+bun --version -> 1.3.10
+bun test -> 8 pass, 0 fail
+bun run typecheck -> passed
+```
+
+Manual HTTP check:
+
+```bash
+bun run dev
+curl -s http://localhost:3000/execute \
+  -H 'content-type: application/json' \
+  -d '{
+    "language": "javascript",
+    "timeoutMs": 50,
+    "input": null,
+    "code": "async function main() { while (true) {} }"
+  }'
+```
+
+Expected result is HTTP 200 with `error.code: "TIMEOUT"`.
+
+## Follow-up Issue Drafts
+
+### 1. Implement JavaScript `execution-worker`
+
+Parent: #986
+
+Build the production-facing JavaScript worker from the spike pattern.
+
+Acceptance criteria:
+
+- Create the production `execution-worker` package.
+- Implement `POST /execute` with the finalized JavaScript contract.
+- Keep QuickJS runtime/context per request.
+- Enforce timeout, code size, input size, output size, and concurrency limits.
+- Return the documented error codes and HTTP statuses.
+
+### 2. Add sandbox lifecycle and resource tests
+
+Parent: #986
+
+Add focused tests around cleanup and resource boundaries.
+
+Acceptance criteria:
+
+- Verify timeout releases concurrency slots.
+- Verify output-limit paths release concurrency slots.
+- Verify runtime/context disposal after success and errors.
+- Verify state reset between repeated executions.
+- Verify no host APIs such as `process`, `Bun`, filesystem, subprocess, or network are exposed.
+
+### 3. Add Docker and compose packaging for the worker
+
+Parent: #986
+
+Package the worker for local PoC operation.
+
+Acceptance criteria:
+
+- Add Dockerfile for the worker.
+- Add compose service wiring for `app-api -> execution-worker`.
+- Keep Redis/queue out of Phase 1.
+- Document local run commands and health checks.
+
+### 4. Investigate Python/Pyodide for Phase 2
+
+Parent: #986
+
+Investigate whether Pyodide can satisfy the same sandbox lifecycle contract.
+
+Acceptance criteria:
+
+- Measure initialization cost.
+- Define virtual filesystem reset behavior.
+- Verify timeout and cancellation options.
+- Verify stdout/stderr/result collection.
+- Compare Python limits with the JavaScript Phase 1 limits.

--- a/projects/poc/execution-sandbox/package.json
+++ b/projects/poc/execution-sandbox/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "execution-sandbox-poc",
+  "type": "module",
+  "scripts": {
+    "dev": "bun run --hot src/server.ts",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "hono": "^4.8.5",
+    "quickjs-emscripten": "^0.32.0"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.2.18",
+    "typescript": "^5.8.3"
+  }
+}

--- a/projects/poc/execution-sandbox/src/sandbox.ts
+++ b/projects/poc/execution-sandbox/src/sandbox.ts
@@ -1,6 +1,5 @@
 import {
   getQuickJS,
-  shouldInterruptAfterDeadline,
   type QuickJSContext,
   type QuickJSHandle,
 } from "quickjs-emscripten";
@@ -13,6 +12,8 @@ export const LIMITS = {
   outputSizeMaxBytes: 64 * 1024,
   maxConcurrency: 2,
 } as const;
+
+const textEncoder = new TextEncoder();
 
 export type ExecuteRequest = {
   language: "javascript";
@@ -46,6 +47,7 @@ export type ExecuteErrorResponse = {
       | "OUTPUT_LIMIT_EXCEEDED"
       | "RESULT_SERIALIZATION_ERROR"
       | "MAIN_FUNCTION_NOT_FOUND"
+      | "MAIN_FUNCTION_NOT_ASYNC"
       | "EXECUTION_ERROR";
     message: string;
     details?: string[];
@@ -69,13 +71,12 @@ class OutputCapture {
   stderr = "";
   private usedBytes = 0;
   private limitExceeded = false;
-  private readonly encoder = new TextEncoder();
 
   constructor(private readonly maxBytes: number) {}
 
   write(stream: "stdout" | "stderr", values: unknown[]) {
     const line = `${values.map(formatConsoleValue).join(" ")}\n`;
-    const bytes = this.encoder.encode(line).byteLength;
+    const bytes = textEncoder.encode(line).byteLength;
     if (this.usedBytes + bytes > this.maxBytes) {
       this.limitExceeded = true;
       throw new Error("Output limit exceeded");
@@ -149,8 +150,13 @@ export function validateExecuteRequest(payload: unknown): ValidationResult {
 
   const code = data.code as string;
   const input = data.input ?? null;
-  const codeBytes = new TextEncoder().encode(code).byteLength;
-  const inputBytes = new TextEncoder().encode(JSON.stringify(input)).byteLength;
+  const serializedInput = stringifyJsonValue(input);
+  if (!serializedInput.ok) {
+    return validationError(["input is not JSON serializable"]);
+  }
+
+  const codeBytes = textEncoder.encode(code).byteLength;
+  const inputBytes = textEncoder.encode(serializedInput.value).byteLength;
   if (codeBytes > LIMITS.codeSizeMaxBytes || inputBytes > LIMITS.inputSizeMaxBytes) {
     return {
       ok: false,
@@ -188,26 +194,34 @@ export async function executeJavaScript(
 ): Promise<ExecuteHttpResult> {
   const startedAt = performance.now();
   const output = new OutputCapture(LIMITS.outputSizeMaxBytes);
-  const deadline = Date.now() + appliedTimeoutMs;
   const QuickJS = await getQuickJS();
   const runtime = QuickJS.newRuntime();
   const context = runtime.newContext();
   let executionHandle: QuickJSHandle | undefined;
   let resolvedHandle: QuickJSHandle | undefined;
   let jsonHandle: QuickJSHandle | undefined;
+  let deadline = Date.now() + appliedTimeoutMs;
 
   runtime.setMemoryLimit(64 * 1024 * 1024);
   runtime.setMaxStackSize(1024 * 1024);
-  const deadlineInterrupt = shouldInterruptAfterDeadline(deadline);
-  runtime.setInterruptHandler((rt) => output.isLimitExceeded() || deadlineInterrupt(rt));
+  runtime.setInterruptHandler(() => output.isLimitExceeded() || Date.now() > deadline);
 
   try {
     installConsole(context, output);
+    deadline = Date.now() + appliedTimeoutMs;
+    const serializedInput = stringifyJsonValue(request.input ?? null);
+    if (!serializedInput.ok) {
+      return executionError("EXECUTION_ERROR", "Input is not JSON serializable", {
+        output,
+        startedAt,
+        appliedTimeoutMs,
+      });
+    }
 
     context
       .unwrapResult(
         context.evalCode(
-          `globalThis.__sandboxInput = ${JSON.stringify(request.input ?? null)}; undefined;`,
+          `globalThis.__sandboxInput = ${serializedInput.value}; undefined;`,
           "sandbox-input.js",
         ),
       )
@@ -226,6 +240,20 @@ export async function executeJavaScript(
       });
     }
 
+    const mainConstructorName = context.unwrapResult(
+      context.evalCode("main.constructor.name", "main-async-check.js"),
+    );
+    const hasAsyncMain = context.getString(mainConstructorName) === "AsyncFunction";
+    mainConstructorName.dispose();
+    if (!hasAsyncMain) {
+      return executionError("MAIN_FUNCTION_NOT_ASYNC", "main(input) must be an async function", {
+        output,
+        startedAt,
+        appliedTimeoutMs,
+      });
+    }
+
+    deadline = Date.now() + appliedTimeoutMs;
     executionHandle = context.unwrapResult(
       context.evalCode("main(globalThis.__sandboxInput)", "main-call.js"),
     );
@@ -363,6 +391,18 @@ function validationError(details: string[]): ValidationResult {
       },
     },
   };
+}
+
+function stringifyJsonValue(value: unknown): { ok: true; value: string } | { ok: false } {
+  try {
+    const serialized = JSON.stringify(value);
+    if (serialized === undefined) {
+      return { ok: false };
+    }
+    return { ok: true, value: serialized };
+  } catch {
+    return { ok: false };
+  }
 }
 
 function executionError(

--- a/projects/poc/execution-sandbox/src/sandbox.ts
+++ b/projects/poc/execution-sandbox/src/sandbox.ts
@@ -1,0 +1,419 @@
+import {
+  getQuickJS,
+  shouldInterruptAfterDeadline,
+  type QuickJSContext,
+  type QuickJSHandle,
+} from "quickjs-emscripten";
+
+export const LIMITS = {
+  timeoutDefaultMs: 1000,
+  timeoutMaxMs: 3000,
+  codeSizeMaxBytes: 32 * 1024,
+  inputSizeMaxBytes: 1024 * 1024,
+  outputSizeMaxBytes: 64 * 1024,
+  maxConcurrency: 2,
+} as const;
+
+export type ExecuteRequest = {
+  language: "javascript";
+  code: string;
+  input?: unknown;
+  timeoutMs?: number;
+};
+
+export type ExecuteSuccessResponse = {
+  status: "success";
+  stdout: string;
+  stderr: string;
+  result: unknown;
+  durationMs: number;
+  appliedTimeoutMs: number;
+};
+
+export type ExecuteErrorResponse = {
+  status: "error";
+  stdout?: string;
+  stderr?: string;
+  result?: null;
+  durationMs?: number;
+  appliedTimeoutMs?: number;
+  error: {
+    code:
+      | "VALIDATION_ERROR"
+      | "PAYLOAD_TOO_LARGE"
+      | "CONCURRENCY_LIMIT_EXCEEDED"
+      | "TIMEOUT"
+      | "OUTPUT_LIMIT_EXCEEDED"
+      | "RESULT_SERIALIZATION_ERROR"
+      | "MAIN_FUNCTION_NOT_FOUND"
+      | "EXECUTION_ERROR";
+    message: string;
+    details?: string[];
+    limit?: number;
+  };
+};
+
+export type ExecuteResponse = ExecuteSuccessResponse | ExecuteErrorResponse;
+
+export type ExecuteHttpResult = {
+  httpStatus: 200 | 400 | 413 | 429;
+  body: ExecuteResponse;
+};
+
+type ValidationResult =
+  | { ok: true; request: ExecuteRequest; appliedTimeoutMs: number }
+  | { ok: false; result: ExecuteHttpResult };
+
+class OutputCapture {
+  stdout = "";
+  stderr = "";
+  private usedBytes = 0;
+  private limitExceeded = false;
+  private readonly encoder = new TextEncoder();
+
+  constructor(private readonly maxBytes: number) {}
+
+  write(stream: "stdout" | "stderr", values: unknown[]) {
+    const line = `${values.map(formatConsoleValue).join(" ")}\n`;
+    const bytes = this.encoder.encode(line).byteLength;
+    if (this.usedBytes + bytes > this.maxBytes) {
+      this.limitExceeded = true;
+      throw new Error("Output limit exceeded");
+    }
+    this.usedBytes += bytes;
+    if (stream === "stdout") {
+      this.stdout += line;
+    } else {
+      this.stderr += line;
+    }
+  }
+
+  isLimitExceeded() {
+    return this.limitExceeded;
+  }
+}
+
+export class ConcurrencyLimiter {
+  private active = 0;
+
+  constructor(readonly limit = LIMITS.maxConcurrency) {}
+
+  tryAcquire(): (() => void) | null {
+    if (this.active >= this.limit) {
+      return null;
+    }
+    this.active += 1;
+    let released = false;
+    return () => {
+      if (released) {
+        return;
+      }
+      released = true;
+      this.active -= 1;
+    };
+  }
+
+  getActive() {
+    return this.active;
+  }
+}
+
+export function validateExecuteRequest(payload: unknown): ValidationResult {
+  const details: string[] = [];
+
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return validationError(["request body must be a JSON object"]);
+  }
+
+  const data = payload as Record<string, unknown>;
+  if (data.language !== "javascript") {
+    details.push('language must be "javascript"');
+  }
+  if (typeof data.code !== "string") {
+    details.push("code must be a string");
+  }
+
+  if (data.timeoutMs !== undefined) {
+    if (
+      typeof data.timeoutMs !== "number" ||
+      !Number.isFinite(data.timeoutMs) ||
+      data.timeoutMs <= 0
+    ) {
+      details.push("timeoutMs must be a positive number");
+    }
+  }
+
+  if (details.length > 0) {
+    return validationError(details);
+  }
+
+  const code = data.code as string;
+  const input = data.input ?? null;
+  const codeBytes = new TextEncoder().encode(code).byteLength;
+  const inputBytes = new TextEncoder().encode(JSON.stringify(input)).byteLength;
+  if (codeBytes > LIMITS.codeSizeMaxBytes || inputBytes > LIMITS.inputSizeMaxBytes) {
+    return {
+      ok: false,
+      result: {
+        httpStatus: 413,
+        body: {
+          status: "error",
+          error: {
+            code: "PAYLOAD_TOO_LARGE",
+            message: "code or input exceeds the configured size limit",
+          },
+        },
+      },
+    };
+  }
+
+  const requestedTimeout = data.timeoutMs ?? LIMITS.timeoutDefaultMs;
+  const appliedTimeoutMs = Math.min(requestedTimeout as number, LIMITS.timeoutMaxMs);
+
+  return {
+    ok: true,
+    request: {
+      language: "javascript",
+      code,
+      input,
+      timeoutMs: data.timeoutMs as number | undefined,
+    },
+    appliedTimeoutMs,
+  };
+}
+
+export async function executeJavaScript(
+  request: ExecuteRequest,
+  appliedTimeoutMs = clampTimeout(request.timeoutMs),
+): Promise<ExecuteHttpResult> {
+  const startedAt = performance.now();
+  const output = new OutputCapture(LIMITS.outputSizeMaxBytes);
+  const deadline = Date.now() + appliedTimeoutMs;
+  const QuickJS = await getQuickJS();
+  const runtime = QuickJS.newRuntime();
+  const context = runtime.newContext();
+  let executionHandle: QuickJSHandle | undefined;
+  let resolvedHandle: QuickJSHandle | undefined;
+  let jsonHandle: QuickJSHandle | undefined;
+
+  runtime.setMemoryLimit(64 * 1024 * 1024);
+  runtime.setMaxStackSize(1024 * 1024);
+  const deadlineInterrupt = shouldInterruptAfterDeadline(deadline);
+  runtime.setInterruptHandler((rt) => output.isLimitExceeded() || deadlineInterrupt(rt));
+
+  try {
+    installConsole(context, output);
+
+    context
+      .unwrapResult(
+        context.evalCode(
+          `globalThis.__sandboxInput = ${JSON.stringify(request.input ?? null)}; undefined;`,
+          "sandbox-input.js",
+        ),
+      )
+      .dispose();
+
+    context.unwrapResult(context.evalCode(request.code, "user-code.js")).dispose();
+
+    const mainType = context.unwrapResult(context.evalCode("typeof main", "main-check.js"));
+    const hasMain = context.getString(mainType) === "function";
+    mainType.dispose();
+    if (!hasMain) {
+      return executionError("MAIN_FUNCTION_NOT_FOUND", "async function main(input) is required", {
+        output,
+        startedAt,
+        appliedTimeoutMs,
+      });
+    }
+
+    executionHandle = context.unwrapResult(
+      context.evalCode("main(globalThis.__sandboxInput)", "main-call.js"),
+    );
+    const resolved = await resolveGuestPromise(context, runtime, executionHandle, appliedTimeoutMs);
+    if (resolved === "timeout") {
+      return executionError("TIMEOUT", "Execution timed out", {
+        output,
+        startedAt,
+        appliedTimeoutMs,
+      });
+    }
+
+    resolvedHandle = context.unwrapResult(resolved);
+    if (output.isLimitExceeded()) {
+      return executionError("OUTPUT_LIMIT_EXCEEDED", "stdout + stderr exceeded 64KB", {
+        output,
+        startedAt,
+        appliedTimeoutMs,
+      });
+    }
+
+    context.setProp(context.global, "__sandboxResult", resolvedHandle);
+    const serialized = context.evalCode(
+      "JSON.stringify(globalThis.__sandboxResult)",
+      "result-serialization.js",
+    );
+    if (serialized.error) {
+      serialized.error.dispose();
+      return executionError("RESULT_SERIALIZATION_ERROR", "Result is not JSON serializable", {
+        output,
+        startedAt,
+        appliedTimeoutMs,
+      });
+    }
+
+    jsonHandle = serialized.value;
+    if (context.typeof(jsonHandle) === "undefined") {
+      return executionError("RESULT_SERIALIZATION_ERROR", "Result is not JSON serializable", {
+        output,
+        startedAt,
+        appliedTimeoutMs,
+      });
+    }
+
+    const result = JSON.parse(context.getString(jsonHandle));
+    return {
+      httpStatus: 200,
+      body: {
+        status: "success",
+        stdout: output.stdout,
+        stderr: output.stderr,
+        result,
+        durationMs: elapsed(startedAt),
+        appliedTimeoutMs,
+      },
+    };
+  } catch (error) {
+    if (output.isLimitExceeded()) {
+      return executionError("OUTPUT_LIMIT_EXCEEDED", "stdout + stderr exceeded 64KB", {
+        output,
+        startedAt,
+        appliedTimeoutMs,
+      });
+    }
+    if (isInterruptedError(error)) {
+      return executionError("TIMEOUT", "Execution timed out", {
+        output,
+        startedAt,
+        appliedTimeoutMs,
+      });
+    }
+    return executionError("EXECUTION_ERROR", toErrorMessage(error), {
+      output,
+      startedAt,
+      appliedTimeoutMs,
+    });
+  } finally {
+    jsonHandle?.dispose();
+    resolvedHandle?.dispose();
+    executionHandle?.dispose();
+    context.dispose();
+    runtime.dispose();
+  }
+}
+
+function installConsole(context: QuickJSContext, output: OutputCapture) {
+  const consoleHandle = context.newObject();
+  const logHandle = context.newFunction("log", (...args) => {
+    output.write("stdout", args.map((arg) => context.dump(arg)));
+  });
+  const errorHandle = context.newFunction("error", (...args) => {
+    output.write("stderr", args.map((arg) => context.dump(arg)));
+  });
+  const warnHandle = context.newFunction("warn", (...args) => {
+    output.write("stderr", args.map((arg) => context.dump(arg)));
+  });
+
+  context.setProp(consoleHandle, "log", logHandle);
+  context.setProp(consoleHandle, "error", errorHandle);
+  context.setProp(consoleHandle, "warn", warnHandle);
+  context.setProp(context.global, "console", consoleHandle);
+
+  warnHandle.dispose();
+  errorHandle.dispose();
+  logHandle.dispose();
+  consoleHandle.dispose();
+}
+
+async function resolveGuestPromise(
+  context: QuickJSContext,
+  runtime: { executePendingJobs: () => unknown },
+  handle: QuickJSHandle,
+  appliedTimeoutMs: number,
+) {
+  const resolvedPromise = context.resolvePromise(handle);
+  runtime.executePendingJobs();
+  const timeout = new Promise<"timeout">((resolve) =>
+    setTimeout(() => resolve("timeout"), appliedTimeoutMs),
+  );
+  return Promise.race([resolvedPromise, timeout]);
+}
+
+function validationError(details: string[]): ValidationResult {
+  return {
+    ok: false,
+    result: {
+      httpStatus: 400,
+      body: {
+        status: "error",
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Invalid request",
+          details,
+        },
+      },
+    },
+  };
+}
+
+function executionError(
+  code: ExecuteErrorResponse["error"]["code"],
+  message: string,
+  context: {
+    output: OutputCapture;
+    startedAt: number;
+    appliedTimeoutMs: number;
+  },
+): ExecuteHttpResult {
+  return {
+    httpStatus: 200,
+    body: {
+      status: "error",
+      stdout: context.output.stdout,
+      stderr: message,
+      result: null,
+      durationMs: elapsed(context.startedAt),
+      appliedTimeoutMs: context.appliedTimeoutMs,
+      error: { code, message },
+    },
+  };
+}
+
+function clampTimeout(timeoutMs: number | undefined) {
+  return Math.min(timeoutMs ?? LIMITS.timeoutDefaultMs, LIMITS.timeoutMaxMs);
+}
+
+function elapsed(startedAt: number) {
+  return Math.max(0, Math.round(performance.now() - startedAt));
+}
+
+function formatConsoleValue(value: unknown) {
+  if (typeof value === "string") {
+    return value;
+  }
+  return JSON.stringify(value);
+}
+
+function isInterruptedError(error: unknown) {
+  const message = toErrorMessage(error);
+  return message.includes("interrupted") || message.includes("Execution timed out");
+}
+
+function toErrorMessage(error: unknown) {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === "object" && error && "message" in error) {
+    return String((error as { message: unknown }).message);
+  }
+  return String(error);
+}

--- a/projects/poc/execution-sandbox/src/server.ts
+++ b/projects/poc/execution-sandbox/src/server.ts
@@ -1,0 +1,75 @@
+import { Hono } from "hono";
+import {
+  ConcurrencyLimiter,
+  LIMITS,
+  executeJavaScript,
+  validateExecuteRequest,
+} from "./sandbox";
+
+export type ExecutionAppOptions = {
+  beforeExecute?: () => void | Promise<void>;
+};
+
+export function createExecutionApp(options: ExecutionAppOptions = {}) {
+  const app = new Hono();
+  const limiter = new ConcurrencyLimiter(LIMITS.maxConcurrency);
+
+  app.post("/execute", async (c) => {
+    let payload: unknown;
+    try {
+      payload = await c.req.json();
+    } catch {
+      return c.json(
+        {
+          status: "error",
+          error: {
+            code: "VALIDATION_ERROR",
+            message: "Invalid request",
+            details: ["request body must be valid JSON"],
+          },
+        },
+        400,
+      );
+    }
+
+    const validation = validateExecuteRequest(payload);
+    if (!validation.ok) {
+      return c.json(validation.result.body, validation.result.httpStatus);
+    }
+
+    const release = limiter.tryAcquire();
+    if (!release) {
+      return c.json(
+        {
+          status: "error",
+          error: {
+            code: "CONCURRENCY_LIMIT_EXCEEDED",
+            message: "Too many concurrent executions",
+            limit: LIMITS.maxConcurrency,
+          },
+        },
+        429,
+      );
+    }
+
+    try {
+      await options.beforeExecute?.();
+      const result = await executeJavaScript(validation.request, validation.appliedTimeoutMs);
+      return c.json(result.body, result.httpStatus);
+    } finally {
+      release();
+    }
+  });
+
+  return {
+    app,
+    getActiveExecutions: () => limiter.getActive(),
+  };
+}
+
+const { app } = createExecutionApp();
+
+export default {
+  port: Number(Bun.env.PORT ?? 3000),
+  fetch: app.fetch,
+};

--- a/projects/poc/execution-sandbox/tests/execution.test.ts
+++ b/projects/poc/execution-sandbox/tests/execution.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { LIMITS, type ExecuteResponse } from "../src/sandbox";
+import { LIMITS, validateExecuteRequest, type ExecuteResponse } from "../src/sandbox";
 import { createExecutionApp } from "../src/server";
 
 const javascriptHeaders = {
@@ -103,6 +103,22 @@ describe("execution sandbox spike", () => {
       throw new Error("expected error");
     }
     expect(response.body.error.code).toBe("RESULT_SERIALIZATION_ERROR");
+  });
+
+  test("rejects a non-async main function", async () => {
+    const { app } = createExecutionApp();
+    const response = await postExecute(app, {
+      language: "javascript",
+      input: null,
+      code: "function main() { return 1; }",
+    });
+
+    expect(response.httpStatus).toBe(200);
+    expect(response.body.status).toBe("error");
+    if (response.body.status !== "error") {
+      throw new Error("expected error");
+    }
+    expect(response.body.error.code).toBe("MAIN_FUNCTION_NOT_ASYNC");
   });
 
   test("does not leak global state between executions", async () => {
@@ -217,6 +233,36 @@ describe("execution sandbox spike", () => {
       code: "x".repeat(LIMITS.codeSizeMaxBytes + 1),
     });
     expect(tooLarge.httpStatus).toBe(413);
+  });
+
+  test("validates non-JSON-serializable input before execution", () => {
+    const circular: { self?: unknown } = {};
+    circular.self = circular;
+
+    const circularResult = validateExecuteRequest({
+      language: "javascript",
+      input: circular,
+      code: "async function main() { return 1; }",
+    });
+    expect(circularResult.ok).toBe(false);
+    if (circularResult.ok) {
+      throw new Error("expected validation error");
+    }
+    expect(circularResult.result.httpStatus).toBe(400);
+    expect(circularResult.result.body.status).toBe("error");
+    if (circularResult.result.body.status !== "error") {
+      throw new Error("expected error body");
+    }
+    expect(circularResult.result.body.error.details).toContain(
+      "input is not JSON serializable",
+    );
+
+    const bigintResult = validateExecuteRequest({
+      language: "javascript",
+      input: 1n,
+      code: "async function main() { return 1; }",
+    });
+    expect(bigintResult.ok).toBe(false);
   });
 });
 

--- a/projects/poc/execution-sandbox/tests/execution.test.ts
+++ b/projects/poc/execution-sandbox/tests/execution.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, test } from "bun:test";
+import { LIMITS, type ExecuteResponse } from "../src/sandbox";
+import { createExecutionApp } from "../src/server";
+
+const javascriptHeaders = {
+  "content-type": "application/json",
+};
+
+describe("execution sandbox spike", () => {
+  test("executes async function main(input), captures console, and clamps timeout", async () => {
+    const { app } = createExecutionApp();
+    const response = await postExecute(app, {
+      language: "javascript",
+      timeoutMs: 10_000,
+      input: { values: [1, 2, 3] },
+      code: `
+        async function main(input) {
+          console.log("received", input.values.length);
+          await Promise.resolve();
+          return input.values.reduce((sum, value) => sum + value, 0);
+        }
+      `,
+    });
+
+    expect(response.httpStatus).toBe(200);
+    expect(response.body.status).toBe("success");
+    if (response.body.status !== "success") {
+      throw new Error("expected success");
+    }
+    expect(response.body.result).toBe(6);
+    expect(response.body.stdout).toBe("received 3\n");
+    expect(response.body.stderr).toBe("");
+    expect(response.body.appliedTimeoutMs).toBe(LIMITS.timeoutMaxMs);
+  });
+
+  test("returns HTTP 200 TIMEOUT for a synchronous infinite loop and releases the slot", async () => {
+    const { app, getActiveExecutions } = createExecutionApp();
+    const response = await postExecute(app, {
+      language: "javascript",
+      timeoutMs: 50,
+      input: null,
+      code: `
+        async function main() {
+          while (true) {}
+        }
+      `,
+    });
+
+    expect(response.httpStatus).toBe(200);
+    expect(response.body.status).toBe("error");
+    if (response.body.status !== "error") {
+      throw new Error("expected error");
+    }
+    expect(response.body.error.code).toBe("TIMEOUT");
+    expect(getActiveExecutions()).toBe(0);
+
+    const nextResponse = await postExecute(app, {
+      language: "javascript",
+      input: null,
+      code: "async function main() { return 1; }",
+    });
+    expect(nextResponse.body.status).toBe("success");
+  });
+
+  test("returns OUTPUT_LIMIT_EXCEEDED when stdout and stderr exceed 64KB", async () => {
+    const { app } = createExecutionApp();
+    const response = await postExecute(app, {
+      language: "javascript",
+      input: null,
+      code: `
+        async function main() {
+          console.log("x".repeat(${LIMITS.outputSizeMaxBytes + 1}));
+          return "unreachable";
+        }
+      `,
+    });
+
+    expect(response.httpStatus).toBe(200);
+    expect(response.body.status).toBe("error");
+    if (response.body.status !== "error") {
+      throw new Error("expected error");
+    }
+    expect(response.body.error.code).toBe("OUTPUT_LIMIT_EXCEEDED");
+  });
+
+  test("returns RESULT_SERIALIZATION_ERROR for circular results", async () => {
+    const { app } = createExecutionApp();
+    const response = await postExecute(app, {
+      language: "javascript",
+      input: null,
+      code: `
+        async function main() {
+          const value = {};
+          value.self = value;
+          return value;
+        }
+      `,
+    });
+
+    expect(response.httpStatus).toBe(200);
+    expect(response.body.status).toBe("error");
+    if (response.body.status !== "error") {
+      throw new Error("expected error");
+    }
+    expect(response.body.error.code).toBe("RESULT_SERIALIZATION_ERROR");
+  });
+
+  test("does not leak global state between executions", async () => {
+    const { app } = createExecutionApp();
+    await postExecute(app, {
+      language: "javascript",
+      input: null,
+      code: `
+        async function main() {
+          globalThis.leaked = "previous";
+          return globalThis.leaked;
+        }
+      `,
+    });
+
+    const response = await postExecute(app, {
+      language: "javascript",
+      input: null,
+      code: `
+        async function main() {
+          return typeof globalThis.leaked;
+        }
+      `,
+    });
+
+    expect(response.body.status).toBe("success");
+    if (response.body.status !== "success") {
+      throw new Error("expected success");
+    }
+    expect(response.body.result).toBe("undefined");
+  });
+
+  test("does not expose Bun, Node process, filesystem, subprocess, or network APIs", async () => {
+    const { app } = createExecutionApp();
+    const response = await postExecute(app, {
+      language: "javascript",
+      input: null,
+      code: `
+        async function main() {
+          return {
+            Bun: typeof Bun,
+            process: typeof process,
+            require: typeof require,
+            fetch: typeof fetch,
+            WebSocket: typeof WebSocket
+          };
+        }
+      `,
+    });
+
+    expect(response.body.status).toBe("success");
+    if (response.body.status !== "success") {
+      throw new Error("expected success");
+    }
+    expect(response.body.result).toEqual({
+      Bun: "undefined",
+      process: "undefined",
+      require: "undefined",
+      fetch: "undefined",
+      WebSocket: "undefined",
+    });
+  });
+
+  test("enforces MAX_CONCURRENCY=2 with HTTP 429 and no Retry-After header", async () => {
+    let releaseGate: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      releaseGate = resolve;
+    });
+    const { app, getActiveExecutions } = createExecutionApp({
+      beforeExecute: () => gate,
+    });
+
+    const request = {
+      language: "javascript",
+      input: null,
+      code: "async function main() { return 1; }",
+    };
+    const first = postExecute(app, request);
+    const second = postExecute(app, request);
+
+    await waitUntil(() => getActiveExecutions() === LIMITS.maxConcurrency);
+
+    const rejected = await postExecute(app, request);
+    expect(rejected.httpStatus).toBe(429);
+    expect(rejected.response.headers.has("retry-after")).toBe(false);
+    expect(rejected.body.status).toBe("error");
+    if (rejected.body.status !== "error") {
+      throw new Error("expected error");
+    }
+    expect(rejected.body.error.code).toBe("CONCURRENCY_LIMIT_EXCEEDED");
+
+    releaseGate();
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+    expect(firstResult.body.status).toBe("success");
+    expect(secondResult.body.status).toBe("success");
+    expect(getActiveExecutions()).toBe(0);
+  });
+
+  test("validates timeoutMs and payload size", async () => {
+    const { app } = createExecutionApp();
+    const invalidTimeout = await postExecute(app, {
+      language: "javascript",
+      timeoutMs: 0,
+      input: null,
+      code: "async function main() { return 1; }",
+    });
+    expect(invalidTimeout.httpStatus).toBe(400);
+
+    const tooLarge = await postExecute(app, {
+      language: "javascript",
+      input: null,
+      code: "x".repeat(LIMITS.codeSizeMaxBytes + 1),
+    });
+    expect(tooLarge.httpStatus).toBe(413);
+  });
+});
+
+async function postExecute(
+  app: ReturnType<typeof createExecutionApp>["app"],
+  body: unknown,
+): Promise<{
+  response: Response;
+  httpStatus: number;
+  body: ExecuteResponse;
+}> {
+  const response = await app.request("/execute", {
+    method: "POST",
+    headers: javascriptHeaders,
+    body: JSON.stringify(body),
+  });
+  return {
+    response,
+    httpStatus: response.status,
+    body: (await response.json()) as ExecuteResponse,
+  };
+}
+
+async function waitUntil(predicate: () => boolean) {
+  const startedAt = Date.now();
+  while (!predicate()) {
+    if (Date.now() - startedAt > 1000) {
+      throw new Error("timed out waiting for condition");
+    }
+    await Bun.sleep(5);
+  }
+}

--- a/projects/poc/execution-sandbox/tsconfig.json
+++ b/projects/poc/execution-sandbox/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "types": ["bun-types"],
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
+}


### PR DESCRIPTION
## Issues

- Close #993
- Refs #986

## Why

Issue #993 is the spike gate for deciding whether TypeScript + Bun + Hono with `quickjs-emscripten` can be used as the Phase 1 JavaScript runtime path for the AI Agent Execution Sandbox PoC.

## Summary

This PR adds an isolated `projects/poc/execution-sandbox` spike. It verifies that `quickjs-emscripten` can interrupt synchronous infinite loops on Bun, exposes a minimal Hono `POST /execute`, and documents the runtime selection decision plus follow-up issue drafts.

## Changes

- Add a Bun/Hono QuickJS spike with per-request runtime/context lifecycle.
- Enforce timeout clamp, code/input limits, output limit, result serialization errors, and `MAX_CONCURRENCY=2`.
- Add tests for async `main(input)`, synchronous infinite-loop timeout, HTTP slot release, output limit, serialization error, state reset, host API omission, 429 behavior, and validation.
- Add `docs/runtime-selection.md` with runtime comparison, spike results, API/error contract, initial limits, verification commands, and follow-up issue drafts.

## Verification

- `bun test` - passed, 8 tests
- `bun run typecheck` - passed
- `bun run dev` + `curl POST /execute` with `while (true) {}` - returned HTTP 200 `TIMEOUT`
