### PR TITLE
Add initial raw WebGL2 shader sample

### DIFF
--- a/projects/labs/raw-webgl2-shader/README.md
+++ b/projects/labs/raw-webgl2-shader/README.md
@@ -1,0 +1,25 @@
+# Raw WebGL2 Shader Lab
+
+依存なしの WebGL2 最小ひな型です。頂点シェーダーとフラグメントシェーダーは `src/main.js` 内の文字列として定義しています。
+
+## Run
+
+そのまま `index.html` をブラウザで開けます。
+
+WSL2 から Windows ブラウザで見る場合は、以下でも起動できます。
+
+```bash
+python3 -m http.server 5173
+```
+
+その後、Windows 側の Chrome / Edge で開きます。
+
+```text
+http://localhost:5173
+```
+
+## Edit Points
+
+- `vertexShaderSource`: 頂点位置、変形、varying の実験
+- `fragmentShaderSource`: 色、時間変化、ピクセル単位の表現
+- `vertices`: 頂点座標と頂点カラー

--- a/projects/labs/raw-webgl2-shader/index.html
+++ b/projects/labs/raw-webgl2-shader/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Raw WebGL2 Shader Lab</title>
+    <link rel="stylesheet" href="./src/styles.css" />
+  </head>
+  <body>
+    <canvas id="gl-canvas" aria-label="WebGL2 shader canvas"></canvas>
+    <div class="hud">
+      <strong>Raw WebGL2</strong>
+      <span>vertex + fragment shader</span>
+    </div>
+    <script src="./src/main.js"></script>
+  </body>
+</html>

--- a/projects/labs/raw-webgl2-shader/src/main.js
+++ b/projects/labs/raw-webgl2-shader/src/main.js
@@ -1,0 +1,160 @@
+"use strict";
+
+const canvas = document.querySelector("#gl-canvas");
+const gl = canvas.getContext("webgl2", { antialias: true });
+
+if (!gl) {
+  throw new Error("WebGL2 is not supported by this browser.");
+}
+
+const vertexShaderSource = `#version 300 es
+precision highp float;
+
+in vec3 a_position;
+in vec3 a_color;
+
+uniform float u_time;
+uniform vec2 u_resolution;
+
+out vec3 v_color;
+out float v_wave;
+
+void main() {
+  vec3 pos = a_position;
+
+  float wave = sin((pos.x * 5.0) + u_time * 2.0) * 0.08;
+  pos.y += wave;
+
+  float aspect = u_resolution.x / u_resolution.y;
+  pos.x /= aspect;
+
+  gl_Position = vec4(pos, 1.0);
+  v_color = a_color;
+  v_wave = wave;
+}
+`;
+
+const fragmentShaderSource = `#version 300 es
+precision highp float;
+
+in vec3 v_color;
+in float v_wave;
+
+uniform float u_time;
+
+out vec4 outColor;
+
+void main() {
+  float pulse = 0.65 + 0.35 * sin(u_time + v_wave * 18.0);
+  vec3 color = v_color * pulse;
+  outColor = vec4(color, 1.0);
+}
+`;
+
+const vertices = new Float32Array([
+  // x, y, z, r, g, b
+  -0.7, -0.55, 0.0, 0.95, 0.25, 0.28,
+  0.7, -0.55, 0.0, 0.18, 0.72, 0.95,
+  0.0, 0.65, 0.0, 1.0, 0.82, 0.28,
+]);
+
+const program = createProgram(gl, vertexShaderSource, fragmentShaderSource);
+const vao = gl.createVertexArray();
+const vertexBuffer = gl.createBuffer();
+
+const positionLocation = gl.getAttribLocation(program, "a_position");
+const colorLocation = gl.getAttribLocation(program, "a_color");
+const timeLocation = gl.getUniformLocation(program, "u_time");
+const resolutionLocation = gl.getUniformLocation(program, "u_resolution");
+
+gl.bindVertexArray(vao);
+gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer);
+gl.bufferData(gl.ARRAY_BUFFER, vertices, gl.STATIC_DRAW);
+
+const stride = 6 * Float32Array.BYTES_PER_ELEMENT;
+
+gl.enableVertexAttribArray(positionLocation);
+gl.vertexAttribPointer(positionLocation, 3, gl.FLOAT, false, stride, 0);
+
+gl.enableVertexAttribArray(colorLocation);
+gl.vertexAttribPointer(
+  colorLocation,
+  3,
+  gl.FLOAT,
+  false,
+  stride,
+  3 * Float32Array.BYTES_PER_ELEMENT,
+);
+
+gl.bindVertexArray(null);
+gl.bindBuffer(gl.ARRAY_BUFFER, null);
+
+function render(now) {
+  const time = now * 0.001;
+
+  resizeCanvasToDisplaySize(canvas);
+  gl.viewport(0, 0, canvas.width, canvas.height);
+  gl.clearColor(0.06, 0.07, 0.08, 1.0);
+  gl.clear(gl.COLOR_BUFFER_BIT);
+
+  gl.useProgram(program);
+  gl.bindVertexArray(vao);
+  gl.uniform1f(timeLocation, time);
+  gl.uniform2f(resolutionLocation, canvas.width, canvas.height);
+  gl.drawArrays(gl.TRIANGLES, 0, 3);
+
+  requestAnimationFrame(render);
+}
+
+requestAnimationFrame(render);
+
+function createProgram(glContext, vertexSource, fragmentSource) {
+  const vertexShader = compileShader(glContext, glContext.VERTEX_SHADER, vertexSource);
+  const fragmentShader = compileShader(
+    glContext,
+    glContext.FRAGMENT_SHADER,
+    fragmentSource,
+  );
+  const shaderProgram = glContext.createProgram();
+
+  glContext.attachShader(shaderProgram, vertexShader);
+  glContext.attachShader(shaderProgram, fragmentShader);
+  glContext.linkProgram(shaderProgram);
+
+  if (!glContext.getProgramParameter(shaderProgram, glContext.LINK_STATUS)) {
+    const info = glContext.getProgramInfoLog(shaderProgram);
+    glContext.deleteProgram(shaderProgram);
+    throw new Error(`Program link failed:\n${info}`);
+  }
+
+  glContext.deleteShader(vertexShader);
+  glContext.deleteShader(fragmentShader);
+
+  return shaderProgram;
+}
+
+function compileShader(glContext, type, source) {
+  const shader = glContext.createShader(type);
+
+  glContext.shaderSource(shader, source);
+  glContext.compileShader(shader);
+
+  if (!glContext.getShaderParameter(shader, glContext.COMPILE_STATUS)) {
+    const info = glContext.getShaderInfoLog(shader);
+    glContext.deleteShader(shader);
+    throw new Error(`Shader compile failed:\n${info}`);
+  }
+
+  return shader;
+}
+
+function resizeCanvasToDisplaySize(targetCanvas) {
+  const pixelRatio = window.devicePixelRatio || 1;
+  const width = Math.floor(targetCanvas.clientWidth * pixelRatio);
+  const height = Math.floor(targetCanvas.clientHeight * pixelRatio);
+
+  if (targetCanvas.width !== width || targetCanvas.height !== height) {
+    targetCanvas.width = width;
+    targetCanvas.height = height;
+  }
+}

--- a/projects/labs/raw-webgl2-shader/src/styles.css
+++ b/projects/labs/raw-webgl2-shader/src/styles.css
@@ -1,0 +1,44 @@
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  overflow: hidden;
+  background: #101114;
+  color: #f4f1ea;
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+}
+
+canvas {
+  display: block;
+  width: 100vw;
+  height: 100vh;
+}
+
+.hud {
+  position: fixed;
+  left: 16px;
+  top: 16px;
+  display: grid;
+  gap: 2px;
+  padding: 10px 12px;
+  border: 1px solid rgb(255 255 255 / 14%);
+  background: rgb(16 17 20 / 72%);
+  backdrop-filter: blur(10px);
+  font-size: 13px;
+}
+
+.hud strong {
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.hud span {
+  color: rgb(244 241 234 / 72%);
+}


### PR DESCRIPTION
## Issues

- Refs N/A

## Why

Add a minimal raw WebGL2 sample in the labs area so shader experiments can start from a dependency-free baseline.

## Summary

This PR adds a small WebGL2 starter that runs directly from `index.html`. It includes inline vertex and fragment shaders, fullscreen canvas styling, and a short README with local run notes.

## Changes

- add `index.html` with a fullscreen canvas and simple HUD
- add `src/main.js` with WebGL2 setup, shader compilation, uniforms, and animated triangle rendering
- add `src/styles.css` for fullscreen layout and HUD styling
- add `README.md` with usage and edit points

## Checklist

- [ ] フォーマット
- [ ] リント / 型チェック
- [ ] テスト
