### PR TITLE
Refactor raw-webgl2-shader shader source separation

### DIFF
--- a/projects/labs/raw-webgl2-shader/README.md
+++ b/projects/labs/raw-webgl2-shader/README.md
@@ -1,6 +1,6 @@
 # Raw WebGL2 Shader Lab
 
-依存なしの WebGL2 最小ひな型です。頂点シェーダーとフラグメントシェーダーは `src/main.js` 内の文字列として定義しています。
+依存なしの WebGL2 最小ひな型です。頂点シェーダーとフラグメントシェーダーは `src/shaders.js` 内の文字列として定義しています。
 
 ## Run
 
@@ -20,6 +20,5 @@ http://localhost:5173
 
 ## Edit Points
 
-- `vertexShaderSource`: 頂点位置、変形、varying の実験
-- `fragmentShaderSource`: 色、時間変化、ピクセル単位の表現
+- `src/shaders.js`: 頂点シェーダーとフラグメントシェーダー
 - `vertices`: 頂点座標と頂点カラー

--- a/projects/labs/raw-webgl2-shader/index.html
+++ b/projects/labs/raw-webgl2-shader/index.html
@@ -12,6 +12,7 @@
       <strong>Raw WebGL2</strong>
       <span>vertex + fragment shader</span>
     </div>
+    <script src="./src/shaders.js"></script>
     <script src="./src/main.js"></script>
   </body>
 </html>

--- a/projects/labs/raw-webgl2-shader/src/main.js
+++ b/projects/labs/raw-webgl2-shader/src/main.js
@@ -7,50 +7,6 @@ if (!gl) {
   throw new Error("WebGL2 is not supported by this browser.");
 }
 
-const vertexShaderSource = `#version 300 es
-precision highp float;
-
-in vec3 a_position;
-in vec3 a_color;
-
-uniform float u_time;
-uniform vec2 u_resolution;
-
-out vec3 v_color;
-out float v_wave;
-
-void main() {
-  vec3 pos = a_position;
-
-  float wave = sin((pos.x * 5.0) + u_time * 2.0) * 0.08;
-  pos.y += wave;
-
-  float aspect = u_resolution.x / u_resolution.y;
-  pos.x /= aspect;
-
-  gl_Position = vec4(pos, 1.0);
-  v_color = a_color;
-  v_wave = wave;
-}
-`;
-
-const fragmentShaderSource = `#version 300 es
-precision highp float;
-
-in vec3 v_color;
-in float v_wave;
-
-uniform float u_time;
-
-out vec4 outColor;
-
-void main() {
-  float pulse = 0.65 + 0.35 * sin(u_time + v_wave * 18.0);
-  vec3 color = v_color * pulse;
-  outColor = vec4(color, 1.0);
-}
-`;
-
 const vertices = new Float32Array([
   // x, y, z, r, g, b
   -0.7, -0.55, 0.0, 0.95, 0.25, 0.28,
@@ -58,7 +14,8 @@ const vertices = new Float32Array([
   0.0, 0.65, 0.0, 1.0, 0.82, 0.28,
 ]);
 
-const program = createProgram(gl, vertexShaderSource, fragmentShaderSource);
+const { vertex, fragment } = window.shaderSources;
+const program = createProgram(gl, vertex, fragment);
 const vao = gl.createVertexArray();
 const vertexBuffer = gl.createBuffer();
 

--- a/projects/labs/raw-webgl2-shader/src/shaders.js
+++ b/projects/labs/raw-webgl2-shader/src/shaders.js
@@ -1,0 +1,47 @@
+"use strict";
+
+window.shaderSources = {
+  vertex: `#version 300 es
+precision highp float;
+
+in vec3 a_position;
+in vec3 a_color;
+
+uniform float u_time;
+uniform vec2 u_resolution;
+
+out vec3 v_color;
+out float v_wave;
+
+void main() {
+  vec3 pos = a_position;
+
+  float wave = sin((pos.x * 5.0) + u_time * 2.0) * 0.08;
+  pos.y += wave;
+
+  float aspect = u_resolution.x / u_resolution.y;
+  pos.x /= aspect;
+
+  gl_Position = vec4(pos, 1.0);
+  v_color = a_color;
+  v_wave = wave;
+}
+`,
+
+  fragment: `#version 300 es
+precision highp float;
+
+in vec3 v_color;
+in float v_wave;
+
+uniform float u_time;
+
+out vec4 outColor;
+
+void main() {
+  float pulse = 0.65 + 0.35 * sin(u_time + v_wave * 18.0);
+  vec3 color = v_color * pulse;
+  outColor = vec4(color, 1.0);
+}
+`,
+};


### PR DESCRIPTION
## Why

`src/main.js` に shader 文字列を直書きしており、描画ロジックと shader 定義の見通しが悪くなっていました。shader を別ファイルへ分離しつつ、`index.html` を直接開く運用を壊さない構成に揃えるためです。

## Summary

shader 定義を `src/shaders.js` へ切り出し、`main.js` は `window.shaderSources` を参照するように変更しました。あわせて README の編集ポイント説明も更新しています。

## Changes

- 頂点 shader / fragment shader を `src/shaders.js` に分離
- `index.html` で `src/shaders.js` を `src/main.js` より先に読み込むよう変更
- `main.js` から shader 文字列を削除し、`window.shaderSources` を参照するよう変更
- README の説明を現在の構成に合わせて更新

## Checklist

- [x] `node --check src/shaders.js`
- [x] `node --check src/main.js`
- [ ] ブラウザでの表示確認
