### PR TITLE
Add raw WebGL shader final Docker stage

### DIFF
--- a/projects/labs/raw-webgl2-shader/Dockerfile
+++ b/projects/labs/raw-webgl2-shader/Dockerfile
@@ -1,9 +1,36 @@
-FROM oven/bun:1.3.10 AS test
+ARG COMMIT_HASH=""
+
+# -----------------------------------------------
+# base stage
+# -----------------------------------------------
+FROM oven/bun:1.3.10 AS base
+
+ARG COMMIT_HASH
+ENV COMMIT_HASH=${COMMIT_HASH}
 
 WORKDIR /app
+
+# -----------------------------------------------
+# test stage
+# -----------------------------------------------
+FROM base AS test
 
 COPY package.json ./
 RUN bun install
 
 COPY . .
 RUN bun test
+
+# -----------------------------------------------
+# final stage
+# -----------------------------------------------
+FROM nginxinc/nginx-unprivileged:1.30.2-alpine AS final
+
+ARG COMMIT_HASH
+ENV COMMIT_HASH=${COMMIT_HASH}
+LABEL org.opencontainers.image.revision="${COMMIT_HASH}"
+
+COPY --chown=101:101 index.html /usr/share/nginx/html/index.html
+COPY --chown=101:101 src /usr/share/nginx/html/src
+
+EXPOSE 8080

--- a/projects/labs/raw-webgl2-shader/index.html
+++ b/projects/labs/raw-webgl2-shader/index.html
@@ -12,7 +12,7 @@
       <strong>Raw WebGL2</strong>
       <span>glTF model viewer</span>
       <span id="fps-counter">-- FPS</span>
-      <span id="import-status">Sample: lowpoly_fox_animal.gltf</span>
+      <span id="import-status">Drop a .gltf file</span>
       <div id="render-controls" class="render-controls" aria-label="Render controls"></div>
     </div>
     <div class="drop-overlay" aria-hidden="true"></div>

--- a/projects/labs/raw-webgl2-shader/src/renderer.js
+++ b/projects/labs/raw-webgl2-shader/src/renderer.js
@@ -3,13 +3,12 @@ import {
   makeOrthographicMatrix,
   multiplyMatrices,
 } from "./math.js";
-import { fitModelToGround, loadGltfModel } from "./gltf.js";
+import { fitModelToGround } from "./gltf.js";
 import { shaderSources } from "./shaders.js";
 import { createGeometry, createProgram, resizeCanvasToDisplaySize } from "./webgl.js";
 
 const FLOATS_PER_VERTEX = 12;
 const STRIDE = FLOATS_PER_VERTEX * Float32Array.BYTES_PER_ELEMENT;
-const FOX_MODEL_URL = "./assets/lowpoly_fox_animal.gltf";
 const COLOR_MODE_VERTEX = 0;
 const COLOR_MODE_MATERIAL = 1;
 const CAMERA_INITIAL_TARGET = [0, 0, 0];
@@ -45,17 +44,6 @@ export function createRenderer(canvas) {
   const camera = createOrbitCamera(canvas);
   let currentModel = null;
   let modelRevision = 0;
-
-  const sampleModelRevision = modelRevision;
-  loadGltfModel(FOX_MODEL_URL)
-    .then((model) => {
-      if (sampleModelRevision === modelRevision) {
-        replaceCurrentModel(model);
-      }
-    })
-    .catch((error) => {
-      console.error(error);
-    });
 
   gl.enable(gl.DEPTH_TEST);
   gl.depthFunc(gl.LEQUAL);


### PR DESCRIPTION
## Why

Raw WebGL2 Shader Lab を配布用 Docker image として build できるようにするため。

## Summary

`test` stage に加えて静的配信用の `final` stage を追加します。初期表示は bundled sample model に依存せず、ユーザーが `.gltf` を drop して読み込む形にします。

## Changes

- Dockerfile に `base` / `test` / `final` stage を追加
- `final` stage で `nginxinc/nginx-unprivileged:1.30.2-alpine` から `index.html` と `src` を配信
- bundled `lowpoly_fox_animal.gltf` の自動読込を削除
- 初期 import status を `.gltf` drop 待ちの表示に変更

## Checklist

- [x] `bun test`
- [x] `docker build --target test -t raw-webgl2-shader:test .`
- [x] `docker build --target final -t raw-webgl2-shader:final .`
