### PR TITLE
Add execution worker service

### DIFF
--- a/projects/poc/execution-sandbox/README.md
+++ b/projects/poc/execution-sandbox/README.md
@@ -1,12 +1,95 @@
-# Execution Sandbox PoC
+# Execution Worker
 
-Spike for selecting the JavaScript runtime path for the AI Agent Execution Sandbox.
+Phase 1 JavaScript worker for the AI Agent Execution Sandbox.
+
+This service executes short JavaScript snippets through `POST /execute` with a fresh
+QuickJS Runtime and Context per request. It intentionally exposes only JavaScript in
+Phase 1; Python/Pyodide, queues, streaming output, runtime pooling, Docker packaging,
+and `app-api` integration are tracked as follow-up work.
+
+## Local commands
 
 ```bash
 bun install
 bun test
 bun run typecheck
 bun run dev
+```
+
+The dev server listens on `PORT` or `3000` by default.
+
+## Endpoints
+
+### `GET /healthz`
+
+Returns service readiness metadata.
+
+```json
+{
+  "status": "ok",
+  "service": "execution-worker"
+}
+```
+
+### `POST /execute`
+
+Runs an `async function main(input)` in a disposable QuickJS context.
+
+```json
+{
+  "language": "javascript",
+  "code": "async function main(input) { console.log('run'); return input.values.reduce((a, b) => a + b, 0); }",
+  "input": {
+    "values": [1, 2, 3]
+  },
+  "timeoutMs": 5000
+}
+```
+
+Success responses use HTTP 200.
+
+```json
+{
+  "status": "success",
+  "stdout": "run\n",
+  "stderr": "",
+  "result": 6,
+  "durationMs": 42,
+  "appliedTimeoutMs": 3000
+}
+```
+
+Execution errors also use HTTP 200 and include a stable error code. Validation,
+payload, and concurrency errors use HTTP 400, 413, and 429 respectively.
+
+```json
+{
+  "status": "error",
+  "stdout": "",
+  "stderr": "",
+  "result": null,
+  "durationMs": 50,
+  "appliedTimeoutMs": 50,
+  "error": {
+    "code": "TIMEOUT",
+    "message": "Execution timed out"
+  }
+}
+```
+
+## Limits
+
+```text
+timeout default: 1000ms
+timeout max: 3000ms
+code size max: 32KB
+input size max: 1MB
+stdout + stderr combined max: 64KB
+MAX_CONCURRENCY: 2
+network: disabled by omission
+host filesystem access: disabled by omission
+subprocess: disabled by omission
+thread/background execution from sandbox: disabled by omission
 ```
 
 The runtime selection notes and spike results live in `docs/runtime-selection.md`.

--- a/projects/poc/execution-sandbox/bun.lock
+++ b/projects/poc/execution-sandbox/bun.lock
@@ -3,7 +3,7 @@
   "configVersion": 1,
   "workspaces": {
     "": {
-      "name": "execution-sandbox-poc",
+      "name": "execution-worker",
       "dependencies": {
         "hono": "^4.8.5",
         "quickjs-emscripten": "^0.32.0",

--- a/projects/poc/execution-sandbox/package.json
+++ b/projects/poc/execution-sandbox/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "execution-sandbox-poc",
+  "name": "execution-worker",
   "type": "module",
   "scripts": {
     "dev": "bun run --hot src/server.ts",

--- a/projects/poc/execution-sandbox/src/sandbox.ts
+++ b/projects/poc/execution-sandbox/src/sandbox.ts
@@ -419,7 +419,7 @@ function executionError(
     body: {
       status: "error",
       stdout: context.output.stdout,
-      stderr: message,
+      stderr: context.output.stderr,
       result: null,
       durationMs: elapsed(context.startedAt),
       appliedTimeoutMs: context.appliedTimeoutMs,

--- a/projects/poc/execution-sandbox/src/server.ts
+++ b/projects/poc/execution-sandbox/src/server.ts
@@ -6,6 +6,8 @@ import {
   validateExecuteRequest,
 } from "./sandbox";
 
+const SERVICE_NAME = "execution-worker";
+
 export type ExecutionAppOptions = {
   beforeExecute?: () => void | Promise<void>;
 };
@@ -13,6 +15,13 @@ export type ExecutionAppOptions = {
 export function createExecutionApp(options: ExecutionAppOptions = {}) {
   const app = new Hono();
   const limiter = new ConcurrencyLimiter(LIMITS.maxConcurrency);
+
+  app.get("/healthz", (c) =>
+    c.json({
+      status: "ok",
+      service: SERVICE_NAME,
+    }),
+  );
 
   app.post("/execute", async (c) => {
     let payload: unknown;

--- a/projects/poc/execution-sandbox/src/server.ts
+++ b/projects/poc/execution-sandbox/src/server.ts
@@ -6,7 +6,7 @@ import {
   validateExecuteRequest,
 } from "./sandbox";
 
-const SERVICE_NAME = "execution-worker";
+export const SERVICE_NAME = "execution-worker";
 
 export type ExecutionAppOptions = {
   beforeExecute?: () => void | Promise<void>;

--- a/projects/poc/execution-sandbox/tests/execution.test.ts
+++ b/projects/poc/execution-sandbox/tests/execution.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { LIMITS, validateExecuteRequest, type ExecuteResponse } from "../src/sandbox";
-import { createExecutionApp } from "../src/server";
+import { SERVICE_NAME, createExecutionApp } from "../src/server";
 
 const javascriptHeaders = {
   "content-type": "application/json",
@@ -14,7 +14,7 @@ describe("execution-worker", () => {
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({
       status: "ok",
-      service: "execution-worker",
+      service: SERVICE_NAME,
     });
   });
 

--- a/projects/poc/execution-sandbox/tests/execution.test.ts
+++ b/projects/poc/execution-sandbox/tests/execution.test.ts
@@ -6,7 +6,18 @@ const javascriptHeaders = {
   "content-type": "application/json",
 };
 
-describe("execution sandbox spike", () => {
+describe("execution-worker", () => {
+  test("exposes a health endpoint for service readiness checks", async () => {
+    const { app } = createExecutionApp();
+    const response = await app.request("/healthz");
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      status: "ok",
+      service: "execution-worker",
+    });
+  });
+
   test("executes async function main(input), captures console, and clamps timeout", async () => {
     const { app } = createExecutionApp();
     const response = await postExecute(app, {
@@ -105,6 +116,22 @@ describe("execution sandbox spike", () => {
     expect(response.body.error.code).toBe("RESULT_SERIALIZATION_ERROR");
   });
 
+  test("returns MAIN_FUNCTION_NOT_FOUND when main is missing", async () => {
+    const { app } = createExecutionApp();
+    const response = await postExecute(app, {
+      language: "javascript",
+      input: null,
+      code: "const value = 1;",
+    });
+
+    expect(response.httpStatus).toBe(200);
+    expect(response.body.status).toBe("error");
+    if (response.body.status !== "error") {
+      throw new Error("expected error");
+    }
+    expect(response.body.error.code).toBe("MAIN_FUNCTION_NOT_FOUND");
+  });
+
   test("rejects a non-async main function", async () => {
     const { app } = createExecutionApp();
     const response = await postExecute(app, {
@@ -119,6 +146,29 @@ describe("execution sandbox spike", () => {
       throw new Error("expected error");
     }
     expect(response.body.error.code).toBe("MAIN_FUNCTION_NOT_ASYNC");
+  });
+
+  test("preserves captured stderr separately from execution errors", async () => {
+    const { app } = createExecutionApp();
+    const response = await postExecute(app, {
+      language: "javascript",
+      input: null,
+      code: `
+        async function main() {
+          console.error("before failure");
+          throw new Error("boom");
+        }
+      `,
+    });
+
+    expect(response.httpStatus).toBe(200);
+    expect(response.body.status).toBe("error");
+    if (response.body.status !== "error") {
+      throw new Error("expected error");
+    }
+    expect(response.body.error.code).toBe("EXECUTION_ERROR");
+    expect(response.body.stderr).toBe("before failure\n");
+    expect(response.body.error.message).toContain("boom");
   });
 
   test("does not leak global state between executions", async () => {
@@ -217,8 +267,28 @@ describe("execution sandbox spike", () => {
     expect(getActiveExecutions()).toBe(0);
   });
 
-  test("validates timeoutMs and payload size", async () => {
+  test("validates JSON body, language, timeoutMs, and payload size", async () => {
     const { app } = createExecutionApp();
+    const invalidJson = await postRaw(app, "{");
+    expect(invalidJson.httpStatus).toBe(400);
+    expect(invalidJson.body.status).toBe("error");
+    if (invalidJson.body.status !== "error") {
+      throw new Error("expected error");
+    }
+    expect(invalidJson.body.error.code).toBe("VALIDATION_ERROR");
+
+    const unsupportedLanguage = await postExecute(app, {
+      language: "python",
+      input: null,
+      code: "async function main() { return 1; }",
+    });
+    expect(unsupportedLanguage.httpStatus).toBe(400);
+    expect(unsupportedLanguage.body.status).toBe("error");
+    if (unsupportedLanguage.body.status !== "error") {
+      throw new Error("expected error");
+    }
+    expect(unsupportedLanguage.body.error.code).toBe("VALIDATION_ERROR");
+
     const invalidTimeout = await postExecute(app, {
       language: "javascript",
       timeoutMs: 0,
@@ -233,6 +303,13 @@ describe("execution sandbox spike", () => {
       code: "x".repeat(LIMITS.codeSizeMaxBytes + 1),
     });
     expect(tooLarge.httpStatus).toBe(413);
+
+    const tooLargeInput = await postExecute(app, {
+      language: "javascript",
+      input: "x".repeat(LIMITS.inputSizeMaxBytes + 1),
+      code: "async function main(input) { return input.length; }",
+    });
+    expect(tooLargeInput.httpStatus).toBe(413);
   });
 
   test("validates non-JSON-serializable input before execution", () => {
@@ -278,6 +355,26 @@ async function postExecute(
     method: "POST",
     headers: javascriptHeaders,
     body: JSON.stringify(body),
+  });
+  return {
+    response,
+    httpStatus: response.status,
+    body: (await response.json()) as ExecuteResponse,
+  };
+}
+
+async function postRaw(
+  app: ReturnType<typeof createExecutionApp>["app"],
+  body: string,
+): Promise<{
+  response: Response;
+  httpStatus: number;
+  body: ExecuteResponse;
+}> {
+  const response = await app.request("/execute", {
+    method: "POST",
+    headers: javascriptHeaders,
+    body,
   });
   return {
     response,


### PR DESCRIPTION
## Issues

- Close #996

## Why

The runtime selection spike proved the Phase 1 JavaScript path, but the code still needed to be promoted from a spike boundary into a production-facing worker service contract.

## Summary

This PR promotes the execution sandbox package to `execution-worker`, adds service readiness metadata, tightens the documented execution/error contract, and expands tests around the Issue #996 acceptance criteria.

## Changes

- Rename the package metadata from `execution-sandbox-poc` to `execution-worker`.
- Add `GET /healthz` for independent worker readiness checks.
- Preserve captured `stderr` separately from execution error messages.
- Add contract coverage for missing `main`, invalid JSON, unsupported language, input payload limits, service health, and stderr capture.
- Document local commands, endpoints, response shapes, limits, and Phase 1 scope.

## Verification

- `bun run typecheck` - passed
- `bun test` - passed
- `git diff --check` - passed
