### PR TITLE
Disable nginx caching for raw WebGL2 shader PoC

### DIFF
--- a/projects/raw-webgl2-shader/Dockerfile
+++ b/projects/raw-webgl2-shader/Dockerfile
@@ -30,6 +30,15 @@ ARG COMMIT_HASH
 ENV COMMIT_HASH=${COMMIT_HASH}
 LABEL org.opencontainers.image.revision="${COMMIT_HASH}"
 
+# PoC のため、nginx 側のキャッシュ最適化は使わず常に最新の静的ファイルを返す。
+RUN printf '%s\n' \
+  'etag off;' \
+  'if_modified_since off;' \
+  'add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0" always;' \
+  'add_header Pragma "no-cache" always;' \
+  'add_header Expires "0" always;' \
+  > /etc/nginx/conf.d/no-cache.conf
+
 COPY --chown=101:101 index.html /usr/share/nginx/html/index.html
 COPY --chown=101:101 src /usr/share/nginx/html/src
 


### PR DESCRIPTION
## Issues

- Refs: none

## Why

raw-webgl2-shader は現在 PoC のため、nginx やブラウザ側のキャッシュによって静的ファイルの更新確認が遅れる状態を避けたい。

## Summary

nginx の最終イメージに no-cache 設定を追加し、HTML / JS などの静的ファイルが常に再検証されるようにしました。設定の意図が Dockerfile 上で分かるよう、日本語コメントも追加しています。

## Changes

- `projects/raw-webgl2-shader/Dockerfile` に nginx の no-cache 設定を追加
- `etag` と `if_modified_since` を無効化
- `Cache-Control`, `Pragma`, `Expires` ヘッダーを常に付与

## Checklist

- [x] `bun run test`
- [x] `docker build -f projects/raw-webgl2-shader/Dockerfile projects/raw-webgl2-shader`
