### PR TITLE
fix(edit-vid2): Dockerfile に日本語フォント(fonts-ipafont)を追加

### DIFF
--- a/projects/edit-vid2/Dockerfile
+++ b/projects/edit-vid2/Dockerfile
@@ -22,7 +22,7 @@ RUN bun run build
 # ── Final Stage ─────────────────────────────────────────────
 FROM oven/bun:1-slim AS final
 WORKDIR /app
-RUN apt-get update && apt-get install -y --no-install-recommends ffmpeg && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ffmpeg fonts-ipafont && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /app/package.json /app/bun.lock ./
 RUN bun install --frozen-lockfile --production
 COPY --from=builder /app/dist ./dist


### PR DESCRIPTION
## Issues

- 日本語字幕が豆腐（□）になる問題を修正

## Why

`edit-vid2` の Docker イメージに日本語フォントが含まれておらず、日本語字幕がレンダリング時に豆腐（□）として表示されていた。

## Summary

Final ステージの `apt-get install` に `fonts-ipafont` を追加。`projects/edit-vid/Dockerfile` の対応を参考にした。

## Changes

- `projects/edit-vid2/Dockerfile` の 25行目: `ffmpeg` に加えて `fonts-ipafont` をインストール

## Checklist

- [x] フォーマット（Dockerfile のみの変更のためスキップ）
- [x] リント / 型チェック（Dockerfile のみの変更のためスキップ）
- [x] テスト（Dockerfile のみの変更のためスキップ）
