### PR TITLE
feat(edit-vid2): add spacebar toggle for video play/pause

### DIFF
--- a/projects/edit-vid2/AGENTS.md
+++ b/projects/edit-vid2/AGENTS.md
@@ -9,6 +9,7 @@ Thin router for `edit-vid2`.
 - Never commit secrets, tokens, generated media, DB files, or export data.
 - State assumptions before non-trivial decisions.
 - Use Bun and existing scripts; see [commands](docs/agent/commands.md).
+- Avoid `useEffect`; prefer event handlers (`onKeyDown`, `onClick`, etc.) or other alternatives.
 
 ## Routes
 

--- a/projects/edit-vid2/src/client/features/editor/page.tsx
+++ b/projects/edit-vid2/src/client/features/editor/page.tsx
@@ -18,6 +18,7 @@ export function EditorPage() {
   const projectId = params.projectId
   const queryClient = useQueryClient()
   const videoRef = useRef<HTMLVideoElement>(null)
+  const rootRef = useRef<HTMLDivElement>(null)
   const [currentTime, setCurrentTime] = useState(0)
   const [duration, setDuration] = useState(0)
   const [showLinkVideo, setShowLinkVideo] = useState(false)
@@ -115,7 +116,14 @@ export function EditorPage() {
 
   return (
     <div
-      className='flex h-full flex-col'
+      ref={rootRef}
+      tabIndex={-1}
+      className='flex h-full flex-col outline-none'
+      onClick={(e) => {
+        const tag = (e.target as HTMLElement).tagName
+        if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || tag === 'BUTTON' || tag === 'A') return
+        rootRef.current?.focus()
+      }}
       onKeyDown={(e) => {
         if (e.code !== 'Space') return
         const tag = (e.target as HTMLElement).tagName

--- a/projects/edit-vid2/src/client/features/editor/page.tsx
+++ b/projects/edit-vid2/src/client/features/editor/page.tsx
@@ -114,7 +114,22 @@ export function EditorPage() {
   const subItems: SubtitleItem[] = timelineState.tracks.find((t) => t.type === 'subtitle')?.items ?? []
 
   return (
-    <div className='flex h-full flex-col'>
+    <div
+      className='flex h-full flex-col'
+      onKeyDown={(e) => {
+        if (e.code !== 'Space') return
+        const tag = (e.target as HTMLElement).tagName
+        if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return
+        e.preventDefault()
+        const video = videoRef.current
+        if (!video) return
+        if (video.paused) {
+          video.play()
+        } else {
+          video.pause()
+        }
+      }}
+    >
       <div className='flex items-center gap-4 border-b border-gray-200 px-4 py-3 dark:border-gray-700'>
         <Link
           to='/projects'

--- a/projects/edit-vid2/src/client/features/editor/page.tsx
+++ b/projects/edit-vid2/src/client/features/editor/page.tsx
@@ -118,6 +118,7 @@ export function EditorPage() {
     <div
       ref={rootRef}
       tabIndex={-1}
+      autoFocus
       className='flex h-full flex-col outline-none'
       onClick={(e) => {
         const tag = (e.target as HTMLElement).tagName


### PR DESCRIPTION
## Why

プロジェクト編集画面で、動画の再生/停止をキーボード（スペースキー）で操作できるようにしたい。動画編集中にマウス操作が必要な状態では効率が落ちるため。

## Summary

EditorPage のルート要素に `onKeyDown` を追加し、スペースキーで `<video>` 要素の再生/停止をトグルするキーボードショートカットを実装しました。`useEffect` は使用せず、React の合成イベントで実装しています。

## Changes

- EditorPage のルート div に `onKeyDown` ハンドラを追加し、スペースキーで動画の `.play()` / `.pause()` を切り替え
- フォーム入力中（input / textarea / select）は発動しないようガード
- スペースキーのデフォルト挙動（ページスクロール）を `preventDefault()` で抑制
- AGENTS.md に `useEffect` 回避ルールを追加

## Checklist

- [x] フォーマット
- [x] リント / 型チェック
- [x] テスト
