### PR TITLE
Allow dependency-free package manifests in license check

### DIFF
--- a/scripts/check_licenses.py
+++ b/scripts/check_licenses.py
@@ -32,9 +32,11 @@ REASON_UNKNOWN = "LICENSE_UNKNOWN"
 REASON_EXPRESSION_UNSUPPORTED = "EXPRESSION_UNSUPPORTED"
 REASON_NOT_SUPPORTED = "NOT_SUPPORTED"
 REASON_INSTALL_FAILED = "INSTALL_FAILED"
+REASON_NO_DEPENDENCIES = "NO_DEPENDENCIES"
 
 SUPPORTED_NODE_LOCKS = ("bun.lock", "bun.lockb", "package-lock.json")
 UNSUPPORTED_NODE_LOCKS = ("yarn.lock", "pnpm-lock.yaml")
+NODE_DEPENDENCY_FIELDS = ("dependencies", "devDependencies", "optionalDependencies", "peerDependencies")
 SUPPORTED_PYTHON_LOCKS = ("uv.lock",)
 UNSUPPORTED_PYTHON_LOCKS = ("requirements.txt", "poetry.lock", "Pipfile.lock")
 
@@ -299,6 +301,8 @@ def detect_target_managers(target: Path) -> list[tuple[str, str | None]]:
             managers.append(("bun", None))
         elif (target / "package-lock.json").exists():
             managers.append(("npm", None))
+        elif not has_node_dependencies(target / "package.json"):
+            managers.append(("node-empty", None))
         else:
             managers.append(("node", "missing supported lockfile"))
 
@@ -315,6 +319,25 @@ def detect_target_managers(target: Path) -> list[tuple[str, str | None]]:
         managers.append(("unknown", "package.json or pyproject.toml not found"))
 
     return managers
+
+
+def has_node_dependencies(package_json: Path) -> bool:
+    try:
+        data = json.loads(package_json.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return True
+
+    if not isinstance(data, dict):
+        return True
+
+    for field in NODE_DEPENDENCY_FIELDS:
+        value = data.get(field)
+        if isinstance(value, dict):
+            if value:
+                return True
+        elif value:
+            return True
+    return False
 
 
 def collect_node_packages(target: Path, manager: str) -> tuple[list[PackageInfo], CheckItem | None]:
@@ -549,6 +572,16 @@ def check_target(target: Path, policy: dict) -> TargetSummary:
             continue
         if manager in ("bun", "npm"):
             collected, install_error = collect_node_packages(target, manager)
+        elif manager == "node-empty":
+            items.append(
+                CheckItem(
+                    STATUS_PASS,
+                    REASON_NO_DEPENDENCIES,
+                    None,
+                    f"{target}: no Node dependencies declared; supported lockfile is not required",
+                )
+            )
+            continue
         elif manager == "uv":
             collected, install_error = collect_python_packages(target)
         else:

--- a/scripts/tests/test_check_licenses.py
+++ b/scripts/tests/test_check_licenses.py
@@ -84,6 +84,59 @@ class LicenseExpressionTest(unittest.TestCase):
 
 
 class TargetDetectionTest(unittest.TestCase):
+    def test_dependency_free_package_json_does_not_require_lockfile(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp)
+            (target / "package.json").write_text('{"scripts":{"test":"bun test"}}\n', encoding="utf-8")
+            self.assertEqual(check_licenses.detect_target_managers(target), [("node-empty", None)])
+
+            summary = check_licenses.check_target(target, POLICY)
+            self.assertEqual(summary.packages_checked, 0)
+            self.assertEqual(summary.fail_count, 0)
+            self.assertEqual([(item.status, item.reason_code) for item in summary.items], [("PASS", "NO_DEPENDENCIES")])
+
+    def test_empty_dependency_fields_do_not_require_lockfile(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp)
+            (target / "package.json").write_text(
+                (
+                    "{"
+                    '"dependencies":{},'
+                    '"devDependencies":{},'
+                    '"optionalDependencies":{},'
+                    '"peerDependencies":{}'
+                    "}\n"
+                ),
+                encoding="utf-8",
+            )
+            self.assertEqual(check_licenses.detect_target_managers(target), [("node-empty", None)])
+
+    def test_dependency_free_package_json_with_supported_lockfile_uses_current_manager(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp)
+            (target / "package.json").write_text('{"scripts":{"test":"bun test"}}\n', encoding="utf-8")
+            (target / "package-lock.json").write_text("{}\n", encoding="utf-8")
+            self.assertEqual(check_licenses.detect_target_managers(target), [("npm", None)])
+
+    def test_package_json_with_dependency_still_requires_supported_lockfile(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp)
+            (target / "package.json").write_text('{"dependencies":{"left-pad":"1.3.0"}}\n', encoding="utf-8")
+            self.assertEqual(
+                check_licenses.detect_target_managers(target),
+                [("node", "missing supported lockfile")],
+            )
+
+    def test_dependency_free_package_json_with_unsupported_lockfile_is_not_supported(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp)
+            (target / "package.json").write_text('{"scripts":{"test":"bun test"}}\n', encoding="utf-8")
+            (target / "yarn.lock").write_text("", encoding="utf-8")
+            self.assertEqual(
+                check_licenses.detect_target_managers(target),
+                [("node", "unsupported lockfile: yarn.lock")],
+            )
+
     def test_yarn_is_not_supported(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             target = Path(tmp)


### PR DESCRIPTION
## Issues

- Close #1016

## Why

`Check OSS Licenses` currently fails dependency-free `package.json` targets with `missing supported lockfile`. A manifest used only for scripts has no third-party packages to inspect, so requiring a lockfile makes unrelated CI fail.

## Summary

This PR lets dependency-free Node/Bun manifests pass the license check without a supported lockfile. Manifests with dependencies still require the existing supported lockfiles, and unsupported lockfiles keep failing as before.

## Changes

- Add Node dependency-field detection for `dependencies`, `devDependencies`, `optionalDependencies`, and `peerDependencies`.
- Add a `NO_DEPENDENCIES` pass item for dependency-free `package.json` targets.
- Cover dependency-free, empty dependency-field, supported lockfile, missing lockfile, and unsupported lockfile branches in unit tests.

## Verification

- `python3 -B -m unittest scripts/tests/test_check_licenses.py` - passed
- `python3 -B scripts/check_licenses.py --target /tmp/license-empty-node-check` - passed
- `./scripts/check-licenses --target /tmp/license-empty-node-check` - passed
- `git diff --check` - passed
