### PR TITLE
chore: sync dependabot.yml with projects layout

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,28 @@
 version: 2
 updates:
-  - package-ecosystem: "bun"
-    directory: "/projects/portfolio"
+  - package-ecosystem: "uv"
+    directory: "/projects/edit-vid"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 1
     rebase-strategy: "disabled"
     groups:
-      portfolio-minor-and-patch:
+      edit-vid-minor-and-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "bun"
+    directory: "/projects/edit-vid2"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 1
+    rebase-strategy: "disabled"
+    groups:
+      edit-vid2-minor-and-patch:
         applies-to: version-updates
         patterns:
           - "*"
@@ -30,14 +45,29 @@ updates:
           - "minor"
           - "patch"
 
-  - package-ecosystem: "uv"
-    directory: "/projects/edit-vid"
+  - package-ecosystem: "bun"
+    directory: "/projects/portal"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 1
     rebase-strategy: "disabled"
     groups:
-      edit-vid-minor-and-patch:
+      portal-minor-and-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "bun"
+    directory: "/projects/portfolio"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 1
+    rebase-strategy: "disabled"
+    groups:
+      portfolio-minor-and-patch:
         applies-to: version-updates
         patterns:
           - "*"


### PR DESCRIPTION
## Issues

- Refs #1050

## Why

Dependabot 設定が `projects/` の実際の構成と同期していませんでした。新規プロジェクト `edit-vid2` と `portal` が未登録でした。

## Summary

`.github/dependabot.yml` を `github-dependabot-maintain` skill を使って更新します。

## Changes

- Add entry for `/projects/edit-vid2` (bun)
- Add entry for `/projects/portal` (bun)
- Sort all entries alphabetically by directory

## Verification

- `python3 .claude/skills/github-dependabot-maintain/scripts/maintain-dependabot.py` — generated the diff and applied after approval
- `python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"` — passed
- Rechecked that scanned projects and config entries are 1:1 — passed
