### PR TITLE
feat(edit-vid2): add preview cache clearing

### DIFF
--- a/projects/edit-vid2/src/client/features/editor/page.tsx
+++ b/projects/edit-vid2/src/client/features/editor/page.tsx
@@ -755,6 +755,7 @@ function SubtitleDetailForm({
 }) {
   const queryClient = useQueryClient()
   const [isPreviewOpen, setIsPreviewOpen] = useState(false)
+  const [clearCacheError, setClearCacheError] = useState<string | null>(null)
   const previewText = item.text.trim()
   const previewSourceTime = Math.max(0, Number(item.sourceStart.toFixed(2)))
   const clearCacheMutation = useMutation({
@@ -765,8 +766,14 @@ function SubtitleDetailForm({
         throw new Error(body?.error ?? 'preview cache clear failed')
       }
     },
+    onMutate: () => {
+      setClearCacheError(null)
+    },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['subtitle-preview'] })
+      queryClient.invalidateQueries({ queryKey: ['subtitle-preview', projectId] })
+    },
+    onError: (error) => {
+      setClearCacheError(error instanceof Error ? error.message : 'preview cache clear failed')
     },
   })
   const previewQuery = useQuery<{ path: string; cached: boolean }>({
@@ -881,6 +888,11 @@ function SubtitleDetailForm({
                 キャッシュクリア
               </button>
             </div>
+            {clearCacheError && (
+              <p role='alert' className='border-b border-red-200 px-3 py-2 text-xs text-red-600 dark:border-red-900/60'>
+                キャッシュクリアに失敗しました
+              </p>
+            )}
             <div className='flex aspect-video items-center justify-center bg-gray-100 text-xs text-gray-500 dark:bg-gray-950 dark:text-gray-400'>
               {!canPreview ? (
                 <span>元動画が必要です</span>

--- a/projects/edit-vid2/src/client/features/editor/page.tsx
+++ b/projects/edit-vid2/src/client/features/editor/page.tsx
@@ -12,6 +12,7 @@ import {
   LoaderCircle,
   Plus,
   RotateCcw,
+  Trash2,
   Type,
   X,
 } from 'lucide-react'
@@ -752,9 +753,22 @@ function SubtitleDetailForm({
   onChange: (item: SubtitleItem) => void
   onDelete: () => void
 }) {
+  const queryClient = useQueryClient()
   const [isPreviewOpen, setIsPreviewOpen] = useState(false)
   const previewText = item.text.trim()
   const previewSourceTime = Math.max(0, Number(item.sourceStart.toFixed(2)))
+  const clearCacheMutation = useMutation({
+    mutationFn: async () => {
+      const res = await fetch(`/api/projects/${projectId}/previews`, { method: 'DELETE' })
+      if (!res.ok) {
+        const body = (await res.json().catch(() => null)) as { error?: string } | null
+        throw new Error(body?.error ?? 'preview cache clear failed')
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['subtitle-preview'] })
+    },
+  })
   const previewQuery = useQuery<{ path: string; cached: boolean }>({
     queryKey: ['subtitle-preview', projectId, item.id, previewSourceTime, previewText, item.templateId],
     enabled: canPreview && previewText.length > 0,
@@ -846,9 +860,26 @@ function SubtitleDetailForm({
             data-testid='subtitle-preview'
             className='overflow-hidden rounded-lg border border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-900'
           >
-            <div className='flex items-center gap-2 border-b border-gray-200 px-3 py-2 dark:border-gray-700'>
-              <ImageIcon className='h-3.5 w-3.5 text-gray-500 dark:text-gray-400' />
-              <h3 className='text-xs font-medium text-gray-600 dark:text-gray-300'>静止画プレビュー</h3>
+            <div className='flex items-center justify-between gap-2 border-b border-gray-200 px-3 py-2 dark:border-gray-700'>
+              <div className='flex min-w-0 items-center gap-2'>
+                <ImageIcon className='h-3.5 w-3.5 shrink-0 text-gray-500 dark:text-gray-400' />
+                <h3 className='truncate text-xs font-medium text-gray-600 dark:text-gray-300'>静止画プレビュー</h3>
+              </div>
+              <button
+                type='button'
+                onClick={() => clearCacheMutation.mutate()}
+                disabled={clearCacheMutation.isPending}
+                className='inline-flex shrink-0 items-center gap-1 rounded border border-gray-300 px-2 py-1 text-xs text-gray-600 transition hover:bg-white disabled:opacity-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800'
+                aria-label='プレビューキャッシュをクリア'
+                title='プレビューキャッシュをクリア'
+              >
+                {clearCacheMutation.isPending ? (
+                  <LoaderCircle className='h-3.5 w-3.5 animate-spin' />
+                ) : (
+                  <Trash2 className='h-3.5 w-3.5' />
+                )}
+                キャッシュクリア
+              </button>
             </div>
             <div className='flex aspect-video items-center justify-center bg-gray-100 text-xs text-gray-500 dark:bg-gray-950 dark:text-gray-400'>
               {!canPreview ? (

--- a/projects/edit-vid2/src/server/app.tsx
+++ b/projects/edit-vid2/src/server/app.tsx
@@ -53,7 +53,7 @@ function createApp(deps: AppDeps = {}) {
     .route('/api/videos', createVideoRoutes(deps.videoRoutes))
     .route('/api/projects', createProjectRoutes(deps.projectRoutes))
     .route('/api/templates', createTemplateRoutes(deps.templateRoutes))
-    .route('/api/projects/:projectId/previews/subtitle', createPreviewRoutes(deps.previewRoutes))
+    .route('/api/projects/:projectId/previews', createPreviewRoutes(deps.previewRoutes))
     .route('/api/projects/:projectId/export-jobs', createExportRoutes(deps.exportRoutes))
     .route('/api/export-jobs', createJobRoutes(deps.jobRoutes))
     .route('/', htmlRoutes)

--- a/projects/edit-vid2/src/server/features/preview/preview-service.ts
+++ b/projects/edit-vid2/src/server/features/preview/preview-service.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto'
-import { existsSync, mkdirSync, unlinkSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, rmSync, unlinkSync, writeFileSync } from 'node:fs'
 import { $ } from 'bun'
 import { generateAssContent } from '#/server/features/ass/ass-generator'
 import type { SubtitleStyle } from '#/shared/schemas'
@@ -14,6 +14,13 @@ export function buildPreviewCacheKey(
 ): string {
   const payload = `${projectId}:${videoAssetId}:${sourceTime}:${JSON.stringify(template)}:${text}:${renderVersion}`
   return createHash('sha256').update(payload).digest('hex').substring(0, 16)
+}
+
+export function clearPreviewCache(projectId: string): void {
+  const cacheDir = `data/projects/${projectId}/previews`
+  if (existsSync(cacheDir)) {
+    rmSync(cacheDir, { recursive: true, force: true })
+  }
 }
 
 export async function generateSubtitlePreview(params: {

--- a/projects/edit-vid2/src/server/routes/previews.ts
+++ b/projects/edit-vid2/src/server/routes/previews.ts
@@ -4,6 +4,7 @@ import { Hono } from 'hono'
 import { z } from 'zod'
 import {
   buildPreviewCacheKey,
+  clearPreviewCache as defaultClearPreviewCache,
   generateSubtitlePreview as defaultGenerateSubtitlePreview,
 } from '#/server/features/preview/preview-service'
 import { getProjectById } from '#/server/features/projects/project-repository'
@@ -37,6 +38,7 @@ type PreviewRouteDeps = {
   ensureDir: (path: string) => void
   getCacheDir: (projectId: string) => string
   generateSubtitlePreview: typeof defaultGenerateSubtitlePreview
+  clearProjectPreviews: (projectId: string) => void
 }
 
 const defaultPreviewRouteDeps: PreviewRouteDeps = {
@@ -44,13 +46,14 @@ const defaultPreviewRouteDeps: PreviewRouteDeps = {
   ensureDir: (path) => mkdirSync(path, { recursive: true }),
   getCacheDir: (projectId) => `data/projects/${projectId}/previews`,
   generateSubtitlePreview: defaultGenerateSubtitlePreview,
+  clearProjectPreviews: defaultClearPreviewCache,
 }
 
 function createPreviewRoutes(deps: Partial<PreviewRouteDeps> = {}) {
   const resolvedDeps = { ...defaultPreviewRouteDeps, ...deps }
   const previewRoutes = new Hono<HonoEnv>()
 
-  previewRoutes.post('/', sValidator('json', previewSchema), async (c) => {
+  previewRoutes.post('/subtitle', sValidator('json', previewSchema), async (c) => {
     const db = c.var.db
     const projectId = c.req.param('projectId')
     if (!projectId) {
@@ -101,6 +104,21 @@ function createPreviewRoutes(deps: Partial<PreviewRouteDeps> = {}) {
     }
 
     return c.json({ path: outputPath, cached: false })
+  })
+
+  previewRoutes.delete('/', (c) => {
+    const db = c.var.db
+    const projectId = c.req.param('projectId')
+    if (!projectId) {
+      return c.json({ error: 'projectId required' }, 400)
+    }
+    const project = getProjectById(db, projectId)
+    if (!project) {
+      return c.json({ error: 'project not found' }, 404)
+    }
+
+    resolvedDeps.clearProjectPreviews(projectId)
+    return c.body(null, 204)
   })
 
   return previewRoutes

--- a/projects/edit-vid2/tests/features/server-api.test.ts
+++ b/projects/edit-vid2/tests/features/server-api.test.ts
@@ -184,6 +184,7 @@ describe('server API routes', () => {
           exists: (path) => scenario === 'cached' && path.endsWith('.jpg'),
           ensureDir: () => {},
           getCacheDir: () => '/tmp/previews',
+          clearProjectPreviews: () => {},
           generateSubtitlePreview: async ({ outputPath }) => {
             generatedPaths.push(outputPath)
             return scenario !== 'failed'
@@ -207,6 +208,69 @@ describe('server API routes', () => {
       } finally {
         cleanup()
       }
+    }
+  })
+
+  test('preview cache can be cleared for an existing project', async () => {
+    let cachePresent = true
+    const clearedProjectIds: string[] = []
+    const generatedPaths: string[] = []
+    const { app, db, cleanup } = createTestServer({
+      previewRoutes: {
+        exists: (path) => path.endsWith('.jpg') && cachePresent,
+        ensureDir: () => {},
+        getCacheDir: () => '/tmp/previews',
+        clearProjectPreviews: (projectId) => {
+          clearedProjectIds.push(projectId)
+          cachePresent = false
+        },
+        generateSubtitlePreview: async ({ outputPath }) => {
+          generatedPaths.push(outputPath)
+          return true
+        },
+      },
+    })
+    try {
+      seedVideoAsset(db)
+      seedProject(db)
+      seedTemplate(db)
+
+      const cachedRes = await app.request(
+        '/api/projects/project-1/previews/subtitle',
+        jsonRequest('POST', { sourceTime: 1, text: 'hello', templateId: 'template-1' })
+      )
+      expect(cachedRes.status).toBe(200)
+      expect((await cachedRes.json()).cached).toBe(true)
+
+      const clearRes = await app.request('/api/projects/project-1/previews', { method: 'DELETE' })
+      expect(clearRes.status).toBe(204)
+      expect(clearedProjectIds).toEqual(['project-1'])
+
+      const regeneratedRes = await app.request(
+        '/api/projects/project-1/previews/subtitle',
+        jsonRequest('POST', { sourceTime: 1, text: 'hello', templateId: 'template-1' })
+      )
+      expect(regeneratedRes.status).toBe(200)
+      expect((await regeneratedRes.json()).cached).toBe(false)
+      expect(generatedPaths).toHaveLength(1)
+    } finally {
+      cleanup()
+    }
+  })
+
+  test('preview cache clear returns 404 for a missing project', async () => {
+    const clearedProjectIds: string[] = []
+    const { app, cleanup } = createTestServer({
+      previewRoutes: {
+        clearProjectPreviews: (projectId) => clearedProjectIds.push(projectId),
+      },
+    })
+    try {
+      const res = await app.request('/api/projects/missing/previews', { method: 'DELETE' })
+      expect(res.status).toBe(404)
+      expect(clearedProjectIds).toEqual([])
+    } finally {
+      cleanup()
     }
   })
 


### PR DESCRIPTION
## Issues

- Close #1078

## Why

Subtitle preview images are cached on disk under each project, but stale preview files keep accumulating when subtitle parameters change. Users need a manual way to clear that project-level preview cache.

## Summary

This PR adds a project preview cache clear API and exposes it from the subtitle preview panel. After clearing the disk cache, the UI invalidates subtitle preview queries so previews are regenerated.

## Changes

- Add `clearPreviewCache(projectId)` and `DELETE /api/projects/:projectId/previews`
- Mount preview routes at `/api/projects/:projectId/previews` while preserving `POST /subtitle`
- Add a subtitle preview cache clear button in `SubtitleDetailForm`
- Cover cache clear, regeneration after clear, and missing project handling in server API tests

## Verification

- [x] `bun run lint` - passed
- [x] `bun run format:check` - passed
- [x] `bun test tests/features/server-api.test.ts` - passed
- [x] `bun test tests/features` - passed
- [ ] `bun test` - failed: existing E2E `Subtitle text input IME handling > defers saving during composition and saves once on compositionend` times out after 5000ms even when run alone, then later tests fail because the Playwright page is closed
