### PR TITLE
Fix subtitle text IME input

### DIFF
--- a/projects/edit-vid2/src/client/features/editor/page.tsx
+++ b/projects/edit-vid2/src/client/features/editor/page.tsx
@@ -589,10 +589,34 @@ function SubtitleTextInput({ item, onChange }: { item: SubtitleItem; onChange: (
   const [draftText, setDraftText] = useState(item.text)
   const isComposingRef = useRef(false)
   const committedTextRef = useRef(item.text)
+  const pendingTextRef = useRef<string | null>(null)
+  const itemIdRef = useRef(item.id)
+
+  let inputText = draftText
+  if (itemIdRef.current !== item.id) {
+    itemIdRef.current = item.id
+    pendingTextRef.current = null
+    committedTextRef.current = item.text
+    inputText = item.text
+    if (draftText !== item.text) {
+      setDraftText(item.text)
+    }
+  } else if (!isComposingRef.current && pendingTextRef.current !== null) {
+    if (item.text === pendingTextRef.current) {
+      pendingTextRef.current = null
+    }
+  } else if (!isComposingRef.current && committedTextRef.current !== item.text) {
+    committedTextRef.current = item.text
+    inputText = item.text
+    if (draftText !== item.text) {
+      setDraftText(item.text)
+    }
+  }
 
   const commitText = (text: string) => {
     if (text === committedTextRef.current) return
     committedTextRef.current = text
+    pendingTextRef.current = text
     onChange({ ...item, text })
   }
 
@@ -608,13 +632,12 @@ function SubtitleTextInput({ item, onChange }: { item: SubtitleItem; onChange: (
     if (e.key !== 'Enter') return
     if (isComposingRef.current || e.nativeEvent.isComposing) return
     commitText(e.currentTarget.value)
-    e.currentTarget.blur()
   }
 
   return (
     <input
       type='text'
-      value={draftText}
+      value={inputText}
       onChange={handleChange}
       onCompositionStart={() => {
         isComposingRef.current = true

--- a/projects/edit-vid2/src/client/features/editor/page.tsx
+++ b/projects/edit-vid2/src/client/features/editor/page.tsx
@@ -2,7 +2,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useParams } from '@tanstack/react-router'
 import { Link } from '@tanstack/react-router'
 import { ArrowLeft, Download, FileVideo, Link2, RotateCcw, Type, X } from 'lucide-react'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState, type ChangeEvent, type KeyboardEvent } from 'react'
 import { uuidv7 } from 'uuidv7'
 import { JobCard, type ExportJob } from '#/client/features/exports/job-card'
 import type {
@@ -532,13 +532,7 @@ function SubtitleEditorItem({
   return (
     <div className='rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-600 dark:bg-gray-800'>
       <div className='mb-2 flex items-center gap-2'>
-        <input
-          type='text'
-          value={item.text}
-          onChange={(e) => onChange({ ...item, text: e.target.value })}
-          className='flex-1 rounded border border-gray-300 px-2 py-1 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100'
-          placeholder='字幕テキスト'
-        />
+        <SubtitleTextInput item={item} onChange={onChange} />
         <button
           onClick={onDelete}
           className='rounded p-1 text-gray-400 hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-900 dark:hover:text-red-400'
@@ -588,6 +582,59 @@ function SubtitleEditorItem({
         </select>
       )}
     </div>
+  )
+}
+
+function SubtitleTextInput({ item, onChange }: { item: SubtitleItem; onChange: (item: SubtitleItem) => void }) {
+  const [draftText, setDraftText] = useState(item.text)
+  const isComposingRef = useRef(false)
+  const committedTextRef = useRef(item.text)
+
+  const commitText = (text: string) => {
+    if (text === committedTextRef.current) return
+    committedTextRef.current = text
+    onChange({ ...item, text })
+  }
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const text = e.target.value
+    const nativeEvent = e.nativeEvent as InputEvent
+    setDraftText(text)
+    if (isComposingRef.current || nativeEvent.isComposing) return
+    commitText(text)
+  }
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key !== 'Enter') return
+    if (isComposingRef.current || e.nativeEvent.isComposing) return
+    commitText(e.currentTarget.value)
+    e.currentTarget.blur()
+  }
+
+  return (
+    <input
+      type='text'
+      value={draftText}
+      onChange={handleChange}
+      onCompositionStart={() => {
+        isComposingRef.current = true
+      }}
+      onCompositionEnd={(e) => {
+        isComposingRef.current = false
+        const text = e.currentTarget.value
+        setDraftText(text)
+        commitText(text)
+      }}
+      onBlur={(e) => {
+        isComposingRef.current = false
+        const text = e.currentTarget.value
+        setDraftText(text)
+        commitText(text)
+      }}
+      onKeyDown={handleKeyDown}
+      className='flex-1 rounded border border-gray-300 px-2 py-1 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100'
+      placeholder='字幕テキスト'
+    />
   )
 }
 

--- a/projects/edit-vid2/tests/e2e/editor.spec.ts
+++ b/projects/edit-vid2/tests/e2e/editor.spec.ts
@@ -96,6 +96,21 @@ function trackProjectPatchRequests() {
   }
 }
 
+async function waitForProjectPatchResponse(): Promise<void> {
+  const response = await page.waitForResponse(
+    (res) => res.request().method() === 'PATCH' && res.url().includes(`/api/projects/${TEST_PROJECT_ID}`)
+  )
+  expect(response.ok()).toBe(true)
+}
+
+async function expectProjectSubtitleText(text: string): Promise<void> {
+  const response = await page.request.get(`${BASE_URL}/api/projects/${TEST_PROJECT_ID}`)
+  expect(response.ok()).toBe(true)
+  const project = await response.json()
+  const subtitles = project.timelineState?.tracks?.find((track: { type: string }) => track.type === 'subtitle')?.items
+  expect(subtitles?.some((item: { text: string }) => item.text === text)).toBe(true)
+}
+
 async function inputComposingText(input: Locator, text: string): Promise<void> {
   await input.evaluate((node, value) => {
     const element = node as HTMLInputElement
@@ -211,15 +226,16 @@ describe('Subtitle text input IME handling', () => {
       await input.focus()
       await inputComposingText(input, 'こんに')
       await pressComposingEnter(input)
-      await page.waitForTimeout(100)
 
       expect(tracker.count).toBe(0)
 
+      const patchResponse = waitForProjectPatchResponse()
       await endComposition(input, 'こんにちは')
-      await page.waitForTimeout(100)
+      await patchResponse
 
       expect(tracker.count).toBe(1)
       expect(await input.inputValue()).toBe('こんにちは')
+      await expectProjectSubtitleText('こんにちは')
     } finally {
       tracker.dispose()
     }
@@ -232,20 +248,32 @@ describe('Subtitle text input IME handling', () => {
     try {
       await input.focus()
       await inputComposingText(input, '未確定')
-      await page.waitForTimeout(100)
 
       expect(tracker.count).toBe(0)
 
       await inputComposingText(input, '未確定')
+      const patchResponse = waitForProjectPatchResponse()
       await input.evaluate((node) => {
         ;(node as HTMLInputElement).blur()
       })
-      await page.waitForTimeout(100)
+      await patchResponse
 
       expect(tracker.count).toBe(1)
       expect(await input.inputValue()).toBe('未確定')
+      await expectProjectSubtitleText('未確定')
     } finally {
       tracker.dispose()
     }
+  })
+
+  test('saves normal text input without composition', async () => {
+    const input = await addSubtitle()
+    const patchResponse = waitForProjectPatchResponse()
+
+    await input.fill('plain subtitle')
+    await patchResponse
+
+    expect(await input.inputValue()).toBe('plain subtitle')
+    await expectProjectSubtitleText('plain subtitle')
   })
 })

--- a/projects/edit-vid2/tests/e2e/editor.spec.ts
+++ b/projects/edit-vid2/tests/e2e/editor.spec.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
-import type { Page } from 'playwright'
+import type { Locator, Page, Request } from 'playwright'
 import { BASE_URL, setupE2E, teardownE2E, TEST_PROJECT_ID } from './setup'
 
 let page: Page
@@ -64,6 +64,67 @@ async function waitForPlaybackState(paused: boolean): Promise<void> {
     paused,
     { timeout: 5000 }
   )
+}
+
+async function addSubtitle(): Promise<Locator> {
+  const inputs = page.getByPlaceholder('字幕テキスト')
+  const before = await inputs.count()
+  await page.getByRole('button', { name: /字幕追加/ }).click()
+  await page.waitForFunction(
+    ({ placeholder, count }) => document.querySelectorAll(`input[placeholder="${placeholder}"]`).length > count,
+    { placeholder: '字幕テキスト', count: before }
+  )
+  return inputs.last()
+}
+
+function trackProjectPatchRequests() {
+  let count = 0
+  const handler = (request: Request) => {
+    if (request.method() === 'PATCH' && request.url().includes(`/api/projects/${TEST_PROJECT_ID}`)) {
+      count++
+    }
+  }
+  page.on('request', handler)
+
+  return {
+    get count() {
+      return count
+    },
+    dispose() {
+      page.off('request', handler)
+    },
+  }
+}
+
+async function inputComposingText(input: Locator, text: string): Promise<void> {
+  await input.evaluate((node, value) => {
+    const element = node as HTMLInputElement
+    element.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }))
+    element.value = value
+    element.dispatchEvent(
+      new InputEvent('input', {
+        bubbles: true,
+        data: value,
+        inputType: 'insertCompositionText',
+        isComposing: true,
+      })
+    )
+  }, text)
+}
+
+async function endComposition(input: Locator, text: string): Promise<void> {
+  await input.evaluate((node, value) => {
+    const element = node as HTMLInputElement
+    element.value = value
+    element.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true, data: value }))
+  }, text)
+}
+
+async function pressComposingEnter(input: Locator): Promise<void> {
+  await input.evaluate((node) => {
+    const element = node as HTMLInputElement
+    element.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'Enter', isComposing: true }))
+  })
 }
 
 describe('Editor seek bar', () => {
@@ -138,5 +199,53 @@ describe('Editor seek bar', () => {
       return v ? v.paused : true
     })
     expect(isPaused).toBe(true)
+  })
+})
+
+describe('Subtitle text input IME handling', () => {
+  test('defers saving during composition and saves once on compositionend', async () => {
+    const input = await addSubtitle()
+    const tracker = trackProjectPatchRequests()
+
+    try {
+      await input.focus()
+      await inputComposingText(input, 'こんに')
+      await pressComposingEnter(input)
+      await page.waitForTimeout(100)
+
+      expect(tracker.count).toBe(0)
+
+      await endComposition(input, 'こんにちは')
+      await page.waitForTimeout(100)
+
+      expect(tracker.count).toBe(1)
+      expect(await input.inputValue()).toBe('こんにちは')
+    } finally {
+      tracker.dispose()
+    }
+  })
+
+  test('saves composing draft on blur', async () => {
+    const input = await addSubtitle()
+    const tracker = trackProjectPatchRequests()
+
+    try {
+      await input.focus()
+      await inputComposingText(input, '未確定')
+      await page.waitForTimeout(100)
+
+      expect(tracker.count).toBe(0)
+
+      await inputComposingText(input, '未確定')
+      await input.evaluate((node) => {
+        ;(node as HTMLInputElement).blur()
+      })
+      await page.waitForTimeout(100)
+
+      expect(tracker.count).toBe(1)
+      expect(await input.inputValue()).toBe('未確定')
+    } finally {
+      tracker.dispose()
+    }
   })
 })


### PR DESCRIPTION
## Issues

- None

## Why

字幕テキスト入力で日本語IMEの変換中にも保存と再取得が走り、入力値や変換状態が崩れる可能性がありました。

## Summary

字幕テキスト入力をローカルdraftで制御し、IME composition中は保存を遅延します。確定時とblur時には差分がある場合だけ保存します。

## Changes

- 字幕テキスト入力を `SubtitleTextInput` に分離
- composition中の `PATCH` を抑止し、`compositionend` / `blur` で保存
- IME中Enterの誤保存を防止
- Playwright e2eでIME入力中・確定時・blur時の保存挙動を追加検証

## Checklist

- [x] フォーマット: `bun run format:check`
- [x] リント / 型チェック: `bun run lint`
- [x] テスト: `bun test`
