### PR TITLE
fix(edit-vid2): pause playback when timeline is interacted

### DIFF
--- a/projects/edit-vid2/src/client/features/editor/page.tsx
+++ b/projects/edit-vid2/src/client/features/editor/page.tsx
@@ -259,6 +259,7 @@ export function EditorPage() {
         currentTime={currentTime}
         keepSegments={timelineState.keepSegments}
         subtitleItems={renderableSubItems}
+        onPause={() => videoRef.current?.pause()}
         onSeek={(t) => {
           if (videoRef.current) {
             videoRef.current.currentTime = t
@@ -734,12 +735,14 @@ function TimelineBar({
   currentTime,
   keepSegments,
   subtitleItems,
+  onPause,
   onSeek,
 }: {
   duration: number
   currentTime: number
   keepSegments: KeepSegment[]
   subtitleItems: SubtitleItem[]
+  onPause: () => void
   onSeek: (time: number) => void
 }) {
   const barRef = useRef<HTMLDivElement>(null)
@@ -758,6 +761,7 @@ function TimelineBar({
   const handleMouseDown = (e: React.MouseEvent) => {
     if (e.button !== 0) return
     draggingRef.current = true
+    onPause()
     onSeek(calcTime(e.clientX))
 
     const handleMouseMove = (ev: MouseEvent) => {
@@ -775,6 +779,22 @@ function TimelineBar({
     document.addEventListener('mouseup', handleMouseUp)
   }
 
+  const handleTouchStart = (e: React.TouchEvent) => {
+    if (e.touches.length === 0) return
+    draggingRef.current = true
+    onPause()
+    onSeek(calcTime(e.touches[0].clientX))
+  }
+
+  const handleTouchMove = (e: React.TouchEvent) => {
+    if (!draggingRef.current || e.touches.length === 0) return
+    onSeek(calcTime(e.touches[0].clientX))
+  }
+
+  const handleTouchEnd = () => {
+    draggingRef.current = false
+  }
+
   return (
     <div className='h-20 border-t border-gray-200 bg-white px-4 py-3 dark:border-gray-700 dark:bg-gray-800'>
       <div
@@ -782,6 +802,9 @@ function TimelineBar({
         data-testid='timeline-seek-bar'
         className='relative h-10 cursor-pointer rounded bg-gray-100 dark:bg-gray-700'
         onMouseDown={handleMouseDown}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
       >
         {keepSegments.map((seg) => (
           <div

--- a/projects/edit-vid2/tests/e2e/editor.spec.ts
+++ b/projects/edit-vid2/tests/e2e/editor.spec.ts
@@ -215,6 +215,21 @@ describe('Editor seek bar', () => {
     })
     expect(isPaused).toBe(true)
   })
+
+  test('timeline interaction pauses playback', async () => {
+    await resetVideo()
+
+    await page.getByTestId('editor-root').focus()
+    await page.keyboard.press('Space')
+    await waitForPlaybackState(false)
+
+    const bar = seekBar()
+    const box = await bar.boundingBox()
+    if (!box) throw new Error('Seek bar not found')
+
+    await page.mouse.click(box.x + box.width * 0.5, box.y + box.height / 2)
+    await waitForPlaybackState(true)
+  })
 })
 
 describe('Subtitle text input IME handling', () => {


### PR DESCRIPTION
## Why

編集画面で動画を再生中に、下のタイムラインを操作してシークした際も再生が続いてしまい、意図しない再生位置のズレや操作しにくさがあったため。

## Summary

タイムライン（シークバー）へのマウス・タッチ操作開始時に動画の再生を停止するようにしました。

## Changes

- `TimelineBar` に `onPause` コールバックを追加
- タイムラインの `mousedown` / `touchstart` で `onPause()` を呼び出してからシーク
- タイムラインのタッチ操作（`touchmove` / `touchend`）に対応
- E2E テスト「timeline interaction pauses playback」を追加

## Checklist

- [x] フォーマット (`bun run format:check`)
- [x] リント / 型チェック (`bun run lint`)
- [x] テスト (`bun test`)
- [x] ビルド (`bun run build`)
