### PR TITLE
Add 3D axes to WebGL shader lab

### DIFF
--- a/projects/labs/raw-webgl2-shader/src/main.js
+++ b/projects/labs/raw-webgl2-shader/src/main.js
@@ -9,56 +9,74 @@ if (!gl) {
 
 const vertices = new Float32Array([
   // x, y, z, r, g, b
-  -0.7, -0.55, 0.0, 0.95, 0.25, 0.28,
-  0.7, -0.55, 0.0, 0.18, 0.72, 0.95,
-  0.0, 0.65, 0.0, 1.0, 0.82, 0.28,
+  -0.48, 0.0, -0.32, 0.95, 0.25, 0.28,
+  0.48, 0.0, -0.32, 0.18, 0.72, 0.95,
+  0.0, 0.0, 0.42, 1.0, 0.82, 0.28,
+]);
+
+const axisVertices = new Float32Array([
+  // x axis: red
+  -0.9, 0.0, 0.0, 1.0, 0.18, 0.18,
+  0.9, 0.0, 0.0, 1.0, 0.18, 0.18,
+
+  // y axis: green
+  0.0, -0.9, 0.0, 0.24, 0.9, 0.35,
+  0.0, 0.9, 0.0, 0.24, 0.9, 0.35,
+
+  // z axis: blue
+  0.0, 0.0, -0.9, 0.28, 0.55, 1.0,
+  0.0, 0.0, 0.9, 0.28, 0.55, 1.0,
 ]);
 
 const { vertex, fragment } = window.shaderSources;
 const program = createProgram(gl, vertex, fragment);
-const vao = gl.createVertexArray();
-const vertexBuffer = gl.createBuffer();
+const triangle = createGeometry(gl, vertices);
+const axes = createGeometry(gl, axisVertices);
 
 const positionLocation = gl.getAttribLocation(program, "a_position");
 const colorLocation = gl.getAttribLocation(program, "a_color");
 const timeLocation = gl.getUniformLocation(program, "u_time");
-const resolutionLocation = gl.getUniformLocation(program, "u_resolution");
-
-gl.bindVertexArray(vao);
-gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer);
-gl.bufferData(gl.ARRAY_BUFFER, vertices, gl.STATIC_DRAW);
-
+const matrixLocation = gl.getUniformLocation(program, "u_matrix");
+const waveStrengthLocation = gl.getUniformLocation(program, "u_wave_strength");
+const pulseStrengthLocation = gl.getUniformLocation(program, "u_pulse_strength");
 const stride = 6 * Float32Array.BYTES_PER_ELEMENT;
 
-gl.enableVertexAttribArray(positionLocation);
-gl.vertexAttribPointer(positionLocation, 3, gl.FLOAT, false, stride, 0);
+bindGeometry(gl, triangle, positionLocation, colorLocation);
+bindGeometry(gl, axes, positionLocation, colorLocation);
 
-gl.enableVertexAttribArray(colorLocation);
-gl.vertexAttribPointer(
-  colorLocation,
-  3,
-  gl.FLOAT,
-  false,
-  stride,
-  3 * Float32Array.BYTES_PER_ELEMENT,
-);
+const triangleVertexCount = vertices.length / 6;
+const axisVertexCount = axisVertices.length / 6;
 
-gl.bindVertexArray(null);
-gl.bindBuffer(gl.ARRAY_BUFFER, null);
+gl.enable(gl.DEPTH_TEST);
+gl.depthFunc(gl.LEQUAL);
 
 function render(now) {
   const time = now * 0.001;
 
   resizeCanvasToDisplaySize(canvas);
+  const aspect = canvas.width / canvas.height;
+  const projectionMatrix = makeOrthographicMatrix(-aspect, aspect, -1, 1, 0.1, 10);
+  const viewMatrix = makeLookAtMatrix([1.6, 1.6, 1.6], [0, 0, 0], [0, 1, 0]);
+  const matrix = multiplyMatrices(projectionMatrix, viewMatrix);
+
   gl.viewport(0, 0, canvas.width, canvas.height);
   gl.clearColor(0.06, 0.07, 0.08, 1.0);
-  gl.clear(gl.COLOR_BUFFER_BIT);
+  gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
 
   gl.useProgram(program);
-  gl.bindVertexArray(vao);
   gl.uniform1f(timeLocation, time);
-  gl.uniform2f(resolutionLocation, canvas.width, canvas.height);
-  gl.drawArrays(gl.TRIANGLES, 0, 3);
+  gl.uniformMatrix4fv(matrixLocation, false, matrix);
+
+  gl.bindVertexArray(axes.vao);
+  gl.uniform1f(waveStrengthLocation, 0.0);
+  gl.uniform1f(pulseStrengthLocation, 0.0);
+  gl.lineWidth(2);
+  gl.drawArrays(gl.LINES, 0, axisVertexCount);
+
+  gl.bindVertexArray(triangle.vao);
+  gl.uniform1f(waveStrengthLocation, 0.08);
+  gl.uniform1f(pulseStrengthLocation, 1.0);
+  gl.drawArrays(gl.TRIANGLES, 0, triangleVertexCount);
 
   requestAnimationFrame(render);
 }
@@ -103,6 +121,128 @@ function compileShader(glContext, type, source) {
   }
 
   return shader;
+}
+
+function createGeometry(glContext, data) {
+  const vao = glContext.createVertexArray();
+  const buffer = glContext.createBuffer();
+
+  glContext.bindVertexArray(vao);
+  glContext.bindBuffer(glContext.ARRAY_BUFFER, buffer);
+  glContext.bufferData(glContext.ARRAY_BUFFER, data, glContext.STATIC_DRAW);
+  glContext.bindVertexArray(null);
+  glContext.bindBuffer(glContext.ARRAY_BUFFER, null);
+
+  return { vao, buffer };
+}
+
+function bindGeometry(glContext, geometry, positionLocation, colorLocation) {
+  glContext.bindVertexArray(geometry.vao);
+  glContext.bindBuffer(glContext.ARRAY_BUFFER, geometry.buffer);
+
+  glContext.enableVertexAttribArray(positionLocation);
+  glContext.vertexAttribPointer(positionLocation, 3, glContext.FLOAT, false, stride, 0);
+
+  glContext.enableVertexAttribArray(colorLocation);
+  glContext.vertexAttribPointer(
+    colorLocation,
+    3,
+    glContext.FLOAT,
+    false,
+    stride,
+    3 * Float32Array.BYTES_PER_ELEMENT,
+  );
+
+  glContext.bindVertexArray(null);
+  glContext.bindBuffer(glContext.ARRAY_BUFFER, null);
+}
+
+function makeOrthographicMatrix(left, right, bottom, top, near, far) {
+  return new Float32Array([
+    2 / (right - left),
+    0,
+    0,
+    0,
+    0,
+    2 / (top - bottom),
+    0,
+    0,
+    0,
+    0,
+    2 / (near - far),
+    0,
+    (left + right) / (left - right),
+    (bottom + top) / (bottom - top),
+    (near + far) / (near - far),
+    1,
+  ]);
+}
+
+function makeLookAtMatrix(eye, target, up) {
+  const zAxis = normalize(subtractVectors(eye, target));
+  const xAxis = normalize(cross(up, zAxis));
+  const yAxis = cross(zAxis, xAxis);
+
+  return new Float32Array([
+    xAxis[0],
+    yAxis[0],
+    zAxis[0],
+    0,
+    xAxis[1],
+    yAxis[1],
+    zAxis[1],
+    0,
+    xAxis[2],
+    yAxis[2],
+    zAxis[2],
+    0,
+    -dot(xAxis, eye),
+    -dot(yAxis, eye),
+    -dot(zAxis, eye),
+    1,
+  ]);
+}
+
+function multiplyMatrices(a, b) {
+  const result = new Float32Array(16);
+
+  for (let row = 0; row < 4; row += 1) {
+    for (let column = 0; column < 4; column += 1) {
+      result[column * 4 + row] =
+        a[row] * b[column * 4] +
+        a[4 + row] * b[column * 4 + 1] +
+        a[8 + row] * b[column * 4 + 2] +
+        a[12 + row] * b[column * 4 + 3];
+    }
+  }
+
+  return result;
+}
+
+function subtractVectors(a, b) {
+  return [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
+}
+
+function normalize(vector) {
+  const length = Math.hypot(vector[0], vector[1], vector[2]);
+
+  if (length === 0) {
+    return [0, 0, 0];
+  }
+
+  return [vector[0] / length, vector[1] / length, vector[2] / length];
+}
+
+function cross(a, b) {
+  return [
+    a[1] * b[2] - a[2] * b[1],
+    a[2] * b[0] - a[0] * b[2],
+    a[0] * b[1] - a[1] * b[0],
+  ];
+}
+
+function dot(a, b) {
+  return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
 }
 
 function resizeCanvasToDisplaySize(targetCanvas) {

--- a/projects/labs/raw-webgl2-shader/src/shaders.js
+++ b/projects/labs/raw-webgl2-shader/src/shaders.js
@@ -8,7 +8,8 @@ in vec3 a_position;
 in vec3 a_color;
 
 uniform float u_time;
-uniform vec2 u_resolution;
+uniform mat4 u_matrix;
+uniform float u_wave_strength;
 
 out vec3 v_color;
 out float v_wave;
@@ -16,13 +17,10 @@ out float v_wave;
 void main() {
   vec3 pos = a_position;
 
-  float wave = sin((pos.x * 5.0) + u_time * 2.0) * 0.08;
+  float wave = sin((pos.x * 5.0) + u_time * 2.0) * u_wave_strength;
   pos.y += wave;
 
-  float aspect = u_resolution.x / u_resolution.y;
-  pos.x /= aspect;
-
-  gl_Position = vec4(pos, 1.0);
+  gl_Position = u_matrix * vec4(pos, 1.0);
   v_color = a_color;
   v_wave = wave;
 }
@@ -35,11 +33,13 @@ in vec3 v_color;
 in float v_wave;
 
 uniform float u_time;
+uniform float u_pulse_strength;
 
 out vec4 outColor;
 
 void main() {
-  float pulse = 0.65 + 0.35 * sin(u_time + v_wave * 18.0);
+  float animatedPulse = 0.65 + 0.35 * sin(u_time + v_wave * 18.0);
+  float pulse = mix(1.0, animatedPulse, u_pulse_strength);
   vec3 color = v_color * pulse;
   outColor = vec4(color, 1.0);
 }


### PR DESCRIPTION
## Issues

- None

## Why

WebGL2 shader lab で X/Y/Z 軸と XZ 平面上の三角形を同じ 3D 空間として確認できるようにするため。

## Summary

軸線と三角形を別ジオメトリとして描画し、手書きの疑似投影から view/projection matrix による 3D 投影へ切り替えます。軸の見かけの偏りを抑えるため、等角寄りの正射影カメラに調整しています。

## Changes

- X/Y/Z 軸の Line ジオメトリを追加
- 三角形を XZ 平面上に配置
- view/projection matrix と深度テストを導入
- 軸は先に描画し、三角形は波打ちと色の pulse を維持
- 等角寄りの正射影カメラで軸の見え方を調整

## Checklist

- [x] 構文チェック: `node --check src/main.js`
- [x] 構文チェック: `node --check src/shaders.js`
- [ ] ブラウザでの目視確認
