### PR TITLE
chore(execution-sandbox): add Pyodide runtime spike

### DIFF
--- a/projects/poc/execution-sandbox/README.md
+++ b/projects/poc/execution-sandbox/README.md
@@ -13,6 +13,7 @@ integration are tracked as follow-up work.
 bun install
 bun test
 bun run typecheck
+bun run spike:pyodide
 bun run dev
 ```
 
@@ -136,4 +137,6 @@ subprocess: disabled by omission
 thread/background execution from sandbox: disabled by omission
 ```
 
-The runtime selection notes and spike results live in `docs/runtime-selection.md`.
+The JavaScript runtime selection notes live in `docs/runtime-selection.md`.
+The Python/Pyodide Phase 2 investigation lives in
+`docs/pyodide-runtime-investigation.md`.

--- a/projects/poc/execution-sandbox/bun.lock
+++ b/projects/poc/execution-sandbox/bun.lock
@@ -10,6 +10,7 @@
       },
       "devDependencies": {
         "@types/bun": "^1.2.18",
+        "pyodide": "^0.29.4",
         "typescript": "^5.8.3",
       },
     },
@@ -27,11 +28,15 @@
 
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
+    "@types/emscripten": ["@types/emscripten@1.41.5", "", {}, "sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q=="],
+
     "@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "hono": ["hono@4.12.23", "", {}, "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA=="],
+
+    "pyodide": ["pyodide@0.29.4", "", { "dependencies": { "@types/emscripten": "^1.41.4", "ws": "^8.5.0" } }, "sha512-tCseTsqU3kSxZIjkue5zXxTMNEwrKZwOIIEQRBA/VzHxFN1hoCxe4w41phfCdHd9it9RcCNQb5K/Re0InqMgvA=="],
 
     "quickjs-emscripten": ["quickjs-emscripten@0.32.0", "", { "dependencies": { "@jitl/quickjs-wasmfile-debug-asyncify": "0.32.0", "@jitl/quickjs-wasmfile-debug-sync": "0.32.0", "@jitl/quickjs-wasmfile-release-asyncify": "0.32.0", "@jitl/quickjs-wasmfile-release-sync": "0.32.0", "quickjs-emscripten-core": "0.32.0" } }, "sha512-So0Sqw869y/S2oE3Nuc0uT3Dhqgvsj8FSrwBdsuTosVsG8ME5/OcudU1GxsrIFdFABgy17GHnTVO9TYV/bLQcA=="],
 
@@ -40,5 +45,7 @@
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
   }
 }

--- a/projects/poc/execution-sandbox/docs/pyodide-runtime-investigation.md
+++ b/projects/poc/execution-sandbox/docs/pyodide-runtime-investigation.md
@@ -52,7 +52,7 @@ platform: linux x64
 | Fresh worker initialization | Passed. Worker initialization took about 2.4s to 3.6s in local runs. |
 | Basic execution | Passed. Python summed `[1, 2, 3]` and returned JSON `{"sum": 6}`. |
 | stdout/stderr capture | Passed. `pyodide.setStdout()` captured `received 3\n`; `pyodide.setStderr()` captured `warning\n`. |
-| Timeout/cancellation | Passed for synchronous Python code when using a worker interrupt buffer. `while True: pass` raised `KeyboardInterrupt` at about 1.0s execution time with a 1000ms timeout. |
+| Timeout/cancellation | Passed for synchronous Python code when using a worker interrupt buffer. `while True: pass` produced a JS `PythonError` at about 1.0s execution time with a 1000ms timeout, and the traceback identifies the Python exception as `KeyboardInterrupt`. |
 | Virtual FS reset | Passed only with a fresh worker per execution. Reusing one Pyodide instance leaks `/tmp` files unless explicitly reset. |
 | Global state reset | Passed only with a fresh worker per execution. Reusing one Pyodide instance leaks Python globals unless explicitly reset. |
 | Import control | Not provided as a sandbox policy by Pyodide. Built-in imports such as `math` are available by default, so a production runtime needs an explicit allowlist/enforcement layer. |
@@ -91,6 +91,9 @@ Python/Pyodide fit:
   initialization cost separately from execution duration.
 - Use `SharedArrayBuffer` and `pyodide.setInterruptBuffer()` for synchronous
   Python cancellation.
+- Normalize Pyodide errors before returning them. In local runs, timeout
+  interruption surfaced as JS `PythonError` with Python `KeyboardInterrupt` in
+  the traceback rather than as a JS `KeyboardInterrupt` name.
 - Prefer fresh worker per execution for the first production spike. Pooling can
   be considered later only with reset tests for globals, `/tmp`, loaded modules,
   stream handlers, and interrupt state.

--- a/projects/poc/execution-sandbox/docs/pyodide-runtime-investigation.md
+++ b/projects/poc/execution-sandbox/docs/pyodide-runtime-investigation.md
@@ -1,0 +1,147 @@
+# Python/Pyodide Runtime Investigation
+
+Issue: #1000
+Parent: #986
+Refs: #993, #994
+
+## Decision
+
+Proceed with constraints for Phase 2 investigation follow-up.
+
+Pyodide can execute basic Python code, serialize JSON-compatible results,
+capture stdout/stderr, and stop a synchronous CPU loop when execution runs in a
+dedicated worker with `SharedArrayBuffer` and `pyodide.setInterruptBuffer()`.
+It should not be added to production `execution-worker` until the worker
+lifecycle, import allowlist, and reset strategy are implemented and tested.
+
+## Repeatable Spike
+
+From `projects/poc/execution-sandbox/`:
+
+```bash
+bun install
+bun run spike:pyodide
+```
+
+The spike files are:
+
+```text
+scripts/pyodide-spike.mjs
+scripts/pyodide-worker.mjs
+```
+
+The command prints JSON with environment metadata, initialization timings,
+execution behavior, timeout behavior, state/virtual FS isolation checks, and the
+Phase 2 decision.
+
+## Observed Environment
+
+Observed on 2026-05-31:
+
+```text
+Bun: 1.3.10
+pyodide: 0.29.4
+platform: linux x64
+```
+
+## Observed Results
+
+| Area | Result |
+| --- | --- |
+| In-process initialization | Passed. `loadPyodide()` took about 2.4s to 2.9s in local runs. |
+| Fresh worker initialization | Passed. Worker initialization took about 2.4s to 3.6s in local runs. |
+| Basic execution | Passed. Python summed `[1, 2, 3]` and returned JSON `{"sum": 6}`. |
+| stdout/stderr capture | Passed. `pyodide.setStdout()` captured `received 3\n`; `pyodide.setStderr()` captured `warning\n`. |
+| Timeout/cancellation | Passed for synchronous Python code when using a worker interrupt buffer. `while True: pass` raised `KeyboardInterrupt` at about 1.0s execution time with a 1000ms timeout. |
+| Virtual FS reset | Passed only with a fresh worker per execution. Reusing one Pyodide instance leaks `/tmp` files unless explicitly reset. |
+| Global state reset | Passed only with a fresh worker per execution. Reusing one Pyodide instance leaks Python globals unless explicitly reset. |
+| Import control | Not provided as a sandbox policy by Pyodide. Built-in imports such as `math` are available by default, so a production runtime needs an explicit allowlist/enforcement layer. |
+
+## Contract Comparison
+
+JavaScript Phase 1 limits:
+
+```text
+timeout default: 1000ms
+timeout max: 3000ms
+input size max: 1MB
+stdout + stderr combined max: 64KB
+network: disabled
+host filesystem access: disabled
+state sharing across requests: disabled
+```
+
+Python/Pyodide fit:
+
+| Contract Area | Fit | Notes |
+| --- | --- | --- |
+| Timeout | Medium | Pyodide supports interrupts through a shared interrupt buffer, but the runtime must run inside a worker. The timeout budget should start after runtime initialization. |
+| Cancellation | Medium | Synchronous Python loops can be interrupted. JS functions called from Python or blocking handlers must cooperate by checking interrupts. |
+| stdout/stderr | High | Pyodide exposes standard stream handlers. A production implementation can enforce the same 64KB combined output limit in those handlers. |
+| Result serialization | High for JSON values | The spike serializes results through Python `json.dumps()`. Production should require JSON-serializable return values and normalize errors. |
+| Virtual FS reset | Medium | Pyodide uses an in-memory FS by default. Fresh workers isolate it; pooled workers need explicit cleanup and tests. Do not mount `NODEFS` or native FS handles for sandboxed execution. |
+| Global state reset | Medium | Fresh workers isolate globals. Pooled workers need explicit namespace reset and tests. |
+| Import control | Low to medium | Pyodide does not directly provide the desired import allowlist contract. Production needs a Python import hook, AST/static screening, or a restricted execution wrapper, and still must treat this as policy enforcement rather than a full security boundary. |
+| Network | Low to medium | The Python runtime should not receive JS modules or host APIs that expose network access. Any package loading must be disabled or constrained before user code runs. |
+
+## Implementation Constraints
+
+- Run Python/Pyodide in a dedicated worker, not on the Hono request thread.
+- Start the execution timeout after Pyodide is initialized, and report
+  initialization cost separately from execution duration.
+- Use `SharedArrayBuffer` and `pyodide.setInterruptBuffer()` for synchronous
+  Python cancellation.
+- Prefer fresh worker per execution for the first production spike. Pooling can
+  be considered later only with reset tests for globals, `/tmp`, loaded modules,
+  stream handlers, and interrupt state.
+- Set stdin to an erroring handler so sandboxed code cannot block on input.
+- Install stdout/stderr handlers that enforce the combined 64KB output limit.
+- Do not mount `NODEFS`, `WORKERFS`, `IDBFS`, or native file system handles.
+- Do not expose `fetch`, process, Bun, Node, or arbitrary JS modules to Python.
+- Treat import allowlisting as unresolved implementation work.
+
+## References
+
+- Pyodide Node/Bun usage: https://pyodide.org/en/stable/usage/index.html#node-js
+- Pyodide interrupt mechanism: https://pyodide.org/en/stable/usage/keyboard-interrupts.html
+- Pyodide standard streams: https://pyodide.org/en/stable/usage/streams.html
+- Pyodide file system behavior: https://pyodide.org/en/stable/usage/file-system.html
+- Pyodide JavaScript API: https://pyodide.org/en/stable/usage/api/js-api.html
+
+## Follow-up Implementation Issue Draft
+
+Title: `[execution-sandbox] Add constrained Python/Pyodide worker spike`
+
+Parent: #986
+Refs: #1000
+
+Objective:
+
+Implement a non-production Python runtime path behind the execution-worker
+contract to validate request/response shape, worker lifecycle, cancellation, and
+reset behavior with API-level tests.
+
+Scope:
+
+- Add `language: "python"` behind an experimental flag or spike-only route.
+- Run Pyodide in a dedicated worker.
+- Measure and return initialization and execution duration separately.
+- Enforce timeout default 1000ms and max 3000ms after initialization.
+- Capture stdout/stderr with the same 64KB combined output limit.
+- Serialize JSON-compatible results.
+- Terminate or replace the worker after each request.
+- Reject stdin reads.
+- Keep network, host filesystem, subprocess, package installation, and host JS
+  APIs unavailable.
+- Add tests for timeout, stdout/stderr, result serialization, globals reset,
+  virtual FS reset, and import policy behavior.
+
+Acceptance criteria:
+
+- Python execution returns the same success/error envelope shape as JavaScript.
+- A synchronous infinite loop returns `TIMEOUT` and the next request succeeds.
+- stdout/stderr/result behavior is covered by tests.
+- Globals and virtual FS files do not leak between requests.
+- Import policy behavior is documented and tested for the agreed allowlist.
+- The implementation is clearly marked as spike or experimental until security
+  review is complete.

--- a/projects/poc/execution-sandbox/docs/runtime-selection.md
+++ b/projects/poc/execution-sandbox/docs/runtime-selection.md
@@ -3,6 +3,8 @@
 Parent: #986
 Issue: #993
 
+Python/Pyodide Phase 2 investigation: `docs/pyodide-runtime-investigation.md`
+
 ## Decision
 
 Phase 1 should use TypeScript + Bun + Hono with `quickjs-emscripten` for

--- a/projects/poc/execution-sandbox/package.json
+++ b/projects/poc/execution-sandbox/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "scripts": {
     "dev": "bun run --hot src/server.ts",
+    "spike:pyodide": "bun run scripts/pyodide-spike.mjs",
     "test": "bun test",
     "typecheck": "tsc --noEmit"
   },
@@ -12,6 +13,7 @@
   },
   "devDependencies": {
     "@types/bun": "^1.2.18",
+    "pyodide": "^0.29.4",
     "typescript": "^5.8.3"
   }
 }

--- a/projects/poc/execution-sandbox/scripts/pyodide-spike.mjs
+++ b/projects/poc/execution-sandbox/scripts/pyodide-spike.mjs
@@ -1,0 +1,202 @@
+import { loadPyodide } from "pyodide";
+
+const TIMEOUT_MS = 1000;
+const WORKER_GRACE_MS = 5000;
+
+const environment = {
+  bun: Bun.version,
+  pyodide: "0.29.4",
+  platform: process.platform,
+  arch: process.arch,
+};
+
+const workerUrl = new URL("./pyodide-worker.mjs", import.meta.url);
+
+async function main() {
+  const inProcess = await runInProcessChecks();
+  const workerExecution = await runInFreshWorker({
+    input: { values: [1, 2, 3] },
+    timeoutMs: TIMEOUT_MS,
+    code: `
+import json
+import sys
+
+sandbox_input = json.loads(sandbox_input_json)
+print("received", len(sandbox_input["values"]))
+print("warning", file=sys.stderr)
+json.dumps({"sum": sum(sandbox_input["values"])})
+`,
+  });
+  const timeout = await runInFreshWorker({
+    input: null,
+    timeoutMs: TIMEOUT_MS,
+    code: `
+while True:
+    pass
+`,
+  });
+  const freshWorkerState = await verifyFreshWorkerState();
+
+  console.log(
+    JSON.stringify(
+      {
+        environment,
+        limitsCompared: {
+          timeoutDefaultMs: 1000,
+          timeoutMaxMs: 3000,
+          inputSizeMaxBytes: 1024 * 1024,
+          outputSizeMaxBytes: 64 * 1024,
+          network: "disabled by policy, not by Pyodide primitive",
+          hostFilesystem: "disabled only when running in an isolated worker without host FS bridges",
+          stateSharingAcrossRequests: "requires fresh worker/interpreter or explicit reset",
+        },
+        inProcess,
+        workerExecution,
+        timeout,
+        freshWorkerState,
+        decision: {
+          phase2: "proceed_with_constraints",
+          constraints: [
+            "Run Python/Pyodide in a dedicated worker so SharedArrayBuffer interrupts can stop CPU loops.",
+            "Terminate or replace the worker after each request unless a tested reset layer is added.",
+            "Expose only an import allowlist; Pyodide does not provide this contract directly.",
+            "Treat Pyodide as a resource isolation aid, not as a full security boundary.",
+          ],
+        },
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+async function runInProcessChecks() {
+  const startedAt = performance.now();
+  const pyodide = await loadPyodide();
+  const initializedMs = Math.round(performance.now() - startedAt);
+  const stdout = [];
+  const stderr = [];
+
+  pyodide.setStdin({ error: true });
+  pyodide.setStdout({ batched: (text) => stdout.push(`${text}\n`) });
+  pyodide.setStderr({ batched: (text) => stderr.push(`${text}\n`) });
+
+  const executionStartedAt = performance.now();
+  const resultJson = await pyodide.runPythonAsync(`
+import json
+import sys
+
+print("hello from pyodide")
+print("stderr from pyodide", file=sys.stderr)
+leaked_global = "still here"
+with open("/tmp/pyodide-spike-leak.txt", "w") as handle:
+    handle.write("leak")
+json.dumps({"ok": True, "value": 6})
+`);
+
+  const leaks = await pyodide.runPythonAsync(`
+import json
+import os
+
+json.dumps({
+    "globalLeaked": "leaked_global" in globals(),
+    "tmpFileLeaked": os.path.exists("/tmp/pyodide-spike-leak.txt"),
+    "mathImportAllowedByDefault": __import__("math").sqrt(9) == 3,
+})
+`);
+
+  return {
+    initializedMs,
+    executionMs: Math.round(performance.now() - executionStartedAt),
+    stdout: stdout.join(""),
+    stderr: stderr.join(""),
+    result: JSON.parse(resultJson),
+    leaksWithoutReset: JSON.parse(leaks),
+  };
+}
+
+async function runInFreshWorker({ code, input, timeoutMs }) {
+  const worker = new Worker(workerUrl, { type: "module" });
+  const interruptBuffer = new Uint8Array(new SharedArrayBuffer(1));
+  let timeoutId;
+  let hardKillId;
+
+  const result = await new Promise((resolve) => {
+    const hardKill = () => {
+      worker.terminate();
+      resolve({
+        status: "error",
+        timeoutMs,
+        error: {
+          name: "WorkerTimeout",
+          message: "worker did not stop after interrupt grace period",
+        },
+      });
+    };
+
+    hardKillId = setTimeout(hardKill, timeoutMs + WORKER_GRACE_MS + 10_000);
+
+    worker.onmessage = (event) => {
+      if (event.data.type === "ready") {
+        timeoutId = setTimeout(() => {
+          interruptBuffer[0] = 2;
+        }, timeoutMs);
+        clearTimeout(hardKillId);
+        hardKillId = setTimeout(hardKill, timeoutMs + WORKER_GRACE_MS);
+        worker.postMessage({ code, input, interruptBuffer });
+        return;
+      }
+
+      resolve(event.data);
+    };
+    worker.onerror = (error) =>
+      resolve({
+        status: "error",
+        error: {
+          name: "WorkerError",
+          message: error.message,
+        },
+      });
+  });
+
+  clearTimeout(timeoutId);
+  clearTimeout(hardKillId);
+  worker.terminate();
+  return result;
+}
+
+async function verifyFreshWorkerState() {
+  const first = await runInFreshWorker({
+    input: null,
+    timeoutMs: TIMEOUT_MS,
+    code: `
+import json
+
+leaked_global = "first request"
+with open("/tmp/pyodide-worker-leak.txt", "w") as handle:
+    handle.write("leak")
+json.dumps({"created": True})
+`,
+  });
+  const second = await runInFreshWorker({
+    input: null,
+    timeoutMs: TIMEOUT_MS,
+    code: `
+import json
+import os
+
+json.dumps({
+    "globalLeaked": "leaked_global" in globals(),
+    "tmpFileLeaked": os.path.exists("/tmp/pyodide-worker-leak.txt"),
+})
+`,
+  });
+
+  return {
+    first,
+    second,
+    isolated: second.status === "success" && JSON.parse(second.result).globalLeaked === false,
+  };
+}
+
+await main();

--- a/projects/poc/execution-sandbox/scripts/pyodide-worker.mjs
+++ b/projects/poc/execution-sandbox/scripts/pyodide-worker.mjs
@@ -1,65 +1,85 @@
 import { loadPyodide } from "pyodide";
 
 const startedAt = performance.now();
-let pyodide;
 let initializedMs = 0;
 
-try {
-  pyodide = await loadPyodide();
-  pyodide.setStdin({ error: true });
-  initializedMs = Math.round(performance.now() - startedAt);
-  globalThis.postMessage({ type: "ready", initializedMs });
-} catch (error) {
-  globalThis.postMessage({
-    type: "init-error",
-    status: "error",
-    error: {
-      name: error?.name ?? "Error",
-      message: error?.message ?? String(error),
-    },
-  });
+const pyodide = await loadPyodide().then(
+  (loadedPyodide) => {
+    loadedPyodide.setStdin({ error: true });
+    initializedMs = Math.round(performance.now() - startedAt);
+    globalThis.postMessage({ type: "ready", initializedMs });
+    return loadedPyodide;
+  },
+  (error) => {
+    globalThis.postMessage({
+      type: "init-error",
+      status: "error",
+      error: normalizeError(error),
+    });
+    globalThis.onmessage = null;
+    return null;
+  },
+);
+
+if (pyodide) {
+  globalThis.onmessage = (event) => {
+    const { code, input, interruptBuffer } = event.data;
+    const executionStartedAt = performance.now();
+    const stdout = [];
+    const stderr = [];
+
+    try {
+      pyodide.setInterruptBuffer(interruptBuffer);
+
+      pyodide.setStdout({ batched: (text) => stdout.push(`${text}\n`) });
+      pyodide.setStderr({ batched: (text) => stderr.push(`${text}\n`) });
+      pyodide.globals.set("sandbox_input_json", JSON.stringify(input ?? null));
+
+      const result = pyodide.runPython(code);
+
+      globalThis.postMessage({
+        type: "result",
+        status: "success",
+        initializedMs,
+        executionMs: Math.round(performance.now() - executionStartedAt),
+        totalMs: initializedMs + Math.round(performance.now() - executionStartedAt),
+        stdout: stdout.join(""),
+        stderr: stderr.join(""),
+        result,
+      });
+    } catch (error) {
+      globalThis.postMessage({
+        type: "result",
+        status: "error",
+        initializedMs,
+        executionMs: Math.round(performance.now() - executionStartedAt),
+        totalMs: initializedMs + Math.round(performance.now() - executionStartedAt),
+        stdout: stdout.join(""),
+        stderr: stderr.join(""),
+        error: normalizeError(error),
+      });
+    }
+  };
 }
 
-globalThis.onmessage = async (event) => {
-  const { code, input, interruptBuffer } = event.data;
-  const executionStartedAt = performance.now();
-  const stdout = [];
-  const stderr = [];
+function normalizeError(error) {
+  const message = error?.message ?? String(error);
+  const normalized = {
+    name: error?.name ?? "Error",
+    message,
+  };
 
-  try {
-    if (interruptBuffer) {
-      pyodide.setInterruptBuffer(interruptBuffer);
-    }
-
-    pyodide.setStdout({ batched: (text) => stdout.push(`${text}\n`) });
-    pyodide.setStderr({ batched: (text) => stderr.push(`${text}\n`) });
-    pyodide.globals.set("sandbox_input_json", JSON.stringify(input ?? null));
-
-    const result = pyodide.runPython(code);
-
-    globalThis.postMessage({
-      type: "result",
-      status: "success",
-      initializedMs,
-      executionMs: Math.round(performance.now() - executionStartedAt),
-      totalMs: initializedMs + Math.round(performance.now() - executionStartedAt),
-      stdout: stdout.join(""),
-      stderr: stderr.join(""),
-      result,
-    });
-  } catch (error) {
-    globalThis.postMessage({
-      type: "result",
-      status: "error",
-      initializedMs,
-      executionMs: Math.round(performance.now() - executionStartedAt),
-      totalMs: initializedMs + Math.round(performance.now() - executionStartedAt),
-      stdout: stdout.join(""),
-      stderr: stderr.join(""),
-      error: {
-        name: error?.name ?? "Error",
-        message: error?.message ?? String(error),
-      },
-    });
+  if (normalized.name === "PythonError") {
+    normalized.pythonException = extractPythonException(message);
   }
-};
+
+  return normalized;
+}
+
+function extractPythonException(message) {
+  return message
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .at(-1);
+}

--- a/projects/poc/execution-sandbox/scripts/pyodide-worker.mjs
+++ b/projects/poc/execution-sandbox/scripts/pyodide-worker.mjs
@@ -1,0 +1,65 @@
+import { loadPyodide } from "pyodide";
+
+const startedAt = performance.now();
+let pyodide;
+let initializedMs = 0;
+
+try {
+  pyodide = await loadPyodide();
+  pyodide.setStdin({ error: true });
+  initializedMs = Math.round(performance.now() - startedAt);
+  globalThis.postMessage({ type: "ready", initializedMs });
+} catch (error) {
+  globalThis.postMessage({
+    type: "init-error",
+    status: "error",
+    error: {
+      name: error?.name ?? "Error",
+      message: error?.message ?? String(error),
+    },
+  });
+}
+
+globalThis.onmessage = async (event) => {
+  const { code, input, interruptBuffer } = event.data;
+  const executionStartedAt = performance.now();
+  const stdout = [];
+  const stderr = [];
+
+  try {
+    if (interruptBuffer) {
+      pyodide.setInterruptBuffer(interruptBuffer);
+    }
+
+    pyodide.setStdout({ batched: (text) => stdout.push(`${text}\n`) });
+    pyodide.setStderr({ batched: (text) => stderr.push(`${text}\n`) });
+    pyodide.globals.set("sandbox_input_json", JSON.stringify(input ?? null));
+
+    const result = pyodide.runPython(code);
+
+    globalThis.postMessage({
+      type: "result",
+      status: "success",
+      initializedMs,
+      executionMs: Math.round(performance.now() - executionStartedAt),
+      totalMs: initializedMs + Math.round(performance.now() - executionStartedAt),
+      stdout: stdout.join(""),
+      stderr: stderr.join(""),
+      result,
+    });
+  } catch (error) {
+    globalThis.postMessage({
+      type: "result",
+      status: "error",
+      initializedMs,
+      executionMs: Math.round(performance.now() - executionStartedAt),
+      totalMs: initializedMs + Math.round(performance.now() - executionStartedAt),
+      stdout: stdout.join(""),
+      stderr: stderr.join(""),
+      error: {
+        name: error?.name ?? "Error",
+        message: error?.message ?? String(error),
+      },
+    });
+  }
+};


### PR DESCRIPTION
## Issues

- Close #1000

## Why

Python/Pyodide is a Phase 2 candidate for `execution-worker`, but the project needs a repeatable way to judge lifecycle cost, cancellation, stdout/stderr/result handling, virtual FS reset, global state reset, and import-control risk before adding production Python support.

## Summary

This PR adds a repeatable Pyodide spike command and records the Phase 2 decision as `proceed_with_constraints`.

## Changes

- Add `bun run spike:pyodide` with a Bun worker-based Pyodide cancellation and isolation spike.
- Add `docs/pyodide-runtime-investigation.md` with measured results, constraints, references, and a follow-up implementation issue draft.
- Add the `pyodide` dev dependency and link the investigation from the execution sandbox README/runtime selection docs.

## Verification

- `bun test` - passed
- `bun run typecheck` - passed
- `bun run spike:pyodide` - passed
- `./scripts/check-licenses --target projects/poc/execution-sandbox` - passed
