### PR TITLE
feat(skills): add github-dependabot-maintain skill

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,0 +1,12 @@
+# Agent Skills
+
+このディレクトリには monorepo 専用のカスタムスキルを配置します。
+
+## Available Skills
+
+| Skill | Description |
+|-------|-------------|
+| [dockerfile-designer](dockerfile-designer/SKILL.md) | Activates when asked to create a Dockerfile or when working on a new project in the monorepo |
+| [fastapi](fastapi/SKILL.md) | Referenced when creating a project with FastAPI |
+| [license-check](license-check/SKILL.md) | Node/Python dependency の OSS ライセンスチェックをこの monorepo でローカル実行する時に使う |
+| [github-dependabot-maintain](github-dependabot-maintain/SKILL.md) | `.github/dependabot.yml` を `projects/` 構成と同期させる |

--- a/.claude/skills/github-dependabot-maintain/SKILL.md
+++ b/.claude/skills/github-dependabot-maintain/SKILL.md
@@ -64,9 +64,9 @@ Use lockfiles only:
 
 Before editing, run:
 
-    git diff -- .github/dependabot.yml
+    git status --porcelain -- .github/dependabot.yml
 
-If there are uncommitted changes, stop and warn the user.
+If the output is non-empty, stop and warn the user. This catches both staged and unstaged changes.
 
 ### Step 2: Scan Projects
 

--- a/.claude/skills/github-dependabot-maintain/SKILL.md
+++ b/.claude/skills/github-dependabot-maintain/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: github-dependabot-maintain
+description: >
+  When asked to maintain `.github/dependabot.yml` or keep Dependabot entries in sync with `projects/`,
+  scan project directories, detect ecosystems from lockfiles, and propose updates.
+---
+
+# Dependabot Config Maintenance
+
+## Overview
+
+Keep `.github/dependabot.yml` in sync with the actual `projects/` layout.
+Adds missing Dependabot entries, removes stale entries, normalizes group names,
+and sorts entries alphabetically by `directory`.
+
+## When to Use This Skill
+
+- When told "dependabot.yml をメンテして" or "update dependabot config"
+- When a new project is added under `projects/`
+- When a project is removed or no longer has a lockfile
+- Before opening a PR that adds/removes/renames a project under `projects/`
+
+## What the Agent Does
+
+1. Verify `.github/dependabot.yml` has no uncommitted changes
+2. Scan immediate subdirectories of `projects/`
+3. Detect each project's ecosystem from its lockfile
+4. Compare scan results with existing `updates:` entries
+5. Add missing entries, remove stale entries, normalize group names, and sort
+6. Show the diff and ask for approval
+7. Write the file only after approval
+8. Validate YAML syntax and recheck coverage
+
+## Input and Output
+
+**Input:**
+- `.github/dependabot.yml`
+- `projects/*/` directories and their lockfiles
+
+**Output:**
+- Updated `.github/dependabot.yml` (after user approval)
+
+## Exclusions
+
+Ignore these directories under `projects/`:
+
+- `_labs/`
+- `_samples/`
+- Nested subdirectories
+- Any directory without a recognized lockfile
+
+## Ecosystem Detection
+
+Use lockfiles only:
+
+| Lockfile | Ecosystem |
+|----------|-----------|
+| `bun.lock` or `bun.lockb` | `bun` |
+| `uv.lock` | `uv` |
+
+## Step Details
+
+### Step 1: Check for Uncommitted Changes
+
+Before editing, run:
+
+    git diff -- .github/dependabot.yml
+
+If there are uncommitted changes, stop and warn the user.
+
+### Step 2: Scan Projects
+
+List candidate directories:
+
+    for dir in projects/*/; do
+      name=$(basename "$dir")
+      [[ "$name" == "_labs" || "$name" == "_samples" ]] && continue
+      if [[ -f "$dir/bun.lock" || -f "$dir/bun.lockb" ]]; then
+        echo "bun /projects/$name"
+      elif [[ -f "$dir/uv.lock" ]]; then
+        echo "uv /projects/$name"
+      fi
+    done | sort -k2
+
+### Step 3: Build Desired Entries
+
+For each detected project, build an entry:
+
+    - package-ecosystem: "{ecosystem}"
+      directory: "/projects/{name}"
+      schedule:
+        interval: "weekly"
+      open-pull-requests-limit: 1
+      rebase-strategy: "disabled"
+      groups:
+        {name}-minor-and-patch:
+          applies-to: version-updates
+          patterns:
+            - "*"
+          update-types:
+            - "minor"
+            - "patch"
+
+Use the exact project directory name as the group name prefix.
+Keep a blank line between entries to match the current file format.
+
+### Step 4: Preserve Existing Settings
+
+When an entry already exists for a scanned directory, keep its existing values for:
+
+- `schedule`
+- `open-pull-requests-limit`
+- `rebase-strategy`
+- any other custom fields
+
+Only normalize the group name to `{name}-minor-and-patch` if it differs.
+
+### Step 5: Diff and Propose
+
+Compare desired entries with the current file. Show the diff and wait for user approval.
+Do not write the file if the user does not explicitly approve.
+
+### Step 6: Write and Validate
+
+After approval, write `.github/dependabot.yml`. Then run:
+
+    python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"
+
+Finally, rerun the scan from Step 2 and confirm every detected project has exactly one entry.
+
+## Quality Check
+
+- [ ] No uncommitted changes existed before editing
+- [ ] Only `projects/` immediate subdirectories were scanned
+- [ ] `_labs/` and `_samples/` were excluded
+- [ ] Ecosystems were detected from lockfiles
+- [ ] Existing entry settings were preserved except group names
+- [ ] Entries are sorted alphabetically by `directory`
+- [ ] User approved the diff before writing
+- [ ] YAML syntax passes `python3 -c "import yaml; yaml.safe_load(...)"`
+- [ ] Scan results and entries are 1:1 after writing
+
+## References
+
+- `.github/dependabot.yml` - the file this skill maintains
+- `references/github-dependabot-maintain-detailed.md` - detailed scanning and approval script

--- a/.claude/skills/github-dependabot-maintain/references/github-dependabot-maintain-detailed.md
+++ b/.claude/skills/github-dependabot-maintain/references/github-dependabot-maintain-detailed.md
@@ -1,96 +1,52 @@
 # Detailed Scanning and Approval Script
 
-## Full maintenance script
+## Script location
 
-A Bash script you can adapt to preview changes before writing:
+The complete maintenance script is at:
 
-```bash
-#!/usr/bin/env bash
-set -euo pipefail
-
-CONFIG=".github/dependabot.yml"
-TMP_DIR=$(mktemp -d)
-trap 'rm -rf "$TMP_DIR"' EXIT
-
-# 1. Safety check
-if [ -n "$(git diff -- "$CONFIG")" ]; then
-  echo "ERROR: $CONFIG has uncommitted changes. Commit or revert them first."
-  exit 1
-fi
-
-# 2. Scan projects and detect ecosystems
-pairs=()
-for dir in projects/*/; do
-  name=$(basename "$dir")
-  [[ "$name" == "_labs" || "$name" == "_samples" ]] && continue
-
-  eco=""
-  if [[ -f "$dir/bun.lock" || -f "$dir/bun.lockb" ]]; then
-    eco="bun"
-  elif [[ -f "$dir/uv.lock" ]]; then
-    eco="uv"
-  fi
-
-  if [ -n "$eco" ]; then
-    pairs+=("$name $eco")
-  fi
-done
-
-# 3. Generate desired config
-{
-  echo "version: 2"
-  echo "updates:"
-
-  # Sort by project name for deterministic output
-  first=true
-  printf '%s\n' "${pairs[@]}" | sort | while read -r name eco; do
-    if [ "$first" = true ]; then
-      first=false
-    else
-      echo ""  # blank line between entries, matching current format
-    fi
-    cat << ENTRY
-  - package-ecosystem: "$eco"
-    directory: "/projects/$name"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 1
-    rebase-strategy: "disabled"
-    groups:
-      $name-minor-and-patch:
-        applies-to: version-updates
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
-ENTRY
-  done
-} > "$TMP_DIR/desired.yml"
-
-# 4. Show diff and stop for approval
-diff -u "$CONFIG" "$TMP_DIR/desired.yml" || true
-
-# Do not write the config here. Wait for explicit user approval.
-# After approval, run:
-#   cp "$TMP_DIR/desired.yml" "$CONFIG"
-#   python3 -c "import yaml; yaml.safe_load(open('$CONFIG'))"
+```
+.claude/skills/github-dependabot-maintain/scripts/maintain-dependabot.py
 ```
 
-## After approval
+It loads the existing `.github/dependabot.yml`, preserves settings for
+directories that are still present, adds missing entries, removes stale entries,
+normalizes group names, and waits for explicit approval before writing the file.
 
-Write the file and validate:
+## Running the script
+
+Install PyYAML if it is not already available:
 
 ```bash
-cp "$TMP_DIR/desired.yml" "$CONFIG"
-python3 -c "import yaml; yaml.safe_load(open('$CONFIG'))"
+python3 -m pip install pyyaml
 ```
 
-Recheck coverage by rerunning the scan and confirming each detected project has one entry.
+Then run from the repository root:
+
+```bash
+python3 .claude/skills/github-dependabot-maintain/scripts/maintain-dependabot.py
+```
+
+## What the script does
+
+1. Checks `git status --porcelain -- .github/dependabot.yml` and stops if there
+   are staged or unstaged changes.
+2. Parses the existing `dependabot.yml` into directory-indexed text blocks.
+3. Scans `projects/*/` and detects the ecosystem from lockfiles.
+4. Builds the desired entry list:
+   - If a directory already exists in `dependabot.yml`, reuse its settings
+     (`schedule`, `open-pull-requests-limit`, `rebase-strategy`, etc.) and only
+     normalize `package-ecosystem`, `directory`, and the group name.
+   - If a directory is new, create it from the default template.
+5. Writes a preview to `.github/dependabot.yml.preview` and shows `diff -u`.
+6. Prompts `Apply changes? [y/N]`. If approved, copies the preview to
+   `.github/dependabot.yml`, deletes the preview, validates the YAML, and
+   rechecks coverage. If not approved, keeps the preview file and exits without
+   modifying the config.
 
 ## Edge cases
 
-- If a project has both `bun.lock` and `uv.lock`, treat that as an error and ask the user.
-- If no lockfile is found, exclude the directory from Dependabot.
-- If an existing entry points to a directory that no longer exists, remove it.
-- If an existing entry points to a directory whose lockfile is gone, remove it.
+- If a project has both `bun.lock` and `uv.lock`, the script picks `bun` because
+  it is checked first. Review the result manually if this happens.
+- If no lockfile is found, the directory is excluded from Dependabot.
+- If an existing entry points to a directory that no longer exists, it is removed.
+- If an existing entry points to a directory whose lockfile is gone, it is removed.

--- a/.claude/skills/github-dependabot-maintain/references/github-dependabot-maintain-detailed.md
+++ b/.claude/skills/github-dependabot-maintain/references/github-dependabot-maintain-detailed.md
@@ -1,0 +1,96 @@
+# Detailed Scanning and Approval Script
+
+## Full maintenance script
+
+A Bash script you can adapt to preview changes before writing:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONFIG=".github/dependabot.yml"
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+# 1. Safety check
+if [ -n "$(git diff -- "$CONFIG")" ]; then
+  echo "ERROR: $CONFIG has uncommitted changes. Commit or revert them first."
+  exit 1
+fi
+
+# 2. Scan projects and detect ecosystems
+pairs=()
+for dir in projects/*/; do
+  name=$(basename "$dir")
+  [[ "$name" == "_labs" || "$name" == "_samples" ]] && continue
+
+  eco=""
+  if [[ -f "$dir/bun.lock" || -f "$dir/bun.lockb" ]]; then
+    eco="bun"
+  elif [[ -f "$dir/uv.lock" ]]; then
+    eco="uv"
+  fi
+
+  if [ -n "$eco" ]; then
+    pairs+=("$name $eco")
+  fi
+done
+
+# 3. Generate desired config
+{
+  echo "version: 2"
+  echo "updates:"
+
+  # Sort by project name for deterministic output
+  first=true
+  printf '%s\n' "${pairs[@]}" | sort | while read -r name eco; do
+    if [ "$first" = true ]; then
+      first=false
+    else
+      echo ""  # blank line between entries, matching current format
+    fi
+    cat << ENTRY
+  - package-ecosystem: "$eco"
+    directory: "/projects/$name"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 1
+    rebase-strategy: "disabled"
+    groups:
+      $name-minor-and-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+ENTRY
+  done
+} > "$TMP_DIR/desired.yml"
+
+# 4. Show diff and stop for approval
+diff -u "$CONFIG" "$TMP_DIR/desired.yml" || true
+
+# Do not write the config here. Wait for explicit user approval.
+# After approval, run:
+#   cp "$TMP_DIR/desired.yml" "$CONFIG"
+#   python3 -c "import yaml; yaml.safe_load(open('$CONFIG'))"
+```
+
+## After approval
+
+Write the file and validate:
+
+```bash
+cp "$TMP_DIR/desired.yml" "$CONFIG"
+python3 -c "import yaml; yaml.safe_load(open('$CONFIG'))"
+```
+
+Recheck coverage by rerunning the scan and confirming each detected project has one entry.
+
+## Edge cases
+
+- If a project has both `bun.lock` and `uv.lock`, treat that as an error and ask the user.
+- If no lockfile is found, exclude the directory from Dependabot.
+- If an existing entry points to a directory that no longer exists, remove it.
+- If an existing entry points to a directory whose lockfile is gone, remove it.

--- a/.claude/skills/github-dependabot-maintain/scripts/maintain-dependabot.py
+++ b/.claude/skills/github-dependabot-maintain/scripts/maintain-dependabot.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Maintain .github/dependabot.yml based on projects/* lockfiles."""
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+CONFIG = Path(".github/dependabot.yml")
+PROJECTS = Path("projects")
+
+
+def detect_ecosystem(project_dir: Path) -> str | None:
+    if (project_dir / "bun.lock").exists() or (project_dir / "bun.lockb").exists():
+        return "bun"
+    if (project_dir / "uv.lock").exists():
+        return "uv"
+    return None
+
+
+def parse_entries(text: str) -> tuple[str, dict[str, list[str]]]:
+    """Split dependabot.yml into header and directory-indexed entry blocks.
+
+    The file is expected to follow the simple two-space indentation structure
+    produced by this repository. Each entry starts with ``  - package-ecosystem``
+    and contains a ``    directory: ...`` line.
+    """
+    lines = text.splitlines()
+    header_lines: list[str] = []
+    entries: dict[str, list[str]] = {}
+    current_dir: str | None = None
+    current_block: list[str] = []
+    state = "header"
+    dir_re = re.compile(r'^    directory:\s*"?([^"]+)"?\s*$')
+
+    for line in lines:
+        if state == "header":
+            header_lines.append(line)
+            if line.strip() == "updates:":
+                state = "entries"
+            continue
+
+        if line.startswith("  - package-ecosystem:"):
+            if current_dir is not None:
+                entries[current_dir] = current_block
+            current_dir = None
+            current_block = [line]
+            continue
+
+        if current_dir is None and current_block:
+            m = dir_re.match(line)
+            if m:
+                current_dir = m.group(1)
+
+        current_block.append(line)
+
+    if current_dir is not None:
+        entries[current_dir] = current_block
+
+    return "\n".join(header_lines), entries
+
+
+def normalize_block(block: list[str], ecosystem: str, directory: str) -> list[str]:
+    """Update package-ecosystem, directory, and groups in an existing block."""
+    name = directory.split("/")[-1]
+    new_block: list[str] = []
+    in_groups = False
+
+    for line in block:
+        if line.startswith("  - package-ecosystem:"):
+            new_block.append(f'  - package-ecosystem: "{ecosystem}"')
+            continue
+
+        if line.startswith("    directory:"):
+            new_block.append(f'    directory: "{directory}"')
+            continue
+
+        if line.startswith("    groups:"):
+            in_groups = True
+            new_block.append("    groups:")
+            new_block.append(f"      {name}-minor-and-patch:")
+            new_block.append("        applies-to: version-updates")
+            new_block.append("        patterns:")
+            new_block.append('          - "*"')
+            new_block.append("        update-types:")
+            new_block.append('          - "minor"')
+            new_block.append('          - "patch"')
+            continue
+
+        if in_groups:
+            # The next field at the entry's top level is indented 4 spaces.
+            # Blank lines and deeper indentation belong to the groups section.
+            if line == "":
+                continue
+            if re.match(r"^    \w", line) and not re.match(r"^      ", line):
+                in_groups = False
+            else:
+                continue
+
+        new_block.append(line)
+
+    return new_block
+
+
+def build_new_block(ecosystem: str, directory: str) -> list[str]:
+    name = directory.split("/")[-1]
+    return [
+        f'  - package-ecosystem: "{ecosystem}"',
+        f'    directory: "{directory}"',
+        '    schedule:',
+        '      interval: "weekly"',
+        '    open-pull-requests-limit: 1',
+        '    rebase-strategy: "disabled"',
+        '    groups:',
+        f'      {name}-minor-and-patch:',
+        '        applies-to: version-updates',
+        '        patterns:',
+        '          - "*"',
+        '        update-types:',
+        '          - "minor"',
+        '          - "patch"',
+    ]
+
+
+def main() -> int:
+    # 1. Safety check for staged and unstaged changes
+    result = subprocess.run(
+        ["git", "status", "--porcelain", "--", str(CONFIG)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    if result.stdout.strip():
+        print(
+            f"ERROR: {CONFIG} has uncommitted changes. Commit or revert them first.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # 2. Load existing config text and split into blocks
+    text = (
+        CONFIG.read_text(encoding="utf-8")
+        if CONFIG.exists()
+        else "version: 2\nupdates:\n"
+    )
+    header, existing_entries = parse_entries(text)
+
+    # 3. Scan projects
+    detected: dict[str, str] = {}
+    for project_dir in sorted(PROJECTS.iterdir()):
+        if not project_dir.is_dir():
+            continue
+        name = project_dir.name
+        if name in ("_labs", "_samples"):
+            continue
+        ecosystem = detect_ecosystem(project_dir)
+        if ecosystem is not None:
+            detected[f"/projects/{name}"] = ecosystem
+
+    # 4. Build desired blocks, preserving existing settings
+    desired_blocks: list[list[str]] = []
+    for directory in sorted(detected.keys()):
+        ecosystem = detected[directory]
+        if directory in existing_entries:
+            block = normalize_block(existing_entries[directory], ecosystem, directory)
+        else:
+            block = build_new_block(ecosystem, directory)
+        desired_blocks.append(block)
+
+    # 5. Compose desired text with blank lines between entries
+    desired_lines = header.splitlines()
+    for i, block in enumerate(desired_blocks):
+        if i > 0:
+            desired_lines.append("")
+        desired_lines.extend(block)
+
+    desired_text = "\n".join(desired_lines)
+    if not desired_text.endswith("\n"):
+        desired_text += "\n"
+
+    # 6. Write preview
+    preview_path = CONFIG.with_suffix(".yml.preview")
+    preview_path.write_text(desired_text, encoding="utf-8")
+
+    # 7. Show diff
+    subprocess.run(["diff", "-u", str(CONFIG), str(preview_path)])
+
+    # 8. Wait for explicit approval
+    answer = input("Apply changes? [y/N] ").strip().lower()
+    if answer not in ("y", "yes"):
+        print("Aborted. Preview kept at:", preview_path)
+        return 0
+
+    # 9. Apply and validate
+    CONFIG.write_text(desired_text, encoding="utf-8")
+    preview_path.unlink()
+    yaml.safe_load(CONFIG.read_text(encoding="utf-8"))
+    print("Updated and validated:", CONFIG)
+
+    # 10. Recheck coverage
+    final = yaml.safe_load(CONFIG.read_text(encoding="utf-8"))
+    final_dirs = {entry["directory"] for entry in final.get("updates", [])}
+    missing = set(detected.keys()) - final_dirs
+    extra = final_dirs - set(detected.keys())
+    if missing or extra:
+        print(
+            f"ERROR: coverage mismatch. missing={missing}, extra={extra}",
+            file=sys.stderr,
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Issues

- Close #1050

## Why

Dependabot 設定を `projects/` の実際の構成と同期させる運用を Skill 化し、新規プロジェクト追加や無効エントリの削除を自動検出する。

## Summary

monorepo 専用の `.claude/skills/github-dependabot-maintain/SKILL.md` を追加する。
ロックファイルから ecosystem を判定し、不足・削除対象のエントリを diff 提示して承認後に更新するフローを定義する。
合わせて monorepo 内の既存 Skill 一覧を `.claude/skills/README.md` にまとめる。

## Changes

- Add `.claude/skills/github-dependabot-maintain/SKILL.md`
- Add `.claude/skills/github-dependabot-maintain/references/github-dependabot-maintain-detailed.md`
- Add `.claude/skills/README.md` listing monorepo skills

## Verification

- `bash /home/u7dev/.claude/skills/scripts/validate-skills.sh` — passed (new SKILL.md is within the 180-line limit)
- Dry-run of the skill workflow against current `projects/` and `.github/dependabot.yml` — produced the expected diff (adds `edit-vid2` and `portal`, keeps existing entries, sorts alphabetically)
- `python3 -c "import yaml; yaml.safe_load(open('desired.yml'))"` on the generated desired config — passed
