### PR TITLE
feat(edit-vid2): Phase 2 - timeline subtitle clip drag/move/resize and detail form

### DIFF
--- a/projects/edit-vid2/src/client/features/editor/page.tsx
+++ b/projects/edit-vid2/src/client/features/editor/page.tsx
@@ -24,6 +24,7 @@ export function EditorPage() {
   const [currentTime, setCurrentTime] = useState(0)
   const [duration, setDuration] = useState(0)
   const [showLinkVideo, setShowLinkVideo] = useState(false)
+  const [selectedSubtitleId, setSelectedSubtitleId] = useState<string | null>(null)
 
   const { data: project } = useQuery<Project>({
     queryKey: ['project', projectId],
@@ -70,8 +71,8 @@ export function EditorPage() {
   })
 
   const saveTimelineState = useCallback(
-    (newState: TimelineStateV1) => {
-      updateProject.mutate({ timelineState: newState })
+    (newState: TimelineStateV1, options?: { onSuccess?: () => void }) => {
+      updateProject.mutate({ timelineState: newState }, { onSuccess: options?.onSuccess })
     },
     [updateProject]
   )
@@ -111,7 +112,10 @@ export function EditorPage() {
     const updatedTracks = subTrack
       ? timelineState.tracks.map((t) => (t.type === 'subtitle' ? { ...t, items: [...t.items, newItem] } : t))
       : [...timelineState.tracks, { id: uuidv7(), type: 'subtitle' as const, items: [newItem] }]
-    saveTimelineState({ ...timelineState, tracks: updatedTracks })
+    saveTimelineState(
+      { ...timelineState, tracks: updatedTracks },
+      { onSuccess: () => setSelectedSubtitleId(newItem.id) }
+    )
   }
 
   const subItems: SubtitleItem[] = timelineState.tracks.find((t) => t.type === 'subtitle')?.items ?? []
@@ -221,38 +225,50 @@ export function EditorPage() {
           </div>
 
           <div className='flex min-h-0 flex-1 flex-col px-4'>
-            <h2 className='mb-3 shrink-0 text-sm font-semibold text-gray-700 dark:text-gray-300'>
-              字幕 ({renderableSubItems.length})
-            </h2>
-            <div className='min-h-0 flex-1 space-y-2 overflow-y-auto pr-1'>
-              {sortedSubItems.map((sub) => (
-                <SubtitleEditorItem
-                  key={sub.id}
-                  item={sub}
-                  templates={templates ?? []}
-                  duration={mediaDuration}
-                  onChange={(updated) => {
-                    const newItems = subItems.map((s) => (s.id === updated.id ? updated : s))
-                    const newTracks = timelineState.tracks.map((t) =>
-                      t.type === 'subtitle' ? { ...t, items: newItems } : t
-                    )
-                    saveTimelineState({ ...timelineState, tracks: newTracks })
-                  }}
-                  onDelete={() => {
-                    const newItems = subItems.filter((s) => s.id !== sub.id)
-                    const newTracks = timelineState.tracks.map((t) =>
-                      t.type === 'subtitle' ? { ...t, items: newItems } : t
-                    )
-                    saveTimelineState({ ...timelineState, tracks: newTracks })
-                  }}
-                />
-              ))}
-              {sortedSubItems.length === 0 && (
-                <p className='text-xs text-gray-400 dark:text-gray-500'>
-                  字幕がありません。「字幕追加」ボタンまたは A キーで追加できます。
+            {selectedSubtitleId ? (
+              (() => {
+                const selectedItem = sortedSubItems.find((s) => s.id === selectedSubtitleId)
+                if (!selectedItem) {
+                  return (
+                    <div className='flex flex-1 flex-col items-center justify-center text-center'>
+                      <Type className='mb-2 h-8 w-8 text-gray-300 dark:text-gray-600' />
+                      <p className='text-sm text-gray-500 dark:text-gray-400'>選択した字幕が見つかりません</p>
+                    </div>
+                  )
+                }
+                return (
+                  <SubtitleDetailForm
+                    key={selectedSubtitleId}
+                    item={selectedItem}
+                    templates={templates ?? []}
+                    duration={mediaDuration}
+                    onChange={(updated) => {
+                      const newItems = subItems.map((s) => (s.id === updated.id ? updated : s))
+                      const newTracks = timelineState.tracks.map((t) =>
+                        t.type === 'subtitle' ? { ...t, items: newItems } : t
+                      )
+                      saveTimelineState({ ...timelineState, tracks: newTracks })
+                    }}
+                    onDelete={() => {
+                      const newItems = subItems.filter((s) => s.id !== selectedSubtitleId)
+                      const newTracks = timelineState.tracks.map((t) =>
+                        t.type === 'subtitle' ? { ...t, items: newItems } : t
+                      )
+                      setSelectedSubtitleId(null)
+                      saveTimelineState({ ...timelineState, tracks: newTracks })
+                    }}
+                  />
+                )
+              })()
+            ) : (
+              <div className='flex flex-1 flex-col items-center justify-center text-center'>
+                <Type className='mb-2 h-8 w-8 text-gray-300 dark:text-gray-600' />
+                <p className='text-sm text-gray-500 dark:text-gray-400'>字幕を選択すると詳細が表示されます</p>
+                <p className='mt-1 text-xs text-gray-400 dark:text-gray-500'>
+                  タイムラインのクリップをクリックするか、「字幕追加」ボタンで追加してください
                 </p>
-              )}
-            </div>
+              </div>
+            )}
           </div>
 
           <div className='shrink-0 border-t border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800'>
@@ -266,6 +282,13 @@ export function EditorPage() {
         currentTime={currentTime}
         keepSegments={timelineState.keepSegments}
         subtitleItems={renderableSubItems}
+        selectedId={selectedSubtitleId}
+        onSelect={setSelectedSubtitleId}
+        onChange={(updated) => {
+          const newItems = subItems.map((s) => (s.id === updated.id ? updated : s))
+          const newTracks = timelineState.tracks.map((t) => (t.type === 'subtitle' ? { ...t, items: newItems } : t))
+          saveTimelineState({ ...timelineState, tracks: newTracks })
+        }}
         onPause={() => videoRef.current?.pause()}
         onSeek={(t) => {
           if (videoRef.current) {
@@ -592,7 +615,7 @@ function TrimPanel({
   )
 }
 
-function SubtitleEditorItem({
+function SubtitleDetailForm({
   item,
   templates,
   duration,
@@ -606,9 +629,9 @@ function SubtitleEditorItem({
   onDelete: () => void
 }) {
   return (
-    <div className='rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-600 dark:bg-gray-800'>
-      <div className='mb-2 flex items-center gap-2'>
-        <SubtitleTextInput item={item} onChange={onChange} />
+    <div data-testid='subtitle-detail-form' className='flex min-h-0 flex-1 flex-col overflow-y-auto py-4'>
+      <div className='mb-4 flex items-center justify-between'>
+        <h2 className='text-sm font-semibold text-gray-700 dark:text-gray-300'>字幕詳細</h2>
         <button
           onClick={onDelete}
           className='rounded p-1 text-gray-400 hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-900 dark:hover:text-red-400'
@@ -618,45 +641,54 @@ function SubtitleEditorItem({
           <X className='h-3.5 w-3.5' />
         </button>
       </div>
-      <div className='grid grid-cols-2 gap-2'>
+      <div className='space-y-3'>
         <div>
-          <label className='block text-xs text-gray-500 dark:text-gray-400'>開始 (秒)</label>
-          <input
-            type='number'
-            value={item.sourceStart}
-            step={0.1}
-            min={0}
-            max={duration}
-            onChange={(e) => onChange({ ...item, sourceStart: Number(e.target.value) })}
-            className='w-full rounded border border-gray-300 px-2 py-1 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100'
-          />
+          <label className='mb-1 block text-xs text-gray-500 dark:text-gray-400'>テキスト</label>
+          <SubtitleTextInput item={item} onChange={onChange} />
         </div>
-        <div>
-          <label className='block text-xs text-gray-500 dark:text-gray-400'>終了 (秒)</label>
-          <input
-            type='number'
-            value={item.sourceEnd}
-            step={0.1}
-            min={0}
-            max={duration}
-            onChange={(e) => onChange({ ...item, sourceEnd: Number(e.target.value) })}
-            className='w-full rounded border border-gray-300 px-2 py-1 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100'
-          />
+        <div className='grid grid-cols-2 gap-3'>
+          <div>
+            <label className='block text-xs text-gray-500 dark:text-gray-400'>開始 (秒)</label>
+            <input
+              type='number'
+              value={item.sourceStart}
+              step={0.1}
+              min={0}
+              max={duration}
+              onChange={(e) => onChange({ ...item, sourceStart: Number(e.target.value) })}
+              className='w-full rounded border border-gray-300 px-2 py-1 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100'
+            />
+          </div>
+          <div>
+            <label className='block text-xs text-gray-500 dark:text-gray-400'>終了 (秒)</label>
+            <input
+              type='number'
+              value={item.sourceEnd}
+              step={0.1}
+              min={0}
+              max={duration}
+              onChange={(e) => onChange({ ...item, sourceEnd: Number(e.target.value) })}
+              className='w-full rounded border border-gray-300 px-2 py-1 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100'
+            />
+          </div>
         </div>
+        {templates.length > 0 && (
+          <div>
+            <label className='mb-1 block text-xs text-gray-500 dark:text-gray-400'>テンプレート</label>
+            <select
+              value={item.templateId}
+              onChange={(e) => onChange({ ...item, templateId: e.target.value })}
+              className='w-full rounded border border-gray-300 px-2 py-1 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100'
+            >
+              {templates.map((t) => (
+                <option key={t.id} value={t.id}>
+                  {t.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
       </div>
-      {templates.length > 0 && (
-        <select
-          value={item.templateId}
-          onChange={(e) => onChange({ ...item, templateId: e.target.value })}
-          className='mt-2 w-full rounded border border-gray-300 px-2 py-1 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100'
-        >
-          {templates.map((t) => (
-            <option key={t.id} value={t.id}>
-              {t.name}
-            </option>
-          ))}
-        </select>
-      )}
     </div>
   )
 }
@@ -737,11 +769,16 @@ function SubtitleTextInput({ item, onChange }: { item: SubtitleItem; onChange: (
   )
 }
 
+type DragMode = 'move' | 'resize-start' | 'resize-end'
+
 function TimelineBar({
   duration,
   currentTime,
   keepSegments,
   subtitleItems,
+  selectedId,
+  onSelect,
+  onChange,
   onPause,
   onSeek,
 }: {
@@ -749,11 +786,24 @@ function TimelineBar({
   currentTime: number
   keepSegments: KeepSegment[]
   subtitleItems: SubtitleItem[]
+  selectedId: string | null
+  onSelect: (id: string | null) => void
+  onChange: (item: SubtitleItem) => void
   onPause: () => void
   onSeek: (time: number) => void
 }) {
   const barRef = useRef<HTMLDivElement>(null)
-  const draggingRef = useRef(false)
+  const seekingRef = useRef(false)
+  const dragRef = useRef<{
+    id: string
+    mode: DragMode
+    startX: number
+    startSourceStart: number
+    startSourceEnd: number
+    previewSourceStart: number
+    previewSourceEnd: number
+  } | null>(null)
+  const [dragPreview, setDragPreview] = useState<{ id: string; sourceStart: number; sourceEnd: number } | null>(null)
   const toPercent = (value: number) => (duration > 0 ? (value / duration) * 100 : 0)
   const toWidthPercent = (start: number, end: number) => (duration > 0 ? ((end - start) / duration) * 100 : 0)
 
@@ -765,19 +815,104 @@ function TimelineBar({
     return Math.max(0, Math.min(ratio * duration, duration))
   }
 
+  const calcDeltaTime = (clientX: number) => {
+    const bar = barRef.current
+    if (!bar || duration === 0) return 0
+    const rect = bar.getBoundingClientRect()
+    return ((clientX - rect.left) / rect.width) * duration - calcTime(dragRef.current?.startX ?? clientX)
+  }
+
+  const clampItemRange = (nextStart: number, nextEnd: number) => {
+    const minLength = 0.1
+    const sourceStart = Math.max(0, Math.min(roundTime(nextStart), duration - minLength))
+    const sourceEnd = Math.max(sourceStart + minLength, Math.min(roundTime(nextEnd), duration))
+    return { sourceStart, sourceEnd }
+  }
+
+  const stopDrag = () => {
+    dragRef.current = null
+    setDragPreview(null)
+    document.removeEventListener('mousemove', handleItemMouseMove)
+    document.removeEventListener('mouseup', handleItemMouseUp)
+  }
+
+  const handleItemMouseMove = (ev: MouseEvent) => {
+    const drag = dragRef.current
+    if (!drag) return
+    ev.preventDefault()
+    const delta = calcDeltaTime(ev.clientX)
+    const { id, mode, startSourceStart, startSourceEnd } = drag
+    let nextStart = startSourceStart
+    let nextEnd = startSourceEnd
+    if (mode === 'move') {
+      const originalDuration = startSourceEnd - startSourceStart
+      nextStart = startSourceStart + delta
+      nextEnd = startSourceEnd + delta
+      if (nextEnd > duration) {
+        nextEnd = duration
+        nextStart = Math.max(0, duration - originalDuration)
+      }
+      if (nextStart < 0) {
+        nextStart = 0
+        nextEnd = Math.min(duration, originalDuration)
+      }
+    } else if (mode === 'resize-start') {
+      nextStart = startSourceStart + delta
+    } else {
+      nextEnd = startSourceEnd + delta
+    }
+    const { sourceStart, sourceEnd } = clampItemRange(nextStart, nextEnd)
+    drag.previewSourceStart = sourceStart
+    drag.previewSourceEnd = sourceEnd
+    setDragPreview({ id, sourceStart, sourceEnd })
+  }
+
+  const handleItemMouseUp = () => {
+    const drag = dragRef.current
+    if (drag) {
+      const item = subtitleItems.find((s) => s.id === drag.id)
+      if (item) {
+        const { sourceStart, sourceEnd } = clampItemRange(drag.previewSourceStart, drag.previewSourceEnd)
+        if (sourceStart !== item.sourceStart || sourceEnd !== item.sourceEnd) {
+          onChange({ ...item, sourceStart, sourceEnd })
+        }
+      }
+    }
+    stopDrag()
+  }
+
+  const startItemDrag = (e: React.MouseEvent, item: SubtitleItem, mode: DragMode) => {
+    e.stopPropagation()
+    if (e.button !== 0) return
+    onPause()
+    onSelect(item.id)
+    dragRef.current = {
+      id: item.id,
+      mode,
+      startX: e.clientX,
+      startSourceStart: item.sourceStart,
+      startSourceEnd: item.sourceEnd,
+      previewSourceStart: item.sourceStart,
+      previewSourceEnd: item.sourceEnd,
+    }
+    document.addEventListener('mousemove', handleItemMouseMove)
+    document.addEventListener('mouseup', handleItemMouseUp)
+  }
+
   const handleMouseDown = (e: React.MouseEvent) => {
     if (e.button !== 0) return
-    draggingRef.current = true
+    onSelect(null)
+    seekingRef.current = true
     onPause()
     onSeek(calcTime(e.clientX))
 
     const handleMouseMove = (ev: MouseEvent) => {
-      if (!draggingRef.current) return
+      if (!seekingRef.current) return
       onSeek(calcTime(ev.clientX))
     }
 
     const handleMouseUp = () => {
-      draggingRef.current = false
+      seekingRef.current = false
       document.removeEventListener('mousemove', handleMouseMove)
       document.removeEventListener('mouseup', handleMouseUp)
     }
@@ -788,26 +923,26 @@ function TimelineBar({
 
   const handleTouchStart = (e: React.TouchEvent) => {
     if (e.touches.length === 0) return
-    draggingRef.current = true
+    seekingRef.current = true
     onPause()
     onSeek(calcTime(e.touches[0].clientX))
   }
 
   const handleTouchMove = (e: React.TouchEvent) => {
-    if (!draggingRef.current || e.touches.length === 0) return
+    if (!seekingRef.current || e.touches.length === 0) return
     onSeek(calcTime(e.touches[0].clientX))
   }
 
   const handleTouchEnd = () => {
-    draggingRef.current = false
+    seekingRef.current = false
   }
 
   return (
-    <div className='h-20 border-t border-gray-200 bg-white px-4 py-3 dark:border-gray-700 dark:bg-gray-800'>
+    <div className='h-24 border-t border-gray-200 bg-white px-4 py-3 dark:border-gray-700 dark:bg-gray-800'>
       <div
         ref={barRef}
         data-testid='timeline-seek-bar'
-        className='relative h-10 cursor-pointer rounded bg-gray-100 dark:bg-gray-700'
+        className='relative h-14 cursor-pointer rounded bg-gray-100 dark:bg-gray-700'
         onMouseDown={handleMouseDown}
         onTouchStart={handleTouchStart}
         onTouchMove={handleTouchMove}
@@ -824,18 +959,49 @@ function TimelineBar({
           />
         ))}
 
-        {subtitleItems.map((sub) => (
-          <div
-            key={sub.id}
-            data-testid='timeline-subtitle-item'
-            className='absolute bottom-0 h-3 rounded bg-indigo-400/70 dark:bg-indigo-500/50'
-            style={{
-              left: `${toPercent(sub.sourceStart)}%`,
-              width: `${toWidthPercent(sub.sourceStart, sub.sourceEnd)}%`,
-            }}
-            title={sub.text || '(空)'}
-          />
-        ))}
+        {subtitleItems.map((sub) => {
+          const isSelected = sub.id === selectedId
+          const preview = dragPreview?.id === sub.id ? dragPreview : null
+          const sourceStart = preview?.sourceStart ?? sub.sourceStart
+          const sourceEnd = preview?.sourceEnd ?? sub.sourceEnd
+          return (
+            <div
+              key={sub.id}
+              data-testid='timeline-subtitle-item'
+              data-subtitle-id={sub.id}
+              onMouseDown={(e) => startItemDrag(e, sub, 'move')}
+              onClick={(e) => {
+                e.stopPropagation()
+                onSelect(sub.id)
+              }}
+              className={[
+                'group absolute bottom-1 h-5 cursor-grab rounded border border-indigo-500/30 bg-indigo-400/70 dark:bg-indigo-500/50',
+                isSelected ? 'ring-2 ring-indigo-500' : '',
+              ].join(' ')}
+              style={{
+                left: `${toPercent(sourceStart)}%`,
+                width: `${toWidthPercent(sourceStart, sourceEnd)}%`,
+                minWidth: '4px',
+              }}
+              title={sub.text || '(空)'}
+            >
+              {isSelected && (
+                <>
+                  <div
+                    data-testid='timeline-subtitle-resize-start'
+                    onMouseDown={(e) => startItemDrag(e, sub, 'resize-start')}
+                    className='absolute -left-1.5 top-0 h-full w-3 cursor-w-resize'
+                  />
+                  <div
+                    data-testid='timeline-subtitle-resize-end'
+                    onMouseDown={(e) => startItemDrag(e, sub, 'resize-end')}
+                    className='absolute -right-1.5 top-0 h-full w-3 cursor-e-resize'
+                  />
+                </>
+              )}
+            </div>
+          )
+        })}
 
         <div className='absolute top-0 h-full w-0.5 bg-red-500' style={{ left: `${toPercent(currentTime)}%` }} />
       </div>

--- a/projects/edit-vid2/tests/e2e/editor.spec.ts
+++ b/projects/edit-vid2/tests/e2e/editor.spec.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test'
 import type { Locator, Page, Request } from 'playwright'
 import { BASE_URL, setupE2E, teardownE2E, TEST_PROJECT_ID } from './setup'
 
@@ -67,14 +67,17 @@ async function waitForPlaybackState(paused: boolean): Promise<void> {
 }
 
 async function addSubtitle(): Promise<Locator> {
-  const inputs = page.getByPlaceholder('字幕テキスト')
-  const before = await inputs.count()
   await page.getByRole('button', { name: /字幕追加/ }).click()
+  const input = page.getByPlaceholder('字幕テキスト')
+  await input.waitFor({ state: 'visible', timeout: 5000 })
   await page.waitForFunction(
-    ({ placeholder, count }) => document.querySelectorAll(`input[placeholder="${placeholder}"]`).length > count,
-    { placeholder: '字幕テキスト', count: before }
+    () => {
+      const el = document.querySelector('input[placeholder="字幕テキスト"]') as HTMLInputElement | null
+      return el && el.value === ''
+    },
+    { timeout: 5000 }
   )
-  return inputs.last()
+  return input
 }
 
 function trackProjectPatchRequests() {
@@ -300,6 +303,55 @@ async function expectProjectTrimStart(value: number): Promise<void> {
   expect(project.timelineState?.keepSegments?.[0]?.sourceStart).toBe(value)
 }
 
+async function getSubtitleClipById(id: string): Promise<Locator> {
+  return page.locator(`[data-testid="timeline-subtitle-item"][data-subtitle-id="${id}"]`)
+}
+
+async function addSubtitleWithText(
+  text: string
+): Promise<{ input: Locator; item: NonNullable<Awaited<ReturnType<typeof getLatestSubtitleItem>>> }> {
+  const input = await addSubtitle()
+  const patchResponse = waitForProjectPatchResponse()
+  await input.fill(text)
+  await patchResponse
+  const item = await getLatestSubtitleItem()
+  expect(item).not.toBeNull()
+  return { input, item: item! }
+}
+
+async function clearSubtitles(): Promise<void> {
+  const response = await fetch(`${BASE_URL}/api/projects/${TEST_PROJECT_ID}`)
+  expect(response.ok).toBe(true)
+  const project = await response.json()
+  const tracks = project.timelineState?.tracks ?? []
+  const newTracks = tracks.map((track: { type: string; id: string; items: unknown[] }) =>
+    track.type === 'subtitle' ? { ...track, items: [] } : track
+  )
+  const patch = await fetch(`${BASE_URL}/api/projects/${TEST_PROJECT_ID}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ timelineState: { ...project.timelineState, tracks: newTracks } }),
+  })
+  expect(patch.ok).toBe(true)
+  await page.reload()
+  await page.waitForSelector('video', { timeout: 10000 })
+}
+
+async function getLatestSubtitleItem(): Promise<{
+  id: string
+  sourceStart: number
+  sourceEnd: number
+  text: string
+} | null> {
+  const response = await page.request.get(`${BASE_URL}/api/projects/${TEST_PROJECT_ID}`)
+  expect(response.ok()).toBe(true)
+  const project = await response.json()
+  const items: Array<{ id: string; sourceStart: number; sourceEnd: number; text: string }> =
+    project.timelineState?.tracks?.find((track: { type: string }) => track.type === 'subtitle')?.items ?? []
+  if (items.length === 0) return null
+  return items.sort((a, b) => a.sourceStart - b.sourceStart)[items.length - 1]
+}
+
 describe('Trim time input', () => {
   test('commits start time on blur, not while typing', async () => {
     await resetVideo()
@@ -352,5 +404,83 @@ describe('Trim time input', () => {
       ;(node as HTMLInputElement).blur()
     })
     expect(await input.inputValue()).toBe('2.0')
+  })
+})
+
+describe('Timeline subtitle clip interaction', () => {
+  beforeEach(async () => {
+    await clearSubtitles()
+    await resetVideo()
+  })
+
+  test('clicking a clip selects it and shows the detail form', async () => {
+    const { item } = await addSubtitleWithText('select me')
+
+    const detailForm = page.getByTestId('subtitle-detail-form')
+    await detailForm.waitFor({ state: 'visible', timeout: 5000 })
+
+    // Deselect first by clicking the timeline seek bar empty area.
+    const bar = seekBar()
+    const barBox = await bar.boundingBox()
+    if (!barBox) throw new Error('Seek bar not found')
+    await page.mouse.click(barBox.x + 1, barBox.y + barBox.height / 2)
+
+    const clip = await getSubtitleClipById(item.id)
+    await clip.click()
+
+    const selectedInput = page.getByPlaceholder('字幕テキスト')
+    expect(await selectedInput.inputValue()).toBe('select me')
+  })
+
+  test('dragging a clip body shifts sourceStart and sourceEnd', async () => {
+    const { item } = await addSubtitleWithText('drag me')
+
+    const clip = await getSubtitleClipById(item.id)
+    const box = await clip.boundingBox()
+    if (!box) throw new Error('Subtitle clip not found')
+
+    const startX = box.x + box.width / 2
+    const endX = startX + 40
+    const y = box.y + box.height / 2
+
+    const patchResponse = waitForProjectPatchResponse()
+    await page.mouse.move(startX, y)
+    await page.mouse.down()
+    await page.mouse.move(endX, y, { steps: 10 })
+    await page.mouse.up()
+    await patchResponse
+
+    const after = await getLatestSubtitleItem()
+    expect(after).not.toBeNull()
+    expect(after!.sourceStart).toBeGreaterThan(item.sourceStart)
+    expect(after!.sourceEnd - after!.sourceStart).toBeCloseTo(item.sourceEnd - item.sourceStart, 1)
+  })
+
+  test('dragging the right edge resizes sourceEnd', async () => {
+    const { item } = await addSubtitleWithText('resize me')
+
+    const clip = await getSubtitleClipById(item.id)
+    const box = await clip.boundingBox()
+    if (!box) throw new Error('Subtitle clip not found')
+
+    const handle = clip.locator('[data-testid="timeline-subtitle-resize-end"]')
+    const handleBox = await handle.boundingBox()
+    if (!handleBox) throw new Error('Resize handle not found')
+
+    const startX = handleBox.x + handleBox.width / 2
+    const endX = startX + 30
+    const y = handleBox.y + handleBox.height / 2
+
+    const patchResponse = waitForProjectPatchResponse()
+    await page.mouse.move(startX, y)
+    await page.mouse.down()
+    await page.mouse.move(endX, y, { steps: 10 })
+    await page.mouse.up()
+    await patchResponse
+
+    const after = await getLatestSubtitleItem()
+    expect(after).not.toBeNull()
+    expect(after!.sourceEnd).toBeGreaterThan(item.sourceEnd)
+    expect(after!.sourceStart).toBeCloseTo(item.sourceStart, 1)
   })
 })


### PR DESCRIPTION
## Issues

- Refs #1068

## Why

Phase 2 of the track-based subtitle editor migration. After sorting and pinning the export panel in Phase 1, we now need to make subtitle clips interactive on the timeline and replace the scrolled list with a detail form for the selected clip.

## Summary

Add drag-to-move and edge-drag-to-resize to `TimelineBar` subtitle clips, replace the right-panel subtitle list with a selected-item detail form, and auto-select newly created subtitles.

## Changes

- Extend `TimelineBar` to render subtitle clips with selection state and resize handles
- Implement `mousedown`/`mousemove`/`mouseup` drag handlers for clip body (move) and edges (resize start/end)
- Add `selectedSubtitleId` state to `EditorPage` and pass it through `TimelineBar`
- Replace the right-panel scrollable subtitle list with `SubtitleDetailForm` for the selected subtitle
- Auto-select a newly added subtitle after the creation PATCH succeeds
- Deselect the current subtitle when clicking empty timeline area
- Update `addSubtitle` E2E helper for the single-detail-form UI
- Add E2E tests for clip selection, body drag, and right-edge resize

## Verification

- `bun run format:check` - passed
- `bun run lint` - passed
- `bun test` - 57 pass, 0 fail
- `bun run build` - passed

## Details

- Clips are constrained to `[0, duration]` and maintain their duration when dragged against the boundaries.
- Drag/resize uses global mouse listeners that are cleaned up on `mouseup`, matching the issue's guidance to avoid `useEffect`.
- The right panel keeps `ExportPanel` fixed at the bottom from Phase 1; the upper area now shows either the detail form or an empty-state placeholder.
