### PR TITLE
fix(edit-vid2): improve trim time input UX

### DIFF
--- a/projects/edit-vid2/src/client/features/editor/page.tsx
+++ b/projects/edit-vid2/src/client/features/editor/page.tsx
@@ -411,6 +411,56 @@ function formatDecimalSeconds(value: number): string {
   return roundTime(value).toFixed(1)
 }
 
+function TimeField({
+  value,
+  min,
+  max,
+  disabled,
+  testId,
+  onCommit,
+}: {
+  value: number
+  min: number
+  max: number
+  disabled: boolean
+  testId?: string
+  onCommit: (value: number) => void
+}) {
+  const [draft, setDraft] = useState(formatDecimalSeconds(value))
+
+  useEffect(() => {
+    setDraft(formatDecimalSeconds(value))
+  }, [value])
+
+  const commit = (raw: string) => {
+    const parsed = Number.parseFloat(raw)
+    if (Number.isFinite(parsed)) {
+      const next = Math.max(min, Math.min(parsed, max))
+      onCommit(next)
+      setDraft(formatDecimalSeconds(next))
+    } else {
+      setDraft(formatDecimalSeconds(value))
+    }
+  }
+
+  return (
+    <input
+      type='text'
+      inputMode='decimal'
+      disabled={disabled}
+      data-testid={testId}
+      value={draft}
+      onChange={(e) => setDraft(e.target.value)}
+      onBlur={(e) => commit(e.target.value)}
+      onKeyDown={(e) => {
+        if (e.key !== 'Enter') return
+        e.currentTarget.blur()
+      }}
+      className='w-full rounded border border-gray-300 px-2 py-1 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100'
+    />
+  )
+}
+
 function TrimPanel({
   duration,
   currentTime,
@@ -461,28 +511,24 @@ function TrimPanel({
         <div className='grid grid-cols-2 gap-2'>
           <div>
             <label className='block text-xs text-gray-500 dark:text-gray-400'>開始 (秒)</label>
-            <input
-              type='number'
-              value={formatDecimalSeconds(start)}
-              step={0.1}
+            <TimeField
+              value={start}
               min={0}
               max={duration}
               disabled={duration === 0}
-              onChange={(e) => saveRange(Number(e.target.value), end)}
-              className='w-full rounded border border-gray-300 px-2 py-1 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100'
+              testId='trim-start-input'
+              onCommit={(nextStart) => saveRange(nextStart, end)}
             />
           </div>
           <div>
             <label className='block text-xs text-gray-500 dark:text-gray-400'>終了 (秒)</label>
-            <input
-              type='number'
-              value={formatDecimalSeconds(end)}
-              step={0.1}
+            <TimeField
+              value={end}
               min={0}
               max={duration}
               disabled={duration === 0}
-              onChange={(e) => saveRange(start, Number(e.target.value))}
-              className='w-full rounded border border-gray-300 px-2 py-1 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100'
+              testId='trim-end-input'
+              onCommit={(nextEnd) => saveRange(start, nextEnd)}
             />
           </div>
         </div>

--- a/projects/edit-vid2/src/client/features/editor/page.tsx
+++ b/projects/edit-vid2/src/client/features/editor/page.tsx
@@ -427,10 +427,16 @@ function TimeField({
   onCommit: (value: number) => void
 }) {
   const [draft, setDraft] = useState(formatDecimalSeconds(value))
+  const [isFocused, setIsFocused] = useState(false)
+  const valueRef = useRef(value)
 
-  useEffect(() => {
-    setDraft(formatDecimalSeconds(value))
-  }, [value])
+  if (value !== valueRef.current && !isFocused) {
+    valueRef.current = value
+    const formatted = formatDecimalSeconds(value)
+    if (draft !== formatted) {
+      setDraft(formatted)
+    }
+  }
 
   const isValidDecimal = (raw: string): boolean => {
     const trimmed = raw.trim()
@@ -439,6 +445,7 @@ function TimeField({
   }
 
   const commit = (raw: string) => {
+    setIsFocused(false)
     if (!isValidDecimal(raw)) {
       setDraft(formatDecimalSeconds(value))
       return
@@ -456,6 +463,11 @@ function TimeField({
       disabled={disabled}
       data-testid={testId}
       value={draft}
+      onFocus={() => {
+        valueRef.current = value
+        setDraft(formatDecimalSeconds(value))
+        setIsFocused(true)
+      }}
       onChange={(e) => setDraft(e.target.value)}
       onBlur={(e) => commit(e.target.value)}
       onKeyDown={(e) => {

--- a/projects/edit-vid2/src/client/features/editor/page.tsx
+++ b/projects/edit-vid2/src/client/features/editor/page.tsx
@@ -432,15 +432,21 @@ function TimeField({
     setDraft(formatDecimalSeconds(value))
   }, [value])
 
+  const isValidDecimal = (raw: string): boolean => {
+    const trimmed = raw.trim()
+    if (trimmed === '') return false
+    return /^-?\d+(\.\d*)?$/.test(trimmed) && Number.isFinite(Number(trimmed))
+  }
+
   const commit = (raw: string) => {
-    const parsed = Number.parseFloat(raw)
-    if (Number.isFinite(parsed)) {
-      const next = Math.max(min, Math.min(parsed, max))
-      onCommit(next)
-      setDraft(formatDecimalSeconds(next))
-    } else {
+    if (!isValidDecimal(raw)) {
       setDraft(formatDecimalSeconds(value))
+      return
     }
+    const parsed = Number(raw)
+    const next = Math.max(min, Math.min(parsed, max))
+    onCommit(next)
+    setDraft(formatDecimalSeconds(next))
   }
 
   return (

--- a/projects/edit-vid2/tests/e2e/editor.spec.ts
+++ b/projects/edit-vid2/tests/e2e/editor.spec.ts
@@ -314,14 +314,28 @@ describe('Trim time input', () => {
 
   test('reverts invalid input on blur', async () => {
     const input = page.getByTestId('trim-start-input')
-    expect(await input.inputValue()).toBe('1.5')
 
-    await input.focus()
+    // Prepare a known committed value so this test does not depend on the previous one.
+    await input.fill('2.0')
+    const patchResponse = waitForProjectPatchResponse()
+    await input.evaluate((node) => {
+      ;(node as HTMLInputElement).blur()
+    })
+    await patchResponse
+    expect(await input.inputValue()).toBe('2.0')
+
+    // Non-numeric input should revert to the last committed value.
     await input.fill('abc')
     await input.evaluate((node) => {
       ;(node as HTMLInputElement).blur()
     })
+    expect(await input.inputValue()).toBe('2.0')
 
-    expect(await input.inputValue()).toBe('1.5')
+    // Partial-numeric input (parseFloat would accept the leading digits) should also revert.
+    await input.fill('1abc')
+    await input.evaluate((node) => {
+      ;(node as HTMLInputElement).blur()
+    })
+    expect(await input.inputValue()).toBe('2.0')
   })
 })

--- a/projects/edit-vid2/tests/e2e/editor.spec.ts
+++ b/projects/edit-vid2/tests/e2e/editor.spec.ts
@@ -277,3 +277,51 @@ describe('Subtitle text input IME handling', () => {
     await expectProjectSubtitleText('plain subtitle')
   })
 })
+
+async function expectProjectTrimStart(value: number): Promise<void> {
+  const response = await page.request.get(`${BASE_URL}/api/projects/${TEST_PROJECT_ID}`)
+  expect(response.ok()).toBe(true)
+  const project = await response.json()
+  expect(project.timelineState?.keepSegments?.[0]?.sourceStart).toBe(value)
+}
+
+describe('Trim time input', () => {
+  test('commits start time on blur, not while typing', async () => {
+    await resetVideo()
+
+    const input = page.getByTestId('trim-start-input')
+    expect(await input.inputValue()).toBe('0.0')
+
+    const tracker = trackProjectPatchRequests()
+    try {
+      await input.focus()
+      await input.fill('1.5')
+      expect(tracker.count).toBe(0)
+
+      const patchResponse = waitForProjectPatchResponse()
+      await input.evaluate((node) => {
+        ;(node as HTMLInputElement).blur()
+      })
+      await patchResponse
+
+      expect(tracker.count).toBe(1)
+      expect(await input.inputValue()).toBe('1.5')
+      await expectProjectTrimStart(1.5)
+    } finally {
+      tracker.dispose()
+    }
+  })
+
+  test('reverts invalid input on blur', async () => {
+    const input = page.getByTestId('trim-start-input')
+    expect(await input.inputValue()).toBe('1.5')
+
+    await input.focus()
+    await input.fill('abc')
+    await input.evaluate((node) => {
+      ;(node as HTMLInputElement).blur()
+    })
+
+    expect(await input.inputValue()).toBe('1.5')
+  })
+})


### PR DESCRIPTION
## Why

切り抜き時間の入力欄で、入力中に毎回サーバー PATCH が走り、`toFixed(1)` による強制整形で小数点入力がしづらくなっていました。

## Summary

`TrimPanel` 内の開始・終了時間入力を、ローカルドラフトを保持し blur / Enter で確定する `TimeField` コンポーネントに置き換え、入力 UX を改善します。

## Changes

- `src/client/features/editor/page.tsx`
  - `TimeField` コンポーネントを追加
  - 切り抜き開始・終了入力を `TimeField` に置き換え
  - `type="text" inputMode="decimal"` に変更し小数点入力を自然に
  - 入力中の確定前保存をやめ、blur / Enter で commit
  - 無効な入力は元の値に revert
- `tests/e2e/editor.spec.ts`
  - 入力中に PATCH しないこと、blur で確定すること、無効値が revert することを検証する E2E テストを追加

## Checklist

- [x] フォーマット (`bun run format:check`)
- [x] リント / 型チェック (`bun run lint`)
- [x] テスト (`bun test`)
- [x] ビルド (`bun run build`)
