### PR TITLE
feat(raw-webgl2-shader): add GLB loading support

### DIFF
--- a/projects/labs/raw-webgl2-shader/index.html
+++ b/projects/labs/raw-webgl2-shader/index.html
@@ -12,7 +12,7 @@
       <strong>Raw WebGL2</strong>
       <span>glTF model viewer</span>
       <span id="fps-counter">-- FPS</span>
-      <span id="import-status">Drop a .gltf file</span>
+      <span id="import-status">Drop a .gltf / .glb file</span>
       <div id="render-controls" class="render-controls" aria-label="Render controls"></div>
     </div>
     <div class="drop-overlay" aria-hidden="true"></div>

--- a/projects/labs/raw-webgl2-shader/src/drop-import.js
+++ b/projects/labs/raw-webgl2-shader/src/drop-import.js
@@ -1,4 +1,4 @@
-export function createGltfDropImporter({ onDragChange, onDropFiles }) {
+export function createModelDropImporter({ onDragChange, onDropFiles }) {
   let dragDepth = 0;
 
   window.addEventListener("dragenter", (event) => {
@@ -43,20 +43,30 @@ export function createGltfDropImporter({ onDragChange, onDropFiles }) {
   });
 }
 
-export function pickSingleGltfFile(files) {
+export const createGltfDropImporter = createModelDropImporter;
+
+export function pickSingleModelFile(files) {
   if (files.length !== 1) {
-    throw new Error("Drop exactly one .gltf file.");
+    throw new Error("Drop exactly one .gltf or .glb file.");
   }
 
-  const gltfFiles = files.filter((file) => file.name.toLowerCase().endsWith(".gltf"));
+  const modelFiles = files.filter(isSupportedModelFile);
 
-  if (gltfFiles.length === 0) {
-    throw new Error("Only .gltf files are supported.");
+  if (modelFiles.length === 0) {
+    throw new Error("Only .gltf and .glb files are supported.");
   }
 
-  return gltfFiles[0];
+  return modelFiles[0];
 }
+
+export const pickSingleGltfFile = pickSingleModelFile;
 
 function hasDraggedFiles(event) {
   return Array.from(event.dataTransfer?.types ?? []).includes("Files");
+}
+
+function isSupportedModelFile(file) {
+  const fileName = file.name.toLowerCase();
+
+  return fileName.endsWith(".gltf") || fileName.endsWith(".glb");
 }

--- a/projects/labs/raw-webgl2-shader/src/gltf.js
+++ b/projects/labs/raw-webgl2-shader/src/gltf.js
@@ -29,6 +29,12 @@ const TYPE_COMPONENT_COUNTS = {
 const GL_TRIANGLES = 4;
 const DEFAULT_COLOR = [0.95, 0.72, 0.28];
 const DEFAULT_NORMAL = [0, 1, 0];
+const GLB_MAGIC = 0x46546c67;
+const GLB_VERSION = 2;
+const GLB_JSON_CHUNK_TYPE = 0x4e4f534a;
+const GLB_BIN_CHUNK_TYPE = 0x004e4942;
+const GLB_HEADER_SIZE = 12;
+const GLB_CHUNK_HEADER_SIZE = 8;
 const IDENTITY_MATRIX = new Float32Array([
   1, 0, 0, 0,
   0, 1, 0, 0,
@@ -43,16 +49,32 @@ export async function loadGltfModel(url) {
     throw new Error(`Failed to load glTF: ${response.status} ${response.statusText}`);
   }
 
-  const gltf = await response.json();
   const baseUrl = new URL(url, window.location.href);
+  const format = getModelFormat(url, response);
+
+  if (format === "glb") {
+    const { gltf, buffers } = parseGlb(await response.arrayBuffer());
+
+    return createModelFromGltf(gltf, buffers);
+  }
+
+  const gltf = await response.json();
   const buffers = await loadBuffersFromUrl(gltf, baseUrl);
 
   return createModelFromGltf(gltf, buffers);
 }
 
 export async function loadGltfModelFromFile(file) {
-  if (!file.name.toLowerCase().endsWith(".gltf")) {
-    throw new Error("Only .gltf files are supported.");
+  const fileName = file.name.toLowerCase();
+
+  if (fileName.endsWith(".glb")) {
+    const { gltf, buffers } = parseGlb(await file.arrayBuffer());
+
+    return createModelFromGltf(gltf, buffers);
+  }
+
+  if (!fileName.endsWith(".gltf")) {
+    throw new Error("Only .gltf and .glb files are supported.");
   }
 
   let gltf;
@@ -66,6 +88,111 @@ export async function loadGltfModelFromFile(file) {
   const buffers = await loadEmbeddedBuffers(gltf);
 
   return createModelFromGltf(gltf, buffers);
+}
+
+function getModelFormat(url, response) {
+  const pathname = new URL(url, window.location.href).pathname.toLowerCase();
+
+  if (pathname.endsWith(".glb")) {
+    return "glb";
+  }
+
+  if (pathname.endsWith(".gltf")) {
+    return "gltf";
+  }
+
+  const contentType = response.headers.get("content-type")?.toLowerCase() ?? "";
+
+  if (contentType.split(";")[0].trim() === "model/gltf-binary") {
+    return "glb";
+  }
+
+  return "gltf";
+}
+
+function parseGlb(arrayBuffer) {
+  if (arrayBuffer.byteLength < GLB_HEADER_SIZE) {
+    throw new Error("Invalid GLB: header is too short.");
+  }
+
+  const dataView = new DataView(arrayBuffer);
+  const magic = dataView.getUint32(0, true);
+  const version = dataView.getUint32(4, true);
+  const declaredLength = dataView.getUint32(8, true);
+
+  if (magic !== GLB_MAGIC) {
+    throw new Error("Invalid GLB: magic header does not match.");
+  }
+
+  if (version !== GLB_VERSION) {
+    throw new Error("Invalid GLB: only version 2 is supported.");
+  }
+
+  if (declaredLength !== arrayBuffer.byteLength) {
+    throw new Error("Invalid GLB: header length does not match file length.");
+  }
+
+  const jsonChunk = readGlbChunk(dataView, GLB_HEADER_SIZE, "JSON");
+
+  if (jsonChunk.type !== GLB_JSON_CHUNK_TYPE) {
+    throw new Error("Invalid GLB: first chunk must be JSON.");
+  }
+
+  let gltf;
+
+  try {
+    const jsonBytes = new Uint8Array(arrayBuffer, jsonChunk.offset, jsonChunk.length);
+    gltf = JSON.parse(new TextDecoder().decode(jsonBytes));
+  } catch {
+    throw new Error("Invalid GLB: JSON chunk is not valid JSON.");
+  }
+
+  const binChunkOffset = jsonChunk.offset + jsonChunk.length;
+  const binChunk = readGlbChunk(dataView, binChunkOffset, "BIN");
+
+  if (binChunk.type !== GLB_BIN_CHUNK_TYPE) {
+    throw new Error("Invalid GLB: second chunk must be BIN.");
+  }
+
+  const nextChunkOffset = binChunk.offset + binChunk.length;
+
+  if (nextChunkOffset !== arrayBuffer.byteLength) {
+    throw new Error("Invalid GLB: unexpected chunk data after BIN.");
+  }
+
+  const binBuffer = arrayBuffer.slice(binChunk.offset, nextChunkOffset);
+  const expectedByteLength = gltf.buffers?.[0]?.byteLength;
+
+  if (typeof expectedByteLength === "number") {
+    if (binBuffer.byteLength < expectedByteLength) {
+      throw new Error("Invalid GLB: BIN chunk is shorter than buffers[0].byteLength.");
+    }
+
+    if (binBuffer.byteLength > expectedByteLength + 3) {
+      throw new Error("Invalid GLB: BIN chunk padding is larger than expected.");
+    }
+  }
+
+  return {
+    gltf,
+    buffers: [binBuffer],
+  };
+}
+
+function readGlbChunk(dataView, chunkHeaderOffset, label) {
+  if (chunkHeaderOffset + GLB_CHUNK_HEADER_SIZE > dataView.byteLength) {
+    throw new Error(`Invalid GLB: missing ${label} chunk.`);
+  }
+
+  const length = dataView.getUint32(chunkHeaderOffset, true);
+  const type = dataView.getUint32(chunkHeaderOffset + 4, true);
+  const offset = chunkHeaderOffset + GLB_CHUNK_HEADER_SIZE;
+
+  if (offset + length > dataView.byteLength) {
+    throw new Error(`Invalid GLB: ${label} chunk length exceeds file length.`);
+  }
+
+  return { length, offset, type };
 }
 
 function createModelFromGltf(gltf, buffers) {
@@ -106,9 +233,9 @@ export function fitModelToGround(model, targetHeight = 1.45) {
 
 async function loadBuffersFromUrl(gltf, baseUrl) {
   return Promise.all(
-    (gltf.buffers ?? []).map(async (buffer) => {
+    (gltf.buffers ?? []).map(async (buffer, index) => {
       if (!buffer.uri) {
-        throw new Error("Binary .glb buffers are not supported yet.");
+        throw new Error(`glTF buffer ${index} is missing uri. Use a .glb file for binary GLB data.`);
       }
 
       if (buffer.uri.startsWith("data:")) {
@@ -130,9 +257,11 @@ async function loadBuffersFromUrl(gltf, baseUrl) {
 
 async function loadEmbeddedBuffers(gltf) {
   return Promise.all(
-    (gltf.buffers ?? []).map(async (buffer) => {
+    (gltf.buffers ?? []).map(async (buffer, index) => {
       if (!buffer.uri) {
-        throw new Error("Binary .glb buffers are not supported yet.");
+        throw new Error(
+          `Dropped .gltf buffer ${index} is missing uri. Drop a .glb file for binary GLB data.`,
+        );
       }
 
       if (!buffer.uri.startsWith("data:")) {

--- a/projects/labs/raw-webgl2-shader/src/gltf.js
+++ b/projects/labs/raw-webgl2-shader/src/gltf.js
@@ -147,20 +147,31 @@ function parseGlb(arrayBuffer) {
     throw new Error("Invalid GLB: JSON chunk is not valid JSON.");
   }
 
-  const binChunkOffset = jsonChunk.offset + jsonChunk.length;
-  const binChunk = readGlbChunk(dataView, binChunkOffset, "BIN");
+  let nextChunkOffset = jsonChunk.offset + jsonChunk.length;
+  let binChunk = null;
 
-  if (binChunk.type !== GLB_BIN_CHUNK_TYPE) {
-    throw new Error("Invalid GLB: second chunk must be BIN.");
+  while (nextChunkOffset < arrayBuffer.byteLength) {
+    const chunk = readGlbChunk(dataView, nextChunkOffset, "extension");
+
+    if (chunk.type === GLB_BIN_CHUNK_TYPE) {
+      if (binChunk) {
+        throw new Error("Invalid GLB: multiple BIN chunks are not supported.");
+      }
+
+      binChunk = chunk;
+    }
+
+    nextChunkOffset = chunk.offset + chunk.length;
   }
 
-  const nextChunkOffset = binChunk.offset + binChunk.length;
-
-  if (nextChunkOffset !== arrayBuffer.byteLength) {
-    throw new Error("Invalid GLB: unexpected chunk data after BIN.");
+  if (!binChunk) {
+    throw new Error("Invalid GLB: missing BIN chunk.");
   }
 
-  const binBuffer = arrayBuffer.slice(binChunk.offset, nextChunkOffset);
+  const binBuffer = arrayBuffer.slice(
+    binChunk.offset,
+    binChunk.offset + binChunk.length,
+  );
   const expectedByteLength = gltf.buffers?.[0]?.byteLength;
 
   if (typeof expectedByteLength === "number") {

--- a/projects/labs/raw-webgl2-shader/src/hud.js
+++ b/projects/labs/raw-webgl2-shader/src/hud.js
@@ -58,7 +58,7 @@ export function createImportStatus(element) {
   return {
     setDragging(isDragging) {
       if (isDragging) {
-        render("Drop .gltf to import", "dragging");
+        render("Drop .gltf / .glb to import", "dragging");
         return;
       }
 

--- a/projects/labs/raw-webgl2-shader/src/main.js
+++ b/projects/labs/raw-webgl2-shader/src/main.js
@@ -1,4 +1,4 @@
-import { createGltfDropImporter, pickSingleGltfFile } from "./drop-import.js";
+import { createModelDropImporter, pickSingleModelFile } from "./drop-import.js";
 import { loadGltfModelFromFile } from "./gltf.js";
 import { createFpsCounter, createImportStatus, createRenderControls } from "./hud.js";
 import { createRenderer } from "./renderer.js";
@@ -33,10 +33,10 @@ createRenderControls(
   gameState.renderOptions,
 );
 
-createGltfDropImporter({
+createModelDropImporter({
   onDragChange(isDragging) {
     canvas.classList.toggle("is-drop-target", isDragging);
-    document.body.classList.toggle("is-dropping-gltf", isDragging);
+    document.body.classList.toggle("is-dropping-model", isDragging);
     importStatus.setDragging(isDragging);
   },
   async onDropFiles(files) {
@@ -45,7 +45,7 @@ createGltfDropImporter({
     let file;
 
     try {
-      file = pickSingleGltfFile(files);
+      file = pickSingleModelFile(files);
     } catch (error) {
       importStatus.setError(error.message);
       return;

--- a/projects/labs/raw-webgl2-shader/src/styles.css
+++ b/projects/labs/raw-webgl2-shader/src/styles.css
@@ -44,7 +44,7 @@ canvas.is-drop-target {
   transition: opacity 120ms ease;
 }
 
-body.is-dropping-gltf .drop-overlay {
+body.is-dropping-model .drop-overlay {
   opacity: 1;
 }
 

--- a/projects/labs/raw-webgl2-shader/tests/drop-import.test.js
+++ b/projects/labs/raw-webgl2-shader/tests/drop-import.test.js
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { pickSingleModelFile } from "../src/drop-import.js";
+
+describe("pickSingleModelFile", () => {
+  test(".gltfファイルを受け付ける", () => {
+    const file = new File(["{}"], "model.gltf");
+
+    expect(pickSingleModelFile([file])).toBe(file);
+  });
+
+  test(".glbファイルを受け付ける", () => {
+    const file = new File([new ArrayBuffer(0)], "model.glb");
+
+    expect(pickSingleModelFile([file])).toBe(file);
+  });
+
+  test("複数ファイルを拒否する", () => {
+    expect(() =>
+      pickSingleModelFile([
+        new File(["{}"], "a.gltf"),
+        new File([new ArrayBuffer(0)], "b.glb"),
+      ]),
+    ).toThrow("Drop exactly one .gltf or .glb file.");
+  });
+
+  test("未対応拡張子を拒否する", () => {
+    expect(() => pickSingleModelFile([new File([""], "model.obj")])).toThrow(
+      "Only .gltf and .glb files are supported.",
+    );
+  });
+});

--- a/projects/labs/raw-webgl2-shader/tests/gltf.test.js
+++ b/projects/labs/raw-webgl2-shader/tests/gltf.test.js
@@ -15,6 +15,7 @@ const GLB_MAGIC = 0x46546c67;
 const GLB_VERSION = 2;
 const GLB_JSON_CHUNK_TYPE = 0x4e4f534a;
 const GLB_BIN_CHUNK_TYPE = 0x004e4942;
+const GLB_HEADER_SIZE = 12;
 
 const originalFetch = globalThis.fetch;
 const originalWindow = globalThis.window;
@@ -239,6 +240,18 @@ describe("loadGltfModel", () => {
 });
 
 describe("GLB validation", () => {
+  test("BIN chunk後の未知chunkを無視する", async () => {
+    const model = await loadGltfModelFromFile(
+      createGlbFile(
+        createTriangleGlb({
+          chunksAfterBin: [{ type: 0x12345678, data: [1, 2, 3] }],
+        }),
+      ),
+    );
+
+    expect(model.triangles.length).toBe(3 * PACKED_VERTEX_SIZE);
+  });
+
   test("magic headerが不正なGLBを拒否する", async () => {
     await expect(
       loadGltfModelFromFile(createGlbFile(createTriangleGlb({ magic: 0 }))),
@@ -266,13 +279,25 @@ describe("GLB validation", () => {
   test("BIN chunk typeが不正なGLBを拒否する", async () => {
     await expect(
       loadGltfModelFromFile(createGlbFile(createTriangleGlb({ binChunkType: 0 }))),
-    ).rejects.toThrow("Invalid GLB: second chunk must be BIN.");
+    ).rejects.toThrow("Invalid GLB: missing BIN chunk.");
   });
 
   test("BIN chunkがないGLBを拒否する", async () => {
     await expect(
       loadGltfModelFromFile(createGlbFile(createTriangleGlb({ includeBin: false }))),
     ).rejects.toThrow("Invalid GLB: missing BIN chunk.");
+  });
+
+  test("複数のBIN chunkを拒否する", async () => {
+    await expect(
+      loadGltfModelFromFile(
+        createGlbFile(
+          createTriangleGlb({
+            chunksAfterBin: [{ type: GLB_BIN_CHUNK_TYPE, data: [0] }],
+          }),
+        ),
+      ),
+    ).rejects.toThrow("Invalid GLB: multiple BIN chunks are not supported.");
   });
 
   test("header lengthが不正なGLBを拒否する", async () => {
@@ -468,6 +493,7 @@ function createGlb(
   binBuffer,
   {
     binChunkType = GLB_BIN_CHUNK_TYPE,
+    chunksAfterBin = [],
     declaredLengthDelta = 0,
     includeBin = true,
     jsonChunkType = GLB_JSON_CHUNK_TYPE,
@@ -476,10 +502,30 @@ function createGlb(
     version = GLB_VERSION,
   } = {},
 ) {
-  const jsonChunk = padBytes(new TextEncoder().encode(jsonText), 0x20);
-  const binChunk = padBytes(new Uint8Array(binBuffer), 0);
+  const chunks = [
+    {
+      data: padBytes(new TextEncoder().encode(jsonText), 0x20),
+      type: jsonChunkType,
+    },
+  ];
+
+  if (includeBin) {
+    chunks.push({
+      data: padBytes(new Uint8Array(binBuffer), 0),
+      type: binChunkType,
+    });
+  }
+
+  for (const chunk of chunksAfterBin) {
+    chunks.push({
+      data: padBytes(new Uint8Array(chunk.data), 0),
+      type: chunk.type,
+    });
+  }
+
   const byteLength =
-    12 + 8 + jsonChunk.byteLength + (includeBin ? 8 + binChunk.byteLength : 0);
+    GLB_HEADER_SIZE +
+    chunks.reduce((sum, chunk) => sum + 8 + chunk.data.byteLength, 0);
   const bytes = new Uint8Array(byteLength);
   const view = new DataView(bytes.buffer);
   let offset = 0;
@@ -487,17 +533,13 @@ function createGlb(
   view.setUint32(offset, magic, true);
   view.setUint32(offset + 4, version, true);
   view.setUint32(offset + 8, byteLength + declaredLengthDelta, true);
-  offset += 12;
+  offset += GLB_HEADER_SIZE;
 
-  view.setUint32(offset, jsonChunk.byteLength, true);
-  view.setUint32(offset + 4, jsonChunkType, true);
-  bytes.set(jsonChunk, offset + 8);
-  offset += 8 + jsonChunk.byteLength;
-
-  if (includeBin) {
-    view.setUint32(offset, binChunk.byteLength, true);
-    view.setUint32(offset + 4, binChunkType, true);
-    bytes.set(binChunk, offset + 8);
+  for (const chunk of chunks) {
+    view.setUint32(offset, chunk.data.byteLength, true);
+    view.setUint32(offset + 4, chunk.type, true);
+    bytes.set(chunk.data, offset + 8);
+    offset += 8 + chunk.data.byteLength;
   }
 
   return bytes.buffer;

--- a/projects/labs/raw-webgl2-shader/tests/gltf.test.js
+++ b/projects/labs/raw-webgl2-shader/tests/gltf.test.js
@@ -11,6 +11,10 @@ const GL_TRIANGLES = 4;
 const ARRAY_BUFFER = 34962;
 const ELEMENT_ARRAY_BUFFER = 34963;
 const PACKED_VERTEX_SIZE = 12;
+const GLB_MAGIC = 0x46546c67;
+const GLB_VERSION = 2;
+const GLB_JSON_CHUNK_TYPE = 0x4e4f534a;
+const GLB_BIN_CHUNK_TYPE = 0x004e4942;
 
 const originalFetch = globalThis.fetch;
 const originalWindow = globalThis.window;
@@ -134,9 +138,20 @@ describe("loadGltfModelFromFile", () => {
     expectVector(vertex.materialColor, [0.1, 0.2, 0.3]);
   });
 
+  test("GLBの三角形を読み込める", async () => {
+    const model = await loadGltfModelFromFile(createGlbFile(createTriangleGlb()));
+
+    expect(model.triangles).toBeInstanceOf(Float32Array);
+    expect(model.triangles.length).toBe(3 * PACKED_VERTEX_SIZE);
+    expect(model.wireframe.length).toBe(6 * PACKED_VERTEX_SIZE);
+    expectVector(model.bounds.min, [0, 0, 0]);
+    expectVector(model.bounds.max, [1, 1, 0]);
+    expectVector(readPackedVertex(model.triangles, 2).position, [0, 1, 0]);
+  });
+
   test("gltf以外のファイル名は拒否する", async () => {
-    await expect(loadGltfModelFromFile(createGltfFile({}, "model.glb"))).rejects.toThrow(
-      "Only .gltf files are supported.",
+    await expect(loadGltfModelFromFile(createGltfFile({}, "model.obj"))).rejects.toThrow(
+      "Only .gltf and .glb files are supported.",
     );
   });
 
@@ -185,6 +200,85 @@ describe("loadGltfModel", () => {
       "http://example.test/app/models/mesh.bin",
     ]);
     expect(model.triangles.length).toBe(3 * PACKED_VERTEX_SIZE);
+  });
+
+  test("GLBをURLから読み込める", async () => {
+    const glb = createTriangleGlb();
+
+    globalThis.window = { location: { href: "http://example.test/app/" } };
+    globalThis.fetch = async (input) => {
+      const url = String(input);
+
+      if (url === "models/model.glb") {
+        return new Response(glb, {
+          headers: { "content-type": "application/octet-stream" },
+        });
+      }
+
+      return new Response(null, { status: 404, statusText: "Not Found" });
+    };
+
+    const model = await loadGltfModel("models/model.glb");
+
+    expect(model.triangles.length).toBe(3 * PACKED_VERTEX_SIZE);
+  });
+
+  test("content-typeからGLBを読み込める", async () => {
+    const glb = createTriangleGlb();
+
+    globalThis.window = { location: { href: "http://example.test/app/" } };
+    globalThis.fetch = async () =>
+      new Response(glb, {
+        headers: { "content-type": "model/gltf-binary; charset=binary" },
+      });
+
+    const model = await loadGltfModel("models/model");
+
+    expect(model.triangles.length).toBe(3 * PACKED_VERTEX_SIZE);
+  });
+});
+
+describe("GLB validation", () => {
+  test("magic headerが不正なGLBを拒否する", async () => {
+    await expect(
+      loadGltfModelFromFile(createGlbFile(createTriangleGlb({ magic: 0 }))),
+    ).rejects.toThrow("Invalid GLB: magic header does not match.");
+  });
+
+  test("versionが不正なGLBを拒否する", async () => {
+    await expect(
+      loadGltfModelFromFile(createGlbFile(createTriangleGlb({ version: 1 }))),
+    ).rejects.toThrow("Invalid GLB: only version 2 is supported.");
+  });
+
+  test("JSON chunk typeが不正なGLBを拒否する", async () => {
+    await expect(
+      loadGltfModelFromFile(createGlbFile(createTriangleGlb({ jsonChunkType: 0 }))),
+    ).rejects.toThrow("Invalid GLB: first chunk must be JSON.");
+  });
+
+  test("壊れたJSON chunkを拒否する", async () => {
+    await expect(
+      loadGltfModelFromFile(createGlbFile(createTriangleGlb({ jsonText: "{" }))),
+    ).rejects.toThrow("Invalid GLB: JSON chunk is not valid JSON.");
+  });
+
+  test("BIN chunk typeが不正なGLBを拒否する", async () => {
+    await expect(
+      loadGltfModelFromFile(createGlbFile(createTriangleGlb({ binChunkType: 0 }))),
+    ).rejects.toThrow("Invalid GLB: second chunk must be BIN.");
+  });
+
+  test("BIN chunkがないGLBを拒否する", async () => {
+    await expect(
+      loadGltfModelFromFile(createGlbFile(createTriangleGlb({ includeBin: false }))),
+    ).rejects.toThrow("Invalid GLB: missing BIN chunk.");
+  });
+
+  test("header lengthが不正なGLBを拒否する", async () => {
+    await expect(
+      loadGltfModelFromFile(createGlbFile(createTriangleGlb({ declaredLengthDelta: 4 }))),
+    ).rejects.toThrow("Invalid GLB: header length does not match file length.");
   });
 });
 
@@ -361,8 +455,70 @@ function createBufferBuilder() {
   };
 }
 
+function createTriangleGlb(options = {}) {
+  const { gltf, buffer } = createTriangleGltf({ externalBufferUri: "mesh.bin" });
+
+  delete gltf.buffers[0].uri;
+
+  return createGlb(gltf, buffer, options);
+}
+
+function createGlb(
+  gltf,
+  binBuffer,
+  {
+    binChunkType = GLB_BIN_CHUNK_TYPE,
+    declaredLengthDelta = 0,
+    includeBin = true,
+    jsonChunkType = GLB_JSON_CHUNK_TYPE,
+    jsonText = JSON.stringify(gltf),
+    magic = GLB_MAGIC,
+    version = GLB_VERSION,
+  } = {},
+) {
+  const jsonChunk = padBytes(new TextEncoder().encode(jsonText), 0x20);
+  const binChunk = padBytes(new Uint8Array(binBuffer), 0);
+  const byteLength =
+    12 + 8 + jsonChunk.byteLength + (includeBin ? 8 + binChunk.byteLength : 0);
+  const bytes = new Uint8Array(byteLength);
+  const view = new DataView(bytes.buffer);
+  let offset = 0;
+
+  view.setUint32(offset, magic, true);
+  view.setUint32(offset + 4, version, true);
+  view.setUint32(offset + 8, byteLength + declaredLengthDelta, true);
+  offset += 12;
+
+  view.setUint32(offset, jsonChunk.byteLength, true);
+  view.setUint32(offset + 4, jsonChunkType, true);
+  bytes.set(jsonChunk, offset + 8);
+  offset += 8 + jsonChunk.byteLength;
+
+  if (includeBin) {
+    view.setUint32(offset, binChunk.byteLength, true);
+    view.setUint32(offset + 4, binChunkType, true);
+    bytes.set(binChunk, offset + 8);
+  }
+
+  return bytes.buffer;
+}
+
+function padBytes(bytes, paddingByte) {
+  const paddedLength = bytes.byteLength + ((4 - (bytes.byteLength % 4)) % 4);
+  const paddedBytes = new Uint8Array(paddedLength);
+
+  paddedBytes.set(bytes);
+  paddedBytes.fill(paddingByte, bytes.byteLength);
+
+  return paddedBytes;
+}
+
 function createGltfFile(gltf, name = "model.gltf") {
   return new File([JSON.stringify(gltf)], name, { type: "model/gltf+json" });
+}
+
+function createGlbFile(arrayBuffer, name = "model.glb") {
+  return new File([arrayBuffer], name, { type: "model/gltf-binary" });
 }
 
 function dataUri(arrayBuffer) {


### PR DESCRIPTION
## Issues

- Close #1019

## Why

`projects/labs/raw-webgl2-shader` currently supports `.gltf` JSON loading, but rejects standard GLB binary buffers. This adds `.glb` as an input format without changing the renderer, shaders, or packed vertex model.

## Summary

This PR adds a minimal GLB 2.0 parser in the glTF loader and routes both dropped files and fetched URLs through it when the input is `.glb`. It also updates drop validation and HUD copy so the UI accepts `.gltf` and `.glb` files.

## Changes

- Add GLB header/chunk validation for magic, version, total length, JSON chunk, and BIN chunk.
- Parse GLB JSON as existing glTF data and pass the BIN chunk as `buffers[0]`.
- Detect URL loading format by extension first, with `content-type: model/gltf-binary` as a fallback.
- Keep existing `.gltf` data URI and external `.bin` URL paths intact.
- Update drop import validation and HUD/index copy from `.gltf` only to `.gltf / .glb`.
- Add tests for GLB file loading, GLB fetch loading, content-type detection, invalid GLB cases, and drop validation.

## Verification

- `git diff --check` - passed
- `bun test` - passed, 25 tests
