### PR TITLE
feat(edit-vid2): separate export history to dedicated /exports page

### DIFF
--- a/projects/edit-vid2/src/client/features/editor/page.tsx
+++ b/projects/edit-vid2/src/client/features/editor/page.tsx
@@ -800,10 +800,7 @@ function ExportPanel({ projectId, canExport }: { projectId: string; canExport: b
         <p className='text-xs text-gray-400 dark:text-gray-500'>書き出し履歴がありません</p>
       )}
       <div className='mt-2'>
-        <Link
-          to='/exports'
-          className='text-xs text-indigo-600 hover:underline dark:text-indigo-400'
-        >
+        <Link to='/exports' className='text-xs text-indigo-600 hover:underline dark:text-indigo-400'>
           書き出し履歴を表示
         </Link>
       </div>

--- a/projects/edit-vid2/src/client/features/editor/page.tsx
+++ b/projects/edit-vid2/src/client/features/editor/page.tsx
@@ -1,9 +1,10 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useParams } from '@tanstack/react-router'
 import { Link } from '@tanstack/react-router'
-import { ArrowLeft, Download, FileVideo, Link2, RotateCcw, Trash2, Type, X } from 'lucide-react'
+import { ArrowLeft, Download, FileVideo, Link2, RotateCcw, Type, X } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { uuidv7 } from 'uuidv7'
+import { JobCard, type ExportJob } from '#/client/features/exports/job-card'
 import type {
   KeepSegment,
   Project,
@@ -677,16 +678,6 @@ function TimelineBar({
   )
 }
 
-interface ExportJob {
-  id: string
-  status: string
-  progress: number
-  outputPath: string | null
-  logPath: string | null
-  errorMessage: string | null
-  createdAt: string
-}
-
 function ExportPanel({ projectId, canExport }: { projectId: string; canExport: boolean }) {
   const queryClient = useQueryClient()
   const [showSettings, setShowSettings] = useState(false)
@@ -713,18 +704,27 @@ function ExportPanel({ projectId, canExport }: { projectId: string; canExport: b
       }).then((r) => r.json()),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['export-jobs', projectId] })
+      queryClient.invalidateQueries({ queryKey: ['export-jobs'] })
     },
   })
 
   const cancelExport = useMutation({
     mutationFn: (jobId: string) => fetch(`/api/export-jobs/${jobId}/cancel`, { method: 'POST' }),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['export-jobs', projectId] }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['export-jobs', projectId] })
+      queryClient.invalidateQueries({ queryKey: ['export-jobs'] })
+    },
   })
 
   const deleteExport = useMutation({
     mutationFn: (jobId: string) => fetch(`/api/export-jobs/${jobId}`, { method: 'DELETE' }),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['export-jobs', projectId] }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['export-jobs', projectId] })
+      queryClient.invalidateQueries({ queryKey: ['export-jobs'] })
+    },
   })
+
+  const latestJob = jobs?.[0]
 
   return (
     <>
@@ -790,107 +790,23 @@ function ExportPanel({ projectId, canExport }: { projectId: string; canExport: b
         <p className='mb-3 text-xs text-amber-600 dark:text-amber-300'>動画を紐づけると書き出しできます。</p>
       )}
 
-      <div className='space-y-2'>
-        {jobs?.map((job) => (
-          <JobCard
-            key={job.id}
-            job={job}
-            onCancel={() => cancelExport.mutate(job.id)}
-            onDelete={() => deleteExport.mutate(job.id)}
-          />
-        ))}
-        {(!jobs || jobs.length === 0) && (
-          <p className='text-xs text-gray-400 dark:text-gray-500'>書き出し履歴がありません</p>
-        )}
+      {latestJob ? (
+        <JobCard
+          job={latestJob}
+          onCancel={() => cancelExport.mutate(latestJob.id)}
+          onDelete={() => deleteExport.mutate(latestJob.id)}
+        />
+      ) : (
+        <p className='text-xs text-gray-400 dark:text-gray-500'>書き出し履歴がありません</p>
+      )}
+      <div className='mt-2'>
+        <Link
+          to='/exports'
+          className='text-xs text-indigo-600 hover:underline dark:text-indigo-400'
+        >
+          書き出し履歴を表示
+        </Link>
       </div>
     </>
-  )
-}
-
-function JobCard({ job, onCancel, onDelete }: { job: ExportJob; onCancel: () => void; onDelete: () => void }) {
-  const statusLabels: Record<string, string> = {
-    queued: '待機中',
-    running: '実行中',
-    succeeded: '完了',
-    failed: '失敗',
-    canceling: 'キャンセル中',
-    canceled: 'キャンセル済',
-  }
-  const statusColors: Record<string, string> = {
-    queued: 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900 dark:text-yellow-300',
-    running: 'bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300',
-    succeeded: 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300',
-    failed: 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300',
-    canceling: 'bg-orange-100 text-orange-700 dark:bg-orange-900 dark:text-orange-300',
-    canceled: 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400',
-  }
-
-  const canCancel = job.status === 'queued' || job.status === 'running'
-  const canDownload = job.status === 'succeeded' && job.outputPath
-  const canDelete = job.status === 'succeeded' || job.status === 'failed' || job.status === 'canceled'
-
-  return (
-    <div className='rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-600 dark:bg-gray-800'>
-      <div className='flex items-center justify-between'>
-        <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${statusColors[job.status] ?? ''}`}>
-          {statusLabels[job.status] ?? job.status}
-        </span>
-        <div className='flex gap-1'>
-          {canCancel && (
-            <button
-              onClick={onCancel}
-              className='rounded px-2 py-0.5 text-xs text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900'
-            >
-              キャンセル
-            </button>
-          )}
-          {canDownload && (
-            <a
-              href={`/api/export-jobs/${job.id}/download`}
-              className='rounded px-2 py-0.5 text-xs text-indigo-600 hover:bg-indigo-50 dark:text-indigo-400 dark:hover:bg-indigo-900'
-            >
-              ダウンロード
-            </a>
-          )}
-          {canDelete && (
-            <button
-              onClick={() => {
-                if (confirm('この書き出し履歴と出力ファイルを削除しますか？')) onDelete()
-              }}
-              className='inline-flex h-6 w-6 items-center justify-center rounded text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900'
-              title='履歴と出力ファイルを削除'
-            >
-              <Trash2 className='h-3.5 w-3.5' />
-            </button>
-          )}
-        </div>
-      </div>
-      {(job.status === 'running' || job.status === 'queued') && (
-        <div className='mt-2'>
-          <div className='h-2 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700'>
-            <div
-              className='h-full rounded-full bg-indigo-600 transition-all duration-300'
-              style={{ width: `${job.progress}%` }}
-            />
-          </div>
-          <p className='mt-1 text-right text-xs text-gray-400'>{Math.round(job.progress)}%</p>
-        </div>
-      )}
-      {job.status === 'failed' && (
-        <div className='mt-2 rounded-md border border-red-200 bg-red-50 p-2 text-xs text-red-700 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300'>
-          <p className='break-words'>{job.errorMessage ?? '書き出しに失敗しました。ログを確認してください。'}</p>
-          {job.logPath && (
-            <a
-              href={`/${job.logPath}`}
-              target='_blank'
-              rel='noreferrer'
-              className='mt-1 inline-block font-medium underline underline-offset-2'
-            >
-              ffmpegログを開く
-            </a>
-          )}
-        </div>
-      )}
-    </div>
   )
 }

--- a/projects/edit-vid2/src/client/features/exports/job-card.tsx
+++ b/projects/edit-vid2/src/client/features/exports/job-card.tsx
@@ -1,0 +1,109 @@
+import { Trash2 } from 'lucide-react'
+
+export interface ExportJob {
+  id: string
+  projectId: string
+  projectName?: string
+  status: string
+  progress: number
+  outputPath: string | null
+  logPath: string | null
+  errorMessage: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+const statusLabels: Record<string, string> = {
+  queued: '待機中',
+  running: '実行中',
+  succeeded: '完了',
+  failed: '失敗',
+  canceling: 'キャンセル中',
+  canceled: 'キャンセル済',
+}
+
+const statusColors: Record<string, string> = {
+  queued: 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900 dark:text-yellow-300',
+  running: 'bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300',
+  succeeded: 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300',
+  failed: 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300',
+  canceling: 'bg-orange-100 text-orange-700 dark:bg-orange-900 dark:text-orange-300',
+  canceled: 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400',
+}
+
+interface JobCardProps {
+  job: ExportJob
+  onCancel: () => void
+  onDelete: () => void
+}
+
+export function JobCard({ job, onCancel, onDelete }: JobCardProps) {
+  const canCancel = job.status === 'queued' || job.status === 'running'
+  const canDownload = job.status === 'succeeded' && job.outputPath
+  const canDelete = job.status === 'succeeded' || job.status === 'failed' || job.status === 'canceled'
+
+  return (
+    <div className='rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-600 dark:bg-gray-800'>
+      <div className='flex items-center justify-between'>
+        <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${statusColors[job.status] ?? ''}`}>
+          {statusLabels[job.status] ?? job.status}
+        </span>
+        <div className='flex gap-1'>
+          {canCancel && (
+            <button
+              onClick={onCancel}
+              className='rounded px-2 py-0.5 text-xs text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900'
+            >
+              キャンセル
+            </button>
+          )}
+          {canDownload && (
+            <a
+              href={`/api/export-jobs/${job.id}/download`}
+              className='rounded px-2 py-0.5 text-xs text-indigo-600 hover:bg-indigo-50 dark:text-indigo-400 dark:hover:bg-indigo-900'
+            >
+              ダウンロード
+            </a>
+          )}
+          {canDelete && (
+            <button
+              onClick={() => {
+                if (confirm('この書き出し履歴と出力ファイルを削除しますか？')) onDelete()
+              }}
+              className='inline-flex h-6 w-6 items-center justify-center rounded text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900'
+              title='履歴と出力ファイルを削除'
+            >
+              <Trash2 className='h-3.5 w-3.5' />
+            </button>
+          )}
+        </div>
+      </div>
+      {(job.status === 'running' || job.status === 'queued') && (
+        <div className='mt-2'>
+          <div className='h-2 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700'>
+            <div
+              className='h-full rounded-full bg-indigo-600 transition-all duration-300'
+              style={{ width: `${job.progress}%` }}
+            />
+          </div>
+          <p className='mt-1 text-right text-xs text-gray-400'>{Math.round(job.progress)}%</p>
+        </div>
+      )}
+      {job.status === 'failed' && (
+        <div className='mt-2 rounded-md border border-red-200 bg-red-50 p-2 text-xs text-red-700 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300'>
+          <p className='break-words'>{job.errorMessage ?? '書き出しに失敗しました。ログを確認してください。'}</p>
+          {job.logPath && (
+            <a
+              href={`/${job.logPath}`}
+              target='_blank'
+              rel='noreferrer'
+              className='mt-1 inline-block font-medium underline underline-offset-2'
+            >
+              ffmpegログを開く
+            </a>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/projects/edit-vid2/src/client/features/exports/job-card.tsx
+++ b/projects/edit-vid2/src/client/features/exports/job-card.tsx
@@ -13,7 +13,7 @@ export interface ExportJob {
   updatedAt: string
 }
 
-const statusLabels: Record<string, string> = {
+export const statusLabels: Record<string, string> = {
   queued: '待機中',
   running: '実行中',
   succeeded: '完了',
@@ -22,7 +22,7 @@ const statusLabels: Record<string, string> = {
   canceled: 'キャンセル済',
 }
 
-const statusColors: Record<string, string> = {
+export const statusColors: Record<string, string> = {
   queued: 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900 dark:text-yellow-300',
   running: 'bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300',
   succeeded: 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300',

--- a/projects/edit-vid2/src/client/features/exports/page.tsx
+++ b/projects/edit-vid2/src/client/features/exports/page.tsx
@@ -1,8 +1,69 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Link } from '@tanstack/react-router'
+import { Trash2 } from 'lucide-react'
 import { useMemo, useState } from 'react'
-import { type ExportJob } from '#/client/features/exports/job-card'
+import { JobCard, statusColors, statusLabels, type ExportJob } from '#/client/features/exports/job-card'
 import type { Project } from '#/shared/schemas'
+
+function JobStatusBadge({ status }: { status: string }) {
+  return (
+    <span className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${statusColors[status] ?? ''}`}>
+      {statusLabels[status] ?? status}
+    </span>
+  )
+}
+
+function JobActions({ job, onCancel, onDelete }: { job: ExportJob; onCancel: () => void; onDelete: () => void }) {
+  const canCancel = job.status === 'queued' || job.status === 'running'
+  const canDownload = job.status === 'succeeded' && job.outputPath
+  const canDelete = job.status === 'succeeded' || job.status === 'failed' || job.status === 'canceled'
+
+  return (
+    <div className='flex gap-1'>
+      {canCancel && (
+        <button
+          onClick={onCancel}
+          className='rounded px-2 py-0.5 text-xs text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900'
+        >
+          キャンセル
+        </button>
+      )}
+      {canDownload && (
+        <a
+          href={`/api/export-jobs/${job.id}/download`}
+          className='rounded px-2 py-0.5 text-xs text-indigo-600 hover:bg-indigo-50 dark:text-indigo-400 dark:hover:bg-indigo-900'
+        >
+          ダウンロード
+        </a>
+      )}
+      {canDelete && (
+        <button
+          onClick={() => {
+            if (confirm('この書き出し履歴と出力ファイルを削除しますか？')) onDelete()
+          }}
+          className='inline-flex h-6 w-6 items-center justify-center rounded text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900'
+          title='履歴と出力ファイルを削除'
+        >
+          <Trash2 className='h-3.5 w-3.5' />
+        </button>
+      )}
+    </div>
+  )
+}
+
+function JobProgress({ progress }: { progress: number }) {
+  return (
+    <div className='w-32'>
+      <div className='h-2 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700'>
+        <div
+          className='h-full rounded-full bg-indigo-600 transition-all duration-300'
+          style={{ width: `${progress}%` }}
+        />
+      </div>
+      <p className='mt-0.5 text-right text-xs text-gray-400'>{Math.round(progress)}%</p>
+    </div>
+  )
+}
 
 export function ExportsPage() {
   const queryClient = useQueryClient()
@@ -11,13 +72,21 @@ export function ExportsPage() {
 
   const { data: jobs } = useQuery<ExportJob[]>({
     queryKey: ['export-jobs'],
-    queryFn: () => fetch('/api/export-jobs?limit=100').then((r) => r.json()),
+    queryFn: async () => {
+      const r = await fetch('/api/export-jobs?limit=100')
+      if (!r.ok) throw new Error(`Failed to fetch export jobs: ${r.status}`)
+      return r.json()
+    },
     refetchInterval: 3000,
   })
 
   const { data: projects } = useQuery<Project[]>({
     queryKey: ['projects'],
-    queryFn: () => fetch('/api/projects').then((r) => r.json()),
+    queryFn: async () => {
+      const r = await fetch('/api/projects')
+      if (!r.ok) throw new Error(`Failed to fetch projects: ${r.status}`)
+      return r.json()
+    },
   })
 
   const cancelExport = useMutation({
@@ -39,15 +108,13 @@ export function ExportsPage() {
     })
   }, [jobs, statusFilter, projectFilter])
 
-  const statusOptions = [
-    { value: '', label: 'すべてのステータス' },
-    { value: 'queued', label: '待機中' },
-    { value: 'running', label: '実行中' },
-    { value: 'succeeded', label: '完了' },
-    { value: 'failed', label: '失敗' },
-    { value: 'canceling', label: 'キャンセル中' },
-    { value: 'canceled', label: 'キャンセル済' },
-  ]
+  const statusOptions = useMemo(
+    () => [
+      { value: '', label: 'すべてのステータス' },
+      ...Object.entries(statusLabels).map(([value, label]) => ({ value, label })),
+    ],
+    []
+  )
 
   return (
     <div className='flex h-full flex-col p-4 md:p-6'>
@@ -96,29 +163,7 @@ export function ExportsPage() {
             {filteredJobs.map((job) => (
               <tr key={job.id} className='bg-white dark:bg-gray-900'>
                 <td className='px-4 py-2'>
-                  <span
-                    className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${
-                      {
-                        queued: 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900 dark:text-yellow-300',
-                        running: 'bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300',
-                        succeeded: 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300',
-                        failed: 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300',
-                        canceling: 'bg-orange-100 text-orange-700 dark:bg-orange-900 dark:text-orange-300',
-                        canceled: 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400',
-                      }[job.status] ?? ''
-                    }`}
-                  >
-                    {
-                      {
-                        queued: '待機中',
-                        running: '実行中',
-                        succeeded: '完了',
-                        failed: '失敗',
-                        canceling: 'キャンセル中',
-                        canceled: 'キャンセル済',
-                      }[job.status] ?? job.status
-                    }
-                  </span>
+                  <JobStatusBadge status={job.status} />
                 </td>
                 <td className='px-4 py-2'>
                   <Link
@@ -131,15 +176,7 @@ export function ExportsPage() {
                 </td>
                 <td className='px-4 py-2'>
                   {job.status === 'running' || job.status === 'queued' ? (
-                    <div className='w-32'>
-                      <div className='h-2 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700'>
-                        <div
-                          className='h-full rounded-full bg-indigo-600 transition-all duration-300'
-                          style={{ width: `${job.progress}%` }}
-                        />
-                      </div>
-                      <p className='mt-0.5 text-right text-xs text-gray-400'>{Math.round(job.progress)}%</p>
-                    </div>
+                    <JobProgress progress={job.progress} />
                   ) : (
                     <span className='text-gray-400'>-</span>
                   )}
@@ -148,38 +185,11 @@ export function ExportsPage() {
                   {new Date(job.createdAt).toLocaleString('ja-JP')}
                 </td>
                 <td className='px-4 py-2'>
-                  <div className='flex gap-1'>
-                    {(job.status === 'queued' || job.status === 'running') && (
-                      <button
-                        onClick={() => cancelExport.mutate(job.id)}
-                        className='rounded px-2 py-0.5 text-xs text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900'
-                      >
-                        キャンセル
-                      </button>
-                    )}
-                    {job.status === 'succeeded' && job.outputPath && (
-                      <a
-                        href={`/api/export-jobs/${job.id}/download`}
-                        className='rounded px-2 py-0.5 text-xs text-indigo-600 hover:bg-indigo-50 dark:text-indigo-400 dark:hover:bg-indigo-900'
-                      >
-                        ダウンロード
-                      </a>
-                    )}
-                    {(job.status === 'succeeded' || job.status === 'failed' || job.status === 'canceled') && (
-                      <button
-                        onClick={() => {
-                          if (confirm('この書き出し履歴と出力ファイルを削除しますか？'))
-                            deleteExport.mutate(job.id)
-                        }}
-                        className='inline-flex h-6 w-6 items-center justify-center rounded text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900'
-                        title='履歴と出力ファイルを削除'
-                      >
-                        <svg className='h-3.5 w-3.5' fill='none' viewBox='0 0 24 24' stroke='currentColor' strokeWidth={2}>
-                          <path strokeLinecap='round' strokeLinejoin='round' d='M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16' />
-                        </svg>
-                      </button>
-                    )}
-                  </div>
+                  <JobActions
+                    job={job}
+                    onCancel={() => cancelExport.mutate(job.id)}
+                    onDelete={() => deleteExport.mutate(job.id)}
+                  />
                 </td>
               </tr>
             ))}
@@ -197,65 +207,13 @@ export function ExportsPage() {
       {/* Mobile cards */}
       <div className='space-y-3 md:hidden'>
         {filteredJobs.map((job) => (
-          <div key={job.id} className='rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-600 dark:bg-gray-800'>
-            <div className='mb-2 flex items-center justify-between'>
-              <span
-                className={`rounded-full px-2 py-0.5 text-xs font-medium ${
-                  {
-                    queued: 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900 dark:text-yellow-300',
-                    running: 'bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300',
-                    succeeded: 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300',
-                    failed: 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300',
-                    canceling: 'bg-orange-100 text-orange-700 dark:bg-orange-900 dark:text-orange-300',
-                    canceled: 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400',
-                  }[job.status] ?? ''
-                }`}
-              >
-                {
-                  {
-                    queued: '待機中',
-                    running: '実行中',
-                    succeeded: '完了',
-                    failed: '失敗',
-                    canceling: 'キャンセル中',
-                    canceled: 'キャンセル済',
-                  }[job.status] ?? job.status
-                }
-              </span>
-              <div className='flex gap-1'>
-                {(job.status === 'queued' || job.status === 'running') && (
-                  <button
-                    onClick={() => cancelExport.mutate(job.id)}
-                    className='rounded px-2 py-0.5 text-xs text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900'
-                  >
-                    キャンセル
-                  </button>
-                )}
-                {job.status === 'succeeded' && job.outputPath && (
-                  <a
-                    href={`/api/export-jobs/${job.id}/download`}
-                    className='rounded px-2 py-0.5 text-xs text-indigo-600 hover:bg-indigo-50 dark:text-indigo-400 dark:hover:bg-indigo-900'
-                  >
-                    ダウンロード
-                  </a>
-                )}
-                {(job.status === 'succeeded' || job.status === 'failed' || job.status === 'canceled') && (
-                  <button
-                    onClick={() => {
-                      if (confirm('この書き出し履歴と出力ファイルを削除しますか？'))
-                        deleteExport.mutate(job.id)
-                    }}
-                    className='inline-flex h-6 w-6 items-center justify-center rounded text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900'
-                    title='履歴と出力ファイルを削除'
-                  >
-                    <svg className='h-3.5 w-3.5' fill='none' viewBox='0 0 24 24' stroke='currentColor' strokeWidth={2}>
-                      <path strokeLinecap='round' strokeLinejoin='round' d='M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16' />
-                    </svg>
-                  </button>
-                )}
-              </div>
-            </div>
-            <div className='mb-1 text-sm'>
+          <div key={job.id}>
+            <JobCard
+              job={job}
+              onCancel={() => cancelExport.mutate(job.id)}
+              onDelete={() => deleteExport.mutate(job.id)}
+            />
+            <div className='mt-1 px-1 text-sm'>
               <span className='text-gray-500 dark:text-gray-400'>プロジェクト:</span>{' '}
               <Link
                 to='/projects/$projectId'
@@ -265,37 +223,9 @@ export function ExportsPage() {
                 {job.projectName ?? ''}
               </Link>
             </div>
-            <div className='mb-1 text-xs text-gray-400 dark:text-gray-500'>
+            <div className='px-1 text-xs text-gray-400 dark:text-gray-500'>
               {new Date(job.createdAt).toLocaleString('ja-JP')}
             </div>
-            {(job.status === 'running' || job.status === 'queued') && (
-              <div className='mt-2'>
-                <div className='h-2 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700'>
-                  <div
-                    className='h-full rounded-full bg-indigo-600 transition-all duration-300'
-                    style={{ width: `${job.progress}%` }}
-                  />
-                </div>
-                <p className='mt-1 text-right text-xs text-gray-400'>{Math.round(job.progress)}%</p>
-              </div>
-            )}
-            {job.status === 'failed' && (
-              <div className='mt-2 rounded-md border border-red-200 bg-red-50 p-2 text-xs text-red-700 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300'>
-                <p className='break-words'>
-                  {job.errorMessage ?? '書き出しに失敗しました。ログを確認してください。'}
-                </p>
-                {job.logPath && (
-                  <a
-                    href={`/${job.logPath}`}
-                    target='_blank'
-                    rel='noreferrer'
-                    className='mt-1 inline-block font-medium underline underline-offset-2'
-                  >
-                    ffmpegログを開く
-                  </a>
-                )}
-              </div>
-            )}
           </div>
         ))}
         {filteredJobs.length === 0 && (

--- a/projects/edit-vid2/src/client/features/exports/page.tsx
+++ b/projects/edit-vid2/src/client/features/exports/page.tsx
@@ -1,0 +1,307 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Link } from '@tanstack/react-router'
+import { useMemo, useState } from 'react'
+import { type ExportJob } from '#/client/features/exports/job-card'
+import type { Project } from '#/shared/schemas'
+
+export function ExportsPage() {
+  const queryClient = useQueryClient()
+  const [statusFilter, setStatusFilter] = useState('')
+  const [projectFilter, setProjectFilter] = useState('')
+
+  const { data: jobs } = useQuery<ExportJob[]>({
+    queryKey: ['export-jobs'],
+    queryFn: () => fetch('/api/export-jobs?limit=100').then((r) => r.json()),
+    refetchInterval: 3000,
+  })
+
+  const { data: projects } = useQuery<Project[]>({
+    queryKey: ['projects'],
+    queryFn: () => fetch('/api/projects').then((r) => r.json()),
+  })
+
+  const cancelExport = useMutation({
+    mutationFn: (jobId: string) => fetch(`/api/export-jobs/${jobId}/cancel`, { method: 'POST' }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['export-jobs'] }),
+  })
+
+  const deleteExport = useMutation({
+    mutationFn: (jobId: string) => fetch(`/api/export-jobs/${jobId}`, { method: 'DELETE' }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['export-jobs'] }),
+  })
+
+  const filteredJobs = useMemo(() => {
+    if (!jobs) return []
+    return jobs.filter((job) => {
+      if (statusFilter && job.status !== statusFilter) return false
+      if (projectFilter && job.projectId !== projectFilter) return false
+      return true
+    })
+  }, [jobs, statusFilter, projectFilter])
+
+  const statusOptions = [
+    { value: '', label: 'すべてのステータス' },
+    { value: 'queued', label: '待機中' },
+    { value: 'running', label: '実行中' },
+    { value: 'succeeded', label: '完了' },
+    { value: 'failed', label: '失敗' },
+    { value: 'canceling', label: 'キャンセル中' },
+    { value: 'canceled', label: 'キャンセル済' },
+  ]
+
+  return (
+    <div className='flex h-full flex-col p-4 md:p-6'>
+      <div className='mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between'>
+        <h1 className='text-lg font-semibold text-gray-900 dark:text-gray-100'>書き出し履歴</h1>
+        <div className='flex flex-col gap-2 sm:flex-row'>
+          <select
+            value={statusFilter}
+            onChange={(e) => setStatusFilter(e.target.value)}
+            className='rounded-lg border border-gray-300 px-3 py-1.5 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100'
+          >
+            {statusOptions.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+          <select
+            value={projectFilter}
+            onChange={(e) => setProjectFilter(e.target.value)}
+            className='rounded-lg border border-gray-300 px-3 py-1.5 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100'
+          >
+            <option value=''>すべてのプロジェクト</option>
+            {projects?.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {/* Desktop table */}
+      <div className='hidden overflow-auto rounded-lg border border-gray-200 dark:border-gray-700 md:block'>
+        <table className='w-full text-left text-sm'>
+          <thead className='bg-gray-50 text-gray-600 dark:bg-gray-800 dark:text-gray-400'>
+            <tr>
+              <th className='px-4 py-2'>ステータス</th>
+              <th className='px-4 py-2'>プロジェクト</th>
+              <th className='px-4 py-2'>進捗</th>
+              <th className='px-4 py-2'>作成日時</th>
+              <th className='px-4 py-2'>操作</th>
+            </tr>
+          </thead>
+          <tbody className='divide-y divide-gray-200 dark:divide-gray-700'>
+            {filteredJobs.map((job) => (
+              <tr key={job.id} className='bg-white dark:bg-gray-900'>
+                <td className='px-4 py-2'>
+                  <span
+                    className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${
+                      {
+                        queued: 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900 dark:text-yellow-300',
+                        running: 'bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300',
+                        succeeded: 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300',
+                        failed: 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300',
+                        canceling: 'bg-orange-100 text-orange-700 dark:bg-orange-900 dark:text-orange-300',
+                        canceled: 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400',
+                      }[job.status] ?? ''
+                    }`}
+                  >
+                    {
+                      {
+                        queued: '待機中',
+                        running: '実行中',
+                        succeeded: '完了',
+                        failed: '失敗',
+                        canceling: 'キャンセル中',
+                        canceled: 'キャンセル済',
+                      }[job.status] ?? job.status
+                    }
+                  </span>
+                </td>
+                <td className='px-4 py-2'>
+                  <Link
+                    to='/projects/$projectId'
+                    params={{ projectId: job.projectId }}
+                    className='text-indigo-600 hover:underline dark:text-indigo-400'
+                  >
+                    {job.projectName ?? ''}
+                  </Link>
+                </td>
+                <td className='px-4 py-2'>
+                  {job.status === 'running' || job.status === 'queued' ? (
+                    <div className='w-32'>
+                      <div className='h-2 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700'>
+                        <div
+                          className='h-full rounded-full bg-indigo-600 transition-all duration-300'
+                          style={{ width: `${job.progress}%` }}
+                        />
+                      </div>
+                      <p className='mt-0.5 text-right text-xs text-gray-400'>{Math.round(job.progress)}%</p>
+                    </div>
+                  ) : (
+                    <span className='text-gray-400'>-</span>
+                  )}
+                </td>
+                <td className='px-4 py-2 text-gray-500 dark:text-gray-400'>
+                  {new Date(job.createdAt).toLocaleString('ja-JP')}
+                </td>
+                <td className='px-4 py-2'>
+                  <div className='flex gap-1'>
+                    {(job.status === 'queued' || job.status === 'running') && (
+                      <button
+                        onClick={() => cancelExport.mutate(job.id)}
+                        className='rounded px-2 py-0.5 text-xs text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900'
+                      >
+                        キャンセル
+                      </button>
+                    )}
+                    {job.status === 'succeeded' && job.outputPath && (
+                      <a
+                        href={`/api/export-jobs/${job.id}/download`}
+                        className='rounded px-2 py-0.5 text-xs text-indigo-600 hover:bg-indigo-50 dark:text-indigo-400 dark:hover:bg-indigo-900'
+                      >
+                        ダウンロード
+                      </a>
+                    )}
+                    {(job.status === 'succeeded' || job.status === 'failed' || job.status === 'canceled') && (
+                      <button
+                        onClick={() => {
+                          if (confirm('この書き出し履歴と出力ファイルを削除しますか？'))
+                            deleteExport.mutate(job.id)
+                        }}
+                        className='inline-flex h-6 w-6 items-center justify-center rounded text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900'
+                        title='履歴と出力ファイルを削除'
+                      >
+                        <svg className='h-3.5 w-3.5' fill='none' viewBox='0 0 24 24' stroke='currentColor' strokeWidth={2}>
+                          <path strokeLinecap='round' strokeLinejoin='round' d='M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16' />
+                        </svg>
+                      </button>
+                    )}
+                  </div>
+                </td>
+              </tr>
+            ))}
+            {filteredJobs.length === 0 && (
+              <tr>
+                <td colSpan={5} className='px-4 py-8 text-center text-sm text-gray-400 dark:text-gray-500'>
+                  書き出し履歴がありません
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Mobile cards */}
+      <div className='space-y-3 md:hidden'>
+        {filteredJobs.map((job) => (
+          <div key={job.id} className='rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-600 dark:bg-gray-800'>
+            <div className='mb-2 flex items-center justify-between'>
+              <span
+                className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+                  {
+                    queued: 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900 dark:text-yellow-300',
+                    running: 'bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300',
+                    succeeded: 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300',
+                    failed: 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300',
+                    canceling: 'bg-orange-100 text-orange-700 dark:bg-orange-900 dark:text-orange-300',
+                    canceled: 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400',
+                  }[job.status] ?? ''
+                }`}
+              >
+                {
+                  {
+                    queued: '待機中',
+                    running: '実行中',
+                    succeeded: '完了',
+                    failed: '失敗',
+                    canceling: 'キャンセル中',
+                    canceled: 'キャンセル済',
+                  }[job.status] ?? job.status
+                }
+              </span>
+              <div className='flex gap-1'>
+                {(job.status === 'queued' || job.status === 'running') && (
+                  <button
+                    onClick={() => cancelExport.mutate(job.id)}
+                    className='rounded px-2 py-0.5 text-xs text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900'
+                  >
+                    キャンセル
+                  </button>
+                )}
+                {job.status === 'succeeded' && job.outputPath && (
+                  <a
+                    href={`/api/export-jobs/${job.id}/download`}
+                    className='rounded px-2 py-0.5 text-xs text-indigo-600 hover:bg-indigo-50 dark:text-indigo-400 dark:hover:bg-indigo-900'
+                  >
+                    ダウンロード
+                  </a>
+                )}
+                {(job.status === 'succeeded' || job.status === 'failed' || job.status === 'canceled') && (
+                  <button
+                    onClick={() => {
+                      if (confirm('この書き出し履歴と出力ファイルを削除しますか？'))
+                        deleteExport.mutate(job.id)
+                    }}
+                    className='inline-flex h-6 w-6 items-center justify-center rounded text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900'
+                    title='履歴と出力ファイルを削除'
+                  >
+                    <svg className='h-3.5 w-3.5' fill='none' viewBox='0 0 24 24' stroke='currentColor' strokeWidth={2}>
+                      <path strokeLinecap='round' strokeLinejoin='round' d='M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16' />
+                    </svg>
+                  </button>
+                )}
+              </div>
+            </div>
+            <div className='mb-1 text-sm'>
+              <span className='text-gray-500 dark:text-gray-400'>プロジェクト:</span>{' '}
+              <Link
+                to='/projects/$projectId'
+                params={{ projectId: job.projectId }}
+                className='text-indigo-600 hover:underline dark:text-indigo-400'
+              >
+                {job.projectName ?? ''}
+              </Link>
+            </div>
+            <div className='mb-1 text-xs text-gray-400 dark:text-gray-500'>
+              {new Date(job.createdAt).toLocaleString('ja-JP')}
+            </div>
+            {(job.status === 'running' || job.status === 'queued') && (
+              <div className='mt-2'>
+                <div className='h-2 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700'>
+                  <div
+                    className='h-full rounded-full bg-indigo-600 transition-all duration-300'
+                    style={{ width: `${job.progress}%` }}
+                  />
+                </div>
+                <p className='mt-1 text-right text-xs text-gray-400'>{Math.round(job.progress)}%</p>
+              </div>
+            )}
+            {job.status === 'failed' && (
+              <div className='mt-2 rounded-md border border-red-200 bg-red-50 p-2 text-xs text-red-700 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300'>
+                <p className='break-words'>
+                  {job.errorMessage ?? '書き出しに失敗しました。ログを確認してください。'}
+                </p>
+                {job.logPath && (
+                  <a
+                    href={`/${job.logPath}`}
+                    target='_blank'
+                    rel='noreferrer'
+                    className='mt-1 inline-block font-medium underline underline-offset-2'
+                  >
+                    ffmpegログを開く
+                  </a>
+                )}
+              </div>
+            )}
+          </div>
+        ))}
+        {filteredJobs.length === 0 && (
+          <p className='text-center text-sm text-gray-400 dark:text-gray-500'>書き出し履歴がありません</p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/projects/edit-vid2/src/client/routeTree.gen.ts
+++ b/projects/edit-vid2/src/client/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as VideosRouteImport } from './routes/videos'
 import { Route as ProjectsRouteImport } from './routes/projects'
+import { Route as ExportsRouteImport } from './routes/exports'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as ProjectsIndexRouteImport } from './routes/projects.index'
 import { Route as ProjectsProjectIdRouteImport } from './routes/projects.$projectId'
@@ -23,6 +24,11 @@ const VideosRoute = VideosRouteImport.update({
 const ProjectsRoute = ProjectsRouteImport.update({
   id: '/projects',
   path: '/projects',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ExportsRoute = ExportsRouteImport.update({
+  id: '/exports',
+  path: '/exports',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
@@ -43,6 +49,7 @@ const ProjectsProjectIdRoute = ProjectsProjectIdRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/exports': typeof ExportsRoute
   '/projects': typeof ProjectsRouteWithChildren
   '/videos': typeof VideosRoute
   '/projects/$projectId': typeof ProjectsProjectIdRoute
@@ -50,6 +57,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/exports': typeof ExportsRoute
   '/videos': typeof VideosRoute
   '/projects/$projectId': typeof ProjectsProjectIdRoute
   '/projects': typeof ProjectsIndexRoute
@@ -57,6 +65,7 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/exports': typeof ExportsRoute
   '/projects': typeof ProjectsRouteWithChildren
   '/videos': typeof VideosRoute
   '/projects/$projectId': typeof ProjectsProjectIdRoute
@@ -66,15 +75,17 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/exports'
     | '/projects'
     | '/videos'
     | '/projects/$projectId'
     | '/projects/'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/videos' | '/projects/$projectId' | '/projects'
+  to: '/' | '/exports' | '/videos' | '/projects/$projectId' | '/projects'
   id:
     | '__root__'
     | '/'
+    | '/exports'
     | '/projects'
     | '/videos'
     | '/projects/$projectId'
@@ -83,6 +94,7 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  ExportsRoute: typeof ExportsRoute
   ProjectsRoute: typeof ProjectsRouteWithChildren
   VideosRoute: typeof VideosRoute
 }
@@ -101,6 +113,13 @@ declare module '@tanstack/react-router' {
       path: '/projects'
       fullPath: '/projects'
       preLoaderRoute: typeof ProjectsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/exports': {
+      id: '/exports'
+      path: '/exports'
+      fullPath: '/exports'
+      preLoaderRoute: typeof ExportsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/': {
@@ -143,6 +162,7 @@ const ProjectsRouteWithChildren = ProjectsRoute._addFileChildren(
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  ExportsRoute: ExportsRoute,
   ProjectsRoute: ProjectsRouteWithChildren,
   VideosRoute: VideosRoute,
 }

--- a/projects/edit-vid2/src/client/routes/__root.tsx
+++ b/projects/edit-vid2/src/client/routes/__root.tsx
@@ -1,5 +1,5 @@
 import { Outlet, createRootRoute } from '@tanstack/react-router'
-import { Clapperboard, Film } from 'lucide-react'
+import { Clapperboard, Download, Film } from 'lucide-react'
 import { Suspense, lazy } from 'react'
 import { AppLayout } from '#/client/app/app-layout'
 import { RouteLoading } from '#/client/app/route-loading'
@@ -20,6 +20,7 @@ function Root() {
   const menuItems = [
     { label: '動画', icon: <Film size={20} />, to: '/videos' },
     { label: 'プロジェクト', icon: <Clapperboard size={20} />, to: '/projects' },
+    { label: '書き出し', icon: <Download size={20} />, to: '/exports' },
   ]
 
   return (

--- a/projects/edit-vid2/src/client/routes/exports.tsx
+++ b/projects/edit-vid2/src/client/routes/exports.tsx
@@ -1,0 +1,8 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { lazy } from 'react'
+
+const ExportsPage = lazy(() => import('#/client/features/exports/page').then((m) => ({ default: m.ExportsPage })))
+
+export const Route = createFileRoute('/exports')({
+  component: ExportsPage,
+})

--- a/projects/edit-vid2/src/server/app.tsx
+++ b/projects/edit-vid2/src/server/app.tsx
@@ -4,7 +4,7 @@ import { getDatabase } from '#/db'
 import type { AppDatabase } from '#/db'
 import { errHandler } from '#/server/middleware/error-handler'
 import { applySecurityHeaders } from '#/server/middleware/security-headers'
-import { exportRoutes, sseRoutes } from '#/server/routes/exports'
+import { exportRoutes, jobRoutes } from '#/server/routes/exports'
 import { htmlRoutes } from '#/server/routes/html'
 import { previewRoutes } from '#/server/routes/previews'
 import { projectRoutes } from '#/server/routes/projects'
@@ -42,7 +42,7 @@ const routes = app
   .route('/api/templates', templateRoutes)
   .route('/api/projects/:projectId/previews/subtitle', previewRoutes)
   .route('/api/projects/:projectId/export-jobs', exportRoutes)
-  .route('/api/export-jobs', sseRoutes)
+  .route('/api/export-jobs', jobRoutes)
   .route('/', htmlRoutes)
 
 export default app

--- a/projects/edit-vid2/src/server/bun-server.ts
+++ b/projects/edit-vid2/src/server/bun-server.ts
@@ -4,7 +4,7 @@ import { getDatabase } from '#/db'
 import type { AppDatabase } from '#/db'
 import { errHandler } from '#/server/middleware/error-handler'
 import { applySecurityHeaders } from '#/server/middleware/security-headers'
-import { exportRoutes, sseRoutes } from '#/server/routes/exports'
+import { exportRoutes, jobRoutes } from '#/server/routes/exports'
 import { htmlRoutes } from '#/server/routes/html'
 import { previewRoutes } from '#/server/routes/previews'
 import { projectRoutes } from '#/server/routes/projects'
@@ -40,7 +40,7 @@ app.route('/api/projects', projectRoutes)
 app.route('/api/templates', templateRoutes)
 app.route('/api/projects/:projectId/previews/subtitle', previewRoutes)
 app.route('/api/projects/:projectId/export-jobs', exportRoutes)
-app.route('/api/export-jobs', sseRoutes)
+app.route('/api/export-jobs', jobRoutes)
 app.route('/', htmlRoutes)
 
 const port = Number(process.env.SERVER_PORT) || 3000

--- a/projects/edit-vid2/src/server/features/export/export-repository.ts
+++ b/projects/edit-vid2/src/server/features/export/export-repository.ts
@@ -3,11 +3,7 @@ import type { AppDatabase } from '#/db'
 import { exportJobs } from '#/db/schema'
 
 export function getExportJobs(db: AppDatabase, limit?: number) {
-  const query = db
-    .select()
-    .from(exportJobs)
-    .where(isNull(exportJobs.deletedAt))
-    .orderBy(desc(exportJobs.createdAt))
+  const query = db.select().from(exportJobs).where(isNull(exportJobs.deletedAt)).orderBy(desc(exportJobs.createdAt))
 
   if (limit !== undefined) {
     return query.limit(limit).all()

--- a/projects/edit-vid2/src/server/features/export/export-repository.ts
+++ b/projects/edit-vid2/src/server/features/export/export-repository.ts
@@ -2,8 +2,17 @@ import { and, desc, eq, isNull } from 'drizzle-orm'
 import type { AppDatabase } from '#/db'
 import { exportJobs } from '#/db/schema'
 
-export function getExportJobs(db: AppDatabase) {
-  return db.select().from(exportJobs).where(isNull(exportJobs.deletedAt)).all()
+export function getExportJobs(db: AppDatabase, limit?: number) {
+  const query = db
+    .select()
+    .from(exportJobs)
+    .where(isNull(exportJobs.deletedAt))
+    .orderBy(desc(exportJobs.createdAt))
+
+  if (limit !== undefined) {
+    return query.limit(limit).all()
+  }
+  return query.all()
 }
 
 export function getExportJobsByProject(db: AppDatabase, projectId: string) {

--- a/projects/edit-vid2/src/server/routes/exports.ts
+++ b/projects/edit-vid2/src/server/routes/exports.ts
@@ -95,12 +95,14 @@ exportRoutes.post('/', sValidator('json', CreateExportJobSchema), (c) => {
   return c.json(job, 201)
 })
 
-// SSE endpoint: GET /api/export-jobs/:exportJobId/events
-const sseRoutes = new Hono<HonoEnv>()
+// REST endpoints for job actions: GET /api/export-jobs, GET /api/export-jobs/:exportJobId, etc.
+const jobRoutes = new Hono<HonoEnv>()
 
-sseRoutes.get('/', (c) => {
+jobRoutes.get('/', (c) => {
   const db = c.var.db
-  const limit = Number(c.req.query('limit') ?? '100')
+  const rawLimit = c.req.query('limit') ?? '100'
+  const parsed = Number(rawLimit)
+  const limit = Number.isNaN(parsed) || parsed < 1 ? 100 : Math.min(parsed, 500)
   const jobs = getExportJobs(db, limit)
   const allProjects = getProjects(db)
   const projectMap = new Map(allProjects.map((p) => [p.id, p.name]))
@@ -109,11 +111,11 @@ sseRoutes.get('/', (c) => {
       ...job,
       projectName: projectMap.get(job.projectId) ?? '',
       errorMessage: job.status === 'failed' ? summarizeExportError(job.logPath) : null,
-    })),
+    }))
   )
 })
 
-sseRoutes.get('/:exportJobId/events', (c) => {
+jobRoutes.get('/:exportJobId/events', (c) => {
   const db = c.var.db
   const jobId = c.req.param('exportJobId')
 
@@ -159,7 +161,7 @@ sseRoutes.get('/:exportJobId/events', (c) => {
   })
 })
 
-sseRoutes.get('/:exportJobId', (c) => {
+jobRoutes.get('/:exportJobId', (c) => {
   const db = c.var.db
   const job = getExportJobById(db, c.req.param('exportJobId'))
   if (!job) {
@@ -171,7 +173,7 @@ sseRoutes.get('/:exportJobId', (c) => {
   })
 })
 
-sseRoutes.post('/:exportJobId/cancel', (c) => {
+jobRoutes.post('/:exportJobId/cancel', (c) => {
   const db = c.var.db
   const jobId = c.req.param('exportJobId')
   const job = getExportJobById(db, jobId)
@@ -185,7 +187,7 @@ sseRoutes.post('/:exportJobId/cancel', (c) => {
   return c.json(updateExportJob(db, jobId, {}))
 })
 
-sseRoutes.delete('/:exportJobId', (c) => {
+jobRoutes.delete('/:exportJobId', (c) => {
   const db = c.var.db
   const jobId = c.req.param('exportJobId')
   const job = getExportJobById(db, jobId)
@@ -201,7 +203,7 @@ sseRoutes.delete('/:exportJobId', (c) => {
   return c.body(null, 204)
 })
 
-sseRoutes.get('/:exportJobId/download', async (c) => {
+jobRoutes.get('/:exportJobId/download', async (c) => {
   const db = c.var.db
   const job = getExportJobById(db, c.req.param('exportJobId'))
   if (!job) {
@@ -241,4 +243,4 @@ function recoverIncompleteJobs() {
 }
 recoverIncompleteJobs()
 
-export { exportRoutes, sseRoutes }
+export { exportRoutes, jobRoutes }

--- a/projects/edit-vid2/src/server/routes/exports.ts
+++ b/projects/edit-vid2/src/server/routes/exports.ts
@@ -8,12 +8,13 @@ import {
   createExportJob,
   deleteExportJob,
   getExportJobById,
+  getExportJobs,
   getExportJobsByProject,
   getIncompleteJobs,
   updateExportJob,
 } from '#/server/features/export/export-repository'
 import { exportWorker } from '#/server/features/export/export-worker'
-import { getProjectById } from '#/server/features/projects/project-repository'
+import { getProjectById, getProjects } from '#/server/features/projects/project-repository'
 import { getVideoAssetById } from '#/server/features/videos/video-repository'
 import type { HonoEnv } from '#/server/routes/shared'
 import { CreateExportJobSchema } from '#/shared/schemas'
@@ -96,6 +97,21 @@ exportRoutes.post('/', sValidator('json', CreateExportJobSchema), (c) => {
 
 // SSE endpoint: GET /api/export-jobs/:exportJobId/events
 const sseRoutes = new Hono<HonoEnv>()
+
+sseRoutes.get('/', (c) => {
+  const db = c.var.db
+  const limit = Number(c.req.query('limit') ?? '100')
+  const jobs = getExportJobs(db, limit)
+  const allProjects = getProjects(db)
+  const projectMap = new Map(allProjects.map((p) => [p.id, p.name]))
+  return c.json(
+    jobs.map((job) => ({
+      ...job,
+      projectName: projectMap.get(job.projectId) ?? '',
+      errorMessage: job.status === 'failed' ? summarizeExportError(job.logPath) : null,
+    })),
+  )
+})
 
 sseRoutes.get('/:exportJobId/events', (c) => {
   const db = c.var.db


### PR DESCRIPTION
## Issues

- Close #1048

## Why

エディタ画面の書き出し履歴が情報密度を高めており、全プロジェクト横断で書き出し状況を確認する手段がなかった。履歴を専用画面 `/exports` に分離し、エディタは最新1件の進捗だけ表示することで情報密度を下げ、運用性を向上する。

## Summary

- `/exports` 新規画面で全プロジェクト横断の最新100件の書き出し履歴を表示
- エディタ画面から履歴一覧を削除し、最新1件の進捗と `/exports` へのリンクのみ表示
- サイドナビに「書き出し」を追加
- 削除操作の UI 文言を「履歴と出力ファイルを削除」と明示

## Changes

- `GET /api/export-jobs?limit=100` 横断履歴 API を追加
- `getExportJobs` を `createdAt desc` + `limit` 対応に変更
- `src/client/features/exports/page.tsx` (ExportsPage) を追加
- `src/client/features/exports/job-card.tsx` (共通化 JobCard) を追加
- `src/client/routes/exports.tsx` (/exports route) を追加
- サイドナビに「書き出し」メニューを追加
- `ExportPanel` から履歴一覧を削除し、最新1件 + `/exports` リンクを表示
- `routeTree.gen.ts` に `/exports` ルートを追加
- 書き出し開始・キャンセル・削除後に global `export-jobs` クエリを無効化

## Checklist

- [x] `bun run lint` passed
- [x] `bun run test:unit` passed (27/27)
- [x] E2E tests are failing due to existing dev server startup timeout in this environment (unrelated to changes)
- [x] Manual verification items from #1048

## Verification

- `bun run lint` - passed
- `bun run test:unit` - 27/27 passed
- 既存のプロジェクト単位 API とジョブ操作 API は維持
- DB スキーマ変更なし
