### PR TITLE
fix(edit-vid2): enable video seeking with HTTP Range support and sync timeline

### DIFF
--- a/projects/edit-vid2/src/client/features/editor/page.tsx
+++ b/projects/edit-vid2/src/client/features/editor/page.tsx
@@ -273,7 +273,6 @@ export function EditorPage() {
               src={`/${videoAsset.storagePath}`}
               controls
               onTimeUpdate={(e) => {
-                if (e.currentTarget.paused) return
                 setCurrentTime(e.currentTarget.currentTime)
               }}
               onLoadedMetadata={(e) => setDuration(e.currentTarget.duration)}

--- a/projects/edit-vid2/src/server/app.tsx
+++ b/projects/edit-vid2/src/server/app.tsx
@@ -1,4 +1,8 @@
+import { createReadStream, existsSync, statSync } from 'node:fs'
+import { extname, resolve } from 'node:path'
+import { Readable } from 'node:stream'
 import { Hono } from 'hono'
+import type { Context } from 'hono'
 import { serveStatic } from 'hono/bun'
 import { getDatabase } from '#/db'
 import type { AppDatabase } from '#/db'
@@ -10,6 +14,66 @@ import { createPreviewRoutes } from '#/server/routes/previews'
 import { createProjectRoutes } from '#/server/routes/projects'
 import { createTemplateRoutes } from '#/server/routes/templates'
 import { createVideoRoutes } from '#/server/routes/videos'
+
+const MIME_TYPES: Record<string, string> = {
+  '.mp4': 'video/mp4',
+  '.webm': 'video/webm',
+  '.ogv': 'video/ogg',
+  '.mov': 'video/quicktime',
+  '.avi': 'video/x-msvideo',
+  '.mkv': 'video/x-matroska',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.png': 'image/png',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.svg': 'image/svg+xml',
+}
+
+function serveDataFile(c: Context) {
+  const url = new URL(c.req.url)
+  const filePath = resolve(process.cwd(), `.${url.pathname}`)
+
+  if (!existsSync(filePath)) {
+    return c.notFound()
+  }
+
+  const { size } = statSync(filePath)
+  const ext = extname(filePath).toLowerCase()
+  const contentType = MIME_TYPES[ext] || 'application/octet-stream'
+  const rangeHeader = c.req.header('range')
+
+  if (!rangeHeader) {
+    const stream = createReadStream(filePath)
+    return c.body(Readable.toWeb(stream) as unknown as ReadableStream, 200, {
+      'Content-Type': contentType,
+      'Content-Length': String(size),
+      'Accept-Ranges': 'bytes',
+    })
+  }
+
+  const match = rangeHeader.match(/^bytes=(\d+)-(\d*)$/)
+  if (!match) {
+    return c.body('range not satisfiable', 416)
+  }
+
+  const start = Number.parseInt(match[1], 10)
+  const end = match[2] ? Number.parseInt(match[2], 10) : size - 1
+
+  if (Number.isNaN(start) || Number.isNaN(end) || start >= size || end >= size || start > end) {
+    return c.body('range not satisfiable', 416)
+  }
+
+  const length = end - start + 1
+  const stream = createReadStream(filePath, { start, end })
+
+  return c.body(Readable.toWeb(stream) as unknown as ReadableStream, 206, {
+    'Content-Type': contentType,
+    'Content-Range': `bytes ${start}-${end}/${size}`,
+    'Content-Length': String(length),
+    'Accept-Ranges': 'bytes',
+  })
+}
 
 type AppDeps = {
   db?: AppDatabase
@@ -49,7 +113,7 @@ function createApp(deps: AppDeps = {}) {
 
   return app
     .get('/static/*', serveStatic({ root: './dist' }))
-    .get('/data/*', serveStatic({ root: './' }))
+    .get('/data/*', serveDataFile)
     .route('/api/videos', createVideoRoutes(deps.videoRoutes))
     .route('/api/projects', createProjectRoutes(deps.projectRoutes))
     .route('/api/templates', createTemplateRoutes(deps.templateRoutes))

--- a/projects/edit-vid2/src/server/app.tsx
+++ b/projects/edit-vid2/src/server/app.tsx
@@ -38,7 +38,12 @@ function serveDataFile(c: Context) {
     return c.notFound()
   }
 
-  const { size } = statSync(filePath)
+  const stats = statSync(filePath)
+  if (!stats.isFile()) {
+    return c.notFound()
+  }
+
+  const { size } = stats
   const ext = extname(filePath).toLowerCase()
   const contentType = MIME_TYPES[ext] || 'application/octet-stream'
   const rangeHeader = c.req.header('range')
@@ -52,16 +57,37 @@ function serveDataFile(c: Context) {
     })
   }
 
-  const match = rangeHeader.match(/^bytes=(\d+)-(\d*)$/)
+  const match = rangeHeader.match(/^bytes=(\d*)-(\d*)$/)
   if (!match) {
     return c.body('range not satisfiable', 416)
   }
 
-  const start = Number.parseInt(match[1], 10)
-  const end = match[2] ? Number.parseInt(match[2], 10) : size - 1
+  let start: number
+  let end: number
 
-  if (Number.isNaN(start) || Number.isNaN(end) || start >= size || end >= size || start > end) {
-    return c.body('range not satisfiable', 416)
+  if (match[1] === '') {
+    // suffix range: bytes=-N (last N bytes)
+    const suffixLength = Number.parseInt(match[2], 10)
+    if (Number.isNaN(suffixLength) || suffixLength <= 0) {
+      return c.body('range not satisfiable', 416)
+    }
+    start = Math.max(0, size - suffixLength)
+    end = size - 1
+  } else {
+    start = Number.parseInt(match[1], 10)
+    end = match[2] ? Number.parseInt(match[2], 10) : size - 1
+
+    if (Number.isNaN(start) || Number.isNaN(end)) {
+      return c.body('range not satisfiable', 416)
+    }
+
+    if (end >= size) {
+      end = size - 1
+    }
+
+    if (start > end || start >= size) {
+      return c.body('range not satisfiable', 416)
+    }
   }
 
   const length = end - start + 1


### PR DESCRIPTION
## Why

動画のシークバー・タイムライン操作が一切動作しない問題を修正。根本原因は `/data/*` の静的ファイル配信が HTTP Range リクエストに対応しておらず、ブラウザが動画をシーク不可と判断していたため。

## Summary

2つの変更でシークバーとタイムラインの連動を実現：
1. `app.tsx` の `/data/*` を Range 対応カスタムハンドラに置き換え
2. `page.tsx` の `onTimeUpdate` から `paused` ガードを削除しシークバー操作中のタイムライン追従を有効化

## Changes

- **fix(edit-vid2): add HTTP Range support for video file serving**
  - `app.tsx`: `serveStatic` → `createReadStream` ベースのカスタムハンドラ
  - `Range: bytes=` ヘッダーに `206 Partial Content` + `Content-Range` で応答
  - 非 Range リクエストは `200` + `Content-Length` + `Accept-Ranges: bytes`

- **feat(edit-vid2): sync timeline position with video seek bar**
  - `page.tsx`: `onTimeUpdate` の `if (paused) return` ガードを削除
  - シークバー操作中の `timeupdate` がタイムラインの `currentTime` を更新

## Checklist

- [x] フォーマット
- [x] リント / 型チェック
- [x] テスト (56 pass)

## Details

ブラウザは `<video>` のシーク操作に HTTP Range リクエストを使用する。`hono/bun` の `serveStatic` は Range を無視し `Content-Length: 0` で応答していたため、`video.seekable` が `[0, 0]` となり `currentTime` 代入もネイティブシークバーも無視されていた。

修正後:
```
HTTP/1.1 206 Partial Content
Content-Range: bytes 0-1000/5510872
Content-Length: 1001
Content-Type: video/mp4
Accept-Ranges: bytes
```
