### PR TITLE
Add model info and color controls

### DIFF
--- a/projects/labs/raw-webgl2-shader/index.html
+++ b/projects/labs/raw-webgl2-shader/index.html
@@ -13,7 +13,9 @@
       <span>glTF model viewer</span>
       <span id="fps-counter">-- FPS</span>
       <span id="import-status">Drop a .gltf / .glb file</span>
+      <dl id="model-info" class="model-info" aria-label="Model information"></dl>
       <div id="render-controls" class="render-controls" aria-label="Render controls"></div>
+      <div id="color-controls" class="color-controls" aria-label="Color controls"></div>
     </div>
     <div class="drop-overlay" aria-hidden="true"></div>
     <script type="module" src="./src/main.js"></script>

--- a/projects/labs/raw-webgl2-shader/src/colors.js
+++ b/projects/labs/raw-webgl2-shader/src/colors.js
@@ -1,6 +1,7 @@
 export const DEFAULT_BACKGROUND_COLOR = "#0f1214";
 export const DEFAULT_WIREFRAME_COLOR = "#000000";
 
+// Keep this aligned with the canonical value shape emitted by input[type="color"].
 const HEX_COLOR_PATTERN = /^#[\da-f]{6}$/i;
 
 export function normalizeHexColor(value, fallback) {

--- a/projects/labs/raw-webgl2-shader/src/colors.js
+++ b/projects/labs/raw-webgl2-shader/src/colors.js
@@ -1,0 +1,22 @@
+export const DEFAULT_BACKGROUND_COLOR = "#0f1214";
+export const DEFAULT_WIREFRAME_COLOR = "#000000";
+
+const HEX_COLOR_PATTERN = /^#[\da-f]{6}$/i;
+
+export function normalizeHexColor(value, fallback) {
+  if (typeof value === "string" && HEX_COLOR_PATTERN.test(value)) {
+    return value.toLowerCase();
+  }
+
+  return fallback;
+}
+
+export function hexColorToRgb(value) {
+  const color = normalizeHexColor(value, "#000000");
+
+  return [
+    Number.parseInt(color.slice(1, 3), 16) / 255,
+    Number.parseInt(color.slice(3, 5), 16) / 255,
+    Number.parseInt(color.slice(5, 7), 16) / 255,
+  ];
+}

--- a/projects/labs/raw-webgl2-shader/src/hud.js
+++ b/projects/labs/raw-webgl2-shader/src/hud.js
@@ -1,3 +1,5 @@
+import { formatModelSize } from "./model-info.js";
+
 const FPS_UPDATE_INTERVAL = 0.25;
 
 const CONTROL_ITEMS = [
@@ -7,6 +9,11 @@ const CONTROL_ITEMS = [
   ["lightingEnabled", "ライト"],
   ["gridVisible", "グリッド"],
   ["axesVisible", "軸"],
+];
+
+const COLOR_ITEMS = [
+  ["backgroundColor", "背景"],
+  ["wireframeColor", "ワイヤー色"],
 ];
 
 export function createFpsCounter(element) {
@@ -87,6 +94,47 @@ export function createImportStatus(element) {
   };
 }
 
+export function createModelInfoPanel(element) {
+  if (!element) {
+    return {
+      clear() {},
+      setModelInfo() {},
+    };
+  }
+
+  function render(rows) {
+    element.textContent = "";
+
+    for (const [labelText, valueText] of rows) {
+      const label = document.createElement("dt");
+      const value = document.createElement("dd");
+
+      label.textContent = labelText;
+      value.textContent = valueText;
+      element.append(label, value);
+    }
+  }
+
+  return {
+    clear() {
+      render([
+        ["ファイル", "-"],
+        ["頂点", "-"],
+        ["ポリゴン", "-"],
+        ["サイズ", "-"],
+      ]);
+    },
+    setModelInfo(info) {
+      render([
+        ["ファイル", info.fileName],
+        ["頂点", formatCount(info.vertexCount)],
+        ["ポリゴン", formatCount(info.polygonCount)],
+        ["サイズ", formatModelSize(info.size)],
+      ]);
+    },
+  };
+}
+
 export function createRenderControls(element, renderOptions) {
   if (!element) {
     return;
@@ -107,4 +155,31 @@ export function createRenderControls(element, renderOptions) {
     label.append(input, text);
     element.append(label);
   }
+}
+
+export function createColorControls(element, renderOptions, onChange = () => {}) {
+  if (!element) {
+    return;
+  }
+
+  for (const [key, labelText] of COLOR_ITEMS) {
+    const label = document.createElement("label");
+    const text = document.createElement("span");
+    const input = document.createElement("input");
+
+    input.type = "color";
+    input.value = renderOptions[key];
+    input.addEventListener("input", () => {
+      renderOptions[key] = input.value;
+      onChange(key, input.value);
+    });
+
+    text.textContent = labelText;
+    label.append(text, input);
+    element.append(label);
+  }
+}
+
+function formatCount(value) {
+  return Math.round(value).toLocaleString("ja-JP");
 }

--- a/projects/labs/raw-webgl2-shader/src/main.js
+++ b/projects/labs/raw-webgl2-shader/src/main.js
@@ -1,9 +1,25 @@
 import { createModelDropImporter, pickSingleModelFile } from "./drop-import.js";
 import { loadGltfModelFromFile } from "./gltf.js";
-import { createFpsCounter, createImportStatus, createRenderControls } from "./hud.js";
+import {
+  createColorControls,
+  createFpsCounter,
+  createImportStatus,
+  createModelInfoPanel,
+  createRenderControls,
+} from "./hud.js";
+import {
+  DEFAULT_BACKGROUND_COLOR,
+  DEFAULT_WIREFRAME_COLOR,
+  normalizeHexColor,
+} from "./colors.js";
+import { createModelInfo } from "./model-info.js";
 import { createRenderer } from "./renderer.js";
 
 const canvas = document.querySelector("#gl-canvas");
+const STORAGE_KEYS = {
+  backgroundColor: "raw-webgl2.backgroundColor",
+  wireframeColor: "raw-webgl2.wireframeColor",
+};
 
 if (!canvas) {
   throw new Error("Canvas element #gl-canvas was not found.");
@@ -12,6 +28,7 @@ if (!canvas) {
 const renderer = createRenderer(canvas);
 const fpsCounter = createFpsCounter(document.querySelector("#fps-counter"));
 const importStatus = createImportStatus(document.querySelector("#import-status"));
+const modelInfoPanel = createModelInfoPanel(document.querySelector("#model-info"));
 
 const gameState = {
   time: 0,
@@ -23,6 +40,14 @@ const gameState = {
     lightingEnabled: true,
     gridVisible: true,
     axesVisible: true,
+    backgroundColor: loadStoredColor(
+      STORAGE_KEYS.backgroundColor,
+      DEFAULT_BACKGROUND_COLOR,
+    ),
+    wireframeColor: loadStoredColor(
+      STORAGE_KEYS.wireframeColor,
+      DEFAULT_WIREFRAME_COLOR,
+    ),
   },
 };
 
@@ -32,6 +57,12 @@ createRenderControls(
   document.querySelector("#render-controls"),
   gameState.renderOptions,
 );
+createColorControls(
+  document.querySelector("#color-controls"),
+  gameState.renderOptions,
+  saveRenderColor,
+);
+modelInfoPanel.clear();
 
 createModelDropImporter({
   onDragChange(isDragging) {
@@ -41,6 +72,7 @@ createModelDropImporter({
   },
   async onDropFiles(files) {
     renderer.clearModel();
+    modelInfoPanel.clear();
 
     let file;
 
@@ -57,6 +89,7 @@ createModelDropImporter({
       const model = await loadGltfModelFromFile(file);
 
       renderer.setModel(model);
+      modelInfoPanel.setModelInfo(createModelInfo(file.name, model));
       importStatus.setLoaded(file.name);
     } catch (error) {
       console.error(error);
@@ -84,3 +117,19 @@ function gameLoop(now) {
 }
 
 requestAnimationFrame(gameLoop);
+
+function loadStoredColor(key, fallback) {
+  try {
+    return normalizeHexColor(localStorage.getItem(key), fallback);
+  } catch {
+    return fallback;
+  }
+}
+
+function saveRenderColor(key, value) {
+  try {
+    localStorage.setItem(STORAGE_KEYS[key], normalizeHexColor(value, value));
+  } catch {
+    // Rendering should continue even when storage is unavailable.
+  }
+}

--- a/projects/labs/raw-webgl2-shader/src/main.js
+++ b/projects/labs/raw-webgl2-shader/src/main.js
@@ -20,6 +20,10 @@ const STORAGE_KEYS = {
   backgroundColor: "raw-webgl2.backgroundColor",
   wireframeColor: "raw-webgl2.wireframeColor",
 };
+const COLOR_FALLBACKS = {
+  backgroundColor: DEFAULT_BACKGROUND_COLOR,
+  wireframeColor: DEFAULT_WIREFRAME_COLOR,
+};
 
 if (!canvas) {
   throw new Error("Canvas element #gl-canvas was not found.");
@@ -127,8 +131,15 @@ function loadStoredColor(key, fallback) {
 }
 
 function saveRenderColor(key, value) {
+  const storageKey = STORAGE_KEYS[key];
+  const fallback = COLOR_FALLBACKS[key];
+
+  if (!storageKey || !fallback) {
+    return;
+  }
+
   try {
-    localStorage.setItem(STORAGE_KEYS[key], normalizeHexColor(value, value));
+    localStorage.setItem(storageKey, normalizeHexColor(value, fallback));
   } catch {
     // Rendering should continue even when storage is unavailable.
   }

--- a/projects/labs/raw-webgl2-shader/src/model-info.js
+++ b/projects/labs/raw-webgl2-shader/src/model-info.js
@@ -1,0 +1,31 @@
+const FLOATS_PER_VERTEX = 12;
+
+export function createModelInfo(fileName, model) {
+  const vertexCount = model.triangles.length / FLOATS_PER_VERTEX;
+  const polygonCount = vertexCount / 3;
+
+  return {
+    fileName,
+    vertexCount,
+    polygonCount,
+    size: [
+      model.bounds.max[0] - model.bounds.min[0],
+      model.bounds.max[1] - model.bounds.min[1],
+      model.bounds.max[2] - model.bounds.min[2],
+    ],
+  };
+}
+
+export function formatModelSize(size) {
+  return size.map(formatLength).join(" x ");
+}
+
+function formatLength(value) {
+  const rounded = Math.round(value * 1000) / 1000;
+
+  if (Number.isInteger(rounded)) {
+    return String(rounded);
+  }
+
+  return rounded.toFixed(3).replace(/0+$/, "").replace(/\.$/, "");
+}

--- a/projects/labs/raw-webgl2-shader/src/model-info.js
+++ b/projects/labs/raw-webgl2-shader/src/model-info.js
@@ -1,4 +1,4 @@
-const FLOATS_PER_VERTEX = 12;
+import { FLOATS_PER_VERTEX } from "./vertex-layout.js";
 
 export function createModelInfo(fileName, model) {
   const vertexCount = model.triangles.length / FLOATS_PER_VERTEX;

--- a/projects/labs/raw-webgl2-shader/src/renderer.js
+++ b/projects/labs/raw-webgl2-shader/src/renderer.js
@@ -4,6 +4,7 @@ import {
   multiplyMatrices,
 } from "./math.js";
 import { fitModelToGround } from "./gltf.js";
+import { hexColorToRgb } from "./colors.js";
 import { shaderSources } from "./shaders.js";
 import { createGeometry, createProgram, resizeCanvasToDisplaySize } from "./webgl.js";
 
@@ -11,6 +12,7 @@ const FLOATS_PER_VERTEX = 12;
 const STRIDE = FLOATS_PER_VERTEX * Float32Array.BYTES_PER_ELEMENT;
 const COLOR_MODE_VERTEX = 0;
 const COLOR_MODE_MATERIAL = 1;
+const COLOR_MODE_SOLID = 2;
 const CAMERA_INITIAL_TARGET = [0, 0, 0];
 const CAMERA_RADIUS = Math.hypot(1.6, 1.6, 1.6);
 const CAMERA_ROTATION_SPEED = 0.006;
@@ -56,6 +58,7 @@ export function createRenderer(canvas) {
         camera.getEye(),
         camera.getTarget(),
         camera.getViewScale(),
+        renderOptions.backgroundColor,
       );
 
       gl.useProgram(program);
@@ -74,7 +77,7 @@ export function createRenderer(canvas) {
         drawLines(gl, axes, 2);
       }
 
-      drawModel(gl, currentModel, renderOptions);
+      drawModel(gl, currentModel, renderOptions, uniforms);
     },
     clearModel() {
       modelRevision += 1;
@@ -288,6 +291,7 @@ function getUniforms(gl, program) {
   return {
     matrix: gl.getUniformLocation(program, "u_matrix"),
     colorMode: gl.getUniformLocation(program, "u_color_mode"),
+    solidColor: gl.getUniformLocation(program, "u_solid_color"),
     lightingEnabled: gl.getUniformLocation(program, "u_lighting_enabled"),
   };
 }
@@ -367,7 +371,7 @@ function bindGeometry(gl, geometry, attributes) {
   gl.bindBuffer(gl.ARRAY_BUFFER, null);
 }
 
-function prepareFrame(gl, canvas, cameraEye, cameraTarget, viewScale) {
+function prepareFrame(gl, canvas, cameraEye, cameraTarget, viewScale, backgroundColor) {
   resizeCanvasToDisplaySize(canvas);
 
   const aspect = canvas.width / canvas.height;
@@ -382,7 +386,7 @@ function prepareFrame(gl, canvas, cameraEye, cameraTarget, viewScale) {
   const viewMatrix = makeLookAtMatrix(cameraEye, cameraTarget, [0, 1, 0]);
 
   gl.viewport(0, 0, canvas.width, canvas.height);
-  gl.clearColor(0.06, 0.07, 0.08, 1.0);
+  gl.clearColor(...hexColorToRgb(backgroundColor), 1.0);
   gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
 
   return multiplyMatrices(projectionMatrix, viewMatrix);
@@ -406,12 +410,17 @@ function cross(a, b) {
   ];
 }
 
-function drawModel(gl, model, renderOptions) {
+function drawModel(gl, model, renderOptions, uniforms) {
   if (!model) {
     return;
   }
 
   if (renderOptions.surfaceVisible) {
+    gl.uniform1i(
+      uniforms.colorMode,
+      renderOptions.useVertexColors ? COLOR_MODE_VERTEX : COLOR_MODE_MATERIAL,
+    );
+    gl.uniform1i(uniforms.lightingEnabled, renderOptions.lightingEnabled ? 1 : 0);
     gl.disable(gl.CULL_FACE);
     gl.enable(gl.POLYGON_OFFSET_FILL);
     gl.polygonOffset(1, 1);
@@ -421,6 +430,9 @@ function drawModel(gl, model, renderOptions) {
   }
 
   if (renderOptions.wireframeVisible) {
+    gl.uniform1i(uniforms.colorMode, COLOR_MODE_SOLID);
+    gl.uniform3fv(uniforms.solidColor, hexColorToRgb(renderOptions.wireframeColor));
+    gl.uniform1i(uniforms.lightingEnabled, 0);
     drawLines(gl, model.wireframe);
   }
 

--- a/projects/labs/raw-webgl2-shader/src/renderer.js
+++ b/projects/labs/raw-webgl2-shader/src/renderer.js
@@ -6,9 +6,9 @@ import {
 import { fitModelToGround } from "./gltf.js";
 import { hexColorToRgb } from "./colors.js";
 import { shaderSources } from "./shaders.js";
+import { FLOATS_PER_VERTEX } from "./vertex-layout.js";
 import { createGeometry, createProgram, resizeCanvasToDisplaySize } from "./webgl.js";
 
-const FLOATS_PER_VERTEX = 12;
 const STRIDE = FLOATS_PER_VERTEX * Float32Array.BYTES_PER_ELEMENT;
 const COLOR_MODE_VERTEX = 0;
 const COLOR_MODE_MATERIAL = 1;

--- a/projects/labs/raw-webgl2-shader/src/shaders.js
+++ b/projects/labs/raw-webgl2-shader/src/shaders.js
@@ -9,6 +9,7 @@ in vec3 a_material_color;
 
 uniform mat4 u_matrix;
 uniform int u_color_mode;
+uniform vec3 u_solid_color;
 uniform bool u_lighting_enabled;
 
 out vec3 v_color;
@@ -16,7 +17,11 @@ out vec3 v_normal;
 
 void main() {
   gl_Position = u_matrix * vec4(a_position, 1.0);
-  v_color = u_color_mode == 0 ? a_vertex_color : a_material_color;
+  v_color = u_color_mode == 0
+    ? a_vertex_color
+    : u_color_mode == 1
+      ? a_material_color
+      : u_solid_color;
   v_normal = normalize(a_normal);
 }
 `,

--- a/projects/labs/raw-webgl2-shader/src/styles.css
+++ b/projects/labs/raw-webgl2-shader/src/styles.css
@@ -80,6 +80,33 @@ body.is-dropping-model .drop-overlay {
   color: #ff8a7a;
 }
 
+.model-info {
+  display: grid;
+  grid-template-columns: auto minmax(96px, 1fr);
+  gap: 5px 12px;
+  margin: 8px 0 0;
+  padding-top: 8px;
+  border-top: 1px solid rgb(255 255 255 / 12%);
+}
+
+.model-info dt,
+.model-info dd {
+  margin: 0;
+  line-height: 1.15;
+}
+
+.model-info dt {
+  color: rgb(244 241 234 / 62%);
+}
+
+.model-info dd {
+  overflow: hidden;
+  color: rgb(244 241 234 / 88%);
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .render-controls {
   display: grid;
   grid-template-columns: repeat(2, minmax(76px, 1fr));
@@ -103,4 +130,30 @@ body.is-dropping-model .drop-overlay {
   height: 14px;
   margin: 0;
   accent-color: #f2b84b;
+}
+
+.color-controls {
+  display: grid;
+  gap: 6px;
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid rgb(255 255 255 / 12%);
+}
+
+.color-controls label {
+  display: grid;
+  grid-template-columns: 1fr 32px;
+  align-items: center;
+  gap: 10px;
+  color: rgb(244 241 234 / 86%);
+  line-height: 1;
+}
+
+.color-controls input {
+  width: 32px;
+  height: 20px;
+  margin: 0;
+  padding: 0;
+  border: 1px solid rgb(255 255 255 / 20%);
+  background: transparent;
 }

--- a/projects/labs/raw-webgl2-shader/src/vertex-layout.js
+++ b/projects/labs/raw-webgl2-shader/src/vertex-layout.js
@@ -1,0 +1,1 @@
+export const FLOATS_PER_VERTEX = 12;

--- a/projects/labs/raw-webgl2-shader/tests/colors.test.js
+++ b/projects/labs/raw-webgl2-shader/tests/colors.test.js
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import { hexColorToRgb, normalizeHexColor } from "../src/colors.js";
+
+describe("normalizeHexColor", () => {
+  test("6桁hex色を小文字へ正規化する", () => {
+    expect(normalizeHexColor("#A1B2C3", "#000000")).toBe("#a1b2c3");
+  });
+
+  test("不正な値はfallbackにする", () => {
+    expect(normalizeHexColor("red", "#0f1214")).toBe("#0f1214");
+    expect(normalizeHexColor(null, "#0f1214")).toBe("#0f1214");
+  });
+});
+
+describe("hexColorToRgb", () => {
+  test("hex色をWebGL向けの0-1 RGBへ変換する", () => {
+    expect(hexColorToRgb("#000000")).toEqual([0, 0, 0]);
+    expect(hexColorToRgb("#ffffff")).toEqual([1, 1, 1]);
+    expect(hexColorToRgb("#804020")).toEqual([
+      128 / 255,
+      64 / 255,
+      32 / 255,
+    ]);
+  });
+});

--- a/projects/labs/raw-webgl2-shader/tests/model-info.test.js
+++ b/projects/labs/raw-webgl2-shader/tests/model-info.test.js
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { createModelInfo, formatModelSize } from "../src/model-info.js";
+
+describe("createModelInfo", () => {
+  test("描画頂点数、三角形ポリゴン数、モデルサイズを算出する", () => {
+    const model = {
+      bounds: {
+        min: [-1, 2, 0.25],
+        max: [3, 5.5, 1],
+      },
+      triangles: new Float32Array(6 * 12),
+    };
+
+    expect(createModelInfo("sample.glb", model)).toEqual({
+      fileName: "sample.glb",
+      vertexCount: 6,
+      polygonCount: 2,
+      size: [4, 3.5, 0.75],
+    });
+  });
+});
+
+describe("formatModelSize", () => {
+  test("小数を3桁までに丸めてXYZを表示する", () => {
+    expect(formatModelSize([1, 2.34567, 0.5])).toBe("1 x 2.346 x 0.5");
+  });
+});


### PR DESCRIPTION
## Why

モデルビューアのHUDで、読み込んだモデルの規模と表示設定を確認・調整できるようにします。

## Summary

infoパネルにモデル情報を追加し、背景色とモデルワイヤーフレーム色をHUDから変更できるようにしました。色設定はlocalStorageに保存され、再読み込み後も復元されます。
<img width="1915" height="896" alt="image" src="https://github.com/user-attachments/assets/18de2a4b-83e7-4497-b2ae-9a6c00855641" />

## Changes

- モデルのファイル名、描画頂点数、三角形ポリゴン数、サイズXYZをHUDに表示
- 背景色とモデルワイヤーフレーム色のカラーピッカーを追加
- 背景色をWebGLのclearColorへ、ワイヤー色をモデルのワイヤーフレーム描画へ反映
- 色値の正規化・RGB変換とモデル情報算出のテストを追加

## Checklist

- [ ] フォーマット（scriptなし）
- [ ] リント / 型チェック（scriptなし）
- [x] テスト: `bun test`
