### PR TITLE
Fix empty subtitles in timeline rendering

### DIFF
--- a/projects/edit-vid2/src/client/features/editor/page.tsx
+++ b/projects/edit-vid2/src/client/features/editor/page.tsx
@@ -13,6 +13,7 @@ import type {
   TimelineStateV1,
   VideoAsset,
 } from '#/shared/schemas'
+import { getRenderableSubtitles } from '#/shared/subtitles'
 
 export function EditorPage() {
   const params = useParams({ from: '/projects/$projectId' })
@@ -114,6 +115,7 @@ export function EditorPage() {
   }
 
   const subItems: SubtitleItem[] = timelineState.tracks.find((t) => t.type === 'subtitle')?.items ?? []
+  const renderableSubItems = getRenderableSubtitles(subItems)
 
   return (
     <div
@@ -215,7 +217,9 @@ export function EditorPage() {
             onChange={(keepSegments) => saveTimelineState({ ...timelineState, keepSegments })}
           />
 
-          <h2 className='mb-3 text-sm font-semibold text-gray-700 dark:text-gray-300'>字幕 ({subItems.length})</h2>
+          <h2 className='mb-3 text-sm font-semibold text-gray-700 dark:text-gray-300'>
+            字幕 ({renderableSubItems.length})
+          </h2>
           <div className='space-y-2'>
             {subItems.map((sub) => (
               <SubtitleEditorItem
@@ -254,7 +258,7 @@ export function EditorPage() {
         duration={mediaDuration}
         currentTime={currentTime}
         keepSegments={timelineState.keepSegments}
-        subtitleItems={subItems}
+        subtitleItems={renderableSubItems}
         onSeek={(t) => {
           if (videoRef.current) {
             videoRef.current.currentTime = t
@@ -729,6 +733,7 @@ function TimelineBar({
         {subtitleItems.map((sub) => (
           <div
             key={sub.id}
+            data-testid='timeline-subtitle-item'
             className='absolute bottom-0 h-3 rounded bg-indigo-400/70 dark:bg-indigo-500/50'
             style={{
               left: `${toPercent(sub.sourceStart)}%`,

--- a/projects/edit-vid2/src/server/features/export/export-worker.ts
+++ b/projects/edit-vid2/src/server/features/export/export-worker.ts
@@ -8,6 +8,7 @@ import { mapSubtitlesToOutputTime, normalizeKeepSegments } from '#/server/featur
 import { getVideoAssetById } from '#/server/features/videos/video-repository'
 import { toSubtitleStyle } from '#/shared/schemas'
 import type { ExportPreset, KeepSegment, SubtitleItem, SubtitleStyle, TimelineStateV1 } from '#/shared/schemas'
+import { getRenderableSubtitles } from '#/shared/subtitles'
 import { getExportJobById, updateExportJob } from './export-repository'
 
 interface ExportJobRecord {
@@ -141,6 +142,7 @@ class ExportWorker {
 
       const keepSegments: KeepSegment[] = timelineState.keepSegments ?? []
       const subItems: SubtitleItem[] = timelineState.tracks?.find((t) => t.type === 'subtitle')?.items ?? []
+      const renderableSubItems = getRenderableSubtitles(subItems)
 
       const preset = (exportJob.preset ?? {
         format: 'mp4',
@@ -161,8 +163,8 @@ class ExportWorker {
       let vfFilter = ''
       let assPath = ''
 
-      if (subItems.length > 0) {
-        const defaultTemplate = getTemplateById(db, subItems[0]?.templateId ?? '')
+      if (renderableSubItems.length > 0) {
+        const defaultTemplate = getTemplateById(db, renderableSubItems[0]?.templateId ?? '')
         const defaultStyle: SubtitleStyle = defaultTemplate
           ? toSubtitleStyle(defaultTemplate)
           : {
@@ -179,7 +181,7 @@ class ExportWorker {
               margin: { x: 0, y: 0 },
             }
 
-        const mapped = mapSubtitlesToOutputTime(subItems, keepSegments)
+        const mapped = mapSubtitlesToOutputTime(renderableSubItems, keepSegments)
         const assContent = generateAssContent(mapped, videoAsset.width ?? 1920, videoAsset.height ?? 1080, defaultStyle)
         assPath = resolve(exportDir, 'subtitles.ass')
         const { writeFileSync } = await import('node:fs')

--- a/projects/edit-vid2/src/server/features/export/export-worker.ts
+++ b/projects/edit-vid2/src/server/features/export/export-worker.ts
@@ -164,7 +164,7 @@ class ExportWorker {
       let assPath = ''
 
       if (renderableSubItems.length > 0) {
-        const defaultTemplate = getTemplateById(db, renderableSubItems[0]?.templateId ?? '')
+        const defaultTemplate = getTemplateById(db, renderableSubItems[0].templateId)
         const defaultStyle: SubtitleStyle = defaultTemplate
           ? toSubtitleStyle(defaultTemplate)
           : {

--- a/projects/edit-vid2/src/server/features/timeline/timeline-logic.ts
+++ b/projects/edit-vid2/src/server/features/timeline/timeline-logic.ts
@@ -1,4 +1,5 @@
 import type { KeepSegment, MappedSubtitle, SubtitleItem } from '#/shared/schemas'
+import { getRenderableSubtitles } from '#/shared/subtitles'
 
 export function normalizeKeepSegments(segments: KeepSegment[]): KeepSegment[] {
   if (segments.length === 0) return []
@@ -19,8 +20,10 @@ export function normalizeKeepSegments(segments: KeepSegment[]): KeepSegment[] {
 }
 
 export function mapSubtitlesToOutputTime(subtitles: SubtitleItem[], keepSegments: KeepSegment[]): MappedSubtitle[] {
+  const renderableSubtitles = getRenderableSubtitles(subtitles)
+
   if (keepSegments.length === 0) {
-    return subtitles.map((sub) => ({
+    return renderableSubtitles.map((sub) => ({
       text: sub.text,
       outputStart: sub.sourceStart,
       outputEnd: sub.sourceEnd,
@@ -54,7 +57,7 @@ export function mapSubtitlesToOutputTime(subtitles: SubtitleItem[], keepSegments
 
   const result: MappedSubtitle[] = []
 
-  for (const sub of subtitles) {
+  for (const sub of renderableSubtitles) {
     for (const seg of normalized) {
       const intersectStart = Math.max(sub.sourceStart, seg.sourceStart)
       const intersectEnd = Math.min(sub.sourceEnd, seg.sourceEnd)

--- a/projects/edit-vid2/src/shared/subtitles.ts
+++ b/projects/edit-vid2/src/shared/subtitles.ts
@@ -1,0 +1,9 @@
+import type { SubtitleItem } from './schemas'
+
+export function isRenderableSubtitle(item: SubtitleItem): boolean {
+  return item.text.trim().length > 0
+}
+
+export function getRenderableSubtitles(items: SubtitleItem[]): SubtitleItem[] {
+  return items.filter(isRenderableSubtitle)
+}

--- a/projects/edit-vid2/tests/features/timeline-logic.test.ts
+++ b/projects/edit-vid2/tests/features/timeline-logic.test.ts
@@ -77,6 +77,18 @@ describe('mapSubtitlesToOutputTime', () => {
     expect(result[0].text).toBe('Hello')
   })
 
+  test('excludes empty text subtitles with keepSegments', () => {
+    const subtitles: SubtitleItem[] = [
+      { id: 's1', sourceStart: 1, sourceEnd: 3, text: 'Hello', templateId: 't1', styleOverrides: {} },
+      { id: 's2', sourceStart: 3, sourceEnd: 5, text: '', templateId: 't1', styleOverrides: {} },
+      { id: 's3', sourceStart: 5, sourceEnd: 7, text: '   ', templateId: 't1', styleOverrides: {} },
+    ]
+    const keepSegments: KeepSegment[] = [{ id: 'k1', sourceStart: 0, sourceEnd: 8 }]
+    const result = mapSubtitlesToOutputTime(subtitles, keepSegments)
+    expect(result).toHaveLength(1)
+    expect(result[0].text).toBe('Hello')
+  })
+
   test('maps simple case with single keepSegment', () => {
     const subtitles: SubtitleItem[] = [
       { id: 's1', sourceStart: 2, sourceEnd: 6, text: 'Hello', templateId: 't1', styleOverrides: {} },

--- a/projects/edit-vid2/tests/features/timeline-logic.test.ts
+++ b/projects/edit-vid2/tests/features/timeline-logic.test.ts
@@ -66,6 +66,17 @@ describe('mapSubtitlesToOutputTime', () => {
     expect(result[0].text).toBe('Hello')
   })
 
+  test('excludes empty text subtitles', () => {
+    const subtitles: SubtitleItem[] = [
+      { id: 's1', sourceStart: 1, sourceEnd: 3, text: 'Hello', templateId: 't1', styleOverrides: {} },
+      { id: 's2', sourceStart: 3, sourceEnd: 5, text: '', templateId: 't1', styleOverrides: {} },
+      { id: 's3', sourceStart: 5, sourceEnd: 7, text: '   ', templateId: 't1', styleOverrides: {} },
+    ]
+    const result = mapSubtitlesToOutputTime(subtitles, [])
+    expect(result).toHaveLength(1)
+    expect(result[0].text).toBe('Hello')
+  })
+
   test('maps simple case with single keepSegment', () => {
     const subtitles: SubtitleItem[] = [
       { id: 's1', sourceStart: 2, sourceEnd: 6, text: 'Hello', templateId: 't1', styleOverrides: {} },


### PR DESCRIPTION
## Issues

- Refs subtitle timeline bug report

## Why

未入力の空字幕アイテムが字幕件数とタイムラインバーに含まれ、実際の字幕数より多い線が表示されていました。

## Summary

空白のみ/未入力の字幕を描画・書き出し対象から除外します。編集カード自体は残すため、未入力字幕の入力や削除は引き続き可能です。

## Changes

- renderable な字幕判定を共通関数化
- エディタの字幕件数とタイムラインバーを入力済み字幕だけで表示
- 書き出し時の ASS 生成でも空字幕を除外
- 空字幕除外のユニットテストを追加

## Checklist

- [x] フォーマット: `bun run format:check`
- [x] リント / 型チェック: `bun run lint`
- [x] テスト: `bun test tests/features`
