### PR TITLE
[edit-vid2] Add subtitle preview panel

### DIFF
--- a/projects/edit-vid2/src/client/features/editor/page.tsx
+++ b/projects/edit-vid2/src/client/features/editor/page.tsx
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useParams } from '@tanstack/react-router'
 import { Link } from '@tanstack/react-router'
-import { ArrowLeft, Download, FileVideo, Link2, RotateCcw, Type, X } from 'lucide-react'
+import { ArrowLeft, Download, FileVideo, ImageIcon, Link2, LoaderCircle, RotateCcw, Type, X } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent, type KeyboardEvent } from 'react'
 import { uuidv7 } from 'uuidv7'
 import { JobCard, type ExportJob } from '#/client/features/exports/job-card'
@@ -239,9 +239,11 @@ export function EditorPage() {
                 return (
                   <SubtitleDetailForm
                     key={selectedSubtitleId}
+                    projectId={projectId}
                     item={selectedItem}
                     templates={templates ?? []}
                     duration={mediaDuration}
+                    canPreview={hasVideo}
                     onChange={(updated) => {
                       const newItems = subItems.map((s) => (s.id === updated.id ? updated : s))
                       const newTracks = timelineState.tracks.map((t) =>
@@ -616,18 +618,50 @@ function TrimPanel({
 }
 
 function SubtitleDetailForm({
+  projectId,
   item,
   templates,
   duration,
+  canPreview,
   onChange,
   onDelete,
 }: {
+  projectId: string
   item: SubtitleItem
   templates: SubtitleTemplate[]
   duration: number
+  canPreview: boolean
   onChange: (item: SubtitleItem) => void
   onDelete: () => void
 }) {
+  const previewText = item.text.trim()
+  const previewSourceTime = Math.max(0, Number(item.sourceStart.toFixed(2)))
+  const previewQuery = useQuery<{ path: string; cached: boolean }>({
+    queryKey: ['subtitle-preview', projectId, item.id, previewSourceTime, previewText, item.templateId],
+    enabled: canPreview && previewText.length > 0,
+    queryFn: async () => {
+      const res = await fetch(`/api/projects/${projectId}/previews/subtitle`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          sourceTime: previewSourceTime,
+          text: previewText,
+          templateId: item.templateId,
+        }),
+      })
+      if (!res.ok) {
+        const body = (await res.json().catch(() => null)) as { error?: string } | null
+        throw new Error(body?.error ?? 'preview generation failed')
+      }
+      return res.json()
+    },
+  })
+  const previewSrc = previewQuery.data?.path
+    ? previewQuery.data.path.startsWith('/')
+      ? previewQuery.data.path
+      : `/${previewQuery.data.path}`
+    : null
+
   return (
     <div data-testid='subtitle-detail-form' className='flex min-h-0 flex-1 flex-col overflow-y-auto py-4'>
       <div className='mb-4 flex items-center justify-between'>
@@ -688,6 +722,38 @@ function SubtitleDetailForm({
             </select>
           </div>
         )}
+        <section
+          data-testid='subtitle-preview'
+          className='overflow-hidden rounded-lg border border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-900'
+        >
+          <div className='flex items-center gap-2 border-b border-gray-200 px-3 py-2 dark:border-gray-700'>
+            <ImageIcon className='h-3.5 w-3.5 text-gray-500 dark:text-gray-400' />
+            <h3 className='text-xs font-medium text-gray-600 dark:text-gray-300'>静止画プレビュー</h3>
+          </div>
+          <div className='flex aspect-video items-center justify-center bg-gray-100 text-xs text-gray-500 dark:bg-gray-950 dark:text-gray-400'>
+            {!canPreview ? (
+              <span>元動画が必要です</span>
+            ) : previewText.length === 0 ? (
+              <span>テキスト入力後に表示されます</span>
+            ) : previewQuery.isFetching ? (
+              <span className='inline-flex items-center gap-2'>
+                <LoaderCircle className='h-3.5 w-3.5 animate-spin' />
+                生成中...
+              </span>
+            ) : previewQuery.isError ? (
+              <span>プレビューを生成できませんでした</span>
+            ) : previewSrc ? (
+              <img
+                data-testid='subtitle-preview-image'
+                src={previewSrc}
+                alt='字幕プレビュー'
+                className='h-full w-full object-contain'
+              />
+            ) : (
+              <span>プレビュー未生成</span>
+            )}
+          </div>
+        </section>
       </div>
     </div>
   )

--- a/projects/edit-vid2/src/client/features/editor/page.tsx
+++ b/projects/edit-vid2/src/client/features/editor/page.tsx
@@ -735,7 +735,7 @@ function SubtitleDetailForm({
               <span>元動画が必要です</span>
             ) : previewText.length === 0 ? (
               <span>テキスト入力後に表示されます</span>
-            ) : previewQuery.isFetching ? (
+            ) : previewQuery.isPending ? (
               <span className='inline-flex items-center gap-2'>
                 <LoaderCircle className='h-3.5 w-3.5 animate-spin' />
                 生成中...

--- a/projects/edit-vid2/tests/e2e/editor.spec.ts
+++ b/projects/edit-vid2/tests/e2e/editor.spec.ts
@@ -1,11 +1,29 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test'
-import type { Locator, Page, Request } from 'playwright'
+import type { Locator, Page, Request, Route } from 'playwright'
 import { BASE_URL, setupE2E, teardownE2E, TEST_PROJECT_ID } from './setup'
 
 let page: Page
 
+const e2ePreviewImagePath = 'data/e2e-subtitle-preview.svg'
+const e2ePreviewImageBody =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="320" height="180"><rect width="320" height="180" fill="black"/><text x="160" y="100" fill="white" text-anchor="middle">preview</text></svg>'
+
 beforeAll(async () => {
   ;({ page } = await setupE2E())
+  await page.route('**/api/projects/*/previews/subtitle', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ path: e2ePreviewImagePath, cached: false }),
+    })
+  })
+  await page.route(`**/${e2ePreviewImagePath}`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'image/svg+xml',
+      body: e2ePreviewImageBody,
+    })
+  })
   await page.goto(`${BASE_URL}/projects/${TEST_PROJECT_ID}`)
   await page.waitForSelector('video', { timeout: 10000 })
   await page.waitForFunction(
@@ -19,7 +37,7 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await teardownE2E(page)
-}, 10000)
+}, 15000)
 
 async function getTimeDisplay(): Promise<string> {
   return (await page.getByTestId('timeline-current-time').textContent()) ?? ''
@@ -342,11 +360,12 @@ async function getLatestSubtitleItem(): Promise<{
   sourceStart: number
   sourceEnd: number
   text: string
+  templateId: string
 } | null> {
   const response = await page.request.get(`${BASE_URL}/api/projects/${TEST_PROJECT_ID}`)
   expect(response.ok()).toBe(true)
   const project = await response.json()
-  const items: Array<{ id: string; sourceStart: number; sourceEnd: number; text: string }> =
+  const items: Array<{ id: string; sourceStart: number; sourceEnd: number; text: string; templateId: string }> =
     project.timelineState?.tracks?.find((track: { type: string }) => track.type === 'subtitle')?.items ?? []
   if (items.length === 0) return null
   return items.sort((a, b) => a.sourceStart - b.sourceStart)[items.length - 1]
@@ -411,7 +430,7 @@ describe('Timeline subtitle clip interaction', () => {
   beforeEach(async () => {
     await clearSubtitles()
     await resetVideo()
-  })
+  }, 10000)
 
   test('clicking a clip selects it and shows the detail form', async () => {
     const { item } = await addSubtitleWithText('select me')
@@ -430,6 +449,39 @@ describe('Timeline subtitle clip interaction', () => {
 
     const selectedInput = page.getByPlaceholder('字幕テキスト')
     expect(await selectedInput.inputValue()).toBe('select me')
+  })
+
+  test('selecting a subtitle requests and shows a still preview', async () => {
+    const previewRoute = async (route: Route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ path: e2ePreviewImagePath, cached: false }),
+      })
+    }
+
+    await page.route(`**/api/projects/${TEST_PROJECT_ID}/previews/subtitle`, previewRoute)
+
+    try {
+      const previewResponsePromise = page.waitForResponse(
+        (res) =>
+          res.request().method() === 'POST' && res.url().includes(`/api/projects/${TEST_PROJECT_ID}/previews/subtitle`)
+      )
+      const { item } = await addSubtitleWithText('preview me')
+      const previewResponse = await previewResponsePromise
+      expect(previewResponse.ok()).toBe(true)
+      expect(previewResponse.request().postDataJSON()).toEqual({
+        sourceTime: Number(item.sourceStart.toFixed(2)),
+        text: 'preview me',
+        templateId: item.templateId,
+      })
+
+      const previewImage = page.getByTestId('subtitle-preview-image')
+      await previewImage.waitFor({ state: 'visible', timeout: 5000 })
+      expect(await previewImage.getAttribute('src')).toBe(`/${e2ePreviewImagePath}`)
+    } finally {
+      await page.unroute(`**/api/projects/${TEST_PROJECT_ID}/previews/subtitle`, previewRoute)
+    }
   })
 
   test('dragging a clip body shifts sourceStart and sourceEnd', async () => {
@@ -454,7 +506,7 @@ describe('Timeline subtitle clip interaction', () => {
     expect(after).not.toBeNull()
     expect(after!.sourceStart).toBeGreaterThan(item.sourceStart)
     expect(after!.sourceEnd - after!.sourceStart).toBeCloseTo(item.sourceEnd - item.sourceStart, 1)
-  })
+  }, 10000)
 
   test('dragging the right edge resizes sourceEnd', async () => {
     const { item } = await addSubtitleWithText('resize me')
@@ -482,5 +534,5 @@ describe('Timeline subtitle clip interaction', () => {
     expect(after).not.toBeNull()
     expect(after!.sourceEnd).toBeGreaterThan(item.sourceEnd)
     expect(after!.sourceStart).toBeCloseTo(item.sourceStart, 1)
-  })
+  }, 10000)
 })

--- a/projects/edit-vid2/tests/e2e/editor.spec.ts
+++ b/projects/edit-vid2/tests/e2e/editor.spec.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test'
-import type { Locator, Page, Request, Route } from 'playwright'
+import type { Locator, Page, Request } from 'playwright'
 import { BASE_URL, setupE2E, teardownE2E, TEST_PROJECT_ID } from './setup'
 
 let page: Page
@@ -452,36 +452,22 @@ describe('Timeline subtitle clip interaction', () => {
   })
 
   test('selecting a subtitle requests and shows a still preview', async () => {
-    const previewRoute = async (route: Route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ path: e2ePreviewImagePath, cached: false }),
-      })
-    }
+    const previewResponsePromise = page.waitForResponse(
+      (res) =>
+        res.request().method() === 'POST' && res.url().includes(`/api/projects/${TEST_PROJECT_ID}/previews/subtitle`)
+    )
+    const { item } = await addSubtitleWithText('preview me')
+    const previewResponse = await previewResponsePromise
+    expect(previewResponse.ok()).toBe(true)
+    expect(previewResponse.request().postDataJSON()).toEqual({
+      sourceTime: Number(item.sourceStart.toFixed(2)),
+      text: 'preview me',
+      templateId: item.templateId,
+    })
 
-    await page.route(`**/api/projects/${TEST_PROJECT_ID}/previews/subtitle`, previewRoute)
-
-    try {
-      const previewResponsePromise = page.waitForResponse(
-        (res) =>
-          res.request().method() === 'POST' && res.url().includes(`/api/projects/${TEST_PROJECT_ID}/previews/subtitle`)
-      )
-      const { item } = await addSubtitleWithText('preview me')
-      const previewResponse = await previewResponsePromise
-      expect(previewResponse.ok()).toBe(true)
-      expect(previewResponse.request().postDataJSON()).toEqual({
-        sourceTime: Number(item.sourceStart.toFixed(2)),
-        text: 'preview me',
-        templateId: item.templateId,
-      })
-
-      const previewImage = page.getByTestId('subtitle-preview-image')
-      await previewImage.waitFor({ state: 'visible', timeout: 5000 })
-      expect(await previewImage.getAttribute('src')).toBe(`/${e2ePreviewImagePath}`)
-    } finally {
-      await page.unroute(`**/api/projects/${TEST_PROJECT_ID}/previews/subtitle`, previewRoute)
-    }
+    const previewImage = page.getByTestId('subtitle-preview-image')
+    await previewImage.waitFor({ state: 'visible', timeout: 5000 })
+    expect(await previewImage.getAttribute('src')).toBe(`/${e2ePreviewImagePath}`)
   })
 
   test('dragging a clip body shifts sourceStart and sourceEnd', async () => {

--- a/projects/edit-vid2/tests/e2e/seed.ts
+++ b/projects/edit-vid2/tests/e2e/seed.ts
@@ -6,8 +6,9 @@ import { projects, videoAssets } from '#/db/schema'
 
 export const TEST_VIDEO_ID = 'e2e-test-video'
 export const TEST_PROJECT_ID = 'e2e-test-project'
-const TEST_DB_PATH = '/tmp/edit-vid2-test.db'
-const TEST_VIDEO_DIR = 'data/videos/e2e-test-video'
+const E2E_WORKER_KEY = (process.env.BUN_TEST_WORKER_ID ?? String(process.pid)).replace(/[^a-zA-Z0-9_-]/g, '-')
+export const TEST_DB_PATH = `/tmp/edit-vid2-test-${E2E_WORKER_KEY}.db`
+const TEST_VIDEO_DIR = `data/videos/e2e-test-video-${E2E_WORKER_KEY}`
 
 export function seedTestData() {
   try {
@@ -25,7 +26,7 @@ export function seedTestData() {
       id: TEST_VIDEO_ID,
       originalFilename: 'test-compat.mp4',
       displayName: 'E2E Test Video',
-      storagePath: 'data/videos/e2e-test-video/source.mp4',
+      storagePath: `${TEST_VIDEO_DIR}/source.mp4`,
       status: 'ready',
       duration: 5.0,
       width: 320,

--- a/projects/edit-vid2/tests/e2e/setup.ts
+++ b/projects/edit-vid2/tests/e2e/setup.ts
@@ -1,5 +1,5 @@
 import { type Browser, type Page, chromium } from 'playwright'
-import { seedTestData, TEST_DB_PATH, TEST_PROJECT_ID } from './seed'
+import { seedTestData, TEST_DB_PATH, TEST_PROJECT_ID, TEST_VIDEO_ID } from './seed'
 
 export { TEST_PROJECT_ID }
 const workerId = Number(process.env.BUN_TEST_WORKER_ID)
@@ -66,6 +66,22 @@ async function startDevServer(): Promise<void> {
   throw new Error('Dev server did not start within 30 seconds')
 }
 
+async function resetServerState(): Promise<void> {
+  const res = await fetch(`${BASE_URL}/api/projects/${TEST_PROJECT_ID}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      name: 'E2E Test Project',
+      videoAssetId: TEST_VIDEO_ID,
+      timelineState: { version: 1, tracks: [], keepSegments: [] },
+    }),
+  })
+  if (!res.ok) {
+    throw new Error(`Failed to reset E2E state: ${res.status}`)
+  }
+  await res.body?.cancel()
+}
+
 export async function setupE2E(): Promise<{ browser: Browser; page: Page }> {
   refCount++
   if (serverTeardownTimer) {
@@ -74,6 +90,8 @@ export async function setupE2E(): Promise<{ browser: Browser; page: Page }> {
   }
   if (!serverProcess) {
     await startDevServer()
+  } else {
+    await resetServerState()
   }
   if (!sharedBrowser) {
     sharedBrowser = await chromium.launch({ headless: true, args: ['--no-sandbox'] })

--- a/projects/edit-vid2/tests/e2e/setup.ts
+++ b/projects/edit-vid2/tests/e2e/setup.ts
@@ -1,10 +1,13 @@
 import { type Browser, type Page, chromium } from 'playwright'
-import { seedTestData, TEST_PROJECT_ID } from './seed'
+import { seedTestData, TEST_DB_PATH, TEST_PROJECT_ID } from './seed'
 
 export { TEST_PROJECT_ID }
-export const BASE_URL = 'http://localhost:9999'
+const workerId = Number(process.env.BUN_TEST_WORKER_ID)
+const serverPort = Number.isFinite(workerId) ? 9999 + workerId : 12000 + (process.pid % 20000)
+export const BASE_URL = `http://localhost:${serverPort}`
 
 let serverProcess: ReturnType<typeof Bun.spawn> | null = null
+let serverTeardownTimer: ReturnType<typeof setTimeout> | null = null
 let sharedBrowser: Browser | null = null
 let refCount = 0
 let seeded = false
@@ -34,7 +37,7 @@ async function startDevServer(): Promise<void> {
   await waitForServerPortAvailable()
 
   const proc = Bun.spawn(['bun', '--bun', 'vite', '--mode', 'dev', '--host', '0.0.0.0'], {
-    env: { ...process.env, SERVER_PORT: '9999', DATABASE_URL: '/tmp/edit-vid2-test.db' },
+    env: { ...process.env, SERVER_PORT: String(serverPort), DATABASE_URL: TEST_DB_PATH },
     stdout: 'pipe',
     stderr: 'pipe',
   })
@@ -65,6 +68,10 @@ async function startDevServer(): Promise<void> {
 
 export async function setupE2E(): Promise<{ browser: Browser; page: Page }> {
   refCount++
+  if (serverTeardownTimer) {
+    clearTimeout(serverTeardownTimer)
+    serverTeardownTimer = null
+  }
   if (!serverProcess) {
     await startDevServer()
   }
@@ -84,10 +91,15 @@ export async function teardownE2E(page?: Page): Promise<void> {
       sharedBrowser = null
     }
     if (serverProcess) {
-      serverProcess.kill()
-      await serverProcess.exited
-      serverProcess = null
+      serverTeardownTimer = setTimeout(() => {
+        if (refCount > 0 || !serverProcess) return
+        const proc = serverProcess
+        serverProcess = null
+        seeded = false
+        proc.kill()
+      }, 2000)
+    } else {
+      seeded = false
     }
-    seeded = false
   }
 }


### PR DESCRIPTION
## Issues

- Close #1068

## Why

Phase 3 requires the selected subtitle detail panel to automatically show a still preview using the existing subtitle preview API.

## Summary

This PR adds a still preview section to the selected subtitle detail form. It posts the selected subtitle text, template, and source start time to the existing preview endpoint and displays the returned image path.

## Changes

- Add React Query based subtitle preview fetching to `SubtitleDetailForm`
- Render loading, empty, error, and image states inside the right-panel detail form
- Add E2E coverage for preview request payload and image rendering
- Isolate E2E server/database state and delay dev server teardown to avoid cross-spec port/DB interference

## Verification

- `bun run format` - passed
- `bun run lint` - passed
- `bun test tests/e2e/editor.spec.ts` - passed
- `bun test tests/e2e/smoke.spec.ts tests/e2e/editor.spec.ts` - passed
- `bun test` - passed
- `bun run build` - passed
