### PR TITLE
feat(edit-vid2): add export job preview endpoint and modal

### DIFF
--- a/projects/edit-vid2/src/client/features/exports/job-card.tsx
+++ b/projects/edit-vid2/src/client/features/exports/job-card.tsx
@@ -35,11 +35,13 @@ interface JobCardProps {
   job: ExportJob
   onCancel: () => void
   onDelete: () => void
+  onPreview?: () => void
 }
 
-export function JobCard({ job, onCancel, onDelete }: JobCardProps) {
+export function JobCard({ job, onCancel, onDelete, onPreview }: JobCardProps) {
   const canCancel = job.status === 'queued' || job.status === 'running'
   const canDownload = job.status === 'succeeded' && job.outputPath
+  const canPreview = canDownload && onPreview != null
   const canDelete = job.status === 'succeeded' || job.status === 'failed' || job.status === 'canceled'
 
   return (
@@ -55,6 +57,14 @@ export function JobCard({ job, onCancel, onDelete }: JobCardProps) {
               className='rounded px-2 py-0.5 text-xs text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900'
             >
               キャンセル
+            </button>
+          )}
+          {canPreview && (
+            <button
+              onClick={onPreview}
+              className='rounded px-2 py-0.5 text-xs text-indigo-600 hover:bg-indigo-50 dark:text-indigo-400 dark:hover:bg-indigo-900'
+            >
+              プレビュー
             </button>
           )}
           {canDownload && (

--- a/projects/edit-vid2/src/client/features/exports/page.tsx
+++ b/projects/edit-vid2/src/client/features/exports/page.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Link } from '@tanstack/react-router'
-import { Trash2 } from 'lucide-react'
+import { Trash2, X } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { JobCard, statusColors, statusLabels, type ExportJob } from '#/client/features/exports/job-card'
 import type { Project } from '#/shared/schemas'
@@ -13,9 +13,20 @@ function JobStatusBadge({ status }: { status: string }) {
   )
 }
 
-function JobActions({ job, onCancel, onDelete }: { job: ExportJob; onCancel: () => void; onDelete: () => void }) {
+function JobActions({
+  job,
+  onCancel,
+  onDelete,
+  onPreview,
+}: {
+  job: ExportJob
+  onCancel: () => void
+  onDelete: () => void
+  onPreview: () => void
+}) {
   const canCancel = job.status === 'queued' || job.status === 'running'
   const canDownload = job.status === 'succeeded' && job.outputPath
+  const canPreview = canDownload
   const canDelete = job.status === 'succeeded' || job.status === 'failed' || job.status === 'canceled'
 
   return (
@@ -26,6 +37,14 @@ function JobActions({ job, onCancel, onDelete }: { job: ExportJob; onCancel: () 
           className='rounded px-2 py-0.5 text-xs text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900'
         >
           キャンセル
+        </button>
+      )}
+      {canPreview && (
+        <button
+          onClick={onPreview}
+          className='rounded px-2 py-0.5 text-xs text-indigo-600 hover:bg-indigo-50 dark:text-indigo-400 dark:hover:bg-indigo-900'
+        >
+          プレビュー
         </button>
       )}
       {canDownload && (
@@ -65,10 +84,46 @@ function JobProgress({ progress }: { progress: number }) {
   )
 }
 
+type ExportPreviewTarget = {
+  id: string
+  projectName?: string
+  createdAt: string
+}
+
+function ExportPreviewModal({ target, onClose }: { target: ExportPreviewTarget; onClose: () => void }) {
+  return (
+    <div
+      className='fixed inset-0 z-50 flex items-center justify-center bg-black/80'
+      onClick={onClose}
+      role='presentation'
+    >
+      <div className='relative w-full max-w-4xl px-4' onClick={(e) => e.stopPropagation()}>
+        <button
+          onClick={onClose}
+          className='absolute -top-10 right-0 rounded-full p-1 text-white/70 hover:text-white'
+          aria-label='閉じる'
+        >
+          <X className='h-6 w-6' />
+        </button>
+        <video
+          src={`/api/export-jobs/${target.id}/preview`}
+          controls
+          autoPlay
+          className='w-full max-h-[80vh] rounded-lg bg-black'
+        />
+        <p className='mt-2 text-center text-sm text-white/70'>
+          {target.projectName ?? ''} · {new Date(target.createdAt).toLocaleString('ja-JP')}
+        </p>
+      </div>
+    </div>
+  )
+}
+
 export function ExportsPage() {
   const queryClient = useQueryClient()
   const [statusFilter, setStatusFilter] = useState('')
   const [projectFilter, setProjectFilter] = useState('')
+  const [previewTarget, setPreviewTarget] = useState<ExportPreviewTarget | null>(null)
 
   const { data: jobs } = useQuery<ExportJob[]>({
     queryKey: ['export-jobs'],
@@ -189,6 +244,13 @@ export function ExportsPage() {
                     job={job}
                     onCancel={() => cancelExport.mutate(job.id)}
                     onDelete={() => deleteExport.mutate(job.id)}
+                    onPreview={() =>
+                      setPreviewTarget({
+                        id: job.id,
+                        projectName: job.projectName,
+                        createdAt: job.createdAt,
+                      })
+                    }
                   />
                 </td>
               </tr>
@@ -212,6 +274,13 @@ export function ExportsPage() {
               job={job}
               onCancel={() => cancelExport.mutate(job.id)}
               onDelete={() => deleteExport.mutate(job.id)}
+              onPreview={() =>
+                setPreviewTarget({
+                  id: job.id,
+                  projectName: job.projectName,
+                  createdAt: job.createdAt,
+                })
+              }
             />
             <div className='mt-1 px-1 text-sm'>
               <span className='text-gray-500 dark:text-gray-400'>プロジェクト:</span>{' '}
@@ -232,6 +301,7 @@ export function ExportsPage() {
           <p className='text-center text-sm text-gray-400 dark:text-gray-500'>書き出し履歴がありません</p>
         )}
       </div>
+      {previewTarget && <ExportPreviewModal target={previewTarget} onClose={() => setPreviewTarget(null)} />}
     </div>
   )
 }

--- a/projects/edit-vid2/src/server/app.tsx
+++ b/projects/edit-vid2/src/server/app.tsx
@@ -4,7 +4,7 @@ import { getDatabase } from '#/db'
 import type { AppDatabase } from '#/db'
 import { errHandler } from '#/server/middleware/error-handler'
 import { applySecurityHeaders } from '#/server/middleware/security-headers'
-import { exportRoutes, jobRoutes } from '#/server/routes/exports'
+import { exportRoutes, jobRoutes, recoverIncompleteJobs } from '#/server/routes/exports'
 import { htmlRoutes } from '#/server/routes/html'
 import { previewRoutes } from '#/server/routes/previews'
 import { projectRoutes } from '#/server/routes/projects'
@@ -44,5 +44,7 @@ const routes = app
   .route('/api/projects/:projectId/export-jobs', exportRoutes)
   .route('/api/export-jobs', jobRoutes)
   .route('/', htmlRoutes)
+
+recoverIncompleteJobs()
 
 export default app

--- a/projects/edit-vid2/src/server/bun-server.ts
+++ b/projects/edit-vid2/src/server/bun-server.ts
@@ -4,7 +4,7 @@ import { getDatabase } from '#/db'
 import type { AppDatabase } from '#/db'
 import { errHandler } from '#/server/middleware/error-handler'
 import { applySecurityHeaders } from '#/server/middleware/security-headers'
-import { exportRoutes, jobRoutes } from '#/server/routes/exports'
+import { exportRoutes, jobRoutes, recoverIncompleteJobs } from '#/server/routes/exports'
 import { htmlRoutes } from '#/server/routes/html'
 import { previewRoutes } from '#/server/routes/previews'
 import { projectRoutes } from '#/server/routes/projects'
@@ -49,5 +49,7 @@ Bun.serve({
   fetch: app.fetch,
   port,
 })
+
+recoverIncompleteJobs()
 
 console.log(`edit-vid2 server running on port ${port}`)

--- a/projects/edit-vid2/src/server/routes/exports.ts
+++ b/projects/edit-vid2/src/server/routes/exports.ts
@@ -1,5 +1,6 @@
-import { existsSync, readFileSync, rmSync, statSync } from 'node:fs'
+import { createReadStream, existsSync, readFileSync, rmSync, statSync } from 'node:fs'
 import { resolve } from 'node:path'
+import { Readable } from 'node:stream'
 import { sValidator } from '@hono/standard-validator'
 import { Hono } from 'hono'
 import { streamSSE } from 'hono/streaming'
@@ -248,8 +249,11 @@ jobRoutes.get('/:exportJobId/preview', async (c) => {
   }
 
   if (!rangeHeader) {
-    const file = readFileSync(job.outputPath)
-    return c.body(file, 200, baseHeaders)
+    const stream = createReadStream(job.outputPath)
+    return c.body(Readable.toWeb(stream) as unknown as ReadableStream, 200, {
+      ...baseHeaders,
+      'Content-Length': String(size),
+    })
   }
 
   const match = rangeHeader.match(/^bytes=(\d+)-(\d*)$/)
@@ -265,8 +269,8 @@ jobRoutes.get('/:exportJobId/preview', async (c) => {
   }
 
   const length = end - start + 1
-  const file = readFileSync(job.outputPath).subarray(start, end + 1)
-  return c.body(file, 206, {
+  const stream = createReadStream(job.outputPath, { start, end })
+  return c.body(Readable.toWeb(stream) as unknown as ReadableStream, 206, {
     ...baseHeaders,
     'Content-Range': `bytes ${start}-${end}/${size}`,
     'Content-Length': String(length),

--- a/projects/edit-vid2/src/server/routes/exports.ts
+++ b/projects/edit-vid2/src/server/routes/exports.ts
@@ -277,8 +277,9 @@ jobRoutes.get('/:exportJobId/preview', async (c) => {
   })
 })
 
-// Recover incomplete jobs on startup
-function recoverIncompleteJobs() {
+// Recover incomplete jobs on startup.
+// This is exported so server entrypoints can call it after migrations are applied.
+export function recoverIncompleteJobs() {
   const dbUrl = process.env.DATABASE_URL ?? 'data/edit-vid2.db'
   import('#/db').then(({ getDatabase }) => {
     const db = getDatabase(dbUrl)
@@ -293,6 +294,5 @@ function recoverIncompleteJobs() {
     }
   })
 }
-recoverIncompleteJobs()
 
 export { exportRoutes, jobRoutes }

--- a/projects/edit-vid2/src/server/routes/exports.ts
+++ b/projects/edit-vid2/src/server/routes/exports.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, rmSync } from 'node:fs'
+import { existsSync, readFileSync, rmSync, statSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { sValidator } from '@hono/standard-validator'
 import { Hono } from 'hono'
@@ -222,6 +222,54 @@ jobRoutes.get('/:exportJobId/download', async (c) => {
   return c.body(file, 200, {
     'Content-Type': 'video/mp4',
     'Content-Disposition': `attachment; filename="export-${job.id}.mp4"`,
+  })
+})
+
+jobRoutes.get('/:exportJobId/preview', async (c) => {
+  const db = c.var.db
+  const job = getExportJobById(db, c.req.param('exportJobId'))
+  if (!job) {
+    return c.json({ error: 'not found' }, 404)
+  }
+  if (job.status !== 'succeeded' || !job.outputPath) {
+    return c.json({ error: 'not ready' }, 400)
+  }
+  if (!existsSync(job.outputPath)) {
+    return c.json({ error: 'output file not found' }, 404)
+  }
+
+  const { size } = statSync(job.outputPath)
+  const rangeHeader = c.req.header('range')
+
+  const baseHeaders = {
+    'Content-Type': 'video/mp4',
+    'Content-Disposition': `inline; filename="export-${job.id}.mp4"`,
+    'Accept-Ranges': 'bytes',
+  }
+
+  if (!rangeHeader) {
+    const file = readFileSync(job.outputPath)
+    return c.body(file, 200, baseHeaders)
+  }
+
+  const match = rangeHeader.match(/^bytes=(\d+)-(\d*)$/)
+  if (!match) {
+    return c.json({ error: 'range not satisfiable' }, 416)
+  }
+
+  const start = Number.parseInt(match[1], 10)
+  const end = match[2] ? Number.parseInt(match[2], 10) : size - 1
+
+  if (Number.isNaN(start) || Number.isNaN(end) || start >= size || end >= size || start > end) {
+    return c.json({ error: 'range not satisfiable' }, 416)
+  }
+
+  const length = end - start + 1
+  const file = readFileSync(job.outputPath).subarray(start, end + 1)
+  return c.body(file, 206, {
+    ...baseHeaders,
+    'Content-Range': `bytes ${start}-${end}/${size}`,
+    'Content-Length': String(length),
   })
 })
 

--- a/projects/edit-vid2/tests/features/export-preview.test.ts
+++ b/projects/edit-vid2/tests/features/export-preview.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test } from 'bun:test'
+import { copyFileSync, mkdirSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { migrate } from 'drizzle-orm/bun-sqlite/migrator'
+import { Hono } from 'hono'
+import { getDatabase } from '#/db'
+import { exportJobs, projects, videoAssets } from '#/db/schema'
+import { jobRoutes } from '#/server/routes/exports'
+
+const fixturePath = 'tests/fixtures/test-compat.mp4'
+
+function createTestApp() {
+  const dbPath = join(tmpdir(), `edit-vid2-preview-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`)
+  const db = getDatabase(dbPath)
+  migrate(db, { migrationsFolder: './drizzle' })
+
+  const app = new Hono<{ Variables: { db: typeof db } }>()
+  app.use('*', async (c, next) => {
+    c.set('db', db)
+    await next()
+  })
+  app.route('/', jobRoutes)
+
+  db.insert(videoAssets)
+    .values({
+      id: 'video-1',
+      originalFilename: 'test.mp4',
+      displayName: 'Test Video',
+      storagePath: 'data/videos/video-1/source.mp4',
+      status: 'ready',
+    })
+    .run()
+
+  db.insert(projects)
+    .values({
+      id: 'project-1',
+      videoAssetId: 'video-1',
+      name: 'Test Project',
+    })
+    .run()
+
+  const exportDir = join(tmpdir(), `edit-vid2-preview-${Date.now()}`)
+  mkdirSync(exportDir, { recursive: true })
+
+  return { app, db, dbPath, exportDir }
+}
+
+function seedSucceededJob(db: ReturnType<typeof getDatabase>, exportDir: string, jobId: string) {
+  copyFileSync(fixturePath, join(exportDir, `${jobId}.mp4`))
+  db.insert(exportJobs)
+    .values({
+      id: jobId,
+      projectId: 'project-1',
+      status: 'succeeded',
+      outputPath: join(exportDir, `${jobId}.mp4`),
+    })
+    .run()
+}
+
+function cleanup(exportDir: string, dbPath: string) {
+  try {
+    rmSync(exportDir, { recursive: true, force: true })
+  } catch {}
+  try {
+    rmSync(dbPath)
+  } catch {}
+}
+
+describe('export preview API', () => {
+  test('returns 200 inline video/mp4 without range', async () => {
+    const { app, db, dbPath, exportDir } = createTestApp()
+    try {
+      seedSucceededJob(db, exportDir, 'job-1')
+      const res = await app.request('/job-1/preview')
+      expect(res.status).toBe(200)
+      expect(res.headers.get('content-type')).toBe('video/mp4')
+      expect(res.headers.get('content-disposition')).toBe('inline; filename="export-job-1.mp4"')
+      expect(res.headers.get('accept-ranges')).toBe('bytes')
+    } finally {
+      cleanup(exportDir, dbPath)
+    }
+  })
+
+  test('returns 206 partial content with valid range', async () => {
+    const { app, db, dbPath, exportDir } = createTestApp()
+    try {
+      seedSucceededJob(db, exportDir, 'job-1')
+      const res = await app.request('/job-1/preview', {
+        headers: { Range: 'bytes=0-1023' },
+      })
+      expect(res.status).toBe(206)
+      expect(res.headers.get('content-type')).toBe('video/mp4')
+      const contentRange = res.headers.get('content-range')
+      expect(contentRange).toContain('bytes 0-1023/')
+      expect(res.headers.get('content-length')).toBe('1024')
+    } finally {
+      cleanup(exportDir, dbPath)
+    }
+  })
+
+  test('returns 404 for missing job', async () => {
+    const { app, dbPath, exportDir } = createTestApp()
+    try {
+      const res = await app.request('/missing/preview')
+      expect(res.status).toBe(404)
+    } finally {
+      cleanup(exportDir, dbPath)
+    }
+  })
+
+  test('returns 400 for unfinished job', async () => {
+    const { app, db, dbPath, exportDir } = createTestApp()
+    try {
+      db.insert(exportJobs)
+        .values({
+          id: 'job-2',
+          projectId: 'project-1',
+          status: 'running',
+          outputPath: null,
+        })
+        .run()
+      const res = await app.request('/job-2/preview')
+      expect(res.status).toBe(400)
+    } finally {
+      cleanup(exportDir, dbPath)
+    }
+  })
+
+  test('returns 404 for missing output file', async () => {
+    const { app, db, dbPath, exportDir } = createTestApp()
+    try {
+      db.insert(exportJobs)
+        .values({
+          id: 'job-3',
+          projectId: 'project-1',
+          status: 'succeeded',
+          outputPath: join(exportDir, 'missing.mp4'),
+        })
+        .run()
+      const res = await app.request('/job-3/preview')
+      expect(res.status).toBe(404)
+    } finally {
+      cleanup(exportDir, dbPath)
+    }
+  })
+
+  test('returns 416 for invalid range', async () => {
+    const { app, db, dbPath, exportDir } = createTestApp()
+    try {
+      seedSucceededJob(db, exportDir, 'job-1')
+      const res = await app.request('/job-1/preview', {
+        headers: { Range: 'bytes=99999999-99999999' },
+      })
+      expect(res.status).toBe(416)
+    } finally {
+      cleanup(exportDir, dbPath)
+    }
+  })
+})


### PR DESCRIPTION
## Issues

- Close #1060

## Why

書き出し履歴では成功ジョブの成果物をダウンロードするしかなく、ダウンロード前に編集結果を確認するフローが長かった。

## Summary

完了済みの書き出しジョブの output.mp4 を、インライン配信するプレビュー API とモーダルから再生できるようにする。既存のダウンロード API は維持する。

## Changes

- `GET /api/export-jobs/:exportJobId/preview` を追加（Range 対応、`Content-Disposition: inline`）
- 書き出し履歴のデスクトップ表とモバイルカードに「プレビュー」ボタンを追加
- プレビューモーダルで `<video controls autoPlay>` を表示
- 未完了ジョブ・ファイル欠損・不正 Range に対するエラー応答を実装
- プレビュー API のテストを追加

## Checklist

- [x] フォーマット (`bun run format:check`)
- [x] リント / 型チェック (`bun run lint`)
- [x] テスト (`bun test tests/features`)
