### PR TITLE
refactor(edit-vid2): remove avoidable effects

### DIFF
--- a/projects/edit-vid2/src/client/features/editor/page.tsx
+++ b/projects/edit-vid2/src/client/features/editor/page.tsx
@@ -93,25 +93,6 @@ export function EditorPage() {
     setDuration(0)
   }, [videoAsset?.id])
 
-  useEffect(() => {
-    const video = videoRef.current
-    if (!video) return
-
-    const onTimeUpdate = () => {
-      if (video.paused) return
-      setCurrentTime(video.currentTime)
-    }
-    const onLoadedMetadata = () => setDuration(video.duration)
-
-    video.addEventListener('timeupdate', onTimeUpdate)
-    video.addEventListener('loadedmetadata', onLoadedMetadata)
-
-    return () => {
-      video.removeEventListener('timeupdate', onTimeUpdate)
-      video.removeEventListener('loadedmetadata', onLoadedMetadata)
-    }
-  }, [])
-
   const addSubtitle = () => {
     if (!hasVideo) return
     const subTrack = timelineState.tracks.find((t) => t.type === 'subtitle')
@@ -181,6 +162,11 @@ export function EditorPage() {
               ref={videoRef}
               src={`/${videoAsset.storagePath}`}
               controls
+              onTimeUpdate={(e) => {
+                if (e.currentTarget.paused) return
+                setCurrentTime(e.currentTarget.currentTime)
+              }}
+              onLoadedMetadata={(e) => setDuration(e.currentTarget.duration)}
               className='max-h-[60vh] w-full rounded-lg'
             />
           ) : (
@@ -261,12 +247,7 @@ function MissingVideoPlaceholder({
   onSubmit: (videoAssetId: string) => void
 }) {
   const [selectedVideoId, setSelectedVideoId] = useState(videos[0]?.id ?? '')
-
-  useEffect(() => {
-    if (!selectedVideoId && videos[0]) {
-      setSelectedVideoId(videos[0].id)
-    }
-  }, [selectedVideoId, videos])
+  const resolvedSelectedVideoId = selectedVideoId || videos[0]?.id || ''
 
   return (
     <div className='flex min-h-[360px] w-full items-center justify-center rounded-lg border border-dashed border-gray-600 bg-gray-950 p-6 text-center'>
@@ -278,7 +259,7 @@ function MissingVideoPlaceholder({
         </p>
         <div className='mt-5 flex flex-col gap-2 sm:flex-row'>
           <select
-            value={selectedVideoId}
+            value={resolvedSelectedVideoId}
             onChange={(e) => setSelectedVideoId(e.target.value)}
             className='min-w-0 flex-1 rounded-lg border border-gray-600 bg-gray-900 px-3 py-2 text-sm text-gray-100'
           >
@@ -291,8 +272,8 @@ function MissingVideoPlaceholder({
           </select>
           <button
             type='button'
-            onClick={() => onSubmit(selectedVideoId)}
-            disabled={loading || !selectedVideoId}
+            onClick={() => onSubmit(resolvedSelectedVideoId)}
+            disabled={loading || !resolvedSelectedVideoId}
             className='inline-flex items-center justify-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50'
           >
             <Link2 className='h-4 w-4' />
@@ -318,23 +299,18 @@ function EditorLinkVideoModal({
   onClose: () => void
 }) {
   const [selectedVideoId, setSelectedVideoId] = useState(currentVideo?.id ?? videos[0]?.id ?? '')
-
-  useEffect(() => {
-    if (!selectedVideoId && videos[0]) {
-      setSelectedVideoId(videos[0].id)
-    }
-  }, [selectedVideoId, videos])
+  const resolvedSelectedVideoId = selectedVideoId || currentVideo?.id || videos[0]?.id || ''
 
   const submit = () => {
-    if (!selectedVideoId) return
+    if (!resolvedSelectedVideoId) return
     if (
       currentVideo &&
-      selectedVideoId !== currentVideo.id &&
+      resolvedSelectedVideoId !== currentVideo.id &&
       !confirm('動画を変更すると、字幕や切り抜き位置が新しい動画と合わなくなる場合があります。変更しますか？')
     ) {
       return
     }
-    onSubmit(selectedVideoId)
+    onSubmit(resolvedSelectedVideoId)
   }
 
   return (
@@ -349,7 +325,7 @@ function EditorLinkVideoModal({
         )}
         <label className='mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300'>元動画</label>
         <select
-          value={selectedVideoId}
+          value={resolvedSelectedVideoId}
           onChange={(e) => setSelectedVideoId(e.target.value)}
           className='w-full rounded-lg border border-gray-300 px-3 py-2 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100'
         >
@@ -371,7 +347,7 @@ function EditorLinkVideoModal({
           <button
             type='button'
             onClick={submit}
-            disabled={loading || !selectedVideoId || selectedVideoId === currentVideo?.id}
+            disabled={loading || !resolvedSelectedVideoId || resolvedSelectedVideoId === currentVideo?.id}
             className='inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50'
           >
             <Link2 className='h-4 w-4' />

--- a/projects/edit-vid2/src/client/features/editor/page.tsx
+++ b/projects/edit-vid2/src/client/features/editor/page.tsx
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useParams } from '@tanstack/react-router'
 import { Link } from '@tanstack/react-router'
-import { ArrowLeft, Download, RotateCcw, Trash2, Type, X } from 'lucide-react'
+import { ArrowLeft, Download, FileVideo, Link2, RotateCcw, Trash2, Type, X } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { uuidv7 } from 'uuidv7'
 import type {
@@ -26,10 +26,19 @@ export function EditorPage() {
     queryFn: () => fetch(`/api/projects/${projectId}`).then((r) => r.json()),
   })
 
-  const { data: videoAsset } = useQuery<VideoAsset>({
+  const { data: videoAsset } = useQuery<VideoAsset | null>({
     queryKey: ['video', project?.videoAssetId],
     enabled: !!project?.videoAssetId,
-    queryFn: () => fetch(`/api/videos/${project!.videoAssetId}`).then((r) => r.json()),
+    queryFn: async () => {
+      const res = await fetch(`/api/videos/${project!.videoAssetId}`)
+      if (!res.ok) return null
+      return res.json()
+    },
+  })
+
+  const { data: videos } = useQuery<VideoAsset[]>({
+    queryKey: ['videos'],
+    queryFn: () => fetch('/api/videos').then((r) => r.json()),
   })
 
   const { data: templates } = useQuery<SubtitleTemplate[]>({
@@ -43,6 +52,8 @@ export function EditorPage() {
     keepSegments: [],
   }
   const mediaDuration = duration || videoAsset?.duration || 0
+  const hasVideo = !!videoAsset?.storagePath
+  const readyVideos = videos?.filter((video) => video.status === 'ready') ?? []
 
   const updateProject = useMutation({
     mutationFn: (data: { timelineState: TimelineStateV1 }) =>
@@ -60,6 +71,25 @@ export function EditorPage() {
     },
     [updateProject]
   )
+
+  const linkVideo = useMutation({
+    mutationFn: (videoAssetId: string) =>
+      fetch(`/api/projects/${projectId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ videoAssetId }),
+      }),
+    onSuccess: () => {
+      setCurrentTime(0)
+      setDuration(0)
+      queryClient.invalidateQueries({ queryKey: ['project', projectId] })
+    },
+  })
+
+  useEffect(() => {
+    setCurrentTime(0)
+    setDuration(0)
+  }, [videoAsset?.id])
 
   useEffect(() => {
     const video = videoRef.current
@@ -81,6 +111,7 @@ export function EditorPage() {
   }, [])
 
   const addSubtitle = () => {
+    if (!hasVideo) return
     const subTrack = timelineState.tracks.find((t) => t.type === 'subtitle')
     const newItem: SubtitleItem = {
       id: uuidv7(),
@@ -108,11 +139,12 @@ export function EditorPage() {
           <ArrowLeft className='h-5 w-5' />
         </Link>
         <h1 className='text-lg font-semibold text-gray-900 dark:text-gray-100'>{project?.name ?? 'エディタ'}</h1>
-        <span className='text-sm text-gray-400'>{videoAsset?.displayName}</span>
+        <span className='text-sm text-gray-400'>{videoAsset?.displayName ?? '動画未紐づけ'}</span>
         <div className='ml-auto flex gap-2'>
           <button
             onClick={addSubtitle}
-            className='inline-flex items-center gap-1 rounded-lg bg-indigo-600 px-3 py-1.5 text-sm text-white hover:bg-indigo-700'
+            disabled={!hasVideo}
+            className='inline-flex items-center gap-1 rounded-lg bg-indigo-600 px-3 py-1.5 text-sm text-white hover:bg-indigo-700 disabled:opacity-50'
           >
             <Type className='h-4 w-4' />
             字幕追加 (A)
@@ -122,12 +154,20 @@ export function EditorPage() {
 
       <div className='flex flex-1 flex-col overflow-auto lg:flex-row'>
         <div className='flex-1 bg-black p-4'>
-          <video
-            ref={videoRef}
-            src={videoAsset ? `/${videoAsset.storagePath}` : undefined}
-            controls
-            className='max-h-[60vh] w-full rounded-lg'
-          />
+          {hasVideo ? (
+            <video
+              ref={videoRef}
+              src={`/${videoAsset.storagePath}`}
+              controls
+              className='max-h-[60vh] w-full rounded-lg'
+            />
+          ) : (
+            <MissingVideoPlaceholder
+              videos={readyVideos}
+              loading={linkVideo.isPending}
+              onSubmit={(videoAssetId) => linkVideo.mutate(videoAssetId)}
+            />
+          )}
         </div>
 
         <div className='w-full overflow-auto border-t border-gray-200 p-4 dark:border-gray-700 lg:w-96 lg:border-l lg:border-t-0'>
@@ -169,7 +209,7 @@ export function EditorPage() {
             )}
           </div>
 
-          <ExportPanel projectId={projectId} />
+          <ExportPanel projectId={projectId} canExport={hasVideo} />
         </div>
       </div>
 
@@ -185,6 +225,59 @@ export function EditorPage() {
           }
         }}
       />
+    </div>
+  )
+}
+
+function MissingVideoPlaceholder({
+  videos,
+  loading,
+  onSubmit,
+}: {
+  videos: VideoAsset[]
+  loading: boolean
+  onSubmit: (videoAssetId: string) => void
+}) {
+  const [selectedVideoId, setSelectedVideoId] = useState(videos[0]?.id ?? '')
+
+  useEffect(() => {
+    if (!selectedVideoId && videos[0]) {
+      setSelectedVideoId(videos[0].id)
+    }
+  }, [selectedVideoId, videos])
+
+  return (
+    <div className='flex min-h-[360px] w-full items-center justify-center rounded-lg border border-dashed border-gray-600 bg-gray-950 p-6 text-center'>
+      <div className='w-full max-w-md'>
+        <FileVideo className='mx-auto mb-4 h-14 w-14 text-gray-500' />
+        <h2 className='text-base font-semibold text-gray-100'>元動画が見つかりません</h2>
+        <p className='mt-1 text-sm text-gray-400'>
+          削除済み、または利用できない動画を参照しています。別の動画を選んで紐づけ直してください。
+        </p>
+        <div className='mt-5 flex flex-col gap-2 sm:flex-row'>
+          <select
+            value={selectedVideoId}
+            onChange={(e) => setSelectedVideoId(e.target.value)}
+            className='min-w-0 flex-1 rounded-lg border border-gray-600 bg-gray-900 px-3 py-2 text-sm text-gray-100'
+          >
+            {videos.length === 0 && <option value=''>利用可能な動画がありません</option>}
+            {videos.map((video) => (
+              <option key={video.id} value={video.id}>
+                {video.displayName}
+              </option>
+            ))}
+          </select>
+          <button
+            type='button'
+            onClick={() => onSubmit(selectedVideoId)}
+            disabled={loading || !selectedVideoId}
+            className='inline-flex items-center justify-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50'
+          >
+            <Link2 className='h-4 w-4' />
+            {loading ? '保存中...' : '紐づけ'}
+          </button>
+        </div>
+      </div>
     </div>
   )
 }
@@ -406,6 +499,8 @@ function TimelineBar({
   onSeek: (time: number) => void
 }) {
   const barRef = useRef<HTMLDivElement>(null)
+  const toPercent = (value: number) => (duration > 0 ? (value / duration) * 100 : 0)
+  const toWidthPercent = (start: number, end: number) => (duration > 0 ? ((end - start) / duration) * 100 : 0)
 
   const handleClick = (e: React.MouseEvent) => {
     const bar = barRef.current
@@ -427,8 +522,8 @@ function TimelineBar({
             key={seg.id}
             className='absolute top-0 h-full rounded bg-green-200/70 dark:bg-green-800/40'
             style={{
-              left: `${(seg.sourceStart / duration) * 100}%`,
-              width: `${((seg.sourceEnd - seg.sourceStart) / duration) * 100}%`,
+              left: `${toPercent(seg.sourceStart)}%`,
+              width: `${toWidthPercent(seg.sourceStart, seg.sourceEnd)}%`,
             }}
           />
         ))}
@@ -438,17 +533,14 @@ function TimelineBar({
             key={sub.id}
             className='absolute bottom-0 h-3 rounded bg-indigo-400/70 dark:bg-indigo-500/50'
             style={{
-              left: `${(sub.sourceStart / duration) * 100}%`,
-              width: `${((sub.sourceEnd - sub.sourceStart) / duration) * 100}%`,
+              left: `${toPercent(sub.sourceStart)}%`,
+              width: `${toWidthPercent(sub.sourceStart, sub.sourceEnd)}%`,
             }}
             title={sub.text || '(空)'}
           />
         ))}
 
-        <div
-          className='absolute top-0 h-full w-0.5 bg-red-500'
-          style={{ left: `${(currentTime / duration) * 100}%` }}
-        />
+        <div className='absolute top-0 h-full w-0.5 bg-red-500' style={{ left: `${toPercent(currentTime)}%` }} />
       </div>
       <div className='mt-1 flex justify-between text-xs text-gray-400'>
         <span>{formatSeconds(currentTime)}</span>
@@ -468,7 +560,7 @@ interface ExportJob {
   createdAt: string
 }
 
-function ExportPanel({ projectId }: { projectId: string }) {
+function ExportPanel({ projectId, canExport }: { projectId: string; canExport: boolean }) {
   const queryClient = useQueryClient()
   const [showSettings, setShowSettings] = useState(false)
   const [preset, setPreset] = useState({
@@ -561,12 +653,15 @@ function ExportPanel({ projectId }: { projectId: string }) {
 
       <button
         onClick={() => createExport.mutate()}
-        disabled={createExport.isPending}
+        disabled={createExport.isPending || !canExport}
         className='mb-3 inline-flex w-full items-center justify-center gap-2 rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700 disabled:opacity-50'
       >
         <Download className='h-4 w-4' />
         {createExport.isPending ? '作成中...' : '書き出しを開始'}
       </button>
+      {!canExport && (
+        <p className='mb-3 text-xs text-amber-600 dark:text-amber-300'>動画を紐づけると書き出しできます。</p>
+      )}
 
       <div className='space-y-2'>
         {jobs?.map((job) => (

--- a/projects/edit-vid2/src/client/features/editor/page.tsx
+++ b/projects/edit-vid2/src/client/features/editor/page.tsx
@@ -20,6 +20,7 @@ export function EditorPage() {
   const videoRef = useRef<HTMLVideoElement>(null)
   const [currentTime, setCurrentTime] = useState(0)
   const [duration, setDuration] = useState(0)
+  const [showLinkVideo, setShowLinkVideo] = useState(false)
 
   const { data: project } = useQuery<Project>({
     queryKey: ['project', projectId],
@@ -82,6 +83,7 @@ export function EditorPage() {
     onSuccess: () => {
       setCurrentTime(0)
       setDuration(0)
+      setShowLinkVideo(false)
       queryClient.invalidateQueries({ queryKey: ['project', projectId] })
     },
   })
@@ -141,6 +143,16 @@ export function EditorPage() {
         <h1 className='text-lg font-semibold text-gray-900 dark:text-gray-100'>{project?.name ?? 'エディタ'}</h1>
         <span className='text-sm text-gray-400'>{videoAsset?.displayName ?? '動画未紐づけ'}</span>
         <div className='ml-auto flex gap-2'>
+          {hasVideo && (
+            <button
+              type='button'
+              onClick={() => setShowLinkVideo(true)}
+              className='inline-flex items-center gap-1 rounded-lg border border-gray-300 px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700'
+            >
+              <Link2 className='h-4 w-4' />
+              動画を変更
+            </button>
+          )}
           <button
             onClick={addSubtitle}
             disabled={!hasVideo}
@@ -151,6 +163,16 @@ export function EditorPage() {
           </button>
         </div>
       </div>
+
+      {showLinkVideo && (
+        <EditorLinkVideoModal
+          currentVideo={videoAsset}
+          videos={readyVideos}
+          loading={linkVideo.isPending}
+          onSubmit={(videoAssetId) => linkVideo.mutate(videoAssetId)}
+          onClose={() => setShowLinkVideo(false)}
+        />
+      )}
 
       <div className='flex flex-1 flex-col overflow-auto lg:flex-row'>
         <div className='flex-1 bg-black p-4'>
@@ -275,6 +297,85 @@ function MissingVideoPlaceholder({
           >
             <Link2 className='h-4 w-4' />
             {loading ? '保存中...' : '紐づけ'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function EditorLinkVideoModal({
+  currentVideo,
+  videos,
+  loading,
+  onSubmit,
+  onClose,
+}: {
+  currentVideo: VideoAsset | null | undefined
+  videos: VideoAsset[]
+  loading: boolean
+  onSubmit: (videoAssetId: string) => void
+  onClose: () => void
+}) {
+  const [selectedVideoId, setSelectedVideoId] = useState(currentVideo?.id ?? videos[0]?.id ?? '')
+
+  useEffect(() => {
+    if (!selectedVideoId && videos[0]) {
+      setSelectedVideoId(videos[0].id)
+    }
+  }, [selectedVideoId, videos])
+
+  const submit = () => {
+    if (!selectedVideoId) return
+    if (
+      currentVideo &&
+      selectedVideoId !== currentVideo.id &&
+      !confirm('動画を変更すると、字幕や切り抜き位置が新しい動画と合わなくなる場合があります。変更しますか？')
+    ) {
+      return
+    }
+    onSubmit(selectedVideoId)
+  }
+
+  return (
+    <div className='fixed inset-0 z-50 flex items-center justify-center bg-black/50' onClick={onClose}>
+      <div
+        className='w-full max-w-md rounded-xl bg-white p-6 shadow-xl dark:bg-gray-800'
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className='mb-1 text-lg font-semibold text-gray-900 dark:text-gray-100'>動画を変更</h2>
+        {currentVideo && (
+          <p className='mb-4 truncate text-sm text-gray-500 dark:text-gray-400'>現在: {currentVideo.displayName}</p>
+        )}
+        <label className='mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300'>元動画</label>
+        <select
+          value={selectedVideoId}
+          onChange={(e) => setSelectedVideoId(e.target.value)}
+          className='w-full rounded-lg border border-gray-300 px-3 py-2 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100'
+        >
+          {videos.length === 0 && <option value=''>利用可能な動画がありません</option>}
+          {videos.map((video) => (
+            <option key={video.id} value={video.id}>
+              {video.displayName}
+            </option>
+          ))}
+        </select>
+        <div className='mt-6 flex justify-end gap-2'>
+          <button
+            type='button'
+            onClick={onClose}
+            className='rounded-lg border border-gray-300 px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700'
+          >
+            キャンセル
+          </button>
+          <button
+            type='button'
+            onClick={submit}
+            disabled={loading || !selectedVideoId || selectedVideoId === currentVideo?.id}
+            className='inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50'
+          >
+            <Link2 className='h-4 w-4' />
+            {loading ? '保存中...' : '変更'}
           </button>
         </div>
       </div>

--- a/projects/edit-vid2/src/client/features/projects/page.tsx
+++ b/projects/edit-vid2/src/client/features/projects/page.tsx
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Link } from '@tanstack/react-router'
-import { Clapperboard, Copy, Edit, FileVideo, Plus, Trash2 } from 'lucide-react'
-import { useState } from 'react'
+import { Clapperboard, Copy, Edit, FileVideo, Link2, Plus, Trash2 } from 'lucide-react'
+import { useEffect, useState } from 'react'
 
 interface Project {
   id: string
@@ -23,6 +23,7 @@ export function ProjectsPage() {
   const queryClient = useQueryClient()
   const [showCreate, setShowCreate] = useState(false)
   const [editingId, setEditingId] = useState<string | null>(null)
+  const [linkingProject, setLinkingProject] = useState<Project | null>(null)
   const [editName, setEditName] = useState('')
 
   const { data: projects, isLoading: projectsLoading } = useQuery<Project[]>({
@@ -64,15 +65,16 @@ export function ProjectsPage() {
   })
 
   const updateMutation = useMutation({
-    mutationFn: ({ id, name }: { id: string; name: string }) =>
+    mutationFn: ({ id, name, videoAssetId }: { id: string; name?: string; videoAssetId?: string }) =>
       fetch(`/api/projects/${id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name }),
+        body: JSON.stringify({ name, videoAssetId }),
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['projects'] })
       setEditingId(null)
+      setLinkingProject(null)
     },
   })
 
@@ -99,6 +101,15 @@ export function ProjectsPage() {
           loading={createMutation.isPending}
         />
       )}
+      {linkingProject && (
+        <LinkVideoModal
+          project={linkingProject}
+          videos={readyVideos}
+          onSubmit={(videoAssetId) => updateMutation.mutate({ id: linkingProject.id, videoAssetId })}
+          onClose={() => setLinkingProject(null)}
+          loading={updateMutation.isPending}
+        />
+      )}
 
       {projectsLoading ? (
         <div className='flex items-center justify-center py-20'>
@@ -108,6 +119,7 @@ export function ProjectsPage() {
         <div className='grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4'>
           {projects.map((project) => {
             const video = videos?.find((v) => v.id === project.videoAssetId)
+            const hasVideo = !!video
             return (
               <div
                 key={project.id}
@@ -118,8 +130,13 @@ export function ProjectsPage() {
                     {video?.thumbnailPath ? (
                       <img src={`/${video.thumbnailPath}`} alt={project.name} className='h-full w-full object-cover' />
                     ) : (
-                      <div className='flex h-full items-center justify-center'>
+                      <div className='flex h-full flex-col items-center justify-center gap-2 px-3 text-center'>
                         <FileVideo className='h-12 w-12 text-gray-400' />
+                        {!hasVideo && (
+                          <span className='text-xs font-medium text-indigo-600 dark:text-indigo-300'>
+                            元動画が見つかりません
+                          </span>
+                        )}
                       </div>
                     )}
                   </div>
@@ -154,7 +171,19 @@ export function ProjectsPage() {
                     </Link>
                   )}
 
-                  <p className='text-xs text-gray-500 dark:text-gray-400 truncate'>{video?.displayName}</p>
+                  <p className='text-xs text-gray-500 dark:text-gray-400 truncate'>
+                    {video?.displayName ?? '動画未紐づけ'}
+                  </p>
+                  {!hasVideo && (
+                    <button
+                      type='button'
+                      onClick={() => setLinkingProject(project)}
+                      className='mt-2 inline-flex w-full items-center justify-center gap-1 rounded-lg border border-indigo-300 px-2 py-1.5 text-xs font-medium text-indigo-700 hover:bg-indigo-50 dark:border-indigo-500/60 dark:text-indigo-300 dark:hover:bg-indigo-500/10'
+                    >
+                      <Link2 className='h-3.5 w-3.5' />
+                      動画を紐づけ
+                    </button>
+                  )}
 
                   <div className='flex items-center gap-1'>
                     <span className='text-xs text-gray-400 dark:text-gray-500'>
@@ -200,6 +229,69 @@ export function ProjectsPage() {
           </p>
         </div>
       )}
+    </div>
+  )
+}
+
+function LinkVideoModal({
+  project,
+  videos,
+  onSubmit,
+  onClose,
+  loading,
+}: {
+  project: Project
+  videos: VideoAsset[]
+  onSubmit: (videoAssetId: string) => void
+  onClose: () => void
+  loading: boolean
+}) {
+  const [selectedVideoId, setSelectedVideoId] = useState(videos[0]?.id ?? '')
+
+  useEffect(() => {
+    if (!selectedVideoId && videos[0]) {
+      setSelectedVideoId(videos[0].id)
+    }
+  }, [selectedVideoId, videos])
+
+  return (
+    <div className='fixed inset-0 z-50 flex items-center justify-center bg-black/50' onClick={onClose}>
+      <div
+        className='w-full max-w-md rounded-xl bg-white p-6 shadow-xl dark:bg-gray-800'
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className='mb-1 text-lg font-semibold text-gray-900 dark:text-gray-100'>動画を紐づけ</h2>
+        <p className='mb-4 truncate text-sm text-gray-500 dark:text-gray-400'>{project.name}</p>
+        <label className='mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300'>元動画</label>
+        <select
+          value={selectedVideoId}
+          onChange={(e) => setSelectedVideoId(e.target.value)}
+          className='w-full rounded-lg border border-gray-300 px-3 py-2 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100'
+        >
+          {videos.length === 0 && <option value=''>利用可能な動画がありません</option>}
+          {videos.map((v) => (
+            <option key={v.id} value={v.id}>
+              {v.displayName}
+            </option>
+          ))}
+        </select>
+        <div className='mt-6 flex justify-end gap-2'>
+          <button
+            onClick={onClose}
+            className='rounded-lg border border-gray-300 px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700'
+          >
+            キャンセル
+          </button>
+          <button
+            onClick={() => onSubmit(selectedVideoId)}
+            disabled={loading || !selectedVideoId}
+            className='inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50'
+          >
+            <Link2 className='h-4 w-4' />
+            {loading ? '保存中...' : '紐づけ'}
+          </button>
+        </div>
+      </div>
     </div>
   )
 }

--- a/projects/edit-vid2/src/client/features/projects/page.tsx
+++ b/projects/edit-vid2/src/client/features/projects/page.tsx
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Link } from '@tanstack/react-router'
 import { Clapperboard, Copy, Edit, FileVideo, Link2, Plus, Trash2 } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 
 interface Project {
   id: string
@@ -248,24 +248,19 @@ function LinkVideoModal({
   loading: boolean
 }) {
   const [selectedVideoId, setSelectedVideoId] = useState(currentVideo?.id ?? videos[0]?.id ?? '')
-
-  useEffect(() => {
-    if (!selectedVideoId && videos[0]) {
-      setSelectedVideoId(videos[0].id)
-    }
-  }, [selectedVideoId, videos])
+  const resolvedSelectedVideoId = selectedVideoId || currentVideo?.id || videos[0]?.id || ''
 
   const isChangingVideo = !!currentVideo
   const submit = () => {
-    if (!selectedVideoId) return
+    if (!resolvedSelectedVideoId) return
     if (
       isChangingVideo &&
-      selectedVideoId !== currentVideo.id &&
+      resolvedSelectedVideoId !== currentVideo.id &&
       !confirm('動画を変更すると、字幕や切り抜き位置が新しい動画と合わなくなる場合があります。変更しますか？')
     ) {
       return
     }
-    onSubmit(selectedVideoId)
+    onSubmit(resolvedSelectedVideoId)
   }
 
   return (
@@ -283,7 +278,7 @@ function LinkVideoModal({
         )}
         <label className='mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300'>元動画</label>
         <select
-          value={selectedVideoId}
+          value={resolvedSelectedVideoId}
           onChange={(e) => setSelectedVideoId(e.target.value)}
           className='w-full rounded-lg border border-gray-300 px-3 py-2 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100'
         >
@@ -303,7 +298,7 @@ function LinkVideoModal({
           </button>
           <button
             onClick={submit}
-            disabled={loading || !selectedVideoId || selectedVideoId === currentVideo?.id}
+            disabled={loading || !resolvedSelectedVideoId || resolvedSelectedVideoId === currentVideo?.id}
             className='inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50'
           >
             <Link2 className='h-4 w-4' />

--- a/projects/edit-vid2/src/client/features/projects/page.tsx
+++ b/projects/edit-vid2/src/client/features/projects/page.tsx
@@ -104,6 +104,7 @@ export function ProjectsPage() {
       {linkingProject && (
         <LinkVideoModal
           project={linkingProject}
+          currentVideo={videos?.find((v) => v.id === linkingProject.videoAssetId)}
           videos={readyVideos}
           onSubmit={(videoAssetId) => updateMutation.mutate({ id: linkingProject.id, videoAssetId })}
           onClose={() => setLinkingProject(null)}
@@ -174,16 +175,14 @@ export function ProjectsPage() {
                   <p className='text-xs text-gray-500 dark:text-gray-400 truncate'>
                     {video?.displayName ?? '動画未紐づけ'}
                   </p>
-                  {!hasVideo && (
-                    <button
-                      type='button'
-                      onClick={() => setLinkingProject(project)}
-                      className='mt-2 inline-flex w-full items-center justify-center gap-1 rounded-lg border border-indigo-300 px-2 py-1.5 text-xs font-medium text-indigo-700 hover:bg-indigo-50 dark:border-indigo-500/60 dark:text-indigo-300 dark:hover:bg-indigo-500/10'
-                    >
-                      <Link2 className='h-3.5 w-3.5' />
-                      動画を紐づけ
-                    </button>
-                  )}
+                  <button
+                    type='button'
+                    onClick={() => setLinkingProject(project)}
+                    className='mt-2 inline-flex w-full items-center justify-center gap-1 rounded-lg border border-indigo-300 px-2 py-1.5 text-xs font-medium text-indigo-700 hover:bg-indigo-50 dark:border-indigo-500/60 dark:text-indigo-300 dark:hover:bg-indigo-500/10'
+                  >
+                    <Link2 className='h-3.5 w-3.5' />
+                    {hasVideo ? '動画を変更' : '動画を紐づけ'}
+                  </button>
 
                   <div className='flex items-center gap-1'>
                     <span className='text-xs text-gray-400 dark:text-gray-500'>
@@ -235,18 +234,20 @@ export function ProjectsPage() {
 
 function LinkVideoModal({
   project,
+  currentVideo,
   videos,
   onSubmit,
   onClose,
   loading,
 }: {
   project: Project
+  currentVideo?: VideoAsset
   videos: VideoAsset[]
   onSubmit: (videoAssetId: string) => void
   onClose: () => void
   loading: boolean
 }) {
-  const [selectedVideoId, setSelectedVideoId] = useState(videos[0]?.id ?? '')
+  const [selectedVideoId, setSelectedVideoId] = useState(currentVideo?.id ?? videos[0]?.id ?? '')
 
   useEffect(() => {
     if (!selectedVideoId && videos[0]) {
@@ -254,14 +255,32 @@ function LinkVideoModal({
     }
   }, [selectedVideoId, videos])
 
+  const isChangingVideo = !!currentVideo
+  const submit = () => {
+    if (!selectedVideoId) return
+    if (
+      isChangingVideo &&
+      selectedVideoId !== currentVideo.id &&
+      !confirm('動画を変更すると、字幕や切り抜き位置が新しい動画と合わなくなる場合があります。変更しますか？')
+    ) {
+      return
+    }
+    onSubmit(selectedVideoId)
+  }
+
   return (
     <div className='fixed inset-0 z-50 flex items-center justify-center bg-black/50' onClick={onClose}>
       <div
         className='w-full max-w-md rounded-xl bg-white p-6 shadow-xl dark:bg-gray-800'
         onClick={(e) => e.stopPropagation()}
       >
-        <h2 className='mb-1 text-lg font-semibold text-gray-900 dark:text-gray-100'>動画を紐づけ</h2>
+        <h2 className='mb-1 text-lg font-semibold text-gray-900 dark:text-gray-100'>
+          {isChangingVideo ? '動画を変更' : '動画を紐づけ'}
+        </h2>
         <p className='mb-4 truncate text-sm text-gray-500 dark:text-gray-400'>{project.name}</p>
+        {currentVideo && (
+          <p className='mb-3 truncate text-xs text-gray-500 dark:text-gray-400'>現在: {currentVideo.displayName}</p>
+        )}
         <label className='mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300'>元動画</label>
         <select
           value={selectedVideoId}
@@ -283,12 +302,12 @@ function LinkVideoModal({
             キャンセル
           </button>
           <button
-            onClick={() => onSubmit(selectedVideoId)}
-            disabled={loading || !selectedVideoId}
+            onClick={submit}
+            disabled={loading || !selectedVideoId || selectedVideoId === currentVideo?.id}
             className='inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50'
           >
             <Link2 className='h-4 w-4' />
-            {loading ? '保存中...' : '紐づけ'}
+            {loading ? '保存中...' : isChangingVideo ? '変更' : '紐づけ'}
           </button>
         </div>
       </div>

--- a/projects/edit-vid2/src/server/features/preview/preview-service.ts
+++ b/projects/edit-vid2/src/server/features/preview/preview-service.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto'
-import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, unlinkSync, writeFileSync } from 'node:fs'
 import { $ } from 'bun'
 import { generateAssContent } from '#/server/features/ass/ass-generator'
 import type { SubtitleStyle } from '#/shared/schemas'

--- a/projects/edit-vid2/src/server/routes/exports.ts
+++ b/projects/edit-vid2/src/server/routes/exports.ts
@@ -14,6 +14,7 @@ import {
 } from '#/server/features/export/export-repository'
 import { exportWorker } from '#/server/features/export/export-worker'
 import { getProjectById } from '#/server/features/projects/project-repository'
+import { getVideoAssetById } from '#/server/features/videos/video-repository'
 import type { HonoEnv } from '#/server/routes/shared'
 import { CreateExportJobSchema } from '#/shared/schemas'
 
@@ -74,6 +75,10 @@ exportRoutes.post('/', sValidator('json', CreateExportJobSchema), (c) => {
   const project = getProjectById(db, projectId)
   if (!project) {
     return c.json({ error: 'project not found' }, 404)
+  }
+  const videoAsset = getVideoAssetById(db, project.videoAssetId)
+  if (videoAsset?.status !== 'ready' || !videoAsset.storagePath) {
+    return c.json({ error: 'video asset not ready' }, 400)
   }
 
   const body = c.req.valid('json')

--- a/projects/edit-vid2/src/server/routes/projects.ts
+++ b/projects/edit-vid2/src/server/routes/projects.ts
@@ -8,10 +8,16 @@ import {
   softDeleteProject,
   updateProject,
 } from '#/server/features/projects/project-repository'
+import { getVideoAssetById } from '#/server/features/videos/video-repository'
 import type { HonoEnv } from '#/server/routes/shared'
 import { CreateProjectSchema, DuplicateProjectSchema, UpdateProjectSchema } from '#/shared/schemas'
 
 const projectRoutes = new Hono<HonoEnv>()
+
+function getReadyVideoAsset(db: HonoEnv['Variables']['db'], videoAssetId: string) {
+  const videoAsset = getVideoAssetById(db, videoAssetId)
+  return videoAsset?.status === 'ready' ? videoAsset : null
+}
 
 projectRoutes.get('/', (c) => {
   const db = c.var.db
@@ -31,6 +37,9 @@ projectRoutes.get('/:projectId', (c) => {
 projectRoutes.post('/', sValidator('json', CreateProjectSchema), (c) => {
   const db = c.var.db
   const body = c.req.valid('json')
+  if (!getReadyVideoAsset(db, body.videoAssetId)) {
+    return c.json({ error: 'video asset not ready' }, 400)
+  }
   const project = createProject(db, {
     id: uuidv7(),
     videoAssetId: body.videoAssetId,
@@ -46,7 +55,11 @@ projectRoutes.patch('/:projectId', sValidator('json', UpdateProjectSchema), (c) 
   if (!existing) {
     return c.json({ error: 'not found' }, 404)
   }
-  const updated = updateProject(db, id, c.req.valid('json'))
+  const body = c.req.valid('json')
+  if (body.videoAssetId && !getReadyVideoAsset(db, body.videoAssetId)) {
+    return c.json({ error: 'video asset not ready' }, 400)
+  }
+  const updated = updateProject(db, id, body)
   return c.json(updated)
 })
 

--- a/projects/edit-vid2/src/server/routes/videos.ts
+++ b/projects/edit-vid2/src/server/routes/videos.ts
@@ -1,5 +1,4 @@
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
-import { dirname } from 'node:path'
+import { mkdirSync, writeFileSync } from 'node:fs'
 import { sValidator } from '@hono/standard-validator'
 import { Hono } from 'hono'
 import { uuidv7 } from 'uuidv7'
@@ -12,7 +11,7 @@ import {
   updateVideoAsset,
 } from '#/server/features/videos/video-repository'
 import type { HonoEnv } from '#/server/routes/shared'
-import { UpdateVideoAssetSchema, VideoAssetSchema } from '#/shared/schemas'
+import { UpdateVideoAssetSchema } from '#/shared/schemas'
 
 const videoRoutes = new Hono<HonoEnv>()
 
@@ -67,7 +66,6 @@ videoRoutes.post('/', async (c) => {
     return c.json({ error: 'file too large' }, 413)
   }
 
-  const allowedMimes = ['video/mp4', 'video/quicktime', 'video/webm', 'video/x-matroska']
   const extMap: Record<string, string> = {
     'video/mp4': '.mp4',
     'video/quicktime': '.mov',

--- a/projects/edit-vid2/src/shared/schemas/project.ts
+++ b/projects/edit-vid2/src/shared/schemas/project.ts
@@ -19,6 +19,7 @@ export const CreateProjectSchema = z.object({
 
 export const UpdateProjectSchema = z.object({
   name: z.string().min(1).max(255).optional(),
+  videoAssetId: z.string().optional(),
   timelineState: TimelineStateV1Schema.optional(),
 })
 

--- a/projects/edit-vid2/src/shared/schemas/template.ts
+++ b/projects/edit-vid2/src/shared/schemas/template.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod'
-import { SubtitleStyleSchema } from './subtitle-style'
 
 export const SubtitleTemplateSchema = z.object({
   id: z.string(),

--- a/projects/edit-vid2/tests/features/schemas.test.ts
+++ b/projects/edit-vid2/tests/features/schemas.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import { CreateProjectSchema, CreateVideoAssetSchema, ExportPresetSchema } from '#/shared/schemas'
+import { CreateProjectSchema, CreateVideoAssetSchema, ExportPresetSchema, UpdateProjectSchema } from '#/shared/schemas'
 
 describe('CreateVideoAssetSchema', () => {
   test('accepts valid minimal input', () => {
@@ -30,6 +30,13 @@ describe('CreateProjectSchema', () => {
   test('rejects missing videoAssetId', () => {
     const result = CreateProjectSchema.safeParse({ name: 'Test' })
     expect(result.success).toBe(false)
+  })
+})
+
+describe('UpdateProjectSchema', () => {
+  test('accepts videoAssetId relink', () => {
+    const result = UpdateProjectSchema.safeParse({ videoAssetId: 'va2' })
+    expect(result.success).toBe(true)
   })
 })
 


### PR DESCRIPTION
## Issues

- なし

## Why

`useEffect` が不要な派生状態や DOM イベント購読に使われていた箇所を減らし、React の描画・イベント処理に沿った実装にします。

## Summary

低リスクに置き換えられる `useEffect` のみを削除しました。外部同期に該当する動画切替リセット、OSテーマ監視、Escapeキー監視は残しています。

## Changes

- `<video>` の `timeupdate` / `loadedmetadata` を手動購読から React イベント props に変更
- 動画選択モーダルの初期選択補正を `useEffect` ではなく派生値で処理
- `projects/page.tsx` から不要になった `useEffect` import を削除

## Checklist

- [x] フォーマット: `bun run format:check`
- [x] リント / 型チェック: `bun run lint`
- [x] テスト: `bun test`
