### PR TITLE
Refactor raw WebGL glTF model into primitives

### DIFF
--- a/projects/labs/raw-webgl2-shader/src/gltf.js
+++ b/projects/labs/raw-webgl2-shader/src/gltf.js
@@ -1,3 +1,5 @@
+import { FLOATS_PER_VERTEX } from "./vertex-layout.js";
+
 const COMPONENT_READERS = {
   5120: { byteSize: 1, read: (view, offset) => view.getInt8(offset) },
   5121: { byteSize: 1, read: (view, offset) => view.getUint8(offset) },
@@ -210,8 +212,7 @@ function createModelFromGltf(gltf, buffers) {
   const model = {
     bounds: createEmptyBounds(),
     materials: getModelMaterials(gltf),
-    triangles: [],
-    wireframe: [],
+    primitives: [],
   };
 
   for (const sceneIndex of getSceneNodeIndices(gltf)) {
@@ -221,8 +222,12 @@ function createModelFromGltf(gltf, buffers) {
   return {
     bounds: model.bounds,
     materials: model.materials,
-    triangles: new Float32Array(model.triangles),
-    wireframe: new Float32Array(model.wireframe),
+    primitives: model.primitives.map((primitive) => ({
+      materialIndex: primitive.materialIndex,
+      texcoords: primitive.texcoords === null ? null : new Float32Array(primitive.texcoords),
+      triangles: new Float32Array(primitive.triangles),
+      wireframe: new Float32Array(primitive.wireframe),
+    })),
   };
 }
 
@@ -240,8 +245,12 @@ export function fitModelToGround(model, targetHeight = 1.45) {
   return {
     bounds: model.bounds,
     materials: model.materials ?? [],
-    triangles: fitVertices(model.triangles, centerX, bounds.min[1], centerZ, scale),
-    wireframe: fitVertices(model.wireframe, centerX, bounds.min[1], centerZ, scale),
+    primitives: model.primitives.map((primitive) => ({
+      materialIndex: primitive.materialIndex,
+      texcoords: primitive.texcoords,
+      triangles: fitVertices(primitive.triangles, centerX, bounds.min[1], centerZ, scale),
+      wireframe: fitVertices(primitive.wireframe, centerX, bounds.min[1], centerZ, scale),
+    })),
   };
 }
 
@@ -343,11 +352,22 @@ function appendPrimitive(model, gltf, buffers, primitive, matrix) {
     primitive.attributes.COLOR_0 === undefined
       ? null
       : readAccessor(gltf, buffers, primitive.attributes.COLOR_0);
+  const texcoords =
+    primitive.attributes.TEXCOORD_0 === undefined
+      ? null
+      : readAccessor(gltf, buffers, primitive.attributes.TEXCOORD_0);
   const indices =
     primitive.indices === undefined
       ? createSequentialIndices(positions.count)
       : readAccessor(gltf, buffers, primitive.indices);
-  const materialColor = getMaterialColor(gltf, primitive.material);
+  const materialIndex = primitive.material ?? null;
+  const materialColor = getMaterialColor(gltf, materialIndex);
+  const modelPrimitive = {
+    materialIndex,
+    texcoords: texcoords === null ? null : [],
+    triangles: [],
+    wireframe: [],
+  };
 
   for (let index = 0; index < indices.count; index += 3) {
     const a = indices.get(index);
@@ -359,16 +379,26 @@ function appendPrimitive(model, gltf, buffers, primitive, matrix) {
       createVertex(positions, normals, colors, materialColor, matrix, c),
     ];
 
-    pushPackedVertex(model.triangles, model.bounds, triangle[0]);
-    pushPackedVertex(model.triangles, model.bounds, triangle[1]);
-    pushPackedVertex(model.triangles, model.bounds, triangle[2]);
+    pushPackedVertex(modelPrimitive.triangles, model.bounds, triangle[0]);
+    pushPackedVertex(modelPrimitive.triangles, model.bounds, triangle[1]);
+    pushPackedVertex(modelPrimitive.triangles, model.bounds, triangle[2]);
 
-    pushPackedVertex(model.wireframe, model.bounds, triangle[0]);
-    pushPackedVertex(model.wireframe, model.bounds, triangle[1]);
-    pushPackedVertex(model.wireframe, model.bounds, triangle[1]);
-    pushPackedVertex(model.wireframe, model.bounds, triangle[2]);
-    pushPackedVertex(model.wireframe, model.bounds, triangle[2]);
-    pushPackedVertex(model.wireframe, model.bounds, triangle[0]);
+    pushPackedVertex(modelPrimitive.wireframe, model.bounds, triangle[0]);
+    pushPackedVertex(modelPrimitive.wireframe, model.bounds, triangle[1]);
+    pushPackedVertex(modelPrimitive.wireframe, model.bounds, triangle[1]);
+    pushPackedVertex(modelPrimitive.wireframe, model.bounds, triangle[2]);
+    pushPackedVertex(modelPrimitive.wireframe, model.bounds, triangle[2]);
+    pushPackedVertex(modelPrimitive.wireframe, model.bounds, triangle[0]);
+
+    if (texcoords !== null) {
+      pushTexcoord(modelPrimitive.texcoords, texcoords, a);
+      pushTexcoord(modelPrimitive.texcoords, texcoords, b);
+      pushTexcoord(modelPrimitive.texcoords, texcoords, c);
+    }
+  }
+
+  if (modelPrimitive.triangles.length > 0) {
+    model.primitives.push(modelPrimitive);
   }
 }
 
@@ -404,25 +434,39 @@ function pushPackedVertex(vertices, bounds, vertex) {
 }
 
 function getMaterialColor(gltf, materialIndex) {
-  const factor =
-    gltf.materials?.[materialIndex]?.pbrMetallicRoughness?.baseColorFactor ??
-    DEFAULT_COLOR;
+  const factor = getMaterialBaseColorFactor(gltf, materialIndex);
 
   return [factor[0], factor[1], factor[2]];
 }
 
 function getModelMaterials(gltf) {
   return (gltf.materials ?? []).map((material, index) => ({
+    baseColorFactor: getMaterialBaseColorFactor(gltf, index),
     baseColor: getMaterialColor(gltf, index),
+    baseColorTexture: null,
     index,
     name: material.name ?? "",
   }));
 }
 
+function getMaterialBaseColorFactor(gltf, materialIndex) {
+  const factor =
+    gltf.materials?.[materialIndex]?.pbrMetallicRoughness?.baseColorFactor ??
+    DEFAULT_COLOR;
+
+  return [factor[0], factor[1], factor[2], factor[3] ?? 1];
+}
+
+function pushTexcoord(texcoords, accessor, vertexIndex) {
+  const texcoord = accessor.get(vertexIndex);
+
+  texcoords.push(texcoord[0], texcoord[1]);
+}
+
 function fitVertices(vertices, centerX, minY, centerZ, scale) {
   const fitted = new Float32Array(vertices);
 
-  for (let index = 0; index < fitted.length; index += 12) {
+  for (let index = 0; index < fitted.length; index += FLOATS_PER_VERTEX) {
     fitted[index] = (fitted[index] - centerX) * scale;
     fitted[index + 1] = (fitted[index + 1] - minY) * scale;
     fitted[index + 2] = (fitted[index + 2] - centerZ) * scale;

--- a/projects/labs/raw-webgl2-shader/src/model-info.js
+++ b/projects/labs/raw-webgl2-shader/src/model-info.js
@@ -1,7 +1,10 @@
 import { FLOATS_PER_VERTEX } from "./vertex-layout.js";
 
 export function createModelInfo(fileName, model) {
-  const vertexCount = model.triangles.length / FLOATS_PER_VERTEX;
+  const vertexCount = model.primitives.reduce(
+    (sum, primitive) => sum + primitive.triangles.length / FLOATS_PER_VERTEX,
+    0,
+  );
   const polygonCount = vertexCount / 3;
 
   return {

--- a/projects/labs/raw-webgl2-shader/src/renderer.js
+++ b/projects/labs/raw-webgl2-shader/src/renderer.js
@@ -408,8 +408,10 @@ function createRenderModel(gl, attributes, model, autoFitModel) {
   const renderModel = autoFitModel ? fitModelToGround(model, MODEL_TARGET_HEIGHT) : model;
 
   return {
-    surface: createDrawable(gl, renderModel.triangles, attributes),
-    wireframe: createDrawable(gl, renderModel.wireframe, attributes),
+    primitives: renderModel.primitives.map((primitive) => ({
+      surface: createDrawable(gl, primitive.triangles, attributes),
+      wireframe: createDrawable(gl, primitive.wireframe, attributes),
+    })),
   };
 }
 
@@ -418,8 +420,10 @@ function disposeModel(gl, model) {
     return;
   }
 
-  disposeDrawable(gl, model.surface);
-  disposeDrawable(gl, model.wireframe);
+  for (const primitive of model.primitives) {
+    disposeDrawable(gl, primitive.surface);
+    disposeDrawable(gl, primitive.wireframe);
+  }
 }
 
 function disposeDrawable(gl, drawable) {
@@ -521,8 +525,12 @@ function drawModel(gl, model, renderOptions, uniforms) {
     gl.disable(gl.CULL_FACE);
     gl.enable(gl.POLYGON_OFFSET_FILL);
     gl.polygonOffset(1, 1);
-    gl.bindVertexArray(model.surface.vao);
-    gl.drawArrays(gl.TRIANGLES, 0, model.surface.vertexCount);
+
+    for (const primitive of model.primitives) {
+      gl.bindVertexArray(primitive.surface.vao);
+      gl.drawArrays(gl.TRIANGLES, 0, primitive.surface.vertexCount);
+    }
+
     gl.disable(gl.POLYGON_OFFSET_FILL);
   }
 
@@ -530,7 +538,10 @@ function drawModel(gl, model, renderOptions, uniforms) {
     gl.uniform1i(uniforms.colorMode, COLOR_MODE_SOLID);
     gl.uniform3fv(uniforms.solidColor, hexColorToRgb(renderOptions.wireframeColor));
     gl.uniform1i(uniforms.lightingEnabled, 0);
-    drawLines(gl, model.wireframe);
+
+    for (const primitive of model.primitives) {
+      drawLines(gl, primitive.wireframe);
+    }
   }
 
   gl.disable(gl.CULL_FACE);

--- a/projects/labs/raw-webgl2-shader/tests/gltf.test.js
+++ b/projects/labs/raw-webgl2-shader/tests/gltf.test.js
@@ -48,19 +48,26 @@ describe("loadGltfModelFromFile", () => {
 
     const model = await loadGltfModelFromFile(createGltfFile(gltf));
 
-    expect(model.triangles).toBeInstanceOf(Float32Array);
-    expect(model.wireframe).toBeInstanceOf(Float32Array);
-    expect(model.triangles.length).toBe(3 * PACKED_VERTEX_SIZE);
-    expect(model.wireframe.length).toBe(6 * PACKED_VERTEX_SIZE);
+    expect(model).not.toHaveProperty("triangles");
+    expect(model).not.toHaveProperty("wireframe");
+    expect(model.primitives).toHaveLength(1);
+    expect(model.primitives[0].materialIndex).toBe(0);
+    expect(model.primitives[0].texcoords).toBe(null);
+    expect(model.primitives[0].triangles).toBeInstanceOf(Float32Array);
+    expect(model.primitives[0].wireframe).toBeInstanceOf(Float32Array);
+    expect(model.primitives[0].triangles.length).toBe(3 * PACKED_VERTEX_SIZE);
+    expect(model.primitives[0].wireframe.length).toBe(6 * PACKED_VERTEX_SIZE);
     expectVector(model.bounds.min, [0, 0, 0]);
     expectVector(model.bounds.max, [1, 1, 0]);
-    expectVector(readPackedVertex(model.triangles, 0).position, [0, 0, 0]);
-    expectVector(readPackedVertex(model.triangles, 0).normal, [0, 0, 1]);
-    expectVector(readPackedVertex(model.triangles, 0).color, [1, 0, 0]);
-    expectVector(readPackedVertex(model.triangles, 0).materialColor, [0.25, 0.5, 0.75]);
+    expectVector(readPackedVertex(model.primitives[0].triangles, 0).position, [0, 0, 0]);
+    expectVector(readPackedVertex(model.primitives[0].triangles, 0).normal, [0, 0, 1]);
+    expectVector(readPackedVertex(model.primitives[0].triangles, 0).color, [1, 0, 0]);
+    expectVector(readPackedVertex(model.primitives[0].triangles, 0).materialColor, [0.25, 0.5, 0.75]);
     expect(model.materials).toEqual([
       {
+        baseColorFactor: [0.25, 0.5, 0.75, 1],
         baseColor: [0.25, 0.5, 0.75],
+        baseColorTexture: null,
         index: 0,
         name: "",
       },
@@ -72,10 +79,10 @@ describe("loadGltfModelFromFile", () => {
 
     const model = await loadGltfModelFromFile(createGltfFile(gltf));
 
-    expect(model.triangles.length).toBe(3 * PACKED_VERTEX_SIZE);
-    expectVector(readPackedVertex(model.triangles, 0).position, [0, 0, 0]);
-    expectVector(readPackedVertex(model.triangles, 1).position, [1, 0, 0]);
-    expectVector(readPackedVertex(model.triangles, 2).position, [0, 1, 0]);
+    expect(model.primitives[0].triangles.length).toBe(3 * PACKED_VERTEX_SIZE);
+    expectVector(readPackedVertex(model.primitives[0].triangles, 0).position, [0, 0, 0]);
+    expectVector(readPackedVertex(model.primitives[0].triangles, 1).position, [1, 0, 0]);
+    expectVector(readPackedVertex(model.primitives[0].triangles, 2).position, [0, 1, 0]);
   });
 
   test("byteStride付きのaccessorを読める", async () => {
@@ -92,7 +99,7 @@ describe("loadGltfModelFromFile", () => {
 
     const model = await loadGltfModelFromFile(createGltfFile(gltf));
 
-    expectVector(readPackedVertex(model.triangles, 2).position, [0, 1, 0]);
+    expectVector(readPackedVertex(model.primitives[0].triangles, 2).position, [0, 1, 0]);
     expectVector(model.bounds.max, [1, 1, 0]);
   });
 
@@ -111,8 +118,8 @@ describe("loadGltfModelFromFile", () => {
 
     const model = await loadGltfModelFromFile(createGltfFile(gltf));
 
-    expectVector(readPackedVertex(model.triangles, 0).position, [0, 0, 0]);
-    expectVector(readPackedVertex(model.triangles, 2).position, [0, 1, 0]);
+    expectVector(readPackedVertex(model.primitives[0].triangles, 0).position, [0, 0, 0]);
+    expectVector(readPackedVertex(model.primitives[0].triangles, 2).position, [0, 1, 0]);
     expectVector(model.bounds.min, [0, 0, 0]);
     expectVector(model.bounds.max, [1, 1, 0]);
   });
@@ -130,7 +137,7 @@ describe("loadGltfModelFromFile", () => {
 
     expectVector(model.bounds.min, [10, 20, 30]);
     expectVector(model.bounds.max, [12, 23, 30]);
-    expectVector(readPackedVertex(model.triangles, 1).position, [12, 20, 30]);
+    expectVector(readPackedVertex(model.primitives[0].triangles, 1).position, [12, 20, 30]);
   });
 
   test("NORMALとCOLOR_0がない場合はデフォルト値とmaterial色を使う", async () => {
@@ -139,22 +146,105 @@ describe("loadGltfModelFromFile", () => {
     });
 
     const model = await loadGltfModelFromFile(createGltfFile(gltf));
-    const vertex = readPackedVertex(model.triangles, 0);
+    const vertex = readPackedVertex(model.primitives[0].triangles, 0);
 
     expectVector(vertex.normal, [0, 1, 0]);
     expectVector(vertex.color, [0.1, 0.2, 0.3]);
     expectVector(vertex.materialColor, [0.1, 0.2, 0.3]);
   });
 
+  test("複数primitiveを分けて読み込む", async () => {
+    const gltf = createTriangleGltf({
+      primitiveOverrides: [
+        { material: 0 },
+        {
+          indices: [2, 1, 0],
+          material: 1,
+        },
+      ],
+      materials: [
+        { pbrMetallicRoughness: { baseColorFactor: [0.1, 0.2, 0.3, 0.4] } },
+        { name: "Default factor material" },
+      ],
+    });
+
+    const model = await loadGltfModelFromFile(createGltfFile(gltf));
+
+    expect(model.primitives).toHaveLength(2);
+    expect(model.primitives[0].materialIndex).toBe(0);
+    expect(model.primitives[1].materialIndex).toBe(1);
+    expect(model.primitives[0].triangles.length).toBe(3 * PACKED_VERTEX_SIZE);
+    expect(model.primitives[1].triangles.length).toBe(3 * PACKED_VERTEX_SIZE);
+    expectVector(
+      readPackedVertex(model.primitives[1].triangles, 0).materialColor,
+      [0.95, 0.72, 0.28],
+    );
+    expect(model.materials).toEqual([
+      {
+        baseColor: [0.1, 0.2, 0.3],
+        baseColorFactor: [0.1, 0.2, 0.3, 0.4],
+        baseColorTexture: null,
+        index: 0,
+        name: "",
+      },
+      {
+        baseColor: [0.95, 0.72, 0.28],
+        baseColorFactor: [0.95, 0.72, 0.28, 1],
+        baseColorTexture: null,
+        index: 1,
+        name: "Default factor material",
+      },
+    ]);
+  });
+
+  test("material未指定primitiveはdefault色を焼き込みmaterialsには追加しない", async () => {
+    const gltf = createTriangleGltf({
+      primitiveOverrides: [{ material: undefined }],
+    });
+
+    const model = await loadGltfModelFromFile(createGltfFile(gltf));
+
+    expect(model.primitives[0].materialIndex).toBe(null);
+    expectVector(
+      readPackedVertex(model.primitives[0].triangles, 0).color,
+      [0.95, 0.72, 0.28],
+    );
+    expectVector(
+      readPackedVertex(model.primitives[0].triangles, 0).materialColor,
+      [0.95, 0.72, 0.28],
+    );
+    expect(model.materials).toHaveLength(1);
+  });
+
+  test("TEXCOORD_0をtriangle頂点順のprimitive texcoordsに展開する", async () => {
+    const gltf = createTriangleGltf({
+      indices: [2, 0, 1],
+      texcoords: [
+        0, 0,
+        1, 0,
+        0.5, 1,
+      ],
+    });
+
+    const model = await loadGltfModelFromFile(createGltfFile(gltf));
+
+    expect(model.primitives[0].texcoords).toBeInstanceOf(Float32Array);
+    expectVector(Array.from(model.primitives[0].texcoords), [
+      0.5, 1,
+      0, 0,
+      1, 0,
+    ]);
+  });
+
   test("GLBの三角形を読み込める", async () => {
     const model = await loadGltfModelFromFile(createGlbFile(createTriangleGlb()));
 
-    expect(model.triangles).toBeInstanceOf(Float32Array);
-    expect(model.triangles.length).toBe(3 * PACKED_VERTEX_SIZE);
-    expect(model.wireframe.length).toBe(6 * PACKED_VERTEX_SIZE);
+    expect(model.primitives[0].triangles).toBeInstanceOf(Float32Array);
+    expect(model.primitives[0].triangles.length).toBe(3 * PACKED_VERTEX_SIZE);
+    expect(model.primitives[0].wireframe.length).toBe(6 * PACKED_VERTEX_SIZE);
     expectVector(model.bounds.min, [0, 0, 0]);
     expectVector(model.bounds.max, [1, 1, 0]);
-    expectVector(readPackedVertex(model.triangles, 2).position, [0, 1, 0]);
+    expectVector(readPackedVertex(model.primitives[0].triangles, 2).position, [0, 1, 0]);
   });
 
   test("gltf以外のファイル名は拒否する", async () => {
@@ -207,7 +297,7 @@ describe("loadGltfModel", () => {
       "models/model.gltf",
       "http://example.test/app/models/mesh.bin",
     ]);
-    expect(model.triangles.length).toBe(3 * PACKED_VERTEX_SIZE);
+    expect(model.primitives[0].triangles.length).toBe(3 * PACKED_VERTEX_SIZE);
   });
 
   test("GLBをURLから読み込める", async () => {
@@ -228,7 +318,7 @@ describe("loadGltfModel", () => {
 
     const model = await loadGltfModel("models/model.glb");
 
-    expect(model.triangles.length).toBe(3 * PACKED_VERTEX_SIZE);
+    expect(model.primitives[0].triangles.length).toBe(3 * PACKED_VERTEX_SIZE);
   });
 
   test("content-typeからGLBを読み込める", async () => {
@@ -242,7 +332,7 @@ describe("loadGltfModel", () => {
 
     const model = await loadGltfModel("models/model");
 
-    expect(model.triangles.length).toBe(3 * PACKED_VERTEX_SIZE);
+    expect(model.primitives[0].triangles.length).toBe(3 * PACKED_VERTEX_SIZE);
   });
 });
 
@@ -256,7 +346,7 @@ describe("GLB validation", () => {
       ),
     );
 
-    expect(model.triangles.length).toBe(3 * PACKED_VERTEX_SIZE);
+    expect(model.primitives[0].triangles.length).toBe(3 * PACKED_VERTEX_SIZE);
   });
 
   test("magic headerが不正なGLBを拒否する", async () => {
@@ -321,18 +411,26 @@ describe("fitModelToGround", () => {
         min: [0, 0, 0],
         max: [2, 4, 2],
       },
-      triangles: new Float32Array([
-        0, 0, 0, 0, 1, 0, 1, 1, 1, 1, 1, 1,
-      ]),
-      wireframe: new Float32Array([
-        2, 4, 2, 0, 1, 0, 1, 1, 1, 1, 1, 1,
-      ]),
+      materials: [],
+      primitives: [
+        {
+          materialIndex: null,
+          texcoords: new Float32Array([0, 0]),
+          triangles: new Float32Array([
+            0, 0, 0, 0, 1, 0, 1, 1, 1, 1, 1, 1,
+          ]),
+          wireframe: new Float32Array([
+            2, 4, 2, 0, 1, 0, 1, 1, 1, 1, 1, 1,
+          ]),
+        },
+      ],
     };
 
     const fitted = fitModelToGround(model, 2);
 
-    expectVector(Array.from(fitted.triangles.slice(0, 3)), [-0.5, 0, -0.5]);
-    expectVector(Array.from(fitted.wireframe.slice(0, 3)), [0.5, 2, 0.5]);
+    expectVector(Array.from(fitted.primitives[0].triangles.slice(0, 3)), [-0.5, 0, -0.5]);
+    expectVector(Array.from(fitted.primitives[0].wireframe.slice(0, 3)), [0.5, 2, 0.5]);
+    expect(fitted.primitives[0].texcoords).toBe(model.primitives[0].texcoords);
   });
 });
 
@@ -341,6 +439,13 @@ function createTriangleGltf({
   externalBufferUri = null,
   indices = [0, 1, 2],
   materialColor = [0.95, 0.72, 0.28],
+  materials = [
+    {
+      pbrMetallicRoughness: {
+        baseColorFactor: [...materialColor, 1],
+      },
+    },
+  ],
   node = { mesh: 0 },
   normals = null,
   positionBuffer = null,
@@ -351,6 +456,8 @@ function createTriangleGltf({
     1, 0, 0,
     0, 1, 0,
   ],
+  primitiveOverrides = null,
+  texcoords = null,
 } = {}) {
   const bufferBuilder = createBufferBuilder();
   const accessors = [];
@@ -389,20 +496,38 @@ function createTriangleGltf({
     });
   }
 
-  const primitive = {
-    attributes,
-    material: 0,
-    mode: GL_TRIANGLES,
-  };
-
-  if (indices) {
-    primitive.indices = addAccessor(bufferBuilder, accessors, uint16Buffer(indices), {
-      componentType: GL_UNSIGNED_SHORT,
-      count: indices.length,
-      target: ELEMENT_ARRAY_BUFFER,
-      type: "SCALAR",
+  if (texcoords) {
+    attributes.TEXCOORD_0 = addAccessor(bufferBuilder, accessors, floatBuffer(texcoords), {
+      componentType: GL_FLOAT,
+      count: 3,
+      target: ARRAY_BUFFER,
+      type: "VEC2",
     });
   }
+
+  const createPrimitive = (override = {}) => {
+    const { indices: overrideIndices, ...primitiveOptions } = override;
+    const primitive = {
+      attributes,
+      mode: GL_TRIANGLES,
+      ...("material" in override ? {} : { material: 0 }),
+      ...primitiveOptions,
+    };
+    const primitiveIndices = "indices" in override ? overrideIndices : indices;
+
+    if (primitiveIndices) {
+      primitive.indices = addAccessor(bufferBuilder, accessors, uint16Buffer(primitiveIndices), {
+        componentType: GL_UNSIGNED_SHORT,
+        count: primitiveIndices.length,
+        target: ELEMENT_ARRAY_BUFFER,
+        type: "SCALAR",
+      });
+    }
+
+    return primitive;
+  };
+
+  const primitives = (primitiveOverrides ?? [{}]).map(createPrimitive);
 
   const buffer = bufferBuilder.build();
   const gltf = {
@@ -415,16 +540,10 @@ function createTriangleGltf({
       },
     ],
     bufferViews: bufferBuilder.bufferViews,
-    materials: [
-      {
-        pbrMetallicRoughness: {
-          baseColorFactor: [...materialColor, 1],
-        },
-      },
-    ],
+    materials,
     meshes: [
       {
-        primitives: [primitive],
+        primitives,
       },
     ],
     nodes: [node],

--- a/projects/labs/raw-webgl2-shader/tests/model-info.test.js
+++ b/projects/labs/raw-webgl2-shader/tests/model-info.test.js
@@ -10,19 +10,30 @@ describe("createModelInfo", () => {
       },
       materials: [
         {
+          baseColorFactor: [0.95, 0.72, 0.28, 1],
           baseColor: [0.95, 0.72, 0.28],
+          baseColorTexture: null,
           index: 0,
           name: "Body",
         },
       ],
-      triangles: new Float32Array(6 * 12),
+      primitives: [
+        {
+          triangles: new Float32Array(3 * 12),
+        },
+        {
+          triangles: new Float32Array(3 * 12),
+        },
+      ],
     };
 
     expect(createModelInfo("sample.glb", model)).toEqual({
       fileName: "sample.glb",
       materials: [
         {
+          baseColorFactor: [0.95, 0.72, 0.28, 1],
           baseColor: [0.95, 0.72, 0.28],
+          baseColorTexture: null,
           index: 0,
           name: "Body",
         },


### PR DESCRIPTION
## Issues

- Close #1027

## Why

The glTF loader previously exposed top-level `triangles` and `wireframe` buffers, which made it hard to associate geometry with per-primitive material and UV data needed by later texture work.

## Summary

This refactors the loaded model shape to expose `model.primitives`, while keeping the existing packed vertex buffers and rendering behavior. It also adds the material and triangle-order `TEXCOORD_0` fields needed as a base for later texture support.

## Changes

- Return glTF geometry as per-primitive `triangles`, `wireframe`, `texcoords`, and `materialIndex` data.
- Preserve material color fallback behavior and add `baseColorFactor` / `baseColorTexture: null` to material records.
- Update renderer drawable creation, model info counting, and auto-fit geometry transforms to consume primitive arrays.
- Update and extend Bun tests for primitive splitting, material defaults, UV expansion, and model info aggregation.

## Verification

- `bun test` - passed
