### PR TITLE
feat(raw-webgl2-shader): add auto fit toggle

### DIFF
--- a/projects/labs/raw-webgl2-shader/src/hud.js
+++ b/projects/labs/raw-webgl2-shader/src/hud.js
@@ -9,6 +9,7 @@ const CONTROL_ITEMS = [
   ["lightingEnabled", "ライト"],
   ["gridVisible", "グリッド"],
   ["axesVisible", "軸"],
+  ["autoFitModel", "自動フィット"],
 ];
 
 const COLOR_ITEMS = [

--- a/projects/labs/raw-webgl2-shader/src/main.js
+++ b/projects/labs/raw-webgl2-shader/src/main.js
@@ -55,6 +55,7 @@ const gameState = {
     lightingEnabled: true,
     gridVisible: true,
     axesVisible: true,
+    autoFitModel: false,
     backgroundColor: loadStoredColor(
       STORAGE_KEYS.backgroundColor,
       DEFAULT_BACKGROUND_COLOR,
@@ -155,7 +156,7 @@ async function importModelFiles(files) {
   try {
     const model = await loadGltfModelFromFile(file);
 
-    renderer.setModel(model);
+    renderer.setModel(model, gameState.renderOptions);
     modelInfoPanel.setModelInfo(createModelInfo(file.name, model));
     importStatus.setLoaded(file.name);
   } catch (error) {

--- a/projects/labs/raw-webgl2-shader/src/renderer.js
+++ b/projects/labs/raw-webgl2-shader/src/renderer.js
@@ -44,14 +44,16 @@ export function createRenderer(canvas) {
   const xzGrid = createDrawable(gl, xzGridVertices, attributes);
   const axes = createDrawable(gl, axisVertices, attributes);
   const camera = createOrbitCamera(canvas);
+  let sourceModel = null;
   let currentModel = null;
-  let modelRevision = 0;
+  let currentAutoFitModel = null;
 
   gl.enable(gl.DEPTH_TEST);
   gl.depthFunc(gl.LEQUAL);
 
   return {
     render({ renderOptions }) {
+      syncCurrentModel(renderOptions);
       const matrix = prepareFrame(
         gl,
         canvas,
@@ -80,19 +82,32 @@ export function createRenderer(canvas) {
       drawModel(gl, currentModel, renderOptions, uniforms);
     },
     clearModel() {
-      modelRevision += 1;
+      sourceModel = null;
       replaceCurrentModel(null);
     },
-    setModel(model) {
-      modelRevision += 1;
-      replaceCurrentModel(model);
+    setModel(model, renderOptions = {}) {
+      sourceModel = model;
+      replaceCurrentModel(model, Boolean(renderOptions.autoFitModel));
       camera.reset();
     },
   };
 
-  function replaceCurrentModel(model) {
+  function replaceCurrentModel(model, autoFitModel = false) {
     disposeModel(gl, currentModel);
-    currentModel = model === null ? null : createRenderModel(gl, attributes, model);
+    currentModel = model === null ? null : createRenderModel(gl, attributes, model, autoFitModel);
+    currentAutoFitModel = model === null ? null : autoFitModel;
+  }
+
+  function syncCurrentModel(renderOptions) {
+    if (sourceModel === null) {
+      return;
+    }
+
+    const autoFitModel = Boolean(renderOptions.autoFitModel);
+
+    if (currentAutoFitModel !== autoFitModel) {
+      replaceCurrentModel(sourceModel, autoFitModel);
+    }
   }
 }
 
@@ -389,12 +404,12 @@ function createDrawable(gl, vertices, attributes) {
   };
 }
 
-function createRenderModel(gl, attributes, model) {
-  const fittedModel = fitModelToGround(model, MODEL_TARGET_HEIGHT);
+function createRenderModel(gl, attributes, model, autoFitModel) {
+  const renderModel = autoFitModel ? fitModelToGround(model, MODEL_TARGET_HEIGHT) : model;
 
   return {
-    surface: createDrawable(gl, fittedModel.triangles, attributes),
-    wireframe: createDrawable(gl, fittedModel.wireframe, attributes),
+    surface: createDrawable(gl, renderModel.triangles, attributes),
+    wireframe: createDrawable(gl, renderModel.wireframe, attributes),
   };
 }
 

--- a/projects/labs/raw-webgl2-shader/tests/hud.test.js
+++ b/projects/labs/raw-webgl2-shader/tests/hud.test.js
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { createHudDisclosure, createModelInfoPanel } from "../src/hud.js";
+import { createHudDisclosure, createModelInfoPanel, createRenderControls } from "../src/hud.js";
 
 const originalDocument = globalThis.document;
 
@@ -88,6 +88,35 @@ describe("createModelInfoPanel", () => {
     expect(content.style.display).toBe("");
     expect(content.getAttribute("aria-hidden")).toBe("false");
     expect(icon.textContent).toBe("-");
+  });
+});
+
+describe("createRenderControls", () => {
+  test("自動フィットをデフォルトOffのトグルとして表示する", () => {
+    globalThis.document = createFakeDocument();
+    const root = document.createElement("div");
+    const renderOptions = {
+      autoFitModel: false,
+      axesVisible: true,
+      gridVisible: true,
+      lightingEnabled: true,
+      surfaceVisible: true,
+      useVertexColors: true,
+      wireframeVisible: true,
+    };
+
+    createRenderControls(root, renderOptions);
+
+    const autoFitLabel = root.children.find((label) => label.children[1].textContent === "自動フィット");
+    const input = autoFitLabel.children[0];
+
+    expect(autoFitLabel).toBeDefined();
+    expect(input.checked).toBe(false);
+
+    input.checked = true;
+    input.dispatchEvent(new Event("change"));
+
+    expect(renderOptions.autoFitModel).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Why

モデルソフト側で設定した原点やオフセットを確認したい場合に、読み込み後の自動接地・中央寄せ補正が意図した配置を隠していました。

## Summary

デフォルトでは元モデルの座標情報をそのまま描画し、必要な場合だけ HUD から自動フィットを有効化できるようにします。

<img width="968" height="493" alt="image" src="https://github.com/user-attachments/assets/c784b6e0-35f8-4e3d-8c32-4c97dc8d671b" />
<img width="975" height="459" alt="image" src="https://github.com/user-attachments/assets/019bd7fc-b923-4165-8e8f-2c2f107213cd" />


## Changes

- HUD の描画設定に `自動フィット` トグルを追加
- `autoFitModel` の初期値を Off に変更
- renderer が元モデルを保持し、トグル切り替え時に補正あり/なしの描画バッファを再生成するよう変更
- HUD トグルの表示と状態更新をテストで追加

## Checklist

- [x] `bun test`
- [x] `git diff --check`
