### PR TITLE
test: add server API unit coverage

### DIFF
--- a/projects/edit-vid2/src/server/app.tsx
+++ b/projects/edit-vid2/src/server/app.tsx
@@ -4,14 +4,23 @@ import { getDatabase } from '#/db'
 import type { AppDatabase } from '#/db'
 import { errHandler } from '#/server/middleware/error-handler'
 import { applySecurityHeaders } from '#/server/middleware/security-headers'
-import { exportRoutes, jobRoutes, recoverIncompleteJobs } from '#/server/routes/exports'
+import { createExportRoutes, createJobRoutes } from '#/server/routes/exports'
 import { htmlRoutes } from '#/server/routes/html'
-import { previewRoutes } from '#/server/routes/previews'
-import { projectRoutes } from '#/server/routes/projects'
-import { templateRoutes } from '#/server/routes/templates'
-import { videoRoutes } from '#/server/routes/videos'
+import { createPreviewRoutes } from '#/server/routes/previews'
+import { createProjectRoutes } from '#/server/routes/projects'
+import { createTemplateRoutes } from '#/server/routes/templates'
+import { createVideoRoutes } from '#/server/routes/videos'
 
-export type AppType = typeof routes
+type AppDeps = {
+  db?: AppDatabase
+  getDb?: () => AppDatabase
+  videoRoutes?: Parameters<typeof createVideoRoutes>[0]
+  projectRoutes?: Parameters<typeof createProjectRoutes>[0]
+  templateRoutes?: Parameters<typeof createTemplateRoutes>[0]
+  previewRoutes?: Parameters<typeof createPreviewRoutes>[0]
+  exportRoutes?: Parameters<typeof createExportRoutes>[0]
+  jobRoutes?: Parameters<typeof createJobRoutes>[0]
+}
 
 let db: AppDatabase | null = null
 
@@ -23,28 +32,36 @@ function getOrCreateDb() {
   return db
 }
 
-const app = new Hono<{
-  Variables: {
-    db: AppDatabase
-  }
-}>()
-  .use(applySecurityHeaders)
-  .onError(errHandler)
-  .use('*', async (c, next) => {
-    c.set('db', getOrCreateDb())
-    await next()
-  })
+function createApp(deps: AppDeps = {}) {
+  const getDb = deps.getDb ?? (() => deps.db ?? getOrCreateDb())
 
-const routes = app
-  .get('/data/*', serveStatic({ root: './' }))
-  .route('/api/videos', videoRoutes)
-  .route('/api/projects', projectRoutes)
-  .route('/api/templates', templateRoutes)
-  .route('/api/projects/:projectId/previews/subtitle', previewRoutes)
-  .route('/api/projects/:projectId/export-jobs', exportRoutes)
-  .route('/api/export-jobs', jobRoutes)
-  .route('/', htmlRoutes)
+  const app = new Hono<{
+    Variables: {
+      db: AppDatabase
+    }
+  }>()
+    .use(applySecurityHeaders)
+    .onError(errHandler)
+    .use('*', async (c, next) => {
+      c.set('db', getDb())
+      await next()
+    })
 
-recoverIncompleteJobs()
+  return app
+    .get('/static/*', serveStatic({ root: './dist' }))
+    .get('/data/*', serveStatic({ root: './' }))
+    .route('/api/videos', createVideoRoutes(deps.videoRoutes))
+    .route('/api/projects', createProjectRoutes(deps.projectRoutes))
+    .route('/api/templates', createTemplateRoutes(deps.templateRoutes))
+    .route('/api/projects/:projectId/previews/subtitle', createPreviewRoutes(deps.previewRoutes))
+    .route('/api/projects/:projectId/export-jobs', createExportRoutes(deps.exportRoutes))
+    .route('/api/export-jobs', createJobRoutes(deps.jobRoutes))
+    .route('/', htmlRoutes)
+}
+
+const app = createApp()
+
+export type AppType = typeof app
+export { createApp }
 
 export default app

--- a/projects/edit-vid2/src/server/bun-server.ts
+++ b/projects/edit-vid2/src/server/bun-server.ts
@@ -1,49 +1,8 @@
-import { Hono } from 'hono'
-import { serveStatic } from 'hono/bun'
-import { getDatabase } from '#/db'
-import type { AppDatabase } from '#/db'
-import { errHandler } from '#/server/middleware/error-handler'
-import { applySecurityHeaders } from '#/server/middleware/security-headers'
-import { exportRoutes, jobRoutes, recoverIncompleteJobs } from '#/server/routes/exports'
-import { htmlRoutes } from '#/server/routes/html'
-import { previewRoutes } from '#/server/routes/previews'
-import { projectRoutes } from '#/server/routes/projects'
-import { templateRoutes } from '#/server/routes/templates'
-import { videoRoutes } from '#/server/routes/videos'
-
-let db: AppDatabase | null = null
-
-function getOrCreateDb() {
-  if (!db) {
-    const dbPath = process.env.DATABASE_URL ?? 'data/edit-vid2.db'
-    db = getDatabase(dbPath)
-  }
-  return db
-}
-
-const app = new Hono<{
-  Variables: {
-    db: AppDatabase
-  }
-}>()
-  .use(applySecurityHeaders)
-  .onError(errHandler)
-  .use('*', async (c, next) => {
-    c.set('db', getOrCreateDb())
-    await next()
-  })
-
-app.use('/static/*', serveStatic({ root: './dist' }))
-app.use('/data/*', serveStatic({ root: './' }))
-app.route('/api/videos', videoRoutes)
-app.route('/api/projects', projectRoutes)
-app.route('/api/templates', templateRoutes)
-app.route('/api/projects/:projectId/previews/subtitle', previewRoutes)
-app.route('/api/projects/:projectId/export-jobs', exportRoutes)
-app.route('/api/export-jobs', jobRoutes)
-app.route('/', htmlRoutes)
+import { createApp } from '#/server/app'
+import { recoverIncompleteJobs } from '#/server/routes/exports'
 
 const port = Number(process.env.SERVER_PORT) || 3000
+const app = createApp()
 
 Bun.serve({
   fetch: app.fetch,

--- a/projects/edit-vid2/src/server/dev-server.ts
+++ b/projects/edit-vid2/src/server/dev-server.ts
@@ -1,0 +1,6 @@
+import app from '#/server/app'
+import { recoverIncompleteJobs } from '#/server/routes/exports'
+
+recoverIncompleteJobs()
+
+export default app

--- a/projects/edit-vid2/src/server/routes/exports.ts
+++ b/projects/edit-vid2/src/server/routes/exports.ts
@@ -5,6 +5,8 @@ import { sValidator } from '@hono/standard-validator'
 import { Hono } from 'hono'
 import { streamSSE } from 'hono/streaming'
 import { uuidv7 } from 'uuidv7'
+import { getDatabase } from '#/db'
+import type { AppDatabase } from '#/db'
 import {
   createExportJob,
   deleteExportJob,
@@ -25,10 +27,14 @@ function ensureParam(value: string | undefined, name: string): string {
   return value
 }
 
-function summarizeExportError(logPath: string | null): string | null {
-  if (!logPath || !existsSync(logPath)) return null
+function summarizeExportError(
+  logPath: string | null,
+  exists = existsSync,
+  readFile: (path: string, encoding: 'utf8') => string = readFileSync
+): string | null {
+  if (!logPath || !exists(logPath)) return null
 
-  const log = readFileSync(logPath, 'utf8').slice(-12000)
+  const log = readFile(logPath, 'utf8').slice(-12000)
   const lines = log
     .split('\n')
     .map((line) => line.replace(/^\[ERROR\]\s*/, '').trim())
@@ -47,252 +53,295 @@ function summarizeExportError(logPath: string | null): string | null {
   return relevantLine ?? null
 }
 
-function removeExportFiles(jobId: string) {
+function removeExportFiles(
+  jobId: string,
+  removeDir: (path: string, options: { recursive: boolean; force: boolean }) => void = rmSync
+) {
   const exportsRoot = resolve('data/exports')
   const exportDir = resolve(exportsRoot, jobId)
   if (!exportDir.startsWith(`${exportsRoot}/`)) {
     throw new Error('invalid export path')
   }
-  rmSync(exportDir, { recursive: true, force: true })
+  removeDir(exportDir, { recursive: true, force: true })
 }
 
-const exportRoutes = new Hono<HonoEnv>()
+type ExportWorkerLike = {
+  enqueue: (jobId: string, db: AppDatabase) => void
+  cancel: (jobId: string) => void
+  onProgress: (jobId: string, callback: (progress: number, status: string) => void) => () => void
+}
 
-exportRoutes.get('/', (c) => {
-  const db = c.var.db
-  const projectId = ensureParam(c.req.param('projectId'), 'projectId')
-  const jobs = getExportJobsByProject(db, projectId)
-  return c.json(
-    jobs.map((job) => ({
-      ...job,
-      errorMessage: job.status === 'failed' ? summarizeExportError(job.logPath) : null,
-    }))
-  )
-})
+type ExportRouteDeps = {
+  createId: () => string
+  worker: ExportWorkerLike
+  exists: (path: string) => boolean
+  stat: (path: string) => { size: number }
+  readFile: (path: string) => Uint8Array<ArrayBuffer>
+  createReadStream: (path: string, options?: { start?: number; end?: number }) => Readable
+  removeExportFiles: (jobId: string) => void
+  summarizeExportError: (logPath: string | null) => string | null
+}
 
-exportRoutes.post('/', sValidator('json', CreateExportJobSchema), (c) => {
-  const db = c.var.db
-  const projectId = ensureParam(c.req.param('projectId'), 'projectId')
+const defaultExportRouteDeps: ExportRouteDeps = {
+  createId: uuidv7,
+  worker: exportWorker,
+  exists: existsSync,
+  stat: (path) => statSync(path),
+  readFile: (path) => new Uint8Array(readFileSync(path)),
+  createReadStream,
+  removeExportFiles,
+  summarizeExportError,
+}
 
-  const project = getProjectById(db, projectId)
-  if (!project) {
-    return c.json({ error: 'project not found' }, 404)
-  }
-  const videoAsset = getVideoAssetById(db, project.videoAssetId)
-  if (videoAsset?.status !== 'ready' || !videoAsset.storagePath) {
-    return c.json({ error: 'video asset not ready' }, 400)
-  }
+function createExportRoutes(deps: Partial<ExportRouteDeps> = {}) {
+  const resolvedDeps = { ...defaultExportRouteDeps, ...deps }
+  const exportRoutes = new Hono<HonoEnv>()
 
-  const body = c.req.valid('json')
-  const job = createExportJob(db, {
-    id: uuidv7(),
-    projectId,
-    snapshot: project.timelineState as object | undefined,
-    preset: body.preset as object | undefined,
+  exportRoutes.get('/', (c) => {
+    const db = c.var.db
+    const projectId = ensureParam(c.req.param('projectId'), 'projectId')
+    const jobs = getExportJobsByProject(db, projectId)
+    return c.json(
+      jobs.map((job) => ({
+        ...job,
+        errorMessage: job.status === 'failed' ? resolvedDeps.summarizeExportError(job.logPath) : null,
+      }))
+    )
   })
 
-  exportWorker.enqueue(job.id, db)
+  exportRoutes.post('/', sValidator('json', CreateExportJobSchema), (c) => {
+    const db = c.var.db
+    const projectId = ensureParam(c.req.param('projectId'), 'projectId')
 
-  return c.json(job, 201)
-})
+    const project = getProjectById(db, projectId)
+    if (!project) {
+      return c.json({ error: 'project not found' }, 404)
+    }
+    const videoAsset = getVideoAssetById(db, project.videoAssetId)
+    if (videoAsset?.status !== 'ready' || !videoAsset.storagePath) {
+      return c.json({ error: 'video asset not ready' }, 400)
+    }
+
+    const body = c.req.valid('json')
+    const job = createExportJob(db, {
+      id: resolvedDeps.createId(),
+      projectId,
+      snapshot: project.timelineState as object | undefined,
+      preset: body.preset as object | undefined,
+    })
+
+    resolvedDeps.worker.enqueue(job.id, db)
+
+    return c.json(job, 201)
+  })
+
+  return exportRoutes
+}
 
 // REST endpoints for job actions: GET /api/export-jobs, GET /api/export-jobs/:exportJobId, etc.
-const jobRoutes = new Hono<HonoEnv>()
+function createJobRoutes(deps: Partial<ExportRouteDeps> = {}) {
+  const resolvedDeps = { ...defaultExportRouteDeps, ...deps }
+  const jobRoutes = new Hono<HonoEnv>()
 
-jobRoutes.get('/', (c) => {
-  const db = c.var.db
-  const rawLimit = c.req.query('limit') ?? '100'
-  const parsed = Number(rawLimit)
-  const limit = Number.isNaN(parsed) || parsed < 1 ? 100 : Math.min(parsed, 500)
-  const jobs = getExportJobs(db, limit)
-  const allProjects = getProjects(db)
-  const projectMap = new Map(allProjects.map((p) => [p.id, p.name]))
-  return c.json(
-    jobs.map((job) => ({
+  jobRoutes.get('/', (c) => {
+    const db = c.var.db
+    const rawLimit = c.req.query('limit') ?? '100'
+    const parsed = Number(rawLimit)
+    const limit = Number.isNaN(parsed) || parsed < 1 ? 100 : Math.min(parsed, 500)
+    const jobs = getExportJobs(db, limit)
+    const allProjects = getProjects(db)
+    const projectMap = new Map(allProjects.map((p) => [p.id, p.name]))
+    return c.json(
+      jobs.map((job) => ({
+        ...job,
+        projectName: projectMap.get(job.projectId) ?? '',
+        errorMessage: job.status === 'failed' ? resolvedDeps.summarizeExportError(job.logPath) : null,
+      }))
+    )
+  })
+
+  jobRoutes.get('/:exportJobId/events', (c) => {
+    const db = c.var.db
+    const jobId = c.req.param('exportJobId')
+
+    const job = getExportJobById(db, jobId)
+    if (!job) {
+      return c.json({ error: 'not found' }, 404)
+    }
+
+    return streamSSE(c, async (stream) => {
+      await stream.writeSSE({
+        data: JSON.stringify({ progress: job.progress, status: job.status }),
+      })
+
+      const unsubscribe = resolvedDeps.worker.onProgress(jobId, (progress, status) => {
+        stream
+          .writeSSE({
+            data: JSON.stringify({ progress, status }),
+          })
+          .catch(() => {})
+      })
+
+      const keepAlive = setInterval(() => {
+        stream.writeSSE({ data: '' }).catch(() => {})
+      }, 5000)
+
+      while (true) {
+        await new Promise((resolve) => setTimeout(resolve, 1000))
+        const current = getExportJobById(db, jobId)
+        if (
+          !current ||
+          current.status === 'succeeded' ||
+          current.status === 'failed' ||
+          current.status === 'canceled'
+        ) {
+          break
+        }
+      }
+
+      clearInterval(keepAlive)
+      unsubscribe()
+
+      await stream.writeSSE({
+        data: JSON.stringify({
+          progress: getExportJobById(db, jobId)?.progress ?? 0,
+          status: getExportJobById(db, jobId)?.status ?? 'failed',
+        }),
+      })
+    })
+  })
+
+  jobRoutes.get('/:exportJobId', (c) => {
+    const db = c.var.db
+    const job = getExportJobById(db, c.req.param('exportJobId'))
+    if (!job) {
+      return c.json({ error: 'not found' }, 404)
+    }
+    return c.json({
       ...job,
-      projectName: projectMap.get(job.projectId) ?? '',
-      errorMessage: job.status === 'failed' ? summarizeExportError(job.logPath) : null,
-    }))
-  )
-})
-
-jobRoutes.get('/:exportJobId/events', (c) => {
-  const db = c.var.db
-  const jobId = c.req.param('exportJobId')
-
-  const job = getExportJobById(db, jobId)
-  if (!job) {
-    return c.json({ error: 'not found' }, 404)
-  }
-
-  return streamSSE(c, async (stream) => {
-    await stream.writeSSE({
-      data: JSON.stringify({ progress: job.progress, status: job.status }),
+      errorMessage: job.status === 'failed' ? resolvedDeps.summarizeExportError(job.logPath) : null,
     })
+  })
 
-    const unsubscribe = exportWorker.onProgress(jobId, (progress, status) => {
-      stream
-        .writeSSE({
-          data: JSON.stringify({ progress, status }),
-        })
-        .catch(() => {})
-    })
+  jobRoutes.post('/:exportJobId/cancel', (c) => {
+    const db = c.var.db
+    const jobId = c.req.param('exportJobId')
+    const job = getExportJobById(db, jobId)
+    if (!job) {
+      return c.json({ error: 'not found' }, 404)
+    }
+    if (job.status === 'queued' || job.status === 'running') {
+      resolvedDeps.worker.cancel(jobId)
+      updateExportJob(db, jobId, { status: 'canceled' })
+    }
+    return c.json(updateExportJob(db, jobId, {}))
+  })
 
-    const keepAlive = setInterval(() => {
-      stream.writeSSE({ data: '' }).catch(() => {})
-    }, 5000)
-
-    while (true) {
-      await new Promise((resolve) => setTimeout(resolve, 1000))
-      const current = getExportJobById(db, jobId)
-      if (!current || current.status === 'succeeded' || current.status === 'failed' || current.status === 'canceled') {
-        break
-      }
+  jobRoutes.delete('/:exportJobId', (c) => {
+    const db = c.var.db
+    const jobId = c.req.param('exportJobId')
+    const job = getExportJobById(db, jobId)
+    if (!job) {
+      return c.json({ error: 'not found' }, 404)
+    }
+    if (job.status === 'queued' || job.status === 'running' || job.status === 'canceling') {
+      return c.json({ error: 'cancel export before deleting it' }, 409)
     }
 
-    clearInterval(keepAlive)
-    unsubscribe()
+    resolvedDeps.removeExportFiles(jobId)
+    deleteExportJob(db, jobId)
+    return c.body(null, 204)
+  })
 
-    await stream.writeSSE({
-      data: JSON.stringify({
-        progress: getExportJobById(db, jobId)?.progress ?? 0,
-        status: getExportJobById(db, jobId)?.status ?? 'failed',
-      }),
+  jobRoutes.get('/:exportJobId/download', async (c) => {
+    const db = c.var.db
+    const job = getExportJobById(db, c.req.param('exportJobId'))
+    if (!job) {
+      return c.json({ error: 'not found' }, 404)
+    }
+    if (job.status !== 'succeeded' || !job.outputPath) {
+      return c.json({ error: 'not ready' }, 400)
+    }
+
+    if (!resolvedDeps.exists(job.outputPath)) {
+      return c.json({ error: 'output file not found' }, 404)
+    }
+
+    const file = resolvedDeps.readFile(job.outputPath)
+    return c.body(file, 200, {
+      'Content-Type': 'video/mp4',
+      'Content-Disposition': `attachment; filename="export-${job.id}.mp4"`,
     })
   })
-})
 
-jobRoutes.get('/:exportJobId', (c) => {
-  const db = c.var.db
-  const job = getExportJobById(db, c.req.param('exportJobId'))
-  if (!job) {
-    return c.json({ error: 'not found' }, 404)
-  }
-  return c.json({
-    ...job,
-    errorMessage: job.status === 'failed' ? summarizeExportError(job.logPath) : null,
-  })
-})
+  jobRoutes.get('/:exportJobId/preview', async (c) => {
+    const db = c.var.db
+    const job = getExportJobById(db, c.req.param('exportJobId'))
+    if (!job) {
+      return c.json({ error: 'not found' }, 404)
+    }
+    if (job.status !== 'succeeded' || !job.outputPath) {
+      return c.json({ error: 'not ready' }, 400)
+    }
+    if (!resolvedDeps.exists(job.outputPath)) {
+      return c.json({ error: 'output file not found' }, 404)
+    }
 
-jobRoutes.post('/:exportJobId/cancel', (c) => {
-  const db = c.var.db
-  const jobId = c.req.param('exportJobId')
-  const job = getExportJobById(db, jobId)
-  if (!job) {
-    return c.json({ error: 'not found' }, 404)
-  }
-  if (job.status === 'queued' || job.status === 'running') {
-    exportWorker.cancel(jobId)
-    updateExportJob(db, jobId, { status: 'canceled' })
-  }
-  return c.json(updateExportJob(db, jobId, {}))
-})
+    const { size } = resolvedDeps.stat(job.outputPath)
+    const rangeHeader = c.req.header('range')
 
-jobRoutes.delete('/:exportJobId', (c) => {
-  const db = c.var.db
-  const jobId = c.req.param('exportJobId')
-  const job = getExportJobById(db, jobId)
-  if (!job) {
-    return c.json({ error: 'not found' }, 404)
-  }
-  if (job.status === 'queued' || job.status === 'running' || job.status === 'canceling') {
-    return c.json({ error: 'cancel export before deleting it' }, 409)
-  }
+    const baseHeaders = {
+      'Content-Type': 'video/mp4',
+      'Content-Disposition': `inline; filename="export-${job.id}.mp4"`,
+      'Accept-Ranges': 'bytes',
+    }
 
-  removeExportFiles(jobId)
-  deleteExportJob(db, jobId)
-  return c.body(null, 204)
-})
+    if (!rangeHeader) {
+      const stream = resolvedDeps.createReadStream(job.outputPath)
+      return c.body(Readable.toWeb(stream) as unknown as ReadableStream, 200, {
+        ...baseHeaders,
+        'Content-Length': String(size),
+      })
+    }
 
-jobRoutes.get('/:exportJobId/download', async (c) => {
-  const db = c.var.db
-  const job = getExportJobById(db, c.req.param('exportJobId'))
-  if (!job) {
-    return c.json({ error: 'not found' }, 404)
-  }
-  if (job.status !== 'succeeded' || !job.outputPath) {
-    return c.json({ error: 'not ready' }, 400)
-  }
+    const match = rangeHeader.match(/^bytes=(\d+)-(\d*)$/)
+    if (!match) {
+      return c.json({ error: 'range not satisfiable' }, 416)
+    }
 
-  const { readFileSync, existsSync } = await import('node:fs')
-  if (!existsSync(job.outputPath)) {
-    return c.json({ error: 'output file not found' }, 404)
-  }
+    const start = Number.parseInt(match[1], 10)
+    const end = match[2] ? Number.parseInt(match[2], 10) : size - 1
 
-  const file = readFileSync(job.outputPath)
-  return c.body(file, 200, {
-    'Content-Type': 'video/mp4',
-    'Content-Disposition': `attachment; filename="export-${job.id}.mp4"`,
-  })
-})
+    if (Number.isNaN(start) || Number.isNaN(end) || start >= size || end >= size || start > end) {
+      return c.json({ error: 'range not satisfiable' }, 416)
+    }
 
-jobRoutes.get('/:exportJobId/preview', async (c) => {
-  const db = c.var.db
-  const job = getExportJobById(db, c.req.param('exportJobId'))
-  if (!job) {
-    return c.json({ error: 'not found' }, 404)
-  }
-  if (job.status !== 'succeeded' || !job.outputPath) {
-    return c.json({ error: 'not ready' }, 400)
-  }
-  if (!existsSync(job.outputPath)) {
-    return c.json({ error: 'output file not found' }, 404)
-  }
-
-  const { size } = statSync(job.outputPath)
-  const rangeHeader = c.req.header('range')
-
-  const baseHeaders = {
-    'Content-Type': 'video/mp4',
-    'Content-Disposition': `inline; filename="export-${job.id}.mp4"`,
-    'Accept-Ranges': 'bytes',
-  }
-
-  if (!rangeHeader) {
-    const stream = createReadStream(job.outputPath)
-    return c.body(Readable.toWeb(stream) as unknown as ReadableStream, 200, {
+    const length = end - start + 1
+    const stream = resolvedDeps.createReadStream(job.outputPath, { start, end })
+    return c.body(Readable.toWeb(stream) as unknown as ReadableStream, 206, {
       ...baseHeaders,
-      'Content-Length': String(size),
+      'Content-Range': `bytes ${start}-${end}/${size}`,
+      'Content-Length': String(length),
     })
-  }
-
-  const match = rangeHeader.match(/^bytes=(\d+)-(\d*)$/)
-  if (!match) {
-    return c.json({ error: 'range not satisfiable' }, 416)
-  }
-
-  const start = Number.parseInt(match[1], 10)
-  const end = match[2] ? Number.parseInt(match[2], 10) : size - 1
-
-  if (Number.isNaN(start) || Number.isNaN(end) || start >= size || end >= size || start > end) {
-    return c.json({ error: 'range not satisfiable' }, 416)
-  }
-
-  const length = end - start + 1
-  const stream = createReadStream(job.outputPath, { start, end })
-  return c.body(Readable.toWeb(stream) as unknown as ReadableStream, 206, {
-    ...baseHeaders,
-    'Content-Range': `bytes ${start}-${end}/${size}`,
-    'Content-Length': String(length),
   })
-})
 
-// Recover incomplete jobs on startup.
-// This is exported so server entrypoints can call it after migrations are applied.
-export function recoverIncompleteJobs() {
-  const dbUrl = process.env.DATABASE_URL ?? 'data/edit-vid2.db'
-  import('#/db').then(({ getDatabase }) => {
-    const db = getDatabase(dbUrl)
-    const incomplete = getIncompleteJobs(db)
-    for (const job of incomplete) {
-      if (job.status === 'running') {
-        updateExportJob(db, job.id, { status: 'failed' })
-      }
-      if (job.status === 'canceling') {
-        updateExportJob(db, job.id, { status: 'canceled' })
-      }
-    }
-  })
+  return jobRoutes
 }
 
-export { exportRoutes, jobRoutes }
+const exportRoutes = createExportRoutes()
+const jobRoutes = createJobRoutes()
+
+export function recoverIncompleteJobs(options: { db?: AppDatabase; dbUrl?: string } = {}) {
+  const db = options.db ?? getDatabase(options.dbUrl ?? process.env.DATABASE_URL ?? 'data/edit-vid2.db')
+  const incomplete = getIncompleteJobs(db)
+  for (const job of incomplete) {
+    if (job.status === 'running') {
+      updateExportJob(db, job.id, { status: 'failed' })
+    }
+    if (job.status === 'canceling') {
+      updateExportJob(db, job.id, { status: 'canceled' })
+    }
+  }
+}
+
+export { createExportRoutes, createJobRoutes, exportRoutes, jobRoutes, removeExportFiles, summarizeExportError }

--- a/projects/edit-vid2/src/server/routes/previews.ts
+++ b/projects/edit-vid2/src/server/routes/previews.ts
@@ -2,7 +2,10 @@ import { existsSync, mkdirSync } from 'node:fs'
 import { sValidator } from '@hono/standard-validator'
 import { Hono } from 'hono'
 import { z } from 'zod'
-import { buildPreviewCacheKey, generateSubtitlePreview } from '#/server/features/preview/preview-service'
+import {
+  buildPreviewCacheKey,
+  generateSubtitlePreview as defaultGenerateSubtitlePreview,
+} from '#/server/features/preview/preview-service'
 import { getProjectById } from '#/server/features/projects/project-repository'
 import { getTemplateById } from '#/server/features/templates/template-repository'
 import { getVideoAssetById } from '#/server/features/videos/video-repository'
@@ -29,59 +32,80 @@ const defaultStyle = {
   margin: { x: 0, y: 0 },
 }
 
-const previewRoutes = new Hono<HonoEnv>()
+type PreviewRouteDeps = {
+  exists: (path: string) => boolean
+  ensureDir: (path: string) => void
+  getCacheDir: (projectId: string) => string
+  generateSubtitlePreview: typeof defaultGenerateSubtitlePreview
+}
 
-previewRoutes.post('/', sValidator('json', previewSchema), async (c) => {
-  const db = c.var.db
-  const projectId = c.req.param('projectId')
-  if (!projectId) {
-    return c.json({ error: 'projectId required' }, 400)
-  }
-  const project = getProjectById(db, projectId)
-  if (!project) {
-    return c.json({ error: 'project not found' }, 404)
-  }
+const defaultPreviewRouteDeps: PreviewRouteDeps = {
+  exists: existsSync,
+  ensureDir: (path) => mkdirSync(path, { recursive: true }),
+  getCacheDir: (projectId) => `data/projects/${projectId}/previews`,
+  generateSubtitlePreview: defaultGenerateSubtitlePreview,
+}
 
-  const videoAsset = getVideoAssetById(db, project.videoAssetId)
-  if (!videoAsset || !videoAsset.width || !videoAsset.height) {
-    return c.json({ error: 'video asset not ready' }, 400)
-  }
+function createPreviewRoutes(deps: Partial<PreviewRouteDeps> = {}) {
+  const resolvedDeps = { ...defaultPreviewRouteDeps, ...deps }
+  const previewRoutes = new Hono<HonoEnv>()
 
-  if (!videoAsset.storagePath) {
-    return c.json({ error: 'video storage path not set' }, 400)
-  }
+  previewRoutes.post('/', sValidator('json', previewSchema), async (c) => {
+    const db = c.var.db
+    const projectId = c.req.param('projectId')
+    if (!projectId) {
+      return c.json({ error: 'projectId required' }, 400)
+    }
+    const project = getProjectById(db, projectId)
+    if (!project) {
+      return c.json({ error: 'project not found' }, 404)
+    }
 
-  const body = c.req.valid('json')
-  const template = getTemplateById(db, body.templateId)
-  const style = template ? toSubtitleStyle(template) : defaultStyle
+    const videoAsset = getVideoAssetById(db, project.videoAssetId)
+    if (!videoAsset || !videoAsset.width || !videoAsset.height) {
+      return c.json({ error: 'video asset not ready' }, 400)
+    }
 
-  const cacheKey = buildPreviewCacheKey(projectId, videoAsset.id, body.sourceTime, style, body.text, 1)
+    if (!videoAsset.storagePath) {
+      return c.json({ error: 'video storage path not set' }, 400)
+    }
 
-  const cacheDir = `data/projects/${projectId}/previews`
-  if (!existsSync(cacheDir)) {
-    mkdirSync(cacheDir, { recursive: true })
-  }
-  const outputPath = `${cacheDir}/${cacheKey}.jpg`
+    const body = c.req.valid('json')
+    const template = getTemplateById(db, body.templateId)
+    const style = template ? toSubtitleStyle(template) : defaultStyle
 
-  if (existsSync(outputPath)) {
-    return c.json({ path: outputPath, cached: true })
-  }
+    const cacheKey = buildPreviewCacheKey(projectId, videoAsset.id, body.sourceTime, style, body.text, 1)
 
-  const success = await generateSubtitlePreview({
-    videoPath: videoAsset.storagePath,
-    outputPath,
-    sourceTime: body.sourceTime,
-    text: body.text,
-    videoWidth: videoAsset.width,
-    videoHeight: videoAsset.height,
-    defaultStyle: style,
+    const cacheDir = resolvedDeps.getCacheDir(projectId)
+    if (!resolvedDeps.exists(cacheDir)) {
+      resolvedDeps.ensureDir(cacheDir)
+    }
+    const outputPath = `${cacheDir}/${cacheKey}.jpg`
+
+    if (resolvedDeps.exists(outputPath)) {
+      return c.json({ path: outputPath, cached: true })
+    }
+
+    const success = await resolvedDeps.generateSubtitlePreview({
+      videoPath: videoAsset.storagePath,
+      outputPath,
+      sourceTime: body.sourceTime,
+      text: body.text,
+      videoWidth: videoAsset.width,
+      videoHeight: videoAsset.height,
+      defaultStyle: style,
+    })
+
+    if (!success) {
+      return c.json({ error: 'preview generation failed' }, 500)
+    }
+
+    return c.json({ path: outputPath, cached: false })
   })
 
-  if (!success) {
-    return c.json({ error: 'preview generation failed' }, 500)
-  }
+  return previewRoutes
+}
 
-  return c.json({ path: outputPath, cached: false })
-})
+const previewRoutes = createPreviewRoutes()
 
-export { previewRoutes }
+export { createPreviewRoutes, previewRoutes }

--- a/projects/edit-vid2/src/server/routes/projects.ts
+++ b/projects/edit-vid2/src/server/routes/projects.ts
@@ -12,83 +12,98 @@ import { getVideoAssetById } from '#/server/features/videos/video-repository'
 import type { HonoEnv } from '#/server/routes/shared'
 import { CreateProjectSchema, DuplicateProjectSchema, UpdateProjectSchema } from '#/shared/schemas'
 
-const projectRoutes = new Hono<HonoEnv>()
+type ProjectRouteDeps = {
+  createId: () => string
+}
+
+const defaultProjectRouteDeps: ProjectRouteDeps = {
+  createId: uuidv7,
+}
 
 function getReadyVideoAsset(db: HonoEnv['Variables']['db'], videoAssetId: string) {
   const videoAsset = getVideoAssetById(db, videoAssetId)
   return videoAsset?.status === 'ready' ? videoAsset : null
 }
 
-projectRoutes.get('/', (c) => {
-  const db = c.var.db
-  const list = getProjects(db)
-  return c.json(list)
-})
+function createProjectRoutes(deps: Partial<ProjectRouteDeps> = {}) {
+  const resolvedDeps = { ...defaultProjectRouteDeps, ...deps }
+  const projectRoutes = new Hono<HonoEnv>()
 
-projectRoutes.get('/:projectId', (c) => {
-  const db = c.var.db
-  const project = getProjectById(db, c.req.param('projectId'))
-  if (!project) {
-    return c.json({ error: 'not found' }, 404)
-  }
-  return c.json(project)
-})
-
-projectRoutes.post('/', sValidator('json', CreateProjectSchema), (c) => {
-  const db = c.var.db
-  const body = c.req.valid('json')
-  if (!getReadyVideoAsset(db, body.videoAssetId)) {
-    return c.json({ error: 'video asset not ready' }, 400)
-  }
-  const project = createProject(db, {
-    id: uuidv7(),
-    videoAssetId: body.videoAssetId,
-    name: body.name,
+  projectRoutes.get('/', (c) => {
+    const db = c.var.db
+    const list = getProjects(db)
+    return c.json(list)
   })
-  return c.json(project, 201)
-})
 
-projectRoutes.patch('/:projectId', sValidator('json', UpdateProjectSchema), (c) => {
-  const db = c.var.db
-  const id = c.req.param('projectId')
-  const existing = getProjectById(db, id)
-  if (!existing) {
-    return c.json({ error: 'not found' }, 404)
-  }
-  const body = c.req.valid('json')
-  if (body.videoAssetId && !getReadyVideoAsset(db, body.videoAssetId)) {
-    return c.json({ error: 'video asset not ready' }, 400)
-  }
-  const updated = updateProject(db, id, body)
-  return c.json(updated)
-})
-
-projectRoutes.post('/:projectId/duplicate', sValidator('json', DuplicateProjectSchema), (c) => {
-  const db = c.var.db
-  const id = c.req.param('projectId')
-  const existing = getProjectById(db, id)
-  if (!existing) {
-    return c.json({ error: 'not found' }, 404)
-  }
-  const body = c.req.valid('json')
-  const duplicate = createProject(db, {
-    id: uuidv7(),
-    videoAssetId: existing.videoAssetId,
-    name: body.name ?? `${existing.name} (コピー)`,
-    timelineState: existing.timelineState as object | undefined,
+  projectRoutes.get('/:projectId', (c) => {
+    const db = c.var.db
+    const project = getProjectById(db, c.req.param('projectId'))
+    if (!project) {
+      return c.json({ error: 'not found' }, 404)
+    }
+    return c.json(project)
   })
-  return c.json(duplicate, 201)
-})
 
-projectRoutes.delete('/:projectId', (c) => {
-  const db = c.var.db
-  const id = c.req.param('projectId')
-  const existing = getProjectById(db, id)
-  if (!existing) {
-    return c.json({ error: 'not found' }, 404)
-  }
-  softDeleteProject(db, id)
-  return c.body(null, 204)
-})
+  projectRoutes.post('/', sValidator('json', CreateProjectSchema), (c) => {
+    const db = c.var.db
+    const body = c.req.valid('json')
+    if (!getReadyVideoAsset(db, body.videoAssetId)) {
+      return c.json({ error: 'video asset not ready' }, 400)
+    }
+    const project = createProject(db, {
+      id: resolvedDeps.createId(),
+      videoAssetId: body.videoAssetId,
+      name: body.name,
+    })
+    return c.json(project, 201)
+  })
 
-export { projectRoutes }
+  projectRoutes.patch('/:projectId', sValidator('json', UpdateProjectSchema), (c) => {
+    const db = c.var.db
+    const id = c.req.param('projectId')
+    const existing = getProjectById(db, id)
+    if (!existing) {
+      return c.json({ error: 'not found' }, 404)
+    }
+    const body = c.req.valid('json')
+    if (body.videoAssetId && !getReadyVideoAsset(db, body.videoAssetId)) {
+      return c.json({ error: 'video asset not ready' }, 400)
+    }
+    const updated = updateProject(db, id, body)
+    return c.json(updated)
+  })
+
+  projectRoutes.post('/:projectId/duplicate', sValidator('json', DuplicateProjectSchema), (c) => {
+    const db = c.var.db
+    const id = c.req.param('projectId')
+    const existing = getProjectById(db, id)
+    if (!existing) {
+      return c.json({ error: 'not found' }, 404)
+    }
+    const body = c.req.valid('json')
+    const duplicate = createProject(db, {
+      id: resolvedDeps.createId(),
+      videoAssetId: existing.videoAssetId,
+      name: body.name ?? `${existing.name} (コピー)`,
+      timelineState: existing.timelineState as object | undefined,
+    })
+    return c.json(duplicate, 201)
+  })
+
+  projectRoutes.delete('/:projectId', (c) => {
+    const db = c.var.db
+    const id = c.req.param('projectId')
+    const existing = getProjectById(db, id)
+    if (!existing) {
+      return c.json({ error: 'not found' }, 404)
+    }
+    softDeleteProject(db, id)
+    return c.body(null, 204)
+  })
+
+  return projectRoutes
+}
+
+const projectRoutes = createProjectRoutes()
+
+export { createProjectRoutes, projectRoutes }

--- a/projects/edit-vid2/src/server/routes/templates.ts
+++ b/projects/edit-vid2/src/server/routes/templates.ts
@@ -11,53 +11,68 @@ import {
 import type { HonoEnv } from '#/server/routes/shared'
 import { CreateSubtitleTemplateSchema, UpdateSubtitleTemplateSchema } from '#/shared/schemas'
 
-const templateRoutes = new Hono<HonoEnv>()
+type TemplateRouteDeps = {
+  createId: () => string
+}
 
-templateRoutes.get('/', (c) => {
-  const db = c.var.db
-  const templates = getTemplates(db)
-  return c.json(templates)
-})
+const defaultTemplateRouteDeps: TemplateRouteDeps = {
+  createId: uuidv7,
+}
 
-templateRoutes.get('/:templateId', (c) => {
-  const db = c.var.db
-  const template = getTemplateById(db, c.req.param('templateId'))
-  if (!template) {
-    return c.json({ error: 'not found' }, 404)
-  }
-  return c.json(template)
-})
+function createTemplateRoutes(deps: Partial<TemplateRouteDeps> = {}) {
+  const resolvedDeps = { ...defaultTemplateRouteDeps, ...deps }
+  const templateRoutes = new Hono<HonoEnv>()
 
-templateRoutes.post('/', sValidator('json', CreateSubtitleTemplateSchema), (c) => {
-  const db = c.var.db
-  const body = c.req.valid('json')
-  const template = createTemplate(db, {
-    id: uuidv7(),
-    ...body,
+  templateRoutes.get('/', (c) => {
+    const db = c.var.db
+    const templates = getTemplates(db)
+    return c.json(templates)
   })
-  return c.json(template, 201)
-})
 
-templateRoutes.patch('/:templateId', sValidator('json', UpdateSubtitleTemplateSchema), (c) => {
-  const db = c.var.db
-  const id = c.req.param('templateId')
-  const existing = getTemplateById(db, id)
-  if (!existing) {
-    return c.json({ error: 'not found' }, 404)
-  }
-  const updated = updateTemplate(db, id, c.req.valid('json'))
-  return c.json(updated)
-})
+  templateRoutes.get('/:templateId', (c) => {
+    const db = c.var.db
+    const template = getTemplateById(db, c.req.param('templateId'))
+    if (!template) {
+      return c.json({ error: 'not found' }, 404)
+    }
+    return c.json(template)
+  })
 
-templateRoutes.delete('/:templateId', (c) => {
-  const db = c.var.db
-  const id = c.req.param('templateId')
-  const existing = getTemplateById(db, id)
-  if (!existing) {
-    return c.json({ error: 'not found' }, 404)
-  }
-  softDeleteTemplate(db, id)
-  return c.body(null, 204)
-})
+  templateRoutes.post('/', sValidator('json', CreateSubtitleTemplateSchema), (c) => {
+    const db = c.var.db
+    const body = c.req.valid('json')
+    const template = createTemplate(db, {
+      id: resolvedDeps.createId(),
+      ...body,
+    })
+    return c.json(template, 201)
+  })
 
-export { templateRoutes }
+  templateRoutes.patch('/:templateId', sValidator('json', UpdateSubtitleTemplateSchema), (c) => {
+    const db = c.var.db
+    const id = c.req.param('templateId')
+    const existing = getTemplateById(db, id)
+    if (!existing) {
+      return c.json({ error: 'not found' }, 404)
+    }
+    const updated = updateTemplate(db, id, c.req.valid('json'))
+    return c.json(updated)
+  })
+
+  templateRoutes.delete('/:templateId', (c) => {
+    const db = c.var.db
+    const id = c.req.param('templateId')
+    const existing = getTemplateById(db, id)
+    if (!existing) {
+      return c.json({ error: 'not found' }, 404)
+    }
+    softDeleteTemplate(db, id)
+    return c.body(null, 204)
+  })
+
+  return templateRoutes
+}
+
+const templateRoutes = createTemplateRoutes()
+
+export { createTemplateRoutes, templateRoutes }

--- a/projects/edit-vid2/src/server/routes/videos.ts
+++ b/projects/edit-vid2/src/server/routes/videos.ts
@@ -2,7 +2,10 @@ import { mkdirSync, writeFileSync } from 'node:fs'
 import { sValidator } from '@hono/standard-validator'
 import { Hono } from 'hono'
 import { uuidv7 } from 'uuidv7'
-import { generateThumbnail, probeVideo } from '#/server/features/ffmpeg/ffmpeg-service'
+import {
+  generateThumbnail as defaultGenerateThumbnail,
+  probeVideo as defaultProbeVideo,
+} from '#/server/features/ffmpeg/ffmpeg-service'
 import {
   createVideoAsset,
   getVideoAssetById,
@@ -13,92 +16,122 @@ import {
 import type { HonoEnv } from '#/server/routes/shared'
 import { UpdateVideoAssetSchema } from '#/shared/schemas'
 
-const videoRoutes = new Hono<HonoEnv>()
+type VideoRouteDeps = {
+  createId: () => string
+  getMaxUploadBytes: () => number
+  getVideoDir: (id: string) => string
+  ensureDir: (path: string) => void
+  writeVideoFile: (path: string, file: File) => Promise<void>
+  probeVideo: typeof defaultProbeVideo
+  generateThumbnail: typeof defaultGenerateThumbnail
+  scheduleVideoProcessing: (task: () => Promise<void>) => void
+}
 
-videoRoutes.get('/', (c) => {
-  const db = c.var.db
-  const videos = getVideoAssets(db)
-  return c.json(videos)
-})
+const defaultVideoRouteDeps: VideoRouteDeps = {
+  createId: uuidv7,
+  getMaxUploadBytes: () => Number(process.env.MAX_UPLOAD_BYTES) || 2 * 1024 * 1024 * 1024,
+  getVideoDir: (id) => `data/videos/${id}`,
+  ensureDir: (path) => mkdirSync(path, { recursive: true }),
+  writeVideoFile: async (path, file) => {
+    const buffer = Buffer.from(await file.arrayBuffer())
+    writeFileSync(path, buffer)
+  },
+  probeVideo: defaultProbeVideo,
+  generateThumbnail: defaultGenerateThumbnail,
+  scheduleVideoProcessing: (task) => {
+    task().catch(() => {})
+  },
+}
 
-videoRoutes.get('/:videoAssetId', (c) => {
-  const db = c.var.db
-  const video = getVideoAssetById(db, c.req.param('videoAssetId'))
-  if (!video) {
-    return c.json({ error: 'not found' }, 404)
-  }
-  return c.json(video)
-})
+function createVideoRoutes(deps: Partial<VideoRouteDeps> = {}) {
+  const resolvedDeps = { ...defaultVideoRouteDeps, ...deps }
+  const videoRoutes = new Hono<HonoEnv>()
 
-videoRoutes.patch('/:videoAssetId', sValidator('json', UpdateVideoAssetSchema), (c) => {
-  const db = c.var.db
-  const id = c.req.param('videoAssetId')
-  const existing = getVideoAssetById(db, id)
-  if (!existing) {
-    return c.json({ error: 'not found' }, 404)
-  }
-  const updated = updateVideoAsset(db, id, c.req.valid('json'))
-  return c.json(updated)
-})
-
-videoRoutes.delete('/:videoAssetId', (c) => {
-  const db = c.var.db
-  const id = c.req.param('videoAssetId')
-  const existing = getVideoAssetById(db, id)
-  if (!existing) {
-    return c.json({ error: 'not found' }, 404)
-  }
-  softDeleteVideoAsset(db, id)
-  return c.body(null, 204)
-})
-
-videoRoutes.post('/', async (c) => {
-  const db = c.var.db
-  const formData = await c.req.formData()
-  const file = formData.get('file')
-
-  if (!file || !(file instanceof File)) {
-    return c.json({ error: 'file is required' }, 400)
-  }
-
-  const maxBytes = Number(process.env.MAX_UPLOAD_BYTES) || 2 * 1024 * 1024 * 1024
-  if (file.size > maxBytes) {
-    return c.json({ error: 'file too large' }, 413)
-  }
-
-  const extMap: Record<string, string> = {
-    'video/mp4': '.mp4',
-    'video/quicktime': '.mov',
-    'video/webm': '.webm',
-    'video/x-matroska': '.mkv',
-  }
-  const ext = extMap[file.type]
-  if (!ext) {
-    return c.json({ error: `unsupported format: ${file.type}` }, 400)
-  }
-
-  const id = uuidv7()
-  const dir = `data/videos/${id}`
-  mkdirSync(dir, { recursive: true })
-
-  const storagePath = `${dir}/source${ext}`
-  const buffer = Buffer.from(await file.arrayBuffer())
-  writeFileSync(storagePath, buffer)
-
-  const displayName = formData.get('displayName')?.toString() ?? file.name
-  const record = createVideoAsset(db, {
-    id,
-    originalFilename: file.name,
-    displayName,
-    storagePath,
-    status: 'processing',
+  videoRoutes.get('/', (c) => {
+    const db = c.var.db
+    const videos = getVideoAssets(db)
+    return c.json(videos)
   })
 
-  // Run ffprobe async
-  probeVideo(storagePath)
-    .then((probeResult) => {
+  videoRoutes.get('/:videoAssetId', (c) => {
+    const db = c.var.db
+    const video = getVideoAssetById(db, c.req.param('videoAssetId'))
+    if (!video) {
+      return c.json({ error: 'not found' }, 404)
+    }
+    return c.json(video)
+  })
+
+  videoRoutes.patch('/:videoAssetId', sValidator('json', UpdateVideoAssetSchema), (c) => {
+    const db = c.var.db
+    const id = c.req.param('videoAssetId')
+    const existing = getVideoAssetById(db, id)
+    if (!existing) {
+      return c.json({ error: 'not found' }, 404)
+    }
+    const updated = updateVideoAsset(db, id, c.req.valid('json'))
+    return c.json(updated)
+  })
+
+  videoRoutes.delete('/:videoAssetId', (c) => {
+    const db = c.var.db
+    const id = c.req.param('videoAssetId')
+    const existing = getVideoAssetById(db, id)
+    if (!existing) {
+      return c.json({ error: 'not found' }, 404)
+    }
+    softDeleteVideoAsset(db, id)
+    return c.body(null, 204)
+  })
+
+  videoRoutes.post('/', async (c) => {
+    const db = c.var.db
+    const formData = await c.req.formData()
+    const file = formData.get('file')
+
+    if (!file || !(file instanceof File)) {
+      return c.json({ error: 'file is required' }, 400)
+    }
+
+    if (file.size > resolvedDeps.getMaxUploadBytes()) {
+      return c.json({ error: 'file too large' }, 413)
+    }
+
+    const extMap: Record<string, string> = {
+      'video/mp4': '.mp4',
+      'video/quicktime': '.mov',
+      'video/webm': '.webm',
+      'video/x-matroska': '.mkv',
+    }
+    const ext = extMap[file.type]
+    if (!ext) {
+      return c.json({ error: `unsupported format: ${file.type}` }, 400)
+    }
+
+    const id = resolvedDeps.createId()
+    const dir = resolvedDeps.getVideoDir(id)
+    resolvedDeps.ensureDir(dir)
+
+    const storagePath = `${dir}/source${ext}`
+    await resolvedDeps.writeVideoFile(storagePath, file)
+
+    const displayName = formData.get('displayName')?.toString() ?? file.name
+    const record = createVideoAsset(db, {
+      id,
+      originalFilename: file.name,
+      displayName,
+      storagePath,
+      status: 'processing',
+    })
+
+    resolvedDeps.scheduleVideoProcessing(async () => {
+      const probeResult = await resolvedDeps.probeVideo(storagePath).catch(() => null)
+      if (!probeResult) {
+        updateVideoAsset(db, id, { status: 'failed' })
+        return
+      }
       const thumbnailPath = `${dir}/thumbnail.jpg`
-      generateThumbnail(storagePath, thumbnailPath, probeResult.duration).catch(() => {})
+      resolvedDeps.generateThumbnail(storagePath, thumbnailPath, probeResult.duration).catch(() => {})
 
       const status = probeResult.duration ? 'ready' : 'failed'
       updateVideoAsset(db, id, {
@@ -107,11 +140,13 @@ videoRoutes.post('/', async (c) => {
         status,
       })
     })
-    .catch(() => {
-      updateVideoAsset(db, id, { status: 'failed' })
-    })
 
-  return c.json(record, 201)
-})
+    return c.json(record, 201)
+  })
 
-export { videoRoutes }
+  return videoRoutes
+}
+
+const videoRoutes = createVideoRoutes()
+
+export { createVideoRoutes, videoRoutes }

--- a/projects/edit-vid2/tests/features/export-preview.test.ts
+++ b/projects/edit-vid2/tests/features/export-preview.test.ts
@@ -2,91 +2,58 @@ import { describe, expect, test } from 'bun:test'
 import { copyFileSync, mkdirSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { migrate } from 'drizzle-orm/bun-sqlite/migrator'
-import { Hono } from 'hono'
-import { getDatabase } from '#/db'
-import { exportJobs, projects, videoAssets } from '#/db/schema'
-import { jobRoutes } from '#/server/routes/exports'
+import type { AppDatabase } from '#/db'
+import { exportJobs } from '#/db/schema'
+import { createTestServer, seedExportJob, seedProject, seedVideoAsset } from './server-test-helper'
 
 const fixturePath = 'tests/fixtures/test-compat.mp4'
 
 function createTestApp() {
-  const dbPath = join(tmpdir(), `edit-vid2-preview-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`)
-  const db = getDatabase(dbPath)
-  migrate(db, { migrationsFolder: './drizzle' })
-
-  const app = new Hono<{ Variables: { db: typeof db } }>()
-  app.use('*', async (c, next) => {
-    c.set('db', db)
-    await next()
-  })
-  app.route('/', jobRoutes)
-
-  db.insert(videoAssets)
-    .values({
-      id: 'video-1',
-      originalFilename: 'test.mp4',
-      displayName: 'Test Video',
-      storagePath: 'data/videos/video-1/source.mp4',
-      status: 'ready',
-    })
-    .run()
-
-  db.insert(projects)
-    .values({
-      id: 'project-1',
-      videoAssetId: 'video-1',
-      name: 'Test Project',
-    })
-    .run()
-
+  const server = createTestServer()
+  seedVideoAsset(server.db)
+  seedProject(server.db)
   const exportDir = join(tmpdir(), `edit-vid2-preview-${Date.now()}`)
   mkdirSync(exportDir, { recursive: true })
-
-  return { app, db, dbPath, exportDir }
+  return { ...server, exportDir }
 }
 
-function seedSucceededJob(db: ReturnType<typeof getDatabase>, exportDir: string, jobId: string) {
+function seedSucceededJob(db: AppDatabase, exportDir: string, jobId: string) {
   copyFileSync(fixturePath, join(exportDir, `${jobId}.mp4`))
-  db.insert(exportJobs)
-    .values({
-      id: jobId,
-      projectId: 'project-1',
-      status: 'succeeded',
-      outputPath: join(exportDir, `${jobId}.mp4`),
-    })
-    .run()
+  seedExportJob(db, {
+    id: jobId,
+    projectId: 'project-1',
+    status: 'succeeded',
+    outputPath: join(exportDir, `${jobId}.mp4`),
+  })
 }
 
-function cleanup(exportDir: string, dbPath: string) {
+function cleanup(exportDir: string, cleanupServer: () => void) {
   try {
     rmSync(exportDir, { recursive: true, force: true })
   } catch {}
-  try {
-    rmSync(dbPath)
-  } catch {}
+  cleanupServer()
 }
 
 describe('export preview API', () => {
   test('returns 200 inline video/mp4 without range', async () => {
-    const { app, db, dbPath, exportDir } = createTestApp()
+    const { app, db, cleanup: cleanupServer, exportDir } = createTestApp()
     try {
       seedSucceededJob(db, exportDir, 'job-1')
-      const res = await app.request('/job-1/preview')
+      const res = await app.request('/api/export-jobs/job-1/preview')
       expect(res.status).toBe(200)
       expect(res.headers.get('content-type')).toBe('video/mp4')
       expect(res.headers.get('content-disposition')).toBe('inline; filename="export-job-1.mp4"')
       expect(res.headers.get('accept-ranges')).toBe('bytes')
     } finally {
-      cleanup(exportDir, dbPath)
+      cleanup(exportDir, cleanupServer)
     }
   })
 
   test('returns 206 partial content with valid range', async () => {
-    const { app, db, dbPath, exportDir } = createTestApp()
+    const { app, db, cleanup: cleanupServer, exportDir } = createTestApp()
     try {
       seedSucceededJob(db, exportDir, 'job-1')
-      const res = await app.request('/job-1/preview', {
+      const res = await app.request('/api/export-jobs/job-1/preview', {
         headers: { Range: 'bytes=0-1023' },
       })
       expect(res.status).toBe(206)
@@ -95,22 +62,22 @@ describe('export preview API', () => {
       expect(contentRange).toContain('bytes 0-1023/')
       expect(res.headers.get('content-length')).toBe('1024')
     } finally {
-      cleanup(exportDir, dbPath)
+      cleanup(exportDir, cleanupServer)
     }
   })
 
   test('returns 404 for missing job', async () => {
-    const { app, dbPath, exportDir } = createTestApp()
+    const { app, cleanup: cleanupServer, exportDir } = createTestApp()
     try {
-      const res = await app.request('/missing/preview')
+      const res = await app.request('/api/export-jobs/missing/preview')
       expect(res.status).toBe(404)
     } finally {
-      cleanup(exportDir, dbPath)
+      cleanup(exportDir, cleanupServer)
     }
   })
 
   test('returns 400 for unfinished job', async () => {
-    const { app, db, dbPath, exportDir } = createTestApp()
+    const { app, db, cleanup: cleanupServer, exportDir } = createTestApp()
     try {
       db.insert(exportJobs)
         .values({
@@ -120,15 +87,15 @@ describe('export preview API', () => {
           outputPath: null,
         })
         .run()
-      const res = await app.request('/job-2/preview')
+      const res = await app.request('/api/export-jobs/job-2/preview')
       expect(res.status).toBe(400)
     } finally {
-      cleanup(exportDir, dbPath)
+      cleanup(exportDir, cleanupServer)
     }
   })
 
   test('returns 404 for missing output file', async () => {
-    const { app, db, dbPath, exportDir } = createTestApp()
+    const { app, db, cleanup: cleanupServer, exportDir } = createTestApp()
     try {
       db.insert(exportJobs)
         .values({
@@ -138,23 +105,23 @@ describe('export preview API', () => {
           outputPath: join(exportDir, 'missing.mp4'),
         })
         .run()
-      const res = await app.request('/job-3/preview')
+      const res = await app.request('/api/export-jobs/job-3/preview')
       expect(res.status).toBe(404)
     } finally {
-      cleanup(exportDir, dbPath)
+      cleanup(exportDir, cleanupServer)
     }
   })
 
   test('returns 416 for invalid range', async () => {
-    const { app, db, dbPath, exportDir } = createTestApp()
+    const { app, db, cleanup: cleanupServer, exportDir } = createTestApp()
     try {
       seedSucceededJob(db, exportDir, 'job-1')
-      const res = await app.request('/job-1/preview', {
+      const res = await app.request('/api/export-jobs/job-1/preview', {
         headers: { Range: 'bytes=99999999-99999999' },
       })
       expect(res.status).toBe(416)
     } finally {
-      cleanup(exportDir, dbPath)
+      cleanup(exportDir, cleanupServer)
     }
   })
 })

--- a/projects/edit-vid2/tests/features/server-api.test.ts
+++ b/projects/edit-vid2/tests/features/server-api.test.ts
@@ -1,0 +1,382 @@
+import { describe, expect, test } from 'bun:test'
+import { Readable } from 'node:stream'
+import { eq } from 'drizzle-orm'
+import { exportJobs, projects, videoAssets } from '#/db/schema'
+import { errHandler } from '#/server/middleware/error-handler'
+import { recoverIncompleteJobs, removeExportFiles } from '#/server/routes/exports'
+import { createTestServer, seedExportJob, seedProject, seedTemplate, seedVideoAsset } from './server-test-helper'
+
+function jsonRequest(method: string, body: unknown) {
+  return {
+    method,
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  }
+}
+
+describe('server API routes', () => {
+  test('videos list and detail exclude soft-deleted records', async () => {
+    const { app, db, cleanup } = createTestServer()
+    try {
+      seedVideoAsset(db, { id: 'active-video' })
+      seedVideoAsset(db, { id: 'deleted-video', deletedAt: new Date().toISOString() })
+
+      const listRes = await app.request('/api/videos')
+      expect(listRes.status).toBe(200)
+      const videos = await listRes.json()
+      expect(videos.map((video: { id: string }) => video.id)).toEqual(['active-video'])
+
+      const deletedRes = await app.request('/api/videos/deleted-video')
+      expect(deletedRes.status).toBe(404)
+    } finally {
+      cleanup()
+    }
+  })
+
+  test('video upload validates file presence, MIME type, and max size', async () => {
+    const { app, cleanup } = createTestServer({
+      videoRoutes: {
+        getMaxUploadBytes: () => 4,
+        writeVideoFile: async () => {},
+      },
+    })
+    try {
+      const missingFileRes = await app.request('/api/videos', { method: 'POST', body: new FormData() })
+      expect(missingFileRes.status).toBe(400)
+
+      const unsupported = new FormData()
+      unsupported.set('file', new File(['abc'], 'note.txt', { type: 'text/plain' }))
+      const unsupportedRes = await app.request('/api/videos', { method: 'POST', body: unsupported })
+      expect(unsupportedRes.status).toBe(400)
+
+      const tooLarge = new FormData()
+      tooLarge.set('file', new File(['abcde'], 'movie.mp4', { type: 'video/mp4' }))
+      const tooLargeRes = await app.request('/api/videos', { method: 'POST', body: tooLarge })
+      expect(tooLargeRes.status).toBe(413)
+    } finally {
+      cleanup()
+    }
+  })
+
+  test('video upload stores a processing record and can complete probing through injected deps', async () => {
+    const scheduled: Promise<void>[] = []
+    const { app, db, cleanup } = createTestServer({
+      videoRoutes: {
+        createId: () => 'video-new',
+        getMaxUploadBytes: () => 100,
+        getVideoDir: (id) => `/tmp/${id}`,
+        ensureDir: () => {},
+        writeVideoFile: async () => {},
+        probeVideo: async () => ({
+          duration: 12,
+          width: 1280,
+          height: 720,
+          fps: 30,
+          codec: 'h264',
+          hasAudio: true,
+          fileSize: 5,
+        }),
+        generateThumbnail: async () => true,
+        scheduleVideoProcessing: (task) => {
+          scheduled.push(task())
+        },
+      },
+    })
+    try {
+      const form = new FormData()
+      form.set('file', new File(['mp4'], 'movie.mp4', { type: 'video/mp4' }))
+      form.set('displayName', 'Uploaded')
+
+      const res = await app.request('/api/videos', { method: 'POST', body: form })
+      expect(res.status).toBe(201)
+      const created = await res.json()
+      expect(created.id).toBe('video-new')
+      expect(created.status).toBe('processing')
+      expect(created.displayName).toBe('Uploaded')
+
+      await Promise.all(scheduled)
+      const updated = db.select().from(videoAssets).where(eq(videoAssets.id, 'video-new')).get()
+      expect(updated?.status).toBe('ready')
+      expect(updated?.width).toBe(1280)
+      expect(updated?.height).toBe(720)
+      expect(updated?.thumbnailPath).toBe('/tmp/video-new/thumbnail.jpg')
+    } finally {
+      cleanup()
+    }
+  })
+
+  test('projects require a ready video asset and support duplicate/delete', async () => {
+    const { app, db, cleanup } = createTestServer({
+      projectRoutes: {
+        createId: (() => {
+          const ids = ['project-new', 'project-copy']
+          return () => ids.shift() ?? 'project-extra'
+        })(),
+      },
+    })
+    try {
+      seedVideoAsset(db, { id: 'ready-video', status: 'ready' })
+      seedVideoAsset(db, { id: 'processing-video', status: 'processing' })
+
+      const invalidRes = await app.request(
+        '/api/projects',
+        jsonRequest('POST', { name: 'Project', videoAssetId: 'processing-video' })
+      )
+      expect(invalidRes.status).toBe(400)
+
+      const createRes = await app.request(
+        '/api/projects',
+        jsonRequest('POST', { name: 'Project', videoAssetId: 'ready-video' })
+      )
+      expect(createRes.status).toBe(201)
+
+      db.update(projects)
+        .set({ timelineState: { version: 1, tracks: [], keepSegments: [] } })
+        .where(eq(projects.id, 'project-new'))
+        .run()
+
+      const duplicateRes = await app.request('/api/projects/project-new/duplicate', jsonRequest('POST', {}))
+      expect(duplicateRes.status).toBe(201)
+      const duplicate = await duplicateRes.json()
+      expect(duplicate.id).toBe('project-copy')
+      expect(duplicate.name).toBe('Project (コピー)')
+      expect(duplicate.timelineState).toEqual({ version: 1, tracks: [], keepSegments: [] })
+
+      const deleteRes = await app.request('/api/projects/project-new', { method: 'DELETE' })
+      expect(deleteRes.status).toBe(204)
+      expect((await app.request('/api/projects/project-new')).status).toBe(404)
+    } finally {
+      cleanup()
+    }
+  })
+
+  test('templates enforce validation boundaries and persist defaults', async () => {
+    const { app, cleanup } = createTestServer({
+      templateRoutes: { createId: () => 'template-new' },
+    })
+    try {
+      expect((await app.request('/api/templates', jsonRequest('POST', { name: '' }))).status).toBe(400)
+      expect((await app.request('/api/templates', jsonRequest('POST', { name: 'x', fontSize: 0 }))).status).toBe(400)
+      expect(
+        (await app.request('/api/templates', jsonRequest('POST', { name: 'x', backgroundBoxOpacity: 1.01 }))).status
+      ).toBe(400)
+
+      const validRes = await app.request(
+        '/api/templates',
+        jsonRequest('POST', { name: 'a'.repeat(255), backgroundBoxOpacity: 1 })
+      )
+      expect(validRes.status).toBe(201)
+      const template = await validRes.json()
+      expect(template.id).toBe('template-new')
+      expect(template.name).toBe('a'.repeat(255))
+      expect(template.fontSize).toBe(48)
+      expect(template.backgroundBoxOpacity).toBe(1)
+    } finally {
+      cleanup()
+    }
+  })
+
+  test('preview route handles cache hit, generation success, and generation failure', async () => {
+    for (const scenario of ['cached', 'generated', 'failed'] as const) {
+      const generatedPaths: string[] = []
+      const { app, db, cleanup } = createTestServer({
+        previewRoutes: {
+          exists: (path) => scenario === 'cached' && path.endsWith('.jpg'),
+          ensureDir: () => {},
+          getCacheDir: () => '/tmp/previews',
+          generateSubtitlePreview: async ({ outputPath }) => {
+            generatedPaths.push(outputPath)
+            return scenario !== 'failed'
+          },
+        },
+      })
+      try {
+        seedVideoAsset(db)
+        seedProject(db)
+        seedTemplate(db)
+
+        const res = await app.request(
+          '/api/projects/project-1/previews/subtitle',
+          jsonRequest('POST', { sourceTime: 1, text: 'hello', templateId: 'template-1' })
+        )
+        expect(res.status).toBe(scenario === 'failed' ? 500 : 200)
+        if (scenario !== 'failed') {
+          expect((await res.json()).cached).toBe(scenario === 'cached')
+        }
+        expect(generatedPaths).toHaveLength(scenario === 'cached' ? 0 : 1)
+      } finally {
+        cleanup()
+      }
+    }
+  })
+
+  test('exports create jobs only for ready projects and enqueue once', async () => {
+    const enqueued: string[] = []
+    const { app, db, cleanup } = createTestServer({
+      exportRoutes: {
+        createId: () => 'job-new',
+        worker: {
+          enqueue: (jobId) => enqueued.push(jobId),
+          cancel: () => {},
+          onProgress: () => () => {},
+        },
+      },
+    })
+    try {
+      seedVideoAsset(db)
+      seedProject(db)
+
+      const invalidPresetRes = await app.request(
+        '/api/projects/project-1/export-jobs',
+        jsonRequest('POST', { preset: { crf: 52 } })
+      )
+      expect(invalidPresetRes.status).toBe(400)
+
+      const createRes = await app.request(
+        '/api/projects/project-1/export-jobs',
+        jsonRequest('POST', { preset: { crf: 0 } })
+      )
+      expect(createRes.status).toBe(201)
+      expect(enqueued).toEqual(['job-new'])
+
+      const missingProjectRes = await app.request('/api/projects/missing/export-jobs', jsonRequest('POST', {}))
+      expect(missingProjectRes.status).toBe(404)
+    } finally {
+      cleanup()
+    }
+  })
+
+  test('job list clamps limit and job actions follow status transitions', async () => {
+    const canceled: string[] = []
+    const removed: string[] = []
+    const { app, db, cleanup } = createTestServer({
+      jobRoutes: {
+        worker: {
+          enqueue: () => {},
+          cancel: (jobId) => canceled.push(jobId),
+          onProgress: () => () => {},
+        },
+        removeExportFiles: (jobId) => removed.push(jobId),
+      },
+    })
+    try {
+      seedVideoAsset(db)
+      seedProject(db)
+      seedExportJob(db, { id: 'queued-job', status: 'queued' })
+      seedExportJob(db, { id: 'running-job', status: 'running' })
+      seedExportJob(db, { id: 'succeeded-job', status: 'succeeded' })
+      seedExportJob(db, { id: 'failed-job', status: 'failed' })
+
+      const limitRes = await app.request('/api/export-jobs?limit=1')
+      expect(limitRes.status).toBe(200)
+      expect(await limitRes.json()).toHaveLength(1)
+
+      const cancelRes = await app.request('/api/export-jobs/queued-job/cancel', { method: 'POST' })
+      expect(cancelRes.status).toBe(200)
+      expect(canceled).toEqual(['queued-job'])
+      expect((await cancelRes.json()).status).toBe('canceled')
+
+      const deleteRunningRes = await app.request('/api/export-jobs/running-job', { method: 'DELETE' })
+      expect(deleteRunningRes.status).toBe(409)
+
+      const deleteQueuedRes = await app.request('/api/export-jobs/queued-job', { method: 'DELETE' })
+      expect(deleteQueuedRes.status).toBe(204)
+
+      const deleteSucceededRes = await app.request('/api/export-jobs/succeeded-job', { method: 'DELETE' })
+      expect(deleteSucceededRes.status).toBe(204)
+      expect(removed).toEqual(['queued-job', 'succeeded-job'])
+    } finally {
+      cleanup()
+    }
+  })
+
+  test('download and preview return expected statuses for files and ranges', async () => {
+    const bytes = new Uint8Array(2048).fill(1)
+    const { app, db, cleanup } = createTestServer({
+      jobRoutes: {
+        exists: (path) => path === '/tmp/export.mp4',
+        readFile: () => bytes,
+        stat: () => ({ size: bytes.length }),
+        createReadStream: () => Readable.from(bytes),
+      },
+    })
+    try {
+      seedVideoAsset(db)
+      seedProject(db)
+      seedExportJob(db, { id: 'ready-job', status: 'succeeded', outputPath: '/tmp/export.mp4' })
+      seedExportJob(db, { id: 'missing-file-job', status: 'succeeded', outputPath: '/tmp/missing.mp4' })
+
+      expect((await app.request('/api/export-jobs/ready-job/download')).status).toBe(200)
+      expect((await app.request('/api/export-jobs/missing-file-job/download')).status).toBe(404)
+
+      const rangeRes = await app.request('/api/export-jobs/ready-job/preview', { headers: { Range: 'bytes=0-1023' } })
+      expect(rangeRes.status).toBe(206)
+      expect(rangeRes.headers.get('content-range')).toBe('bytes 0-1023/2048')
+
+      const openRangeRes = await app.request('/api/export-jobs/ready-job/preview', {
+        headers: { Range: 'bytes=1024-' },
+      })
+      expect(openRangeRes.status).toBe(206)
+      expect(openRangeRes.headers.get('content-range')).toBe('bytes 1024-2047/2048')
+
+      const invalidRangeRes = await app.request('/api/export-jobs/ready-job/preview', {
+        headers: { Range: 'bytes=2048-2048' },
+      })
+      expect(invalidRangeRes.status).toBe(416)
+    } finally {
+      cleanup()
+    }
+  })
+
+  test('recoverIncompleteJobs converts running and canceling jobs only', () => {
+    const { db, cleanup } = createTestServer()
+    try {
+      seedVideoAsset(db)
+      seedProject(db)
+      seedExportJob(db, { id: 'queued-job', status: 'queued' })
+      seedExportJob(db, { id: 'running-job', status: 'running' })
+      seedExportJob(db, { id: 'canceling-job', status: 'canceling' })
+
+      recoverIncompleteJobs({ db })
+
+      const rows = db.select().from(exportJobs).all()
+      expect(Object.fromEntries(rows.map((row) => [row.id, row.status]))).toEqual({
+        'queued-job': 'queued',
+        'running-job': 'failed',
+        'canceling-job': 'canceled',
+      })
+    } finally {
+      cleanup()
+    }
+  })
+
+  test('middleware sets security headers and error handler returns JSON without stack', async () => {
+    const { app, cleanup } = createTestServer()
+    const originalError = console.error
+    try {
+      const res = await app.request('/api/videos')
+      expect(res.headers.get('x-content-type-options')).toBe('nosniff')
+      expect(res.headers.get('x-frame-options')).toBe('DENY')
+
+      console.error = () => {}
+      const errorRes = errHandler(new Error('boom'), {
+        json: (body: unknown, status: number) => Response.json(body, { status }),
+      } as Parameters<typeof errHandler>[1])
+      expect(errorRes.status).toBe(500)
+      expect(await errorRes.json()).toEqual({ error: 'boom' })
+    } finally {
+      console.error = originalError
+      cleanup()
+    }
+  })
+
+  test('removeExportFiles rejects traversal-like job ids', () => {
+    let message = ''
+    try {
+      removeExportFiles('../outside', () => {})
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error)
+    }
+    expect(message).toBe('invalid export path')
+  })
+})

--- a/projects/edit-vid2/tests/features/server-test-helper.ts
+++ b/projects/edit-vid2/tests/features/server-test-helper.ts
@@ -1,0 +1,89 @@
+import { rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { eq } from 'drizzle-orm'
+import { migrate } from 'drizzle-orm/bun-sqlite/migrator'
+import { testClient } from 'hono/testing'
+import { getDatabase } from '#/db'
+import type { AppDatabase } from '#/db'
+import { exportJobs, projects, subtitleTemplates, videoAssets } from '#/db/schema'
+import { createApp } from '#/server/app'
+
+type TestServerOptions = Parameters<typeof createApp>[0]
+
+export function createTestServer(options: TestServerOptions = {}) {
+  const dbPath = join(tmpdir(), `edit-vid2-server-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`)
+  const db = getDatabase(dbPath)
+  migrate(db, { migrationsFolder: './drizzle' })
+  const app = createApp({ ...options, db })
+  const client = testClient(app)
+
+  function cleanup() {
+    for (const path of [dbPath, `${dbPath}-wal`, `${dbPath}-shm`]) {
+      try {
+        rmSync(path, { force: true })
+      } catch {}
+    }
+  }
+
+  return { app, client, db, dbPath, cleanup }
+}
+
+export function seedVideoAsset(
+  db: AppDatabase,
+  overrides: Partial<typeof videoAssets.$inferInsert> = {}
+): typeof videoAssets.$inferSelect {
+  const value = {
+    id: 'video-1',
+    originalFilename: 'source.mp4',
+    displayName: 'Source Video',
+    storagePath: 'data/videos/video-1/source.mp4',
+    status: 'ready',
+    width: 1920,
+    height: 1080,
+    ...overrides,
+  }
+  db.insert(videoAssets).values(value).run()
+  return db.select().from(videoAssets).where(eq(videoAssets.id, value.id)).get()!
+}
+
+export function seedProject(
+  db: AppDatabase,
+  overrides: Partial<typeof projects.$inferInsert> = {}
+): typeof projects.$inferSelect {
+  const value = {
+    id: 'project-1',
+    videoAssetId: 'video-1',
+    name: 'Project',
+    ...overrides,
+  }
+  db.insert(projects).values(value).run()
+  return db.select().from(projects).where(eq(projects.id, value.id)).get()!
+}
+
+export function seedTemplate(
+  db: AppDatabase,
+  overrides: Partial<typeof subtitleTemplates.$inferInsert> = {}
+): typeof subtitleTemplates.$inferSelect {
+  const value = {
+    id: 'template-1',
+    name: 'Template',
+    ...overrides,
+  }
+  db.insert(subtitleTemplates).values(value).run()
+  return db.select().from(subtitleTemplates).where(eq(subtitleTemplates.id, value.id)).get()!
+}
+
+export function seedExportJob(
+  db: AppDatabase,
+  overrides: Partial<typeof exportJobs.$inferInsert> = {}
+): typeof exportJobs.$inferSelect {
+  const value = {
+    id: 'job-1',
+    projectId: 'project-1',
+    status: 'queued',
+    ...overrides,
+  }
+  db.insert(exportJobs).values(value).run()
+  return db.select().from(exportJobs).where(eq(exportJobs.id, value.id)).get()!
+}

--- a/projects/edit-vid2/vite.config.ts
+++ b/projects/edit-vid2/vite.config.ts
@@ -34,7 +34,7 @@ export default defineConfig(({ mode }) => {
 
     case 'dev':
       return {
-        plugins: [tanstackRouter({ target: 'react' }), devServer({ entry: './src/server/app.tsx' })],
+        plugins: [tanstackRouter({ target: 'react' }), devServer({ entry: './src/server/dev-server.ts' })],
         resolve: { alias: sourceAlias },
         server: {
           port: process.env.SERVER_PORT ? Number(process.env.SERVER_PORT) : undefined,


### PR DESCRIPTION
## Issues

- Refs server UnitTest coverage / testability plan

## Why

`src/server` の API ルートは、DB・FS・ffmpeg・worker などの副作用がルート内に直結しており、軽量な UnitTest を追加しにくい状態でした。
サーバーサイドの API 契約と状態遷移を継続的に検証できるよう、依存注入とテスト helper を整備します。

## Summary

Hono app と各 server route を factory 化し、テスト時に DB や副作用依存を差し替えられるようにしました。
あわせて server API の UnitTest と共通 helper を追加し、既存 export preview テストも full app 経由へ寄せています。

## Changes

- `createApp(deps)` を追加し、import 時の `recoverIncompleteJobs()` 実行を廃止
- videos / previews / exports / projects / templates routes を factory 化し、副作用依存を注入可能に変更
- `tests/features/server-test-helper.ts` を追加し、temp SQLite DB・seed・Hono test client の準備を共通化
- `tests/features/server-api.test.ts` を追加し、API 契約、validation、状態遷移、preview/export 副作用境界を検証
- 既存 `export-preview.test.ts` を新 helper と full app route 経由に更新

## Checklist

- [x] フォーマット: `bun run format:check`
- [x] リント / 型チェック: `bun run lint`
- [x] テスト: `bun test tests/features`

## Details

- ffmpeg 実行や実 worker 処理は UnitTest では mock し、重い E2E とは責務を分けています。
- `recoverIncompleteJobs()` は `bun-server.ts` 起動時に明示実行する形に変更しました。
