### PR TITLE
feat(edit-vid2): add mobile navigation drawer

### DIFF
--- a/projects/edit-vid2/src/client/app/app-layout.tsx
+++ b/projects/edit-vid2/src/client/app/app-layout.tsx
@@ -1,6 +1,6 @@
 import { Link } from '@tanstack/react-router'
-import { Moon, Sun } from 'lucide-react'
-import type { ReactNode } from 'react'
+import { Menu, Moon, Sun, X } from 'lucide-react'
+import { useState, type ReactNode } from 'react'
 import { useTheme } from '#/client/app/use-theme'
 
 interface Props {
@@ -14,6 +14,7 @@ interface Props {
 
 export function AppLayout({ menuItems, children }: Props) {
   const { isDark, toggle } = useTheme()
+  const [isOpen, setIsOpen] = useState(false)
 
   return (
     <div className='flex min-h-dvh overflow-hidden md:h-dvh'>
@@ -40,6 +41,73 @@ export function AppLayout({ menuItems, children }: Props) {
           {isDark ? <Sun size={18} /> : <Moon size={18} />}
         </button>
       </div>
+
+      <header className='fixed inset-x-0 top-0 z-40 flex h-14 items-center justify-between border-b bg-white px-4 dark:border-gray-700 dark:bg-gray-900 md:hidden'>
+        <span className='font-semibold text-gray-900 dark:text-white'>edit-vid2</span>
+        <button
+          type='button'
+          onClick={() => setIsOpen(true)}
+          className='flex h-10 w-10 items-center justify-center rounded text-gray-500 transition duration-200 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800'
+          aria-label='メニューを開く'
+          aria-expanded={isOpen}
+          aria-controls='mobile-menu'
+        >
+          <Menu size={22} />
+        </button>
+      </header>
+
+      {isOpen && (
+        <>
+          <div
+            className='fixed inset-0 z-50 bg-black/50 md:hidden'
+            onClick={() => setIsOpen(false)}
+            aria-hidden='true'
+          />
+          <div
+            id='mobile-menu'
+            className='fixed left-0 top-14 bottom-0 z-50 w-64 border-r bg-gray-100 px-4 py-4 dark:border-gray-700 dark:bg-gray-800 md:hidden'
+            role='dialog'
+            aria-modal='true'
+            aria-label='ナビゲーションメニュー'
+          >
+            <div className='flex h-full flex-col'>
+              <button
+                type='button'
+                onClick={() => setIsOpen(false)}
+                className='absolute top-3 right-3 flex h-8 w-8 items-center justify-center rounded text-gray-500 transition duration-200 hover:bg-gray-200 dark:text-gray-300 dark:hover:bg-gray-700'
+                aria-label='メニューを閉じる'
+              >
+                <X size={18} />
+              </button>
+              <nav className='flex-1 space-y-1 pt-8'>
+                {menuItems.map((menuItem) => (
+                  <Link
+                    key={menuItem.label}
+                    to={menuItem.to}
+                    onClick={() => setIsOpen(false)}
+                    className='flex items-center space-x-3 rounded px-3 py-3 text-gray-600 transition duration-200 hover:bg-gray-200 dark:text-gray-300 dark:hover:bg-gray-700 [&.active]:bg-gray-200 [&.active]:text-indigo-600 dark:[&.active]:bg-gray-700 dark:[&.active]:text-indigo-400'
+                  >
+                    <span className='flex h-5 w-5 items-center justify-center'>{menuItem.icon}</span>
+                    <span className='text-sm font-medium'>{menuItem.label}</span>
+                  </Link>
+                ))}
+              </nav>
+              <button
+                type='button'
+                onClick={toggle}
+                className='flex w-full items-center space-x-3 rounded px-3 py-3 text-gray-600 transition duration-200 hover:bg-gray-200 dark:text-gray-300 dark:hover:bg-gray-700'
+                aria-label={isDark ? 'ライトモード' : 'ダークモード'}
+              >
+                <span className='flex h-5 w-5 items-center justify-center'>
+                  {isDark ? <Sun size={18} /> : <Moon size={18} />}
+                </span>
+                <span className='text-sm font-medium'>{isDark ? 'ライトモード' : 'ダークモード'}</span>
+              </button>
+            </div>
+          </div>
+        </>
+      )}
+
       <main className='min-h-0 min-w-0 flex-1 overflow-y-auto bg-white pt-14 dark:bg-gray-900 md:pt-0'>{children}</main>
     </div>
   )

--- a/projects/edit-vid2/src/client/app/app-layout.tsx
+++ b/projects/edit-vid2/src/client/app/app-layout.tsx
@@ -1,6 +1,6 @@
 import { Link } from '@tanstack/react-router'
 import { Menu, Moon, Sun, X } from 'lucide-react'
-import { useState, type ReactNode } from 'react'
+import { useCallback, useRef, useState, type KeyboardEvent, type ReactNode } from 'react'
 import { useTheme } from '#/client/app/use-theme'
 
 interface Props {
@@ -12,9 +12,55 @@ interface Props {
   children: ReactNode
 }
 
+function getFocusableElements(container: HTMLElement | null): HTMLElement[] {
+  if (!container) return []
+  const selector =
+    'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'
+  return Array.from(container.querySelectorAll<HTMLElement>(selector)).filter(
+    (el) => el.getAttribute('aria-hidden') !== 'true' && el.offsetParent !== null
+  )
+}
+
 export function AppLayout({ menuItems, children }: Props) {
   const { isDark, toggle } = useTheme()
   const [isOpen, setIsOpen] = useState(false)
+  const drawerRef = useRef<HTMLDivElement>(null)
+  const focusResetRef = useRef(false)
+
+  const close = useCallback(() => {
+    focusResetRef.current = false
+    setIsOpen(false)
+  }, [])
+
+  const handleDrawerRef = useCallback((node: HTMLDivElement | null) => {
+    drawerRef.current = node
+    if (!node || focusResetRef.current) return
+    focusResetRef.current = true
+    const focusable = getFocusableElements(node)
+    focusable[0]?.focus()
+  }, [])
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Escape') {
+      event.stopPropagation()
+      close()
+      return
+    }
+
+    if (event.key !== 'Tab') return
+
+    const focusable = getFocusableElements(drawerRef.current)
+    if (focusable.length === 0) return
+
+    const current = focusable.findIndex((el) => el === document.activeElement)
+    if (current === -1) return
+
+    event.preventDefault()
+    const nextIndex = event.shiftKey
+      ? (current - 1 + focusable.length) % focusable.length
+      : (current + 1) % focusable.length
+    focusable[nextIndex]?.focus()
+  }
 
   return (
     <div className='flex min-h-dvh overflow-hidden md:h-dvh'>
@@ -58,22 +104,21 @@ export function AppLayout({ menuItems, children }: Props) {
 
       {isOpen && (
         <>
+          <div className='fixed inset-0 z-50 bg-black/50 md:hidden' onClick={close} aria-hidden='true' />
           <div
-            className='fixed inset-0 z-50 bg-black/50 md:hidden'
-            onClick={() => setIsOpen(false)}
-            aria-hidden='true'
-          />
-          <div
+            ref={handleDrawerRef}
             id='mobile-menu'
-            className='fixed left-0 top-14 bottom-0 z-50 w-64 border-r bg-gray-100 px-4 py-4 dark:border-gray-700 dark:bg-gray-800 md:hidden'
+            className='fixed left-0 top-14 bottom-0 z-50 w-64 border-r bg-gray-100 px-4 py-4 outline-none dark:border-gray-700 dark:bg-gray-800 md:hidden'
             role='dialog'
             aria-modal='true'
             aria-label='ナビゲーションメニュー'
+            tabIndex={-1}
+            onKeyDown={handleKeyDown}
           >
             <div className='flex h-full flex-col'>
               <button
                 type='button'
-                onClick={() => setIsOpen(false)}
+                onClick={close}
                 className='absolute top-3 right-3 flex h-8 w-8 items-center justify-center rounded text-gray-500 transition duration-200 hover:bg-gray-200 dark:text-gray-300 dark:hover:bg-gray-700'
                 aria-label='メニューを閉じる'
               >
@@ -84,7 +129,7 @@ export function AppLayout({ menuItems, children }: Props) {
                   <Link
                     key={menuItem.label}
                     to={menuItem.to}
-                    onClick={() => setIsOpen(false)}
+                    onClick={close}
                     className='flex items-center space-x-3 rounded px-3 py-3 text-gray-600 transition duration-200 hover:bg-gray-200 dark:text-gray-300 dark:hover:bg-gray-700 [&.active]:bg-gray-200 [&.active]:text-indigo-600 dark:[&.active]:bg-gray-700 dark:[&.active]:text-indigo-400'
                   >
                     <span className='flex h-5 w-5 items-center justify-center'>{menuItem.icon}</span>


### PR DESCRIPTION
## Why

モバイル表示では従来の左サイドバーが `hidden md:flex` で非表示になっており、ページ間の移動ができない状態でした。

## Summary

モバイル画面向けに上部ヘッダーとハンバーガーメニュー、スライドイン式のドロワーを追加しました。デスクトップ表示は既存のサイドバーをそのまま維持しています。

## Changes

- `AppLayout` にモバイル専用の固定ヘッダーを追加
- ハンバーガーアイコン押下で左側からナビゲーションドロワーを表示
- ドロワー内に「動画 / プロジェクト / 書き出し」とテーマ切り替えを配置
- リンク選択時・背景クリック時にドロワーを自動で閉じる
- デスクトップレイアウトへの影響なし

## Checklist

- [x] フォーマット
- [x] リント / 型チェック
- [x] 単体テスト
- [x] E2E スモークテスト
- [x] モバイル / デスクトップの画面確認
