### PR TITLE
Refactor WebGL shader lab game loop

### DIFF
--- a/projects/labs/raw-webgl2-shader/README.md
+++ b/projects/labs/raw-webgl2-shader/README.md
@@ -4,9 +4,7 @@
 
 ## Run
 
-そのまま `index.html` をブラウザで開けます。
-
-WSL2 から Windows ブラウザで見る場合は、以下でも起動できます。
+ES Modules を使っているため、ローカルサーバーで起動します。
 
 ```bash
 python3 -m http.server 5173
@@ -20,5 +18,9 @@ http://localhost:5173
 
 ## Edit Points
 
+- `src/main.js`: game loop と状態更新
+- `src/hud.js`: FPS などの画面表示
+- `src/renderer.js`: WebGL の初期化と描画処理
+- `src/webgl.js`: WebGL の低レベルな補助関数
+- `src/math.js`: 行列・ベクトル計算
 - `src/shaders.js`: 頂点シェーダーとフラグメントシェーダー
-- `vertices`: 頂点座標と頂点カラー

--- a/projects/labs/raw-webgl2-shader/index.html
+++ b/projects/labs/raw-webgl2-shader/index.html
@@ -11,8 +11,8 @@
     <div class="hud">
       <strong>Raw WebGL2</strong>
       <span>vertex + fragment shader</span>
+      <span id="fps-counter">-- FPS</span>
     </div>
-    <script src="./src/shaders.js"></script>
-    <script src="./src/main.js"></script>
+    <script type="module" src="./src/main.js"></script>
   </body>
 </html>

--- a/projects/labs/raw-webgl2-shader/src/hud.js
+++ b/projects/labs/raw-webgl2-shader/src/hud.js
@@ -1,0 +1,28 @@
+const FPS_UPDATE_INTERVAL = 0.25;
+
+export function createFpsCounter(element) {
+  if (!element) {
+    return {
+      update() {},
+    };
+  }
+
+  let elapsedTime = 0;
+  let frameCount = 0;
+
+  return {
+    update(deltaTime) {
+      elapsedTime += deltaTime;
+      frameCount += 1;
+
+      if (elapsedTime < FPS_UPDATE_INTERVAL) {
+        return;
+      }
+
+      const fps = Math.round(frameCount / elapsedTime);
+      element.textContent = `${fps} FPS`;
+      elapsedTime = 0;
+      frameCount = 0;
+    },
+  };
+}

--- a/projects/labs/raw-webgl2-shader/src/main.js
+++ b/projects/labs/raw-webgl2-shader/src/main.js
@@ -1,257 +1,38 @@
-"use strict";
+import { createFpsCounter } from "./hud.js";
+import { createRenderer } from "./renderer.js";
 
 const canvas = document.querySelector("#gl-canvas");
-const gl = canvas.getContext("webgl2", { antialias: true });
 
-if (!gl) {
-  throw new Error("WebGL2 is not supported by this browser.");
+if (!canvas) {
+  throw new Error("Canvas element #gl-canvas was not found.");
 }
 
-const vertices = new Float32Array([
-  // x, y, z, r, g, b
-  -0.48, 0.0, -0.32, 0.95, 0.25, 0.28,
-  0.48, 0.0, -0.32, 0.18, 0.72, 0.95,
-  0.0, 0.0, 0.42, 1.0, 0.82, 0.28,
-]);
+const renderer = createRenderer(canvas);
+const fpsCounter = createFpsCounter(document.querySelector("#fps-counter"));
 
-const axisVertices = new Float32Array([
-  // x axis: red
-  -0.9, 0.0, 0.0, 1.0, 0.18, 0.18,
-  0.9, 0.0, 0.0, 1.0, 0.18, 0.18,
+const gameState = {
+  time: 0,
+  deltaTime: 0,
+};
 
-  // y axis: green
-  0.0, -0.9, 0.0, 0.24, 0.9, 0.35,
-  0.0, 0.9, 0.0, 0.24, 0.9, 0.35,
+let lastFrameTime = null;
 
-  // z axis: blue
-  0.0, 0.0, -0.9, 0.28, 0.55, 1.0,
-  0.0, 0.0, 0.9, 0.28, 0.55, 1.0,
-]);
+function update(deltaTime, time) {
+  gameState.deltaTime = deltaTime;
+  gameState.time = time;
+}
 
-const { vertex, fragment } = window.shaderSources;
-const program = createProgram(gl, vertex, fragment);
-const triangle = createGeometry(gl, vertices);
-const axes = createGeometry(gl, axisVertices);
-
-const positionLocation = gl.getAttribLocation(program, "a_position");
-const colorLocation = gl.getAttribLocation(program, "a_color");
-const timeLocation = gl.getUniformLocation(program, "u_time");
-const matrixLocation = gl.getUniformLocation(program, "u_matrix");
-const waveStrengthLocation = gl.getUniformLocation(program, "u_wave_strength");
-const pulseStrengthLocation = gl.getUniformLocation(program, "u_pulse_strength");
-const stride = 6 * Float32Array.BYTES_PER_ELEMENT;
-
-bindGeometry(gl, triangle, positionLocation, colorLocation);
-bindGeometry(gl, axes, positionLocation, colorLocation);
-
-const triangleVertexCount = vertices.length / 6;
-const axisVertexCount = axisVertices.length / 6;
-
-gl.enable(gl.DEPTH_TEST);
-gl.depthFunc(gl.LEQUAL);
-
-function render(now) {
+function gameLoop(now) {
   const time = now * 0.001;
+  const deltaTime =
+    lastFrameTime === null ? 0 : Math.min((now - lastFrameTime) * 0.001, 0.05);
+  lastFrameTime = now;
 
-  resizeCanvasToDisplaySize(canvas);
-  const aspect = canvas.width / canvas.height;
-  const projectionMatrix = makeOrthographicMatrix(-aspect, aspect, -1, 1, 0.1, 10);
-  const viewMatrix = makeLookAtMatrix([1.6, 1.6, 1.6], [0, 0, 0], [0, 1, 0]);
-  const matrix = multiplyMatrices(projectionMatrix, viewMatrix);
+  update(deltaTime, time);
+  fpsCounter.update(deltaTime);
+  renderer.render(gameState);
 
-  gl.viewport(0, 0, canvas.width, canvas.height);
-  gl.clearColor(0.06, 0.07, 0.08, 1.0);
-  gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-
-  gl.useProgram(program);
-  gl.uniform1f(timeLocation, time);
-  gl.uniformMatrix4fv(matrixLocation, false, matrix);
-
-  gl.bindVertexArray(axes.vao);
-  gl.uniform1f(waveStrengthLocation, 0.0);
-  gl.uniform1f(pulseStrengthLocation, 0.0);
-  gl.lineWidth(2);
-  gl.drawArrays(gl.LINES, 0, axisVertexCount);
-
-  gl.bindVertexArray(triangle.vao);
-  gl.uniform1f(waveStrengthLocation, 0.08);
-  gl.uniform1f(pulseStrengthLocation, 1.0);
-  gl.drawArrays(gl.TRIANGLES, 0, triangleVertexCount);
-
-  requestAnimationFrame(render);
+  requestAnimationFrame(gameLoop);
 }
 
-requestAnimationFrame(render);
-
-function createProgram(glContext, vertexSource, fragmentSource) {
-  const vertexShader = compileShader(glContext, glContext.VERTEX_SHADER, vertexSource);
-  const fragmentShader = compileShader(
-    glContext,
-    glContext.FRAGMENT_SHADER,
-    fragmentSource,
-  );
-  const shaderProgram = glContext.createProgram();
-
-  glContext.attachShader(shaderProgram, vertexShader);
-  glContext.attachShader(shaderProgram, fragmentShader);
-  glContext.linkProgram(shaderProgram);
-
-  if (!glContext.getProgramParameter(shaderProgram, glContext.LINK_STATUS)) {
-    const info = glContext.getProgramInfoLog(shaderProgram);
-    glContext.deleteProgram(shaderProgram);
-    throw new Error(`Program link failed:\n${info}`);
-  }
-
-  glContext.deleteShader(vertexShader);
-  glContext.deleteShader(fragmentShader);
-
-  return shaderProgram;
-}
-
-function compileShader(glContext, type, source) {
-  const shader = glContext.createShader(type);
-
-  glContext.shaderSource(shader, source);
-  glContext.compileShader(shader);
-
-  if (!glContext.getShaderParameter(shader, glContext.COMPILE_STATUS)) {
-    const info = glContext.getShaderInfoLog(shader);
-    glContext.deleteShader(shader);
-    throw new Error(`Shader compile failed:\n${info}`);
-  }
-
-  return shader;
-}
-
-function createGeometry(glContext, data) {
-  const vao = glContext.createVertexArray();
-  const buffer = glContext.createBuffer();
-
-  glContext.bindVertexArray(vao);
-  glContext.bindBuffer(glContext.ARRAY_BUFFER, buffer);
-  glContext.bufferData(glContext.ARRAY_BUFFER, data, glContext.STATIC_DRAW);
-  glContext.bindVertexArray(null);
-  glContext.bindBuffer(glContext.ARRAY_BUFFER, null);
-
-  return { vao, buffer };
-}
-
-function bindGeometry(glContext, geometry, positionLocation, colorLocation) {
-  glContext.bindVertexArray(geometry.vao);
-  glContext.bindBuffer(glContext.ARRAY_BUFFER, geometry.buffer);
-
-  glContext.enableVertexAttribArray(positionLocation);
-  glContext.vertexAttribPointer(positionLocation, 3, glContext.FLOAT, false, stride, 0);
-
-  glContext.enableVertexAttribArray(colorLocation);
-  glContext.vertexAttribPointer(
-    colorLocation,
-    3,
-    glContext.FLOAT,
-    false,
-    stride,
-    3 * Float32Array.BYTES_PER_ELEMENT,
-  );
-
-  glContext.bindVertexArray(null);
-  glContext.bindBuffer(glContext.ARRAY_BUFFER, null);
-}
-
-function makeOrthographicMatrix(left, right, bottom, top, near, far) {
-  return new Float32Array([
-    2 / (right - left),
-    0,
-    0,
-    0,
-    0,
-    2 / (top - bottom),
-    0,
-    0,
-    0,
-    0,
-    2 / (near - far),
-    0,
-    (left + right) / (left - right),
-    (bottom + top) / (bottom - top),
-    (near + far) / (near - far),
-    1,
-  ]);
-}
-
-function makeLookAtMatrix(eye, target, up) {
-  const zAxis = normalize(subtractVectors(eye, target));
-  const xAxis = normalize(cross(up, zAxis));
-  const yAxis = cross(zAxis, xAxis);
-
-  return new Float32Array([
-    xAxis[0],
-    yAxis[0],
-    zAxis[0],
-    0,
-    xAxis[1],
-    yAxis[1],
-    zAxis[1],
-    0,
-    xAxis[2],
-    yAxis[2],
-    zAxis[2],
-    0,
-    -dot(xAxis, eye),
-    -dot(yAxis, eye),
-    -dot(zAxis, eye),
-    1,
-  ]);
-}
-
-function multiplyMatrices(a, b) {
-  const result = new Float32Array(16);
-
-  for (let row = 0; row < 4; row += 1) {
-    for (let column = 0; column < 4; column += 1) {
-      result[column * 4 + row] =
-        a[row] * b[column * 4] +
-        a[4 + row] * b[column * 4 + 1] +
-        a[8 + row] * b[column * 4 + 2] +
-        a[12 + row] * b[column * 4 + 3];
-    }
-  }
-
-  return result;
-}
-
-function subtractVectors(a, b) {
-  return [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
-}
-
-function normalize(vector) {
-  const length = Math.hypot(vector[0], vector[1], vector[2]);
-
-  if (length === 0) {
-    return [0, 0, 0];
-  }
-
-  return [vector[0] / length, vector[1] / length, vector[2] / length];
-}
-
-function cross(a, b) {
-  return [
-    a[1] * b[2] - a[2] * b[1],
-    a[2] * b[0] - a[0] * b[2],
-    a[0] * b[1] - a[1] * b[0],
-  ];
-}
-
-function dot(a, b) {
-  return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
-}
-
-function resizeCanvasToDisplaySize(targetCanvas) {
-  const pixelRatio = window.devicePixelRatio || 1;
-  const width = Math.floor(targetCanvas.clientWidth * pixelRatio);
-  const height = Math.floor(targetCanvas.clientHeight * pixelRatio);
-
-  if (targetCanvas.width !== width || targetCanvas.height !== height) {
-    targetCanvas.width = width;
-    targetCanvas.height = height;
-  }
-}
+requestAnimationFrame(gameLoop);

--- a/projects/labs/raw-webgl2-shader/src/math.js
+++ b/projects/labs/raw-webgl2-shader/src/math.js
@@ -1,0 +1,87 @@
+export function makeOrthographicMatrix(left, right, bottom, top, near, far) {
+  return new Float32Array([
+    2 / (right - left),
+    0,
+    0,
+    0,
+    0,
+    2 / (top - bottom),
+    0,
+    0,
+    0,
+    0,
+    2 / (near - far),
+    0,
+    (left + right) / (left - right),
+    (bottom + top) / (bottom - top),
+    (near + far) / (near - far),
+    1,
+  ]);
+}
+
+export function makeLookAtMatrix(eye, target, up) {
+  const zAxis = normalize(subtractVectors(eye, target));
+  const xAxis = normalize(cross(up, zAxis));
+  const yAxis = cross(zAxis, xAxis);
+
+  return new Float32Array([
+    xAxis[0],
+    yAxis[0],
+    zAxis[0],
+    0,
+    xAxis[1],
+    yAxis[1],
+    zAxis[1],
+    0,
+    xAxis[2],
+    yAxis[2],
+    zAxis[2],
+    0,
+    -dot(xAxis, eye),
+    -dot(yAxis, eye),
+    -dot(zAxis, eye),
+    1,
+  ]);
+}
+
+export function multiplyMatrices(a, b) {
+  const result = new Float32Array(16);
+
+  for (let row = 0; row < 4; row += 1) {
+    for (let column = 0; column < 4; column += 1) {
+      result[column * 4 + row] =
+        a[row] * b[column * 4] +
+        a[4 + row] * b[column * 4 + 1] +
+        a[8 + row] * b[column * 4 + 2] +
+        a[12 + row] * b[column * 4 + 3];
+    }
+  }
+
+  return result;
+}
+
+function subtractVectors(a, b) {
+  return [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
+}
+
+function normalize(vector) {
+  const length = Math.hypot(vector[0], vector[1], vector[2]);
+
+  if (length === 0) {
+    return [0, 0, 0];
+  }
+
+  return [vector[0] / length, vector[1] / length, vector[2] / length];
+}
+
+function cross(a, b) {
+  return [
+    a[1] * b[2] - a[2] * b[1],
+    a[2] * b[0] - a[0] * b[2],
+    a[0] * b[1] - a[1] * b[0],
+  ];
+}
+
+function dot(a, b) {
+  return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+}

--- a/projects/labs/raw-webgl2-shader/src/renderer.js
+++ b/projects/labs/raw-webgl2-shader/src/renderer.js
@@ -1,0 +1,138 @@
+import {
+  makeLookAtMatrix,
+  makeOrthographicMatrix,
+  multiplyMatrices,
+} from "./math.js";
+import { shaderSources } from "./shaders.js";
+import { createGeometry, createProgram, resizeCanvasToDisplaySize } from "./webgl.js";
+
+const FLOATS_PER_VERTEX = 6;
+const STRIDE = FLOATS_PER_VERTEX * Float32Array.BYTES_PER_ELEMENT;
+
+const triangleVertices = new Float32Array([
+  // x, y, z, r, g, b
+  -0.48, 0.0, -0.32, 0.95, 0.25, 0.28,
+  0.48, 0.0, -0.32, 0.18, 0.72, 0.95,
+  0.0, 0.0, 0.42, 1.0, 0.82, 0.28,
+]);
+
+const axisVertices = new Float32Array([
+  // x axis: red
+  -0.9, 0.0, 0.0, 1.0, 0.18, 0.18,
+  0.9, 0.0, 0.0, 1.0, 0.18, 0.18,
+
+  // y axis: green
+  0.0, -0.9, 0.0, 0.24, 0.9, 0.35,
+  0.0, 0.9, 0.0, 0.24, 0.9, 0.35,
+
+  // z axis: blue
+  0.0, 0.0, -0.9, 0.28, 0.55, 1.0,
+  0.0, 0.0, 0.9, 0.28, 0.55, 1.0,
+]);
+
+export function createRenderer(canvas) {
+  const gl = canvas.getContext("webgl2", { antialias: true });
+
+  if (!gl) {
+    throw new Error("WebGL2 is not supported by this browser.");
+  }
+
+  const program = createProgram(gl, shaderSources.vertex, shaderSources.fragment);
+  const attributes = getAttributes(gl, program);
+  const uniforms = getUniforms(gl, program);
+  const triangle = createDrawable(gl, triangleVertices, attributes);
+  const axes = createDrawable(gl, axisVertices, attributes);
+
+  gl.enable(gl.DEPTH_TEST);
+  gl.depthFunc(gl.LEQUAL);
+
+  return {
+    render({ time }) {
+      const matrix = prepareFrame(gl, canvas);
+
+      gl.useProgram(program);
+      gl.uniform1f(uniforms.time, time);
+      gl.uniformMatrix4fv(uniforms.matrix, false, matrix);
+
+      drawAxes(gl, axes, uniforms);
+      drawTriangle(gl, triangle, uniforms);
+    },
+  };
+}
+
+function getAttributes(gl, program) {
+  return {
+    position: gl.getAttribLocation(program, "a_position"),
+    color: gl.getAttribLocation(program, "a_color"),
+  };
+}
+
+function getUniforms(gl, program) {
+  return {
+    time: gl.getUniformLocation(program, "u_time"),
+    matrix: gl.getUniformLocation(program, "u_matrix"),
+    waveStrength: gl.getUniformLocation(program, "u_wave_strength"),
+    pulseStrength: gl.getUniformLocation(program, "u_pulse_strength"),
+  };
+}
+
+function createDrawable(gl, vertices, attributes) {
+  const geometry = createGeometry(gl, vertices);
+
+  bindGeometry(gl, geometry, attributes);
+
+  return {
+    ...geometry,
+    vertexCount: vertices.length / FLOATS_PER_VERTEX,
+  };
+}
+
+function bindGeometry(gl, geometry, attributes) {
+  gl.bindVertexArray(geometry.vao);
+  gl.bindBuffer(gl.ARRAY_BUFFER, geometry.buffer);
+
+  gl.enableVertexAttribArray(attributes.position);
+  gl.vertexAttribPointer(attributes.position, 3, gl.FLOAT, false, STRIDE, 0);
+
+  gl.enableVertexAttribArray(attributes.color);
+  gl.vertexAttribPointer(
+    attributes.color,
+    3,
+    gl.FLOAT,
+    false,
+    STRIDE,
+    3 * Float32Array.BYTES_PER_ELEMENT,
+  );
+
+  gl.bindVertexArray(null);
+  gl.bindBuffer(gl.ARRAY_BUFFER, null);
+}
+
+function prepareFrame(gl, canvas) {
+  resizeCanvasToDisplaySize(canvas);
+
+  const aspect = canvas.width / canvas.height;
+  const projectionMatrix = makeOrthographicMatrix(-aspect, aspect, -1, 1, 0.1, 10);
+  const viewMatrix = makeLookAtMatrix([1.6, 1.6, 1.6], [0, 0, 0], [0, 1, 0]);
+
+  gl.viewport(0, 0, canvas.width, canvas.height);
+  gl.clearColor(0.06, 0.07, 0.08, 1.0);
+  gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+
+  return multiplyMatrices(projectionMatrix, viewMatrix);
+}
+
+function drawAxes(gl, axes, uniforms) {
+  gl.bindVertexArray(axes.vao);
+  gl.uniform1f(uniforms.waveStrength, 0.0);
+  gl.uniform1f(uniforms.pulseStrength, 0.0);
+  gl.lineWidth(2);
+  gl.drawArrays(gl.LINES, 0, axes.vertexCount);
+}
+
+function drawTriangle(gl, triangle, uniforms) {
+  gl.bindVertexArray(triangle.vao);
+  gl.uniform1f(uniforms.waveStrength, 0.08);
+  gl.uniform1f(uniforms.pulseStrength, 1.0);
+  gl.drawArrays(gl.TRIANGLES, 0, triangle.vertexCount);
+}

--- a/projects/labs/raw-webgl2-shader/src/shaders.js
+++ b/projects/labs/raw-webgl2-shader/src/shaders.js
@@ -1,6 +1,4 @@
-"use strict";
-
-window.shaderSources = {
+export const shaderSources = {
   vertex: `#version 300 es
 precision highp float;
 

--- a/projects/labs/raw-webgl2-shader/src/webgl.js
+++ b/projects/labs/raw-webgl2-shader/src/webgl.js
@@ -1,0 +1,59 @@
+export function createProgram(gl, vertexSource, fragmentSource) {
+  const vertexShader = compileShader(gl, gl.VERTEX_SHADER, vertexSource);
+  const fragmentShader = compileShader(gl, gl.FRAGMENT_SHADER, fragmentSource);
+  const shaderProgram = gl.createProgram();
+
+  gl.attachShader(shaderProgram, vertexShader);
+  gl.attachShader(shaderProgram, fragmentShader);
+  gl.linkProgram(shaderProgram);
+
+  if (!gl.getProgramParameter(shaderProgram, gl.LINK_STATUS)) {
+    const info = gl.getProgramInfoLog(shaderProgram);
+    gl.deleteProgram(shaderProgram);
+    throw new Error(`Program link failed:\n${info}`);
+  }
+
+  gl.deleteShader(vertexShader);
+  gl.deleteShader(fragmentShader);
+
+  return shaderProgram;
+}
+
+export function createGeometry(gl, data) {
+  const vao = gl.createVertexArray();
+  const buffer = gl.createBuffer();
+
+  gl.bindVertexArray(vao);
+  gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+  gl.bufferData(gl.ARRAY_BUFFER, data, gl.STATIC_DRAW);
+  gl.bindVertexArray(null);
+  gl.bindBuffer(gl.ARRAY_BUFFER, null);
+
+  return { vao, buffer };
+}
+
+export function resizeCanvasToDisplaySize(canvas) {
+  const pixelRatio = window.devicePixelRatio || 1;
+  const width = Math.floor(canvas.clientWidth * pixelRatio);
+  const height = Math.floor(canvas.clientHeight * pixelRatio);
+
+  if (canvas.width !== width || canvas.height !== height) {
+    canvas.width = width;
+    canvas.height = height;
+  }
+}
+
+function compileShader(gl, type, source) {
+  const shader = gl.createShader(type);
+
+  gl.shaderSource(shader, source);
+  gl.compileShader(shader);
+
+  if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+    const info = gl.getShaderInfoLog(shader);
+    gl.deleteShader(shader);
+    throw new Error(`Shader compile failed:\n${info}`);
+  }
+
+  return shader;
+}


### PR DESCRIPTION
## Issues

- Refs none

## Why

`src/main.js` に WebGL 初期化、描画、行列計算、ゲームループが集まっていたため、今後ゲーム側の状態更新を足すと見通しが悪くなる状態でした。

## Summary

Raw WebGL2 shader lab を ES Modules に移行し、`main.js` を簡単なゲームループ中心に整理します。描画、WebGL補助、数学処理、HUD表示を個別モジュールへ分離し、FPS表示も追加します。

## Changes

- `main.js` を game loop と状態更新の入口に整理
- WebGL描画処理を `renderer.js` に分離
- shader/program/geometry 補助を `webgl.js` に分離
- 行列・ベクトル計算を `math.js` に分離
- FPS表示用の `hud.js` とHUD要素を追加
- `index.html` を `type="module"` に変更
- READMEの起動方法と編集ポイントを更新

## Checklist

- [x] 構文チェック: `node --check src/main.js src/hud.js src/renderer.js src/webgl.js src/math.js`
- [x] ローカルHTTP配信確認: `http://localhost:5173/` と主要moduleファイル
- [ ] フォーマット: project-specific commandなし
- [ ] リント / 型チェック: project-specific commandなし
- [ ] テスト: project-specific commandなし
