### PR TITLE
feat(edit-vid2): Phase 1 - sort subtitles by sourceStart and fix export panel

### DIFF
--- a/projects/edit-vid2/src/client/features/editor/page.tsx
+++ b/projects/edit-vid2/src/client/features/editor/page.tsx
@@ -2,7 +2,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useParams } from '@tanstack/react-router'
 import { Link } from '@tanstack/react-router'
 import { ArrowLeft, Download, FileVideo, Link2, RotateCcw, Type, X } from 'lucide-react'
-import { useCallback, useEffect, useRef, useState, type ChangeEvent, type KeyboardEvent } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent, type KeyboardEvent } from 'react'
 import { uuidv7 } from 'uuidv7'
 import { JobCard, type ExportJob } from '#/client/features/exports/job-card'
 import type {
@@ -13,7 +13,7 @@ import type {
   TimelineStateV1,
   VideoAsset,
 } from '#/shared/schemas'
-import { getRenderableSubtitles } from '#/shared/subtitles'
+import { getRenderableSubtitles, sortSubtitleItemsByStart } from '#/shared/subtitles'
 
 export function EditorPage() {
   const params = useParams({ from: '/projects/$projectId' })
@@ -115,7 +115,8 @@ export function EditorPage() {
   }
 
   const subItems: SubtitleItem[] = timelineState.tracks.find((t) => t.type === 'subtitle')?.items ?? []
-  const renderableSubItems = getRenderableSubtitles(subItems)
+  const sortedSubItems = useMemo(() => sortSubtitleItemsByStart(subItems), [subItems])
+  const renderableSubItems = getRenderableSubtitles(sortedSubItems)
 
   return (
     <div
@@ -209,48 +210,54 @@ export function EditorPage() {
           )}
         </div>
 
-        <div className='w-full overflow-auto border-t border-gray-200 p-4 dark:border-gray-700 lg:w-96 lg:border-l lg:border-t-0'>
-          <TrimPanel
-            duration={mediaDuration}
-            currentTime={currentTime}
-            keepSegments={timelineState.keepSegments}
-            onChange={(keepSegments) => saveTimelineState({ ...timelineState, keepSegments })}
-          />
-
-          <h2 className='mb-3 text-sm font-semibold text-gray-700 dark:text-gray-300'>
-            字幕 ({renderableSubItems.length})
-          </h2>
-          <div className='space-y-2'>
-            {subItems.map((sub) => (
-              <SubtitleEditorItem
-                key={sub.id}
-                item={sub}
-                templates={templates ?? []}
-                duration={mediaDuration}
-                onChange={(updated) => {
-                  const newItems = subItems.map((s) => (s.id === updated.id ? updated : s))
-                  const newTracks = timelineState.tracks.map((t) =>
-                    t.type === 'subtitle' ? { ...t, items: newItems } : t
-                  )
-                  saveTimelineState({ ...timelineState, tracks: newTracks })
-                }}
-                onDelete={() => {
-                  const newItems = subItems.filter((s) => s.id !== sub.id)
-                  const newTracks = timelineState.tracks.map((t) =>
-                    t.type === 'subtitle' ? { ...t, items: newItems } : t
-                  )
-                  saveTimelineState({ ...timelineState, tracks: newTracks })
-                }}
-              />
-            ))}
-            {subItems.length === 0 && (
-              <p className='text-xs text-gray-400 dark:text-gray-500'>
-                字幕がありません。「字幕追加」ボタンまたは A キーで追加できます。
-              </p>
-            )}
+        <div className='flex w-full flex-col overflow-hidden border-t border-gray-200 dark:border-gray-700 lg:w-96 lg:border-l lg:border-t-0'>
+          <div className='shrink-0 p-4 pb-2'>
+            <TrimPanel
+              duration={mediaDuration}
+              currentTime={currentTime}
+              keepSegments={timelineState.keepSegments}
+              onChange={(keepSegments) => saveTimelineState({ ...timelineState, keepSegments })}
+            />
           </div>
 
-          <ExportPanel projectId={projectId} canExport={hasVideo} />
+          <div className='flex min-h-0 flex-1 flex-col px-4'>
+            <h2 className='mb-3 shrink-0 text-sm font-semibold text-gray-700 dark:text-gray-300'>
+              字幕 ({renderableSubItems.length})
+            </h2>
+            <div className='min-h-0 flex-1 space-y-2 overflow-y-auto pr-1'>
+              {sortedSubItems.map((sub) => (
+                <SubtitleEditorItem
+                  key={sub.id}
+                  item={sub}
+                  templates={templates ?? []}
+                  duration={mediaDuration}
+                  onChange={(updated) => {
+                    const newItems = subItems.map((s) => (s.id === updated.id ? updated : s))
+                    const newTracks = timelineState.tracks.map((t) =>
+                      t.type === 'subtitle' ? { ...t, items: newItems } : t
+                    )
+                    saveTimelineState({ ...timelineState, tracks: newTracks })
+                  }}
+                  onDelete={() => {
+                    const newItems = subItems.filter((s) => s.id !== sub.id)
+                    const newTracks = timelineState.tracks.map((t) =>
+                      t.type === 'subtitle' ? { ...t, items: newItems } : t
+                    )
+                    saveTimelineState({ ...timelineState, tracks: newTracks })
+                  }}
+                />
+              ))}
+              {sortedSubItems.length === 0 && (
+                <p className='text-xs text-gray-400 dark:text-gray-500'>
+                  字幕がありません。「字幕追加」ボタンまたは A キーで追加できます。
+                </p>
+              )}
+            </div>
+          </div>
+
+          <div className='shrink-0 border-t border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800'>
+            <ExportPanel projectId={projectId} canExport={hasVideo} />
+          </div>
         </div>
       </div>
 

--- a/projects/edit-vid2/src/shared/subtitles.ts
+++ b/projects/edit-vid2/src/shared/subtitles.ts
@@ -7,3 +7,7 @@ export function isRenderableSubtitle(item: SubtitleItem): boolean {
 export function getRenderableSubtitles(items: SubtitleItem[]): SubtitleItem[] {
   return items.filter(isRenderableSubtitle)
 }
+
+export function sortSubtitleItemsByStart(items: SubtitleItem[]): SubtitleItem[] {
+  return [...items].sort((a, b) => a.sourceStart - b.sourceStart)
+}

--- a/projects/edit-vid2/tests/features/subtitles.test.ts
+++ b/projects/edit-vid2/tests/features/subtitles.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  getRenderableSubtitles,
+  isRenderableSubtitle,
+  sortSubtitleItemsByStart,
+} from '#/shared/subtitles'
+import type { SubtitleItem } from '#/shared/schemas'
+
+describe('isRenderableSubtitle', () => {
+  test('returns true for non-empty text', () => {
+    const item: SubtitleItem = {
+      id: 's1',
+      sourceStart: 0,
+      sourceEnd: 1,
+      text: 'Hello',
+      templateId: 't1',
+      styleOverrides: {},
+    }
+    expect(isRenderableSubtitle(item)).toBe(true)
+  })
+
+  test('returns false for empty text', () => {
+    const item: SubtitleItem = {
+      id: 's1',
+      sourceStart: 0,
+      sourceEnd: 1,
+      text: '',
+      templateId: 't1',
+      styleOverrides: {},
+    }
+    expect(isRenderableSubtitle(item)).toBe(false)
+  })
+
+  test('returns false for whitespace-only text', () => {
+    const item: SubtitleItem = {
+      id: 's1',
+      sourceStart: 0,
+      sourceEnd: 1,
+      text: '   ',
+      templateId: 't1',
+      styleOverrides: {},
+    }
+    expect(isRenderableSubtitle(item)).toBe(false)
+  })
+})
+
+describe('getRenderableSubtitles', () => {
+  test('filters out empty and whitespace-only subtitles', () => {
+    const items: SubtitleItem[] = [
+      { id: 's1', sourceStart: 0, sourceEnd: 1, text: 'Hello', templateId: 't1', styleOverrides: {} },
+      { id: 's2', sourceStart: 1, sourceEnd: 2, text: '', templateId: 't1', styleOverrides: {} },
+      { id: 's3', sourceStart: 2, sourceEnd: 3, text: '   ', templateId: 't1', styleOverrides: {} },
+      { id: 's4', sourceStart: 3, sourceEnd: 4, text: 'World', templateId: 't1', styleOverrides: {} },
+    ]
+    const result = getRenderableSubtitles(items)
+    expect(result).toHaveLength(2)
+    expect(result.map((item) => item.text)).toEqual(['Hello', 'World'])
+  })
+})
+
+describe('sortSubtitleItemsByStart', () => {
+  test('sorts items by sourceStart ascending', () => {
+    const items: SubtitleItem[] = [
+      { id: 's3', sourceStart: 5, sourceEnd: 7, text: 'third', templateId: 't1', styleOverrides: {} },
+      { id: 's1', sourceStart: 1, sourceEnd: 3, text: 'first', templateId: 't1', styleOverrides: {} },
+      { id: 's2', sourceStart: 3, sourceEnd: 5, text: 'second', templateId: 't1', styleOverrides: {} },
+    ]
+    const result = sortSubtitleItemsByStart(items)
+    expect(result.map((item) => item.id)).toEqual(['s1', 's2', 's3'])
+  })
+
+  test('does not mutate the original array', () => {
+    const items: SubtitleItem[] = [
+      { id: 's2', sourceStart: 5, sourceEnd: 7, text: 'second', templateId: 't1', styleOverrides: {} },
+      { id: 's1', sourceStart: 1, sourceEnd: 3, text: 'first', templateId: 't1', styleOverrides: {} },
+    ]
+    sortSubtitleItemsByStart(items)
+    expect(items[0].id).toBe('s2')
+  })
+
+  test('returns empty array for empty input', () => {
+    expect(sortSubtitleItemsByStart([])).toEqual([])
+  })
+})

--- a/projects/edit-vid2/tests/features/subtitles.test.ts
+++ b/projects/edit-vid2/tests/features/subtitles.test.ts
@@ -1,10 +1,6 @@
 import { describe, expect, test } from 'bun:test'
-import {
-  getRenderableSubtitles,
-  isRenderableSubtitle,
-  sortSubtitleItemsByStart,
-} from '#/shared/subtitles'
 import type { SubtitleItem } from '#/shared/schemas'
+import { getRenderableSubtitles, isRenderableSubtitle, sortSubtitleItemsByStart } from '#/shared/subtitles'
 
 describe('isRenderableSubtitle', () => {
   test('returns true for non-empty text', () => {


### PR DESCRIPTION
## Issues

- Refs #1068

## Why

Phase 1 of the track-based subtitle editor migration. The current right panel lists subtitles vertically in insertion order, pushing the export button far down as the list grows. We need to sort subtitles by `sourceStart` and keep the export panel always accessible.

## Summary

Sort subtitle items by `sourceStart` ascending for both the right panel list and the timeline bar, convert the subtitle list into a scrollable area, and pin the export panel to the bottom of the right panel.

## Changes

- Add `sortSubtitleItemsByStart` helper in `src/shared/subtitles.ts`
- Sort subtitles by `sourceStart` in the editor page (right panel + timeline)
- Restructure right panel layout with a scrollable subtitle list and a fixed bottom export panel
- Add unit tests for subtitle helpers including the new sort function

## Verification

- `bun run format:check` - passed
- `bun run lint` - passed
- `bun test` - 54 pass, 0 fail
- `bun run build` - passed
