### PR TITLE
feat(raw-webgl2-shader): add material info panel

### DIFF
--- a/projects/labs/raw-webgl2-shader/index.html
+++ b/projects/labs/raw-webgl2-shader/index.html
@@ -34,7 +34,7 @@
             <input id="model-file-input" class="model-file-input" type="file" accept=".gltf,.glb" />
           </label>
         </div>
-        <dl id="model-info" class="model-info" aria-label="Model information"></dl>
+        <section id="model-info" class="model-info" aria-label="Model information"></section>
         <div id="render-controls" class="render-controls" aria-label="Render controls"></div>
         <div id="color-controls" class="color-controls" aria-label="Color controls"></div>
       </div>

--- a/projects/labs/raw-webgl2-shader/src/gltf.js
+++ b/projects/labs/raw-webgl2-shader/src/gltf.js
@@ -209,6 +209,7 @@ function readGlbChunk(dataView, chunkHeaderOffset, label) {
 function createModelFromGltf(gltf, buffers) {
   const model = {
     bounds: createEmptyBounds(),
+    materials: getModelMaterials(gltf),
     triangles: [],
     wireframe: [],
   };
@@ -219,6 +220,7 @@ function createModelFromGltf(gltf, buffers) {
 
   return {
     bounds: model.bounds,
+    materials: model.materials,
     triangles: new Float32Array(model.triangles),
     wireframe: new Float32Array(model.wireframe),
   };
@@ -237,6 +239,7 @@ export function fitModelToGround(model, targetHeight = 1.45) {
 
   return {
     bounds: model.bounds,
+    materials: model.materials ?? [],
     triangles: fitVertices(model.triangles, centerX, bounds.min[1], centerZ, scale),
     wireframe: fitVertices(model.wireframe, centerX, bounds.min[1], centerZ, scale),
   };
@@ -406,6 +409,14 @@ function getMaterialColor(gltf, materialIndex) {
     DEFAULT_COLOR;
 
   return [factor[0], factor[1], factor[2]];
+}
+
+function getModelMaterials(gltf) {
+  return (gltf.materials ?? []).map((material, index) => ({
+    baseColor: getMaterialColor(gltf, index),
+    index,
+    name: material.name ?? "",
+  }));
 }
 
 function fitVertices(vertices, centerX, minY, centerZ, scale) {

--- a/projects/labs/raw-webgl2-shader/src/hud.js
+++ b/projects/labs/raw-webgl2-shader/src/hud.js
@@ -250,6 +250,11 @@ function createMaterialRow(material) {
   color.className = "material-color";
   index.textContent = `#${material.index}`;
   name.textContent = material.name || "-";
+
+  if (material.name) {
+    name.title = material.name;
+  }
+
   swatch.style.backgroundColor = toCssColor(material.baseColor);
   swatch.title = formatColor(material.baseColor);
   swatch.setAttribute("aria-hidden", "true");

--- a/projects/labs/raw-webgl2-shader/src/hud.js
+++ b/projects/labs/raw-webgl2-shader/src/hud.js
@@ -314,13 +314,7 @@ function formatColor(color) {
 }
 
 function formatColorNumber(value) {
-  const rounded = Math.round(value * 1000) / 1000;
-
-  if (Number.isInteger(rounded)) {
-    return String(rounded);
-  }
-
-  return rounded.toFixed(3).replace(/0+$/, "").replace(/\.$/, "");
+  return value.toFixed(3);
 }
 
 function toCssColor(color) {

--- a/projects/labs/raw-webgl2-shader/src/hud.js
+++ b/projects/labs/raw-webgl2-shader/src/hud.js
@@ -158,16 +158,12 @@ export function createModelInfoPanel(element) {
     };
   }
 
-  function render(rows) {
+  function render(rows, materials = []) {
     element.textContent = "";
+    element.append(createModelInfoList(rows));
 
-    for (const [labelText, valueText] of rows) {
-      const label = document.createElement("dt");
-      const value = document.createElement("dd");
-
-      label.textContent = labelText;
-      value.textContent = valueText;
-      element.append(label, value);
+    if (materials.length > 0) {
+      element.append(createMaterialsSection(materials));
     }
   }
 
@@ -181,14 +177,87 @@ export function createModelInfoPanel(element) {
       ]);
     },
     setModelInfo(info) {
-      render([
-        ["ファイル", info.fileName],
-        ["頂点", formatCount(info.vertexCount)],
-        ["ポリゴン", formatCount(info.polygonCount)],
-        ["サイズ", formatModelSize(info.size)],
-      ]);
+      render(
+        [
+          ["ファイル", info.fileName],
+          ["頂点", formatCount(info.vertexCount)],
+          ["ポリゴン", formatCount(info.polygonCount)],
+          ["サイズ", formatModelSize(info.size)],
+        ],
+        info.materials ?? [],
+      );
     },
   };
+}
+
+function createModelInfoList(rows) {
+  const list = document.createElement("dl");
+  list.className = "model-info-list";
+
+  for (const [labelText, valueText] of rows) {
+    const label = document.createElement("dt");
+    const value = document.createElement("dd");
+
+    label.textContent = labelText;
+    value.textContent = valueText;
+    list.append(label, value);
+  }
+
+  return list;
+}
+
+function createMaterialsSection(materials) {
+  const root = document.createElement("section");
+  const toggle = document.createElement("button");
+  const title = document.createElement("span");
+  const icon = document.createElement("span");
+  const content = document.createElement("div");
+
+  root.className = "materials-panel";
+  toggle.className = "materials-toggle";
+  toggle.type = "button";
+  title.textContent = `Materials (${materials.length})`;
+  icon.className = "materials-toggle-icon";
+  icon.setAttribute("aria-hidden", "true");
+  content.className = "materials-list";
+
+  toggle.append(title, icon);
+  content.append(...materials.map(createMaterialRow));
+  root.append(toggle, content);
+
+  createHudDisclosure({
+    root,
+    toggle,
+    content,
+    icon,
+    initialCollapsed: true,
+  });
+
+  return root;
+}
+
+function createMaterialRow(material) {
+  const row = document.createElement("div");
+  const index = document.createElement("span");
+  const name = document.createElement("span");
+  const swatch = document.createElement("span");
+  const color = document.createElement("span");
+
+  row.className = "material-row";
+  index.className = "material-index";
+  name.className = "material-name";
+  swatch.className = "material-swatch";
+  color.className = "material-color";
+  index.textContent = `#${material.index}`;
+  name.textContent = material.name || "-";
+  swatch.style.backgroundColor = toCssColor(material.baseColor);
+  swatch.title = formatColor(material.baseColor);
+  swatch.setAttribute("aria-hidden", "true");
+  color.textContent = formatColor(material.baseColor);
+
+  row.append(index, name, swatch, color);
+
+  return row;
 }
 
 export function createRenderControls(element, renderOptions) {
@@ -238,4 +307,26 @@ export function createColorControls(element, renderOptions, onChange = () => {})
 
 function formatCount(value) {
   return Math.round(value).toLocaleString("ja-JP");
+}
+
+function formatColor(color) {
+  return `[${color.map(formatColorNumber).join(", ")}]`;
+}
+
+function formatColorNumber(value) {
+  const rounded = Math.round(value * 1000) / 1000;
+
+  if (Number.isInteger(rounded)) {
+    return String(rounded);
+  }
+
+  return rounded.toFixed(3).replace(/0+$/, "").replace(/\.$/, "");
+}
+
+function toCssColor(color) {
+  const [r, g, b] = color.map((value) =>
+    Math.round(Math.max(0, Math.min(value, 1)) * 255),
+  );
+
+  return `rgb(${r} ${g} ${b})`;
 }

--- a/projects/labs/raw-webgl2-shader/src/model-info.js
+++ b/projects/labs/raw-webgl2-shader/src/model-info.js
@@ -6,6 +6,7 @@ export function createModelInfo(fileName, model) {
 
   return {
     fileName,
+    materials: model.materials ?? [],
     vertexCount,
     polygonCount,
     size: [

--- a/projects/labs/raw-webgl2-shader/src/styles.css
+++ b/projects/labs/raw-webgl2-shader/src/styles.css
@@ -193,30 +193,119 @@ body.is-dropping-model .drop-overlay {
 
 .model-info {
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
-  gap: 5px 12px;
-  margin: 8px 0 0;
+  gap: 8px;
+  min-width: 0;
+  margin-top: 8px;
   padding-top: 8px;
   border-top: 1px solid rgb(255 255 255 / 12%);
 }
 
-.model-info dt,
-.model-info dd {
+.model-info-list {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 5px 12px;
+  margin: 0;
+}
+
+.model-info-list dt,
+.model-info-list dd {
   margin: 0;
   line-height: 1.15;
 }
 
-.model-info dt {
+.model-info-list dt {
   color: rgb(244 241 234 / 62%);
 }
 
-.model-info dd {
+.model-info-list dd {
   min-width: 0;
   overflow: hidden;
   color: rgb(244 241 234 / 88%);
   text-align: right;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.materials-panel {
+  display: grid;
+  gap: 6px;
+  padding-top: 8px;
+  border-top: 1px solid rgb(255 255 255 / 12%);
+}
+
+.materials-toggle {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 0;
+  border: 0;
+  appearance: none;
+  background: transparent;
+  color: rgb(244 241 234 / 88%);
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+}
+
+.materials-toggle:hover {
+  color: #f2b84b;
+}
+
+.materials-toggle:hover span:first-child,
+.materials-toggle:hover .materials-toggle-icon {
+  color: #f2b84b;
+}
+
+.materials-toggle:focus-visible {
+  outline: 2px solid #f2b84b;
+  outline-offset: 2px;
+}
+
+.materials-toggle span:first-child {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hud .materials-toggle-icon {
+  color: rgb(244 241 234 / 62%);
+  font-variant-numeric: tabular-nums;
+}
+
+.materials-list {
+  display: grid;
+  gap: 4px;
+}
+
+.material-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) 12px auto;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  color: rgb(244 241 234 / 76%);
+  font-variant-numeric: tabular-nums;
+}
+
+.hud .material-index,
+.hud .material-color {
+  color: rgb(244 241 234 / 62%);
+}
+
+.material-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.material-swatch {
+  width: 12px;
+  height: 12px;
+  border: 1px solid rgb(255 255 255 / 24%);
 }
 
 .render-controls {

--- a/projects/labs/raw-webgl2-shader/tests/gltf.test.js
+++ b/projects/labs/raw-webgl2-shader/tests/gltf.test.js
@@ -58,6 +58,13 @@ describe("loadGltfModelFromFile", () => {
     expectVector(readPackedVertex(model.triangles, 0).normal, [0, 0, 1]);
     expectVector(readPackedVertex(model.triangles, 0).color, [1, 0, 0]);
     expectVector(readPackedVertex(model.triangles, 0).materialColor, [0.25, 0.5, 0.75]);
+    expect(model.materials).toEqual([
+      {
+        baseColor: [0.25, 0.5, 0.75],
+        index: 0,
+        name: "",
+      },
+    ]);
   });
 
   test("indicesがない場合は頂点順で三角形を作る", async () => {

--- a/projects/labs/raw-webgl2-shader/tests/hud.test.js
+++ b/projects/labs/raw-webgl2-shader/tests/hud.test.js
@@ -73,9 +73,11 @@ describe("createModelInfoPanel", () => {
     const toggle = materials.children[0];
     const content = materials.children[1];
     const icon = toggle.children[1];
+    const row = content.children[0];
 
     expect(materials.classList.contains("materials-panel")).toBe(true);
     expect(toggle.children[0].textContent).toBe("Materials (1)");
+    expect(row.children[3].textContent).toBe("[0.250, 0.500, 0.750]");
     expect(content.style.display).toBe("none");
     expect(content.getAttribute("aria-hidden")).toBe("true");
     expect(icon.textContent).toBe("+");

--- a/projects/labs/raw-webgl2-shader/tests/hud.test.js
+++ b/projects/labs/raw-webgl2-shader/tests/hud.test.js
@@ -77,6 +77,7 @@ describe("createModelInfoPanel", () => {
 
     expect(materials.classList.contains("materials-panel")).toBe(true);
     expect(toggle.children[0].textContent).toBe("Materials (1)");
+    expect(row.children[1].title).toBe("Body");
     expect(row.children[3].textContent).toBe("[0.250, 0.500, 0.750]");
     expect(content.style.display).toBe("none");
     expect(content.getAttribute("aria-hidden")).toBe("true");

--- a/projects/labs/raw-webgl2-shader/tests/hud.test.js
+++ b/projects/labs/raw-webgl2-shader/tests/hud.test.js
@@ -1,5 +1,16 @@
-import { describe, expect, test } from "bun:test";
-import { createHudDisclosure } from "../src/hud.js";
+import { afterEach, describe, expect, test } from "bun:test";
+import { createHudDisclosure, createModelInfoPanel } from "../src/hud.js";
+
+const originalDocument = globalThis.document;
+
+afterEach(() => {
+  if (originalDocument === undefined) {
+    delete globalThis.document;
+    return;
+  }
+
+  globalThis.document = originalDocument;
+});
 
 describe("createHudDisclosure", () => {
   test("初期状態で折りたためる", () => {
@@ -36,6 +47,44 @@ describe("createHudDisclosure", () => {
     expect(elements.content.getAttribute("aria-hidden")).toBe("false");
     expect(elements.toggle.getAttribute("aria-expanded")).toBe("true");
     expect(elements.icon.textContent).toBe("-");
+  });
+});
+
+describe("createModelInfoPanel", () => {
+  test("Materialsセクションをデフォルトで閉じて表示する", () => {
+    globalThis.document = createFakeDocument();
+    const panel = document.createElement("section");
+
+    createModelInfoPanel(panel).setModelInfo({
+      fileName: "sample.glb",
+      materials: [
+        {
+          baseColor: [0.25, 0.5, 0.75],
+          index: 0,
+          name: "Body",
+        },
+      ],
+      polygonCount: 1,
+      size: [1, 2, 3],
+      vertexCount: 3,
+    });
+
+    const materials = panel.children[1];
+    const toggle = materials.children[0];
+    const content = materials.children[1];
+    const icon = toggle.children[1];
+
+    expect(materials.classList.contains("materials-panel")).toBe(true);
+    expect(toggle.children[0].textContent).toBe("Materials (1)");
+    expect(content.style.display).toBe("none");
+    expect(content.getAttribute("aria-hidden")).toBe("true");
+    expect(icon.textContent).toBe("+");
+
+    toggle.dispatchEvent(new Event("click"));
+
+    expect(content.style.display).toBe("");
+    expect(content.getAttribute("aria-hidden")).toBe("false");
+    expect(icon.textContent).toBe("-");
   });
 });
 
@@ -92,4 +141,68 @@ function createDisclosureElements() {
     },
     toggle,
   };
+}
+
+function createFakeDocument() {
+  return {
+    createElement(tagName) {
+      return new FakeElement(tagName);
+    },
+  };
+}
+
+class FakeElement extends EventTarget {
+  #attributes = new Map();
+  #classNames = new Set();
+  #textContent = "";
+
+  constructor(tagName) {
+    super();
+    this.children = [];
+    this.style = {};
+    this.tagName = tagName.toUpperCase();
+    this.title = "";
+    this.type = "";
+    this.classList = {
+      add: (className) => {
+        this.#classNames.add(className);
+      },
+      contains: (className) => this.#classNames.has(className),
+      remove: (className) => {
+        this.#classNames.delete(className);
+      },
+    };
+  }
+
+  get className() {
+    return Array.from(this.#classNames).join(" ");
+  }
+
+  set className(value) {
+    this.#classNames = new Set(value.split(/\s+/).filter(Boolean));
+  }
+
+  get textContent() {
+    return this.#textContent;
+  }
+
+  set textContent(value) {
+    this.#textContent = value;
+
+    if (value === "") {
+      this.children = [];
+    }
+  }
+
+  append(...children) {
+    this.children.push(...children.flat());
+  }
+
+  getAttribute(name) {
+    return this.#attributes.get(name);
+  }
+
+  setAttribute(name, value) {
+    this.#attributes.set(name, value);
+  }
 }

--- a/projects/labs/raw-webgl2-shader/tests/model-info.test.js
+++ b/projects/labs/raw-webgl2-shader/tests/model-info.test.js
@@ -8,11 +8,25 @@ describe("createModelInfo", () => {
         min: [-1, 2, 0.25],
         max: [3, 5.5, 1],
       },
+      materials: [
+        {
+          baseColor: [0.95, 0.72, 0.28],
+          index: 0,
+          name: "Body",
+        },
+      ],
       triangles: new Float32Array(6 * 12),
     };
 
     expect(createModelInfo("sample.glb", model)).toEqual({
       fileName: "sample.glb",
+      materials: [
+        {
+          baseColor: [0.95, 0.72, 0.28],
+          index: 0,
+          name: "Body",
+        },
+      ],
       vertexCount: 6,
       polygonCount: 2,
       size: [4, 3.5, 0.75],


### PR DESCRIPTION
## Why

The viewer already reads glTF material base colors, but the HUD did not expose that information for inspection. A collapsed materials section keeps the default HUD compact while making imported material colors easy to verify.

## Summary

Adds material metadata to loaded models and shows a collapsed Materials section below the existing model info. Each material row includes the index, optional name, swatch, and RGB base color.
<img width="966" height="643" alt="image" src="https://github.com/user-attachments/assets/79401a02-fec0-4c0c-bbd0-427c53b4b4a3" />
<img width="340" height="188" alt="image" src="https://github.com/user-attachments/assets/2023e7c0-0bea-4eb5-b912-9e4d5f7a5e11" />

## Changes

- Preserve glTF material index, name, and baseColor in the loaded model
- Include materials in model info passed to the HUD
- Render a default-collapsed Materials section under the model size divider
- Add CSS for the material list, swatches, and disclosure states
- Cover material metadata and HUD disclosure behavior in tests

## Verification

- `bun test` - passed
- `git diff --check` - passed
