### PR TITLE
Improve raw WebGL2 mobile model controls

### DIFF
--- a/projects/labs/raw-webgl2-shader/index.html
+++ b/projects/labs/raw-webgl2-shader/index.html
@@ -8,20 +8,36 @@
   </head>
   <body>
     <canvas id="gl-canvas" aria-label="WebGL2 shader canvas"></canvas>
-    <div class="hud">
-      <strong>Raw WebGL2</strong>
-      <span>glTF model viewer</span>
-      <span id="fps-counter">-- FPS</span>
-      <div class="import-row">
-        <span id="import-status">Drop a .gltf / .glb file</span>
-        <label class="file-upload-button" title="ファイルを選択">
-          <span>選択</span>
-          <input id="model-file-input" class="model-file-input" type="file" accept=".gltf,.glb" />
-        </label>
+    <div id="hud" class="hud">
+      <div class="hud-header">
+        <div class="hud-title">
+          <strong>Raw WebGL2</strong>
+          <span>glTF model viewer</span>
+        </div>
+        <span id="fps-counter" class="hud-fps">-- FPS</span>
+        <button
+          id="hud-toggle"
+          class="hud-toggle"
+          type="button"
+          aria-controls="hud-content"
+          aria-expanded="true"
+          title="パネルを折りたたむ"
+        >
+          <span id="hud-toggle-icon" aria-hidden="true">-</span>
+        </button>
       </div>
-      <dl id="model-info" class="model-info" aria-label="Model information"></dl>
-      <div id="render-controls" class="render-controls" aria-label="Render controls"></div>
-      <div id="color-controls" class="color-controls" aria-label="Color controls"></div>
+      <div id="hud-content" class="hud-content">
+        <div class="import-row">
+          <span id="import-status">Drop a .gltf / .glb file</span>
+          <label class="file-upload-button" title="ファイルを選択">
+            <span>選択</span>
+            <input id="model-file-input" class="model-file-input" type="file" accept=".gltf,.glb" />
+          </label>
+        </div>
+        <dl id="model-info" class="model-info" aria-label="Model information"></dl>
+        <div id="render-controls" class="render-controls" aria-label="Render controls"></div>
+        <div id="color-controls" class="color-controls" aria-label="Color controls"></div>
+      </div>
     </div>
     <div class="drop-overlay" aria-hidden="true"></div>
     <script type="module" src="./src/main.js"></script>

--- a/projects/labs/raw-webgl2-shader/index.html
+++ b/projects/labs/raw-webgl2-shader/index.html
@@ -12,7 +12,13 @@
       <strong>Raw WebGL2</strong>
       <span>glTF model viewer</span>
       <span id="fps-counter">-- FPS</span>
-      <span id="import-status">Drop a .gltf / .glb file</span>
+      <div class="import-row">
+        <span id="import-status">Drop a .gltf / .glb file</span>
+        <label class="file-upload-button" title="ファイルを選択">
+          <span>選択</span>
+          <input id="model-file-input" class="model-file-input" type="file" accept=".gltf,.glb" />
+        </label>
+      </div>
       <dl id="model-info" class="model-info" aria-label="Model information"></dl>
       <div id="render-controls" class="render-controls" aria-label="Render controls"></div>
       <div id="color-controls" class="color-controls" aria-label="Color controls"></div>

--- a/projects/labs/raw-webgl2-shader/src/hud.js
+++ b/projects/labs/raw-webgl2-shader/src/hud.js
@@ -16,6 +16,62 @@ const COLOR_ITEMS = [
   ["wireframeColor", "ワイヤー色"],
 ];
 
+export function createHudDisclosure({
+  root,
+  toggle,
+  content,
+  icon = null,
+  initialCollapsed = false,
+  onChange = () => {},
+}) {
+  if (!root || !toggle || !content) {
+    return {
+      setCollapsed() {},
+      toggle() {},
+    };
+  }
+
+  let isCollapsed = Boolean(initialCollapsed);
+
+  function render() {
+    if (isCollapsed) {
+      root.classList.add("is-collapsed");
+      content.style.display = "none";
+    } else {
+      root.classList.remove("is-collapsed");
+      content.style.display = "";
+    }
+
+    content.setAttribute("aria-hidden", String(isCollapsed));
+    toggle.setAttribute("aria-expanded", String(!isCollapsed));
+    toggle.title = isCollapsed ? "パネルを開く" : "パネルを折りたたむ";
+
+    if (icon) {
+      icon.textContent = isCollapsed ? "+" : "-";
+    }
+  }
+
+  toggle.addEventListener("click", () => {
+    isCollapsed = !isCollapsed;
+    render();
+    onChange(isCollapsed);
+  });
+  render();
+
+  return {
+    setCollapsed(value) {
+      isCollapsed = Boolean(value);
+      render();
+      onChange(isCollapsed);
+    },
+    toggle() {
+      isCollapsed = !isCollapsed;
+      render();
+      onChange(isCollapsed);
+    },
+  };
+}
+
 export function createFpsCounter(element) {
   if (!element) {
     return {

--- a/projects/labs/raw-webgl2-shader/src/main.js
+++ b/projects/labs/raw-webgl2-shader/src/main.js
@@ -3,6 +3,7 @@ import { loadGltfModelFromFile } from "./gltf.js";
 import {
   createColorControls,
   createFpsCounter,
+  createHudDisclosure,
   createImportStatus,
   createModelInfoPanel,
   createRenderControls,
@@ -18,6 +19,7 @@ import { createRenderer } from "./renderer.js";
 const canvas = document.querySelector("#gl-canvas");
 const STORAGE_KEYS = {
   backgroundColor: "raw-webgl2.backgroundColor",
+  hudCollapsed: "raw-webgl2.hudCollapsed",
   wireframeColor: "raw-webgl2.wireframeColor",
 };
 const COLOR_FALLBACKS = {
@@ -34,6 +36,14 @@ const fpsCounter = createFpsCounter(document.querySelector("#fps-counter"));
 const importStatus = createImportStatus(document.querySelector("#import-status"));
 const modelInfoPanel = createModelInfoPanel(document.querySelector("#model-info"));
 const modelFileInput = document.querySelector("#model-file-input");
+createHudDisclosure({
+  root: document.querySelector("#hud"),
+  toggle: document.querySelector("#hud-toggle"),
+  content: document.querySelector("#hud-content"),
+  icon: document.querySelector("#hud-toggle-icon"),
+  initialCollapsed: loadInitialHudCollapsed(),
+  onChange: saveHudCollapsed,
+});
 
 const gameState = {
   time: 0,
@@ -159,6 +169,28 @@ function loadStoredColor(key, fallback) {
     return normalizeHexColor(localStorage.getItem(key), fallback);
   } catch {
     return fallback;
+  }
+}
+
+function loadInitialHudCollapsed() {
+  try {
+    const storedValue = localStorage.getItem(STORAGE_KEYS.hudCollapsed);
+
+    if (storedValue !== null) {
+      return storedValue === "true";
+    }
+  } catch {
+    // Use the viewport default when storage is unavailable.
+  }
+
+  return window.matchMedia("(max-width: 640px)").matches;
+}
+
+function saveHudCollapsed(value) {
+  try {
+    localStorage.setItem(STORAGE_KEYS.hudCollapsed, String(value));
+  } catch {
+    // Rendering should continue even when storage is unavailable.
   }
 }
 

--- a/projects/labs/raw-webgl2-shader/src/main.js
+++ b/projects/labs/raw-webgl2-shader/src/main.js
@@ -33,6 +33,7 @@ const renderer = createRenderer(canvas);
 const fpsCounter = createFpsCounter(document.querySelector("#fps-counter"));
 const importStatus = createImportStatus(document.querySelector("#import-status"));
 const modelInfoPanel = createModelInfoPanel(document.querySelector("#model-info"));
+const modelFileInput = document.querySelector("#model-file-input");
 
 const gameState = {
   time: 0,
@@ -68,38 +69,42 @@ createColorControls(
 );
 modelInfoPanel.clear();
 
+if (modelFileInput) {
+  modelFileInput.addEventListener("change", handleModelFileSelection);
+  modelFileInput.addEventListener("input", handleModelFileSelection);
+}
+
+let pendingFileSelection = null;
+
+async function handleModelFileSelection() {
+  const files = Array.from(modelFileInput.files ?? []);
+
+  if (files.length === 0) {
+    return;
+  }
+
+  if (pendingFileSelection === modelFileInput.files) {
+    return;
+  }
+
+  pendingFileSelection = modelFileInput.files;
+  importStatus.setLoading(files[0].name);
+
+  try {
+    await importModelFiles(files);
+  } finally {
+    pendingFileSelection = null;
+    modelFileInput.value = "";
+  }
+}
+
 createModelDropImporter({
   onDragChange(isDragging) {
     canvas.classList.toggle("is-drop-target", isDragging);
     document.body.classList.toggle("is-dropping-model", isDragging);
     importStatus.setDragging(isDragging);
   },
-  async onDropFiles(files) {
-    renderer.clearModel();
-    modelInfoPanel.clear();
-
-    let file;
-
-    try {
-      file = pickSingleModelFile(files);
-    } catch (error) {
-      importStatus.setError(error.message);
-      return;
-    }
-
-    importStatus.setLoading(file.name);
-
-    try {
-      const model = await loadGltfModelFromFile(file);
-
-      renderer.setModel(model);
-      modelInfoPanel.setModelInfo(createModelInfo(file.name, model));
-      importStatus.setLoaded(file.name);
-    } catch (error) {
-      console.error(error);
-      importStatus.setError(error.message);
-    }
-  },
+  onDropFiles: importModelFiles,
 });
 
 function update(deltaTime, time) {
@@ -121,6 +126,33 @@ function gameLoop(now) {
 }
 
 requestAnimationFrame(gameLoop);
+
+async function importModelFiles(files) {
+  renderer.clearModel();
+  modelInfoPanel.clear();
+
+  let file;
+
+  try {
+    file = pickSingleModelFile(files);
+  } catch (error) {
+    importStatus.setError(error.message);
+    return;
+  }
+
+  importStatus.setLoading(file.name);
+
+  try {
+    const model = await loadGltfModelFromFile(file);
+
+    renderer.setModel(model);
+    modelInfoPanel.setModelInfo(createModelInfo(file.name, model));
+    importStatus.setLoaded(file.name);
+  } catch (error) {
+    console.error(error);
+    importStatus.setError(error.message);
+  }
+}
 
 function loadStoredColor(key, fallback) {
   try {

--- a/projects/labs/raw-webgl2-shader/src/renderer.js
+++ b/projects/labs/raw-webgl2-shader/src/renderer.js
@@ -96,7 +96,7 @@ export function createRenderer(canvas) {
   }
 }
 
-function createOrbitCamera(canvas) {
+export function createOrbitCamera(canvas) {
   const target = [...CAMERA_INITIAL_TARGET];
   let yaw = Math.atan2(1.6, 1.6);
   let pitch = Math.atan2(1.6, Math.hypot(1.6, 1.6));
@@ -104,6 +104,8 @@ function createOrbitCamera(canvas) {
   let dragMode = null;
   let lastPointerX = 0;
   let lastPointerY = 0;
+  let lastPinchDistance = null;
+  const touchPointers = new Map();
 
   canvas.addEventListener("pointerdown", (event) => {
     if (event.button !== 0 && event.button !== 1) {
@@ -111,6 +113,26 @@ function createOrbitCamera(canvas) {
     }
 
     event.preventDefault();
+    if (event.pointerType === "touch") {
+      touchPointers.set(event.pointerId, {
+        x: event.clientX,
+        y: event.clientY,
+      });
+
+      if (touchPointers.size >= 2) {
+        dragMode = null;
+        lastPinchDistance = getTouchPointerDistance(touchPointers);
+      } else {
+        dragMode = "orbit";
+        lastPointerX = event.clientX;
+        lastPointerY = event.clientY;
+      }
+
+      canvas.setPointerCapture(event.pointerId);
+      canvas.classList.add("is-dragging");
+      return;
+    }
+
     dragMode = event.button === 0 ? "orbit" : "pan";
     lastPointerX = event.clientX;
     lastPointerY = event.clientY;
@@ -119,6 +141,34 @@ function createOrbitCamera(canvas) {
   });
 
   canvas.addEventListener("pointermove", (event) => {
+    if (event.pointerType === "touch") {
+      if (!touchPointers.has(event.pointerId)) {
+        return;
+      }
+
+      event.preventDefault();
+      touchPointers.set(event.pointerId, {
+        x: event.clientX,
+        y: event.clientY,
+      });
+
+      if (touchPointers.size >= 2) {
+        const pinchDistance = getTouchPointerDistance(touchPointers);
+
+        if (lastPinchDistance !== null && pinchDistance > 0) {
+          viewScale = clamp(
+            viewScale * (lastPinchDistance / pinchDistance),
+            CAMERA_MIN_VIEW_SCALE,
+            CAMERA_MAX_VIEW_SCALE,
+          );
+        }
+
+        lastPinchDistance = pinchDistance;
+        dragMode = null;
+        return;
+      }
+    }
+
     if (dragMode === null) {
       return;
     }
@@ -142,6 +192,30 @@ function createOrbitCamera(canvas) {
   });
 
   function stopDragging(event) {
+    if (event.pointerType === "touch") {
+      touchPointers.delete(event.pointerId);
+
+      if (touchPointers.size >= 2) {
+        lastPinchDistance = getTouchPointerDistance(touchPointers);
+        dragMode = null;
+      } else if (touchPointers.size === 1) {
+        const remainingPointer = touchPointers.values().next().value;
+        lastPinchDistance = null;
+        dragMode = "orbit";
+        lastPointerX = remainingPointer.x;
+        lastPointerY = remainingPointer.y;
+      } else {
+        lastPinchDistance = null;
+        dragMode = null;
+        canvas.classList.remove("is-dragging");
+      }
+
+      if (canvas.hasPointerCapture(event.pointerId)) {
+        canvas.releasePointerCapture(event.pointerId);
+      }
+      return;
+    }
+
     if (dragMode === null) {
       return;
     }
@@ -199,6 +273,14 @@ function createOrbitCamera(canvas) {
       viewScale = 1;
     },
   };
+}
+
+function getTouchPointerDistance(touchPointers) {
+  const [firstPointer, secondPointer] = touchPointers.values();
+  const deltaX = secondPointer.x - firstPointer.x;
+  const deltaY = secondPointer.y - firstPointer.y;
+
+  return Math.hypot(deltaX, deltaY);
 }
 
 function getEyeOffset(yaw, pitch) {

--- a/projects/labs/raw-webgl2-shader/src/styles.css
+++ b/projects/labs/raw-webgl2-shader/src/styles.css
@@ -54,7 +54,7 @@ body.is-dropping-model .drop-overlay {
   top: 16px;
   z-index: 2;
   display: grid;
-  gap: 2px;
+  gap: 8px;
   width: 280px;
   max-width: calc(100vw - 32px);
   padding: 10px 12px;
@@ -64,9 +64,26 @@ body.is-dropping-model .drop-overlay {
   font-size: 13px;
 }
 
+.hud-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto 28px;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.hud-title {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
 .hud strong {
+  overflow: hidden;
   font-size: 14px;
   font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .hud span {
@@ -74,6 +91,46 @@ body.is-dropping-model .drop-overlay {
   color: rgb(244 241 234 / 72%);
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.hud-fps {
+  justify-self: end;
+  font-variant-numeric: tabular-nums;
+}
+
+.hud-toggle {
+  display: inline-grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 1px solid rgb(255 255 255 / 18%);
+  appearance: none;
+  background: transparent;
+  color: rgb(244 241 234 / 86%);
+  cursor: pointer;
+  font: inherit;
+  line-height: 1;
+}
+
+.hud-toggle:hover {
+  border-color: rgb(242 184 75 / 68%);
+  color: #f2b84b;
+}
+
+.hud-toggle:focus-visible {
+  outline: 2px solid #f2b84b;
+  outline-offset: 2px;
+}
+
+.hud-content {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.hud-content[hidden] {
+  display: none;
 }
 
 .hud span[data-state="dragging"],
@@ -211,4 +268,18 @@ body.is-dropping-model .drop-overlay {
   padding: 0;
   border: 1px solid rgb(255 255 255 / 20%);
   background: transparent;
+}
+
+@media (max-width: 640px) {
+  .hud {
+    left: 10px;
+    top: 10px;
+    width: min(280px, calc(100vw - 20px));
+    max-width: calc(100vw - 20px);
+    padding: 8px 10px;
+  }
+
+  .hud.is-collapsed {
+    width: min(220px, calc(100vw - 20px));
+  }
 }

--- a/projects/labs/raw-webgl2-shader/src/styles.css
+++ b/projects/labs/raw-webgl2-shader/src/styles.css
@@ -55,6 +55,8 @@ body.is-dropping-model .drop-overlay {
   z-index: 2;
   display: grid;
   gap: 2px;
+  width: 280px;
+  max-width: calc(100vw - 32px);
   padding: 10px 12px;
   border: 1px solid rgb(255 255 255 / 14%);
   background: rgb(16 17 20 / 72%);
@@ -68,7 +70,10 @@ body.is-dropping-model .drop-overlay {
 }
 
 .hud span {
+  overflow: hidden;
   color: rgb(244 241 234 / 72%);
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .hud span[data-state="dragging"],
@@ -80,9 +85,58 @@ body.is-dropping-model .drop-overlay {
   color: #ff8a7a;
 }
 
+.import-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+}
+
+.file-upload-button {
+  position: relative;
+  display: inline-grid;
+  place-items: center;
+  min-width: 44px;
+  height: 24px;
+  padding: 0 8px;
+  border: 1px solid rgb(255 255 255 / 18%);
+  appearance: none;
+  background: transparent;
+  color: rgb(244 241 234 / 88%);
+  cursor: pointer;
+  font-size: 12px;
+  font-family: inherit;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.file-upload-button span {
+  pointer-events: none;
+}
+
+.file-upload-button:hover {
+  border-color: rgb(242 184 75 / 68%);
+  color: #f2b84b;
+}
+
+.file-upload-button:focus-visible {
+  outline: 2px solid #f2b84b;
+  outline-offset: 2px;
+}
+
+.model-file-input {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  cursor: pointer;
+  opacity: 0;
+}
+
 .model-info {
   display: grid;
-  grid-template-columns: auto minmax(96px, 1fr);
+  grid-template-columns: auto minmax(0, 1fr);
   gap: 5px 12px;
   margin: 8px 0 0;
   padding-top: 8px;
@@ -100,6 +154,7 @@ body.is-dropping-model .drop-overlay {
 }
 
 .model-info dd {
+  min-width: 0;
   overflow: hidden;
   color: rgb(244 241 234 / 88%);
   text-align: right;

--- a/projects/labs/raw-webgl2-shader/tests/hud.test.js
+++ b/projects/labs/raw-webgl2-shader/tests/hud.test.js
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test";
+import { createHudDisclosure } from "../src/hud.js";
+
+describe("createHudDisclosure", () => {
+  test("初期状態で折りたためる", () => {
+    const elements = createDisclosureElements();
+
+    createHudDisclosure({
+      ...elements,
+      initialCollapsed: true,
+    });
+
+    expect(elements.root.classList.contains("is-collapsed")).toBe(true);
+    expect(elements.content.style.display).toBe("none");
+    expect(elements.content.getAttribute("aria-hidden")).toBe("true");
+    expect(elements.toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(elements.icon.textContent).toBe("+");
+  });
+
+  test("ボタンで開閉状態を切り替える", () => {
+    const elements = createDisclosureElements();
+    const changes = [];
+
+    createHudDisclosure({
+      ...elements,
+      onChange(value) {
+        changes.push(value);
+      },
+    });
+    elements.toggle.dispatchEvent(new Event("click"));
+    elements.toggle.dispatchEvent(new Event("click"));
+
+    expect(changes).toEqual([true, false]);
+    expect(elements.root.classList.contains("is-collapsed")).toBe(false);
+    expect(elements.content.style.display).toBe("");
+    expect(elements.content.getAttribute("aria-hidden")).toBe("false");
+    expect(elements.toggle.getAttribute("aria-expanded")).toBe("true");
+    expect(elements.icon.textContent).toBe("-");
+  });
+});
+
+function createDisclosureElements() {
+  const classNames = new Set();
+  const contentAttributes = new Map();
+  const attributes = new Map();
+  const icon = { textContent: "" };
+  const toggle = Object.assign(new EventTarget(), {
+    title: "",
+    getAttribute(name) {
+      return attributes.get(name);
+    },
+    querySelector(selector) {
+      return selector === "[aria-hidden='true']" ? icon : null;
+    },
+    setAttribute(name, value) {
+      attributes.set(name, value);
+    },
+  });
+
+  return {
+    content: {
+      style: { display: "" },
+      getAttribute(name) {
+        return contentAttributes.get(name);
+      },
+      setAttribute(name, value) {
+        contentAttributes.set(name, value);
+      },
+    },
+    icon,
+    root: {
+      classList: {
+        add(className) {
+          classNames.add(className);
+        },
+        contains(className) {
+          return classNames.has(className);
+        },
+        remove(className) {
+          classNames.delete(className);
+        },
+        toggle(className, force) {
+          if (force) {
+            classNames.add(className);
+            return true;
+          }
+
+          classNames.delete(className);
+          return false;
+        },
+      },
+    },
+    toggle,
+  };
+}

--- a/projects/labs/raw-webgl2-shader/tests/renderer-camera.test.js
+++ b/projects/labs/raw-webgl2-shader/tests/renderer-camera.test.js
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "bun:test";
+import { createOrbitCamera } from "../src/renderer.js";
+
+describe("createOrbitCamera", () => {
+  test("2本指のピンチアウトで拡大する", () => {
+    const canvas = createTestCanvas();
+    const camera = createOrbitCamera(canvas);
+
+    dispatchPointer(canvas, "pointerdown", {
+      clientX: 0,
+      clientY: 0,
+      pointerId: 1,
+    });
+    dispatchPointer(canvas, "pointerdown", {
+      clientX: 0,
+      clientY: 100,
+      pointerId: 2,
+    });
+    dispatchPointer(canvas, "pointermove", {
+      clientX: 0,
+      clientY: 200,
+      pointerId: 2,
+    });
+
+    expect(camera.getViewScale()).toBe(0.5);
+  });
+
+  test("2本指のピンチインで縮小する", () => {
+    const canvas = createTestCanvas();
+    const camera = createOrbitCamera(canvas);
+
+    dispatchPointer(canvas, "pointerdown", {
+      clientX: 0,
+      clientY: 0,
+      pointerId: 1,
+    });
+    dispatchPointer(canvas, "pointerdown", {
+      clientX: 0,
+      clientY: 200,
+      pointerId: 2,
+    });
+    dispatchPointer(canvas, "pointermove", {
+      clientX: 0,
+      clientY: 100,
+      pointerId: 2,
+    });
+
+    expect(camera.getViewScale()).toBe(2);
+  });
+
+  test("1本指では既存どおり回転する", () => {
+    const canvas = createTestCanvas();
+    const camera = createOrbitCamera(canvas);
+    const initialEye = camera.getEye();
+
+    dispatchPointer(canvas, "pointerdown", {
+      clientX: 0,
+      clientY: 0,
+      pointerId: 1,
+    });
+    dispatchPointer(canvas, "pointermove", {
+      clientX: 40,
+      clientY: 0,
+      pointerId: 1,
+    });
+
+    expect(camera.getEye()).not.toEqual(initialEye);
+  });
+});
+
+function createTestCanvas() {
+  const captures = new Set();
+
+  return Object.assign(new EventTarget(), {
+    clientHeight: 1000,
+    classList: {
+      add() {},
+      remove() {},
+    },
+    hasPointerCapture(pointerId) {
+      return captures.has(pointerId);
+    },
+    releasePointerCapture(pointerId) {
+      captures.delete(pointerId);
+    },
+    setPointerCapture(pointerId) {
+      captures.add(pointerId);
+    },
+  });
+}
+
+function dispatchPointer(canvas, type, options) {
+  const event = new Event(type, { cancelable: true });
+
+  Object.assign(event, {
+    button: 0,
+    clientX: options.clientX,
+    clientY: options.clientY,
+    pointerId: options.pointerId,
+    pointerType: "touch",
+  });
+  canvas.dispatchEvent(event);
+
+  return event;
+}


### PR DESCRIPTION
## Issues

- Refs mobile usability improvements for the raw WebGL2 shader lab

## Why

Mobile users could not reliably import models or adjust the camera because the UI depended on desktop-oriented drag/drop and wheel interactions. The fixed HUD also occupied too much canvas space on iPhone-sized screens.

## Summary

This PR improves mobile usability for the raw WebGL2 glTF viewer. It adds a direct file picker, touch pinch zoom, and a collapsible HUD while keeping the existing desktop drag/drop and mouse controls intact.

## Changes

- Add a file upload control beside the glTF drop status label.
- Keep the HUD width stable when long file names are loaded.
- Add two-finger pinch zoom for touch devices.
- Add a collapsible HUD that defaults collapsed on narrow viewports and persists the user's choice.
- Add tests for file selection helpers, camera touch gestures, and HUD disclosure behavior.

## Checklist

- [x] Test: `bun test`
- [ ] Format: no project format script found
- [ ] Lint / typecheck: no project lint/typecheck script found
