### PR TITLE
Add dropped glTF import to raw WebGL2 shader lab

### DIFF
--- a/projects/labs/raw-webgl2-shader/index.html
+++ b/projects/labs/raw-webgl2-shader/index.html
@@ -12,8 +12,10 @@
       <strong>Raw WebGL2</strong>
       <span>glTF model viewer</span>
       <span id="fps-counter">-- FPS</span>
+      <span id="import-status">Sample: lowpoly_fox_animal.gltf</span>
       <div id="render-controls" class="render-controls" aria-label="Render controls"></div>
     </div>
+    <div class="drop-overlay" aria-hidden="true"></div>
     <script type="module" src="./src/main.js"></script>
   </body>
 </html>

--- a/projects/labs/raw-webgl2-shader/src/drop-import.js
+++ b/projects/labs/raw-webgl2-shader/src/drop-import.js
@@ -1,0 +1,62 @@
+export function createGltfDropImporter({ onDragChange, onDropFiles }) {
+  let dragDepth = 0;
+
+  window.addEventListener("dragenter", (event) => {
+    if (!hasDraggedFiles(event)) {
+      return;
+    }
+
+    event.preventDefault();
+    dragDepth += 1;
+    onDragChange(true);
+  });
+
+  window.addEventListener("dragover", (event) => {
+    if (!hasDraggedFiles(event)) {
+      return;
+    }
+
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "copy";
+  });
+
+  window.addEventListener("dragleave", (event) => {
+    if (!hasDraggedFiles(event)) {
+      return;
+    }
+
+    dragDepth = Math.max(dragDepth - 1, 0);
+    if (dragDepth === 0) {
+      onDragChange(false);
+    }
+  });
+
+  window.addEventListener("drop", (event) => {
+    if (!hasDraggedFiles(event)) {
+      return;
+    }
+
+    event.preventDefault();
+    dragDepth = 0;
+    onDragChange(false);
+    onDropFiles(Array.from(event.dataTransfer.files ?? []));
+  });
+}
+
+export function pickSingleGltfFile(files) {
+  if (files.length !== 1) {
+    throw new Error("Drop exactly one .gltf file.");
+  }
+
+  const gltfFiles = files.filter((file) => file.name.toLowerCase().endsWith(".gltf"));
+
+  if (gltfFiles.length === 0) {
+    throw new Error("Only .gltf files are supported.");
+  }
+
+  return gltfFiles[0];
+}
+
+function hasDraggedFiles(event) {
+  return Array.from(event.dataTransfer?.types ?? []).includes("Files");
+}

--- a/projects/labs/raw-webgl2-shader/src/gltf.js
+++ b/projects/labs/raw-webgl2-shader/src/gltf.js
@@ -45,7 +45,30 @@ export async function loadGltfModel(url) {
 
   const gltf = await response.json();
   const baseUrl = new URL(url, window.location.href);
-  const buffers = await loadBuffers(gltf, baseUrl);
+  const buffers = await loadBuffersFromUrl(gltf, baseUrl);
+
+  return createModelFromGltf(gltf, buffers);
+}
+
+export async function loadGltfModelFromFile(file) {
+  if (!file.name.toLowerCase().endsWith(".gltf")) {
+    throw new Error("Only .gltf files are supported.");
+  }
+
+  let gltf;
+
+  try {
+    gltf = JSON.parse(await file.text());
+  } catch {
+    throw new Error("Dropped .gltf is not valid JSON.");
+  }
+
+  const buffers = await loadEmbeddedBuffers(gltf);
+
+  return createModelFromGltf(gltf, buffers);
+}
+
+function createModelFromGltf(gltf, buffers) {
   const model = {
     bounds: createEmptyBounds(),
     triangles: [],
@@ -81,7 +104,7 @@ export function fitModelToGround(model, targetHeight = 1.45) {
   };
 }
 
-async function loadBuffers(gltf, baseUrl) {
+async function loadBuffersFromUrl(gltf, baseUrl) {
   return Promise.all(
     (gltf.buffers ?? []).map(async (buffer) => {
       if (!buffer.uri) {
@@ -101,6 +124,22 @@ async function loadBuffers(gltf, baseUrl) {
       }
 
       return response.arrayBuffer();
+    }),
+  );
+}
+
+async function loadEmbeddedBuffers(gltf) {
+  return Promise.all(
+    (gltf.buffers ?? []).map(async (buffer) => {
+      if (!buffer.uri) {
+        throw new Error("Binary .glb buffers are not supported yet.");
+      }
+
+      if (!buffer.uri.startsWith("data:")) {
+        throw new Error("External .bin buffers are not supported for dropped .gltf files yet.");
+      }
+
+      return decodeDataUri(buffer.uri);
     }),
   );
 }

--- a/projects/labs/raw-webgl2-shader/src/hud.js
+++ b/projects/labs/raw-webgl2-shader/src/hud.js
@@ -36,6 +36,57 @@ export function createFpsCounter(element) {
   };
 }
 
+export function createImportStatus(element) {
+  if (!element) {
+    return {
+      setDragging() {},
+      setError() {},
+      setLoaded() {},
+      setLoading() {},
+      setMessage() {},
+    };
+  }
+
+  let currentText = element.textContent;
+  let currentState = "idle";
+
+  function render(text, state) {
+    element.textContent = text;
+    element.dataset.state = state;
+  }
+
+  return {
+    setDragging(isDragging) {
+      if (isDragging) {
+        render("Drop .gltf to import", "dragging");
+        return;
+      }
+
+      render(currentText, currentState);
+    },
+    setError(message) {
+      currentText = `Unsupported: ${message}`;
+      currentState = "error";
+      render(currentText, currentState);
+    },
+    setLoaded(fileName) {
+      currentText = `Loaded: ${fileName}`;
+      currentState = "loaded";
+      render(currentText, currentState);
+    },
+    setLoading(fileName) {
+      currentText = `Loading: ${fileName}`;
+      currentState = "loading";
+      render(currentText, currentState);
+    },
+    setMessage(message) {
+      currentText = message;
+      currentState = "idle";
+      render(currentText, currentState);
+    },
+  };
+}
+
 export function createRenderControls(element, renderOptions) {
   if (!element) {
     return;

--- a/projects/labs/raw-webgl2-shader/src/main.js
+++ b/projects/labs/raw-webgl2-shader/src/main.js
@@ -1,4 +1,6 @@
-import { createFpsCounter, createRenderControls } from "./hud.js";
+import { createGltfDropImporter, pickSingleGltfFile } from "./drop-import.js";
+import { loadGltfModelFromFile } from "./gltf.js";
+import { createFpsCounter, createImportStatus, createRenderControls } from "./hud.js";
 import { createRenderer } from "./renderer.js";
 
 const canvas = document.querySelector("#gl-canvas");
@@ -9,6 +11,7 @@ if (!canvas) {
 
 const renderer = createRenderer(canvas);
 const fpsCounter = createFpsCounter(document.querySelector("#fps-counter"));
+const importStatus = createImportStatus(document.querySelector("#import-status"));
 
 const gameState = {
   time: 0,
@@ -29,6 +32,38 @@ createRenderControls(
   document.querySelector("#render-controls"),
   gameState.renderOptions,
 );
+
+createGltfDropImporter({
+  onDragChange(isDragging) {
+    canvas.classList.toggle("is-drop-target", isDragging);
+    document.body.classList.toggle("is-dropping-gltf", isDragging);
+    importStatus.setDragging(isDragging);
+  },
+  async onDropFiles(files) {
+    renderer.clearModel();
+
+    let file;
+
+    try {
+      file = pickSingleGltfFile(files);
+    } catch (error) {
+      importStatus.setError(error.message);
+      return;
+    }
+
+    importStatus.setLoading(file.name);
+
+    try {
+      const model = await loadGltfModelFromFile(file);
+
+      renderer.setModel(model);
+      importStatus.setLoaded(file.name);
+    } catch (error) {
+      console.error(error);
+      importStatus.setError(error.message);
+    }
+  },
+});
 
 function update(deltaTime, time) {
   gameState.deltaTime = deltaTime;

--- a/projects/labs/raw-webgl2-shader/src/renderer.js
+++ b/projects/labs/raw-webgl2-shader/src/renderer.js
@@ -127,7 +127,7 @@ function createOrbitCamera(canvas) {
     if (dragMode === "orbit") {
       yaw -= deltaX * CAMERA_ROTATION_SPEED;
       pitch = clamp(
-        pitch - deltaY * CAMERA_ROTATION_SPEED,
+        pitch + deltaY * CAMERA_ROTATION_SPEED,
         CAMERA_MIN_PITCH,
         CAMERA_MAX_PITCH,
       );

--- a/projects/labs/raw-webgl2-shader/src/renderer.js
+++ b/projects/labs/raw-webgl2-shader/src/renderer.js
@@ -138,7 +138,7 @@ function createOrbitCamera(canvas) {
     lastPointerY = event.clientY;
 
     if (dragMode === "orbit") {
-      yaw -= deltaX * CAMERA_ROTATION_SPEED;
+      yaw += deltaX * CAMERA_ROTATION_SPEED;
       pitch = clamp(
         pitch + deltaY * CAMERA_ROTATION_SPEED,
         CAMERA_MIN_PITCH,

--- a/projects/labs/raw-webgl2-shader/src/renderer.js
+++ b/projects/labs/raw-webgl2-shader/src/renderer.js
@@ -43,16 +43,15 @@ export function createRenderer(canvas) {
   const xzGrid = createDrawable(gl, xzGridVertices, attributes);
   const axes = createDrawable(gl, axisVertices, attributes);
   const camera = createOrbitCamera(canvas);
-  let foxModel = null;
+  let currentModel = null;
+  let modelRevision = 0;
 
+  const sampleModelRevision = modelRevision;
   loadGltfModel(FOX_MODEL_URL)
     .then((model) => {
-      const fittedModel = fitModelToGround(model, MODEL_TARGET_HEIGHT);
-
-      foxModel = {
-        surface: createDrawable(gl, fittedModel.triangles, attributes),
-        wireframe: createDrawable(gl, fittedModel.wireframe, attributes),
-      };
+      if (sampleModelRevision === modelRevision) {
+        replaceCurrentModel(model);
+      }
     })
     .catch((error) => {
       console.error(error);
@@ -87,9 +86,23 @@ export function createRenderer(canvas) {
         drawLines(gl, axes, 2);
       }
 
-      drawModel(gl, foxModel, renderOptions);
+      drawModel(gl, currentModel, renderOptions);
+    },
+    clearModel() {
+      modelRevision += 1;
+      replaceCurrentModel(null);
+    },
+    setModel(model) {
+      modelRevision += 1;
+      replaceCurrentModel(model);
+      camera.reset();
     },
   };
+
+  function replaceCurrentModel(model) {
+    disposeModel(gl, currentModel);
+    currentModel = model === null ? null : createRenderModel(gl, attributes, model);
+  }
 }
 
 function createOrbitCamera(canvas) {
@@ -185,6 +198,14 @@ function createOrbitCamera(canvas) {
     },
     getViewScale() {
       return viewScale;
+    },
+    reset() {
+      target[0] = CAMERA_INITIAL_TARGET[0];
+      target[1] = CAMERA_INITIAL_TARGET[1];
+      target[2] = CAMERA_INITIAL_TARGET[2];
+      yaw = Math.atan2(1.6, 1.6);
+      pitch = Math.atan2(1.6, Math.hypot(1.6, 1.6));
+      viewScale = 1;
     },
   };
 }
@@ -292,6 +313,29 @@ function createDrawable(gl, vertices, attributes) {
     ...geometry,
     vertexCount: vertices.length / FLOATS_PER_VERTEX,
   };
+}
+
+function createRenderModel(gl, attributes, model) {
+  const fittedModel = fitModelToGround(model, MODEL_TARGET_HEIGHT);
+
+  return {
+    surface: createDrawable(gl, fittedModel.triangles, attributes),
+    wireframe: createDrawable(gl, fittedModel.wireframe, attributes),
+  };
+}
+
+function disposeModel(gl, model) {
+  if (!model) {
+    return;
+  }
+
+  disposeDrawable(gl, model.surface);
+  disposeDrawable(gl, model.wireframe);
+}
+
+function disposeDrawable(gl, drawable) {
+  gl.deleteVertexArray(drawable.vao);
+  gl.deleteBuffer(drawable.buffer);
 }
 
 function bindGeometry(gl, geometry, attributes) {

--- a/projects/labs/raw-webgl2-shader/src/styles.css
+++ b/projects/labs/raw-webgl2-shader/src/styles.css
@@ -28,10 +28,31 @@ canvas.is-dragging {
   cursor: grabbing;
 }
 
+canvas.is-drop-target {
+  outline: 2px solid #f2b84b;
+  outline-offset: -10px;
+}
+
+.drop-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+  border: 1px solid rgb(242 184 75 / 78%);
+  background: rgb(242 184 75 / 10%);
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+
+body.is-dropping-gltf .drop-overlay {
+  opacity: 1;
+}
+
 .hud {
   position: fixed;
   left: 16px;
   top: 16px;
+  z-index: 2;
   display: grid;
   gap: 2px;
   padding: 10px 12px;
@@ -48,6 +69,15 @@ canvas.is-dragging {
 
 .hud span {
   color: rgb(244 241 234 / 72%);
+}
+
+.hud span[data-state="dragging"],
+.hud span[data-state="loaded"] {
+  color: #f2b84b;
+}
+
+.hud span[data-state="error"] {
+  color: #ff8a7a;
 }
 
 .render-controls {


### PR DESCRIPTION
## Why

Raw WebGL2 Shader Lab should accept a local glTF file during experimentation without requiring users to edit the bundled sample asset. The initial scope is a single dropped `.gltf` file with embedded data URI buffers; external `.bin` and `.glb` remain explicit future work.

## Summary

This PR adds window-level drag and drop import for one `.gltf` file, clears the current model when a file is dropped, and shows import state in the HUD. It also includes the vertical orbit camera inversion requested before starting the import feature branch.

## Changes

- Add dropped `.gltf` file parsing through `loadGltfModelFromFile`
- Add drag/drop event handling in `src/drop-import.js`
- Replace the current render model on import and reset the camera on success
- Clear the current model and keep grid/axes/settings when import fails
- Add HUD import status plus drop highlight styling
- Invert vertical orbit camera drag

## Verification

- `node --check src/main.js` - passed
- `node --check src/gltf.js` - passed
- `node --check src/renderer.js` - passed
- `node --check src/drop-import.js` - passed
- `node --check src/hud.js` - passed
- `node --input-type=module -e "... loadGltfModelFromFile(...)"` - passed
- `curl -I http://localhost:5173/` - passed
- `curl -I http://localhost:5173/src/drop-import.js` - passed
- `curl -I http://localhost:5173/assets/lowpoly_fox_animal.gltf` - passed
