### PR TITLE
feat(edit-vid2): replace text buttons with icon buttons on export history

### DIFF
--- a/projects/edit-vid2/src/client/features/exports/job-card.tsx
+++ b/projects/edit-vid2/src/client/features/exports/job-card.tsx
@@ -86,6 +86,7 @@ export function JobCard({ job, onCancel, onDelete, onPreview }: JobCardProps) {
               }}
               className='inline-flex h-6 w-6 items-center justify-center rounded text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900'
               title='履歴と出力ファイルを削除'
+              aria-label='履歴と出力ファイルを削除'
             >
               <Trash2 className='h-3.5 w-3.5' />
             </button>

--- a/projects/edit-vid2/src/client/features/exports/job-card.tsx
+++ b/projects/edit-vid2/src/client/features/exports/job-card.tsx
@@ -1,4 +1,4 @@
-import { Trash2 } from 'lucide-react'
+import { Download, Play, Trash2 } from 'lucide-react'
 
 export interface ExportJob {
   id: string
@@ -62,17 +62,21 @@ export function JobCard({ job, onCancel, onDelete, onPreview }: JobCardProps) {
           {canPreview && (
             <button
               onClick={onPreview}
-              className='rounded px-2 py-0.5 text-xs text-indigo-600 hover:bg-indigo-50 dark:text-indigo-400 dark:hover:bg-indigo-900'
+              className='inline-flex h-6 w-6 items-center justify-center rounded text-indigo-600 hover:bg-indigo-50 dark:text-indigo-400 dark:hover:bg-indigo-900'
+              title='プレビュー'
+              aria-label='プレビュー'
             >
-              プレビュー
+              <Play className='h-3.5 w-3.5' />
             </button>
           )}
           {canDownload && (
             <a
               href={`/api/export-jobs/${job.id}/download`}
-              className='rounded px-2 py-0.5 text-xs text-indigo-600 hover:bg-indigo-50 dark:text-indigo-400 dark:hover:bg-indigo-900'
+              className='inline-flex h-6 w-6 items-center justify-center rounded text-indigo-600 hover:bg-indigo-50 dark:text-indigo-400 dark:hover:bg-indigo-900'
+              title='ダウンロード'
+              aria-label='ダウンロード'
             >
-              ダウンロード
+              <Download className='h-3.5 w-3.5' />
             </a>
           )}
           {canDelete && (

--- a/projects/edit-vid2/src/client/features/exports/page.tsx
+++ b/projects/edit-vid2/src/client/features/exports/page.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Link } from '@tanstack/react-router'
-import { Trash2, X } from 'lucide-react'
+import { Download, Play, Trash2, X } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { JobCard, statusColors, statusLabels, type ExportJob } from '#/client/features/exports/job-card'
 import type { Project } from '#/shared/schemas'
@@ -42,17 +42,21 @@ function JobActions({
       {canPreview && (
         <button
           onClick={onPreview}
-          className='rounded px-2 py-0.5 text-xs text-indigo-600 hover:bg-indigo-50 dark:text-indigo-400 dark:hover:bg-indigo-900'
+          className='inline-flex h-6 w-6 items-center justify-center rounded text-indigo-600 hover:bg-indigo-50 dark:text-indigo-400 dark:hover:bg-indigo-900'
+          title='プレビュー'
+          aria-label='プレビュー'
         >
-          プレビュー
+          <Play className='h-3.5 w-3.5' />
         </button>
       )}
       {canDownload && (
         <a
           href={`/api/export-jobs/${job.id}/download`}
-          className='rounded px-2 py-0.5 text-xs text-indigo-600 hover:bg-indigo-50 dark:text-indigo-400 dark:hover:bg-indigo-900'
+          className='inline-flex h-6 w-6 items-center justify-center rounded text-indigo-600 hover:bg-indigo-50 dark:text-indigo-400 dark:hover:bg-indigo-900'
+          title='ダウンロード'
+          aria-label='ダウンロード'
         >
-          ダウンロード
+          <Download className='h-3.5 w-3.5' />
         </a>
       )}
       {canDelete && (

--- a/projects/edit-vid2/src/client/features/exports/page.tsx
+++ b/projects/edit-vid2/src/client/features/exports/page.tsx
@@ -66,6 +66,7 @@ function JobActions({
           }}
           className='inline-flex h-6 w-6 items-center justify-center rounded text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900'
           title='履歴と出力ファイルを削除'
+          aria-label='履歴と出力ファイルを削除'
         >
           <Trash2 className='h-3.5 w-3.5' />
         </button>


### PR DESCRIPTION
## Why

書き出し履歴画面の「プレビュー」「ダウンロード」操作がテキストボタンで表示領域を取っており、操作列が冗長になっていたため、アイコンボタンに変更してコンパクトにします。

## Summary

書き出し履歴画面（デスクトップ・モバイル両方）のプレビュー・ダウンロードボタンをアイコンボタンに置き換えます。削除ボタンと同じサイズの角丸アイコンボタンに統一し、ツールチップと `aria-label` で操作の意味を保持します。

## Changes

- デスクトップ履歴テーブル（`src/client/features/exports/page.tsx`）の `JobActions` 内ボタンをアイコン化
- モバイル履歴カード（`src/client/features/exports/job-card.tsx`）のボタンをアイコン化
- プレビューには `Play`、ダウンロードには `Download` アイコンを使用
- 各アイコンボタンに `title` / `aria-label` を追加

## Checklist

- [x] フォーマット (`bun run format:check`)
- [x] リント / 型チェック (`bun run lint`)
- [x] テスト (`bun test`)
