### PR TITLE
execution-worker の Docker/compose packaging を追加

### DIFF
--- a/projects/poc/execution-sandbox/.dockerignore
+++ b/projects/poc/execution-sandbox/.dockerignore
@@ -1,0 +1,8 @@
+.git
+node_modules
+coverage
+dist
+tmp
+tmp-test
+*.log
+.DS_Store

--- a/projects/poc/execution-sandbox/AGENTS.md
+++ b/projects/poc/execution-sandbox/AGENTS.md
@@ -1,0 +1,53 @@
+# execution-worker
+
+Phase 1 JavaScript worker for the AI Agent Execution Sandbox.
+
+## TechStack
+
+- Bun
+- TypeScript
+- Hono
+- quickjs-emscripten
+- Docker
+
+## Commands
+
+```bash
+# local dev
+bun install
+bun test
+bun run typecheck
+bun run dev
+
+# docker build
+docker build --target test -t execution-worker:test .
+docker build --target final -t execution-worker:local .
+
+# compose up
+docker compose up --build execution-worker
+```
+
+## Smoke Test
+
+PR作成時は必ず以下を実行し、結果をPR本文のVerificationセクションに記録すること。
+
+```bash
+# build & up
+docker build --target test -t execution-worker:test .
+docker build --target final -t execution-worker:local .
+EXECUTION_WORKER_PORT=3100 docker compose up --build -d execution-worker
+
+# verify
+docker compose ps
+curl http://localhost:3100/healthz
+curl -s http://localhost:3100/execute \
+  -H 'content-type: application/json' \
+  -d '{
+    "language": "javascript",
+    "code": "async function main(input) { console.log(\"run\"); return input.values.reduce((a, b) => a + b, 0); }",
+    "input": { "values": [1, 2, 3] }
+  }'
+
+# down
+docker compose down
+```

--- a/projects/poc/execution-sandbox/AGENTS.md
+++ b/projects/poc/execution-sandbox/AGENTS.md
@@ -24,12 +24,12 @@ docker build --target test -t execution-worker:test .
 docker build --target final -t execution-worker:local .
 
 # compose up
-docker compose up --build execution-worker
+EXECUTION_WORKER_PORT=3100 docker compose up --build execution-worker
 ```
 
 ## Smoke Test
 
-PR作成時は必ず以下を実行し、結果をPR本文のVerificationセクションに記録すること。
+Dockerfile / compose / runtime 起動に関わる変更では、可能な場合は以下を実行し、結果をPR本文のVerificationセクションに記録すること。環境上実行不可の場合はその理由をPR本文に記録すること。
 
 ```bash
 # build & up

--- a/projects/poc/execution-sandbox/Dockerfile
+++ b/projects/poc/execution-sandbox/Dockerfile
@@ -1,0 +1,54 @@
+FROM oven/bun:1.3.10-alpine AS base
+
+ARG COMMIT_HASH=""
+ENV COMMIT_HASH=${COMMIT_HASH}
+
+WORKDIR /app
+
+COPY package.json bun.lock ./
+
+FROM base AS deps
+
+RUN bun install --frozen-lockfile
+
+FROM base AS test
+
+ARG COMMIT_HASH
+ENV COMMIT_HASH=${COMMIT_HASH}
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY src ./src
+COPY tests ./tests
+COPY tsconfig.json ./
+
+RUN bun run typecheck && \
+    bun test
+
+FROM base AS builder
+
+ENV NODE_ENV=production
+
+RUN bun install --frozen-lockfile --production
+
+COPY src ./src
+COPY tsconfig.json ./
+
+FROM base AS final
+
+ARG COMMIT_HASH
+ENV APP_VERSION=${COMMIT_HASH}
+ENV COMMIT_HASH=${COMMIT_HASH}
+ENV NODE_ENV=production
+ENV PORT=3000
+
+RUN adduser -D -s /sbin/nologin execution
+
+COPY --from=builder --chown=execution:execution /app/node_modules ./node_modules
+COPY --from=builder --chown=execution:execution /app/src ./src
+COPY --from=builder --chown=execution:execution /app/tsconfig.json ./tsconfig.json
+
+USER execution
+
+EXPOSE 3000
+
+CMD ["bun", "run", "src/server.ts"]

--- a/projects/poc/execution-sandbox/Dockerfile
+++ b/projects/poc/execution-sandbox/Dockerfile
@@ -24,7 +24,7 @@ COPY tsconfig.json ./
 RUN bun run typecheck && \
     bun test
 
-FROM base AS builder
+FROM base AS production-deps
 
 ENV NODE_ENV=production
 
@@ -36,16 +36,15 @@ COPY tsconfig.json ./
 FROM base AS final
 
 ARG COMMIT_HASH
-ENV APP_VERSION=${COMMIT_HASH}
 ENV COMMIT_HASH=${COMMIT_HASH}
 ENV NODE_ENV=production
 ENV PORT=3000
 
 RUN adduser -D -s /sbin/nologin execution
 
-COPY --from=builder --chown=execution:execution /app/node_modules ./node_modules
-COPY --from=builder --chown=execution:execution /app/src ./src
-COPY --from=builder --chown=execution:execution /app/tsconfig.json ./tsconfig.json
+COPY --from=production-deps --chown=execution:execution /app/node_modules ./node_modules
+COPY --from=production-deps --chown=execution:execution /app/src ./src
+COPY --from=production-deps --chown=execution:execution /app/tsconfig.json ./tsconfig.json
 
 USER execution
 

--- a/projects/poc/execution-sandbox/README.md
+++ b/projects/poc/execution-sandbox/README.md
@@ -4,8 +4,8 @@ Phase 1 JavaScript worker for the AI Agent Execution Sandbox.
 
 This service executes short JavaScript snippets through `POST /execute` with a fresh
 QuickJS Runtime and Context per request. It intentionally exposes only JavaScript in
-Phase 1; Python/Pyodide, queues, streaming output, runtime pooling, Docker packaging,
-and `app-api` integration are tracked as follow-up work.
+Phase 1; Python/Pyodide, queues, streaming output, runtime pooling, and `app-api`
+integration are tracked as follow-up work.
 
 ## Local commands
 
@@ -17,6 +17,50 @@ bun run dev
 ```
 
 The dev server listens on `PORT` or `3000` by default.
+
+## Docker and compose
+
+Build the CI test stage:
+
+```bash
+docker build --target test -t execution-worker:test .
+```
+
+Build the runtime image:
+
+```bash
+docker build --target final -t execution-worker:local .
+```
+
+Start the worker with compose:
+
+```bash
+docker compose up --build execution-worker
+```
+
+The compose service exposes the worker on `EXECUTION_WORKER_PORT` or `3000` by
+default. It includes a container healthcheck for `GET /healthz`.
+
+Verify health:
+
+```bash
+curl http://localhost:3000/healthz
+```
+
+Run a smoke execution request:
+
+```bash
+curl -s http://localhost:3000/execute \
+  -H 'content-type: application/json' \
+  -d '{
+    "language": "javascript",
+    "code": "async function main(input) { console.log(\"run\"); return input.values.reduce((a, b) => a + b, 0); }",
+    "input": { "values": [1, 2, 3] }
+  }'
+```
+
+Phase 1 compose intentionally starts only `execution-worker`; Redis, queue/retry,
+worker scale-out, and runtime pooling are not included.
 
 ## Endpoints
 

--- a/projects/poc/execution-sandbox/compose.yaml
+++ b/projects/poc/execution-sandbox/compose.yaml
@@ -1,0 +1,26 @@
+services:
+  execution-worker:
+    build:
+      context: .
+      target: final
+      args:
+        COMMIT_HASH: local
+    ports:
+      - "${EXECUTION_WORKER_PORT:-3000}:3000"
+    environment:
+      HOST: 0.0.0.0
+      PORT: "3000"
+      NODE_ENV: production
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "bun",
+          "-e",
+          "const response = await fetch('http://127.0.0.1:3000/healthz'); process.exit(response.ok ? 0 : 1)",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+    restart: unless-stopped

--- a/projects/poc/execution-sandbox/src/server.ts
+++ b/projects/poc/execution-sandbox/src/server.ts
@@ -79,6 +79,7 @@ export function createExecutionApp(options: ExecutionAppOptions = {}) {
 const { app } = createExecutionApp();
 
 export default {
+  hostname: Bun.env.HOST ?? "0.0.0.0",
   port: Number(Bun.env.PORT ?? 3000),
   fetch: app.fetch,
 };

--- a/projects/poc/execution-sandbox/src/server.ts
+++ b/projects/poc/execution-sandbox/src/server.ts
@@ -77,9 +77,10 @@ export function createExecutionApp(options: ExecutionAppOptions = {}) {
 }
 
 const { app } = createExecutionApp();
+const hostname = Bun.env.HOST;
 
 export default {
-  hostname: Bun.env.HOST ?? "0.0.0.0",
+  ...(hostname ? { hostname } : {}),
   port: Number(Bun.env.PORT ?? 3000),
   fetch: app.fetch,
 };


### PR DESCRIPTION
## Issues

- Close #998

## Why

`execution-worker` を app-api から独立した worker service として扱うため、Phase 1 のローカル PoC で再現可能に Docker build / compose 起動できる状態が必要でした。

## Summary

`execution-worker` に monorepo CI/CD 向けの Dockerfile と、ローカル確認用の compose service を追加しました。README に Docker build、compose 起動、health check、`/execute` smoke test の手順も追記しています。

## Changes

- `test` stage と `final` stage を持つ Bun ベースの Dockerfile を追加
- compose で `execution-worker` を起動し、ホスト port と healthcheck を設定
- Docker context 用の `.dockerignore` を追加
- Docker/compose から到達できるよう server の listen host を明示
- README にローカル Docker/compose 検証手順と Phase 1 scope を追記

## Verification

- [x] `bun run typecheck`
- [x] `bun test`
- [x] `docker build --target test -t execution-worker:test .`
- [x] `docker build --target final -t execution-worker:local .`
- [x] `EXECUTION_WORKER_PORT=3100 docker compose up --build -d execution-worker`
- [x] `docker compose ps` で `healthy` を確認
- [x] `curl http://localhost:3100/healthz`
- [x] `curl -s http://localhost:3100/execute ...`
- [x] `docker compose down`
- [x] `git diff --check`
