### PR TITLE
refactor(edit-vid2): clarify remaining effect usage

### DIFF
--- a/projects/edit-vid2/src/client/app/use-theme.ts
+++ b/projects/edit-vid2/src/client/app/use-theme.ts
@@ -1,23 +1,45 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useSyncExternalStore } from 'react'
+
+const DARK_MODE_QUERY = '(prefers-color-scheme: dark)'
+const themeListeners = new Set<() => void>()
 
 function getIsDark() {
   return document.documentElement.classList.contains('dark')
 }
 
-export function useTheme() {
-  const [isDark, setIsDark] = useState(getIsDark)
+function getStoredTheme() {
+  try {
+    return localStorage.getItem('theme')
+  } catch {
+    return null
+  }
+}
 
-  useEffect(() => {
-    const mq = window.matchMedia('(prefers-color-scheme: dark)')
-    const handler = (e: MediaQueryListEvent) => {
-      const stored = localStorage.getItem('theme')
-      if (stored) return
-      document.documentElement.classList.toggle('dark', e.matches)
-      setIsDark(e.matches)
-    }
-    mq.addEventListener('change', handler)
-    return () => mq.removeEventListener('change', handler)
-  }, [])
+function emitThemeChange() {
+  for (const listener of themeListeners) {
+    listener()
+  }
+}
+
+function subscribeTheme(onStoreChange: () => void) {
+  themeListeners.add(onStoreChange)
+
+  const mq = window.matchMedia(DARK_MODE_QUERY)
+  const handleChange = (e: MediaQueryListEvent) => {
+    if (getStoredTheme()) return
+    document.documentElement.classList.toggle('dark', e.matches)
+    emitThemeChange()
+  }
+
+  mq.addEventListener('change', handleChange)
+  return () => {
+    themeListeners.delete(onStoreChange)
+    mq.removeEventListener('change', handleChange)
+  }
+}
+
+export function useTheme() {
+  const isDark = useSyncExternalStore(subscribeTheme, getIsDark, () => false)
 
   const toggle = useCallback(() => {
     const next = !getIsDark()
@@ -27,7 +49,7 @@ export function useTheme() {
     } catch {
       // localStorage unavailable
     }
-    setIsDark(next)
+    emitThemeChange()
   }, [])
 
   return { isDark, toggle } as const

--- a/projects/edit-vid2/src/client/features/editor/page.tsx
+++ b/projects/edit-vid2/src/client/features/editor/page.tsx
@@ -88,6 +88,7 @@ export function EditorPage() {
     },
   })
 
+  // Query refresh or project loading can swap the video outside linkVideo.onSuccess.
   useEffect(() => {
     setCurrentTime(0)
     setDuration(0)

--- a/projects/edit-vid2/src/client/features/videos/page.tsx
+++ b/projects/edit-vid2/src/client/features/videos/page.tsx
@@ -292,6 +292,7 @@ export function VideosPage() {
 }
 
 function VideoPreviewModal({ video, onClose }: { video: VideoAsset; onClose: () => void }) {
+  // Keep document key subscription explicit while the preview modal is mounted.
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') onClose()


### PR DESCRIPTION
## Issues

- Close #1042

## Why

`projects/edit-vid2` に残っている 3 箇所の `useEffect` を、外部同期として残すものと React API に置き換えるものに整理するためです。

## Summary

テーマの OS カラースキーム購読を `useSyncExternalStore` に置き換えました。動画切替時の再生状態リセットと preview modal の Escape キー購読は、外部同期として残す判断をコード上にも残しています。

## Changes

- `src/client/app/use-theme.ts`: `replace` - `matchMedia` 購読を `useSyncExternalStore` 化し、`localStorage` に明示設定がある場合は OS テーマ変更を無視する既存挙動を維持
- `src/client/features/editor/page.tsx`: `keep` - query refresh や project load で動画が切り替わるため、`videoAsset?.id` 変更時の再生状態リセットを外部同期として維持
- `src/client/features/videos/page.tsx`: `keep` - modal mount 中だけの `document.keydown` 購読として Escape close を明示的に維持

## Verification

- `bun run format:check` - passed
- `bun run lint` - passed
- `bun test` - passed
- `rg -n "useEffect" src/client` - confirmed only the editor reset and preview modal key subscription remain
