### PR TITLE
refactor(edit-vid2): split HTTP Range file serving and add server tests

### DIFF
--- a/projects/edit-vid2/src/server/app.tsx
+++ b/projects/edit-vid2/src/server/app.tsx
@@ -1,105 +1,16 @@
-import { createReadStream, existsSync, statSync } from 'node:fs'
-import { extname, resolve } from 'node:path'
-import { Readable } from 'node:stream'
 import { Hono } from 'hono'
-import type { Context } from 'hono'
 import { serveStatic } from 'hono/bun'
 import { getDatabase } from '#/db'
 import type { AppDatabase } from '#/db'
 import { errHandler } from '#/server/middleware/error-handler'
 import { applySecurityHeaders } from '#/server/middleware/security-headers'
+import { createDataFileRoutes, type DataFileRouteDeps } from '#/server/routes/data-files'
 import { createExportRoutes, createJobRoutes } from '#/server/routes/exports'
 import { htmlRoutes } from '#/server/routes/html'
 import { createPreviewRoutes } from '#/server/routes/previews'
 import { createProjectRoutes } from '#/server/routes/projects'
 import { createTemplateRoutes } from '#/server/routes/templates'
 import { createVideoRoutes } from '#/server/routes/videos'
-
-const MIME_TYPES: Record<string, string> = {
-  '.mp4': 'video/mp4',
-  '.webm': 'video/webm',
-  '.ogv': 'video/ogg',
-  '.mov': 'video/quicktime',
-  '.avi': 'video/x-msvideo',
-  '.mkv': 'video/x-matroska',
-  '.jpg': 'image/jpeg',
-  '.jpeg': 'image/jpeg',
-  '.png': 'image/png',
-  '.gif': 'image/gif',
-  '.webp': 'image/webp',
-  '.svg': 'image/svg+xml',
-}
-
-function serveDataFile(c: Context) {
-  const url = new URL(c.req.url)
-  const filePath = resolve(process.cwd(), `.${url.pathname}`)
-
-  if (!existsSync(filePath)) {
-    return c.notFound()
-  }
-
-  const stats = statSync(filePath)
-  if (!stats.isFile()) {
-    return c.notFound()
-  }
-
-  const { size } = stats
-  const ext = extname(filePath).toLowerCase()
-  const contentType = MIME_TYPES[ext] || 'application/octet-stream'
-  const rangeHeader = c.req.header('range')
-
-  if (!rangeHeader) {
-    const stream = createReadStream(filePath)
-    return c.body(Readable.toWeb(stream) as unknown as ReadableStream, 200, {
-      'Content-Type': contentType,
-      'Content-Length': String(size),
-      'Accept-Ranges': 'bytes',
-    })
-  }
-
-  const match = rangeHeader.match(/^bytes=(\d*)-(\d*)$/)
-  if (!match) {
-    return c.body('range not satisfiable', 416)
-  }
-
-  let start: number
-  let end: number
-
-  if (match[1] === '') {
-    // suffix range: bytes=-N (last N bytes)
-    const suffixLength = Number.parseInt(match[2], 10)
-    if (Number.isNaN(suffixLength) || suffixLength <= 0) {
-      return c.body('range not satisfiable', 416)
-    }
-    start = Math.max(0, size - suffixLength)
-    end = size - 1
-  } else {
-    start = Number.parseInt(match[1], 10)
-    end = match[2] ? Number.parseInt(match[2], 10) : size - 1
-
-    if (Number.isNaN(start) || Number.isNaN(end)) {
-      return c.body('range not satisfiable', 416)
-    }
-
-    if (end >= size) {
-      end = size - 1
-    }
-
-    if (start > end || start >= size) {
-      return c.body('range not satisfiable', 416)
-    }
-  }
-
-  const length = end - start + 1
-  const stream = createReadStream(filePath, { start, end })
-
-  return c.body(Readable.toWeb(stream) as unknown as ReadableStream, 206, {
-    'Content-Type': contentType,
-    'Content-Range': `bytes ${start}-${end}/${size}`,
-    'Content-Length': String(length),
-    'Accept-Ranges': 'bytes',
-  })
-}
 
 type AppDeps = {
   db?: AppDatabase
@@ -110,6 +21,7 @@ type AppDeps = {
   previewRoutes?: Parameters<typeof createPreviewRoutes>[0]
   exportRoutes?: Parameters<typeof createExportRoutes>[0]
   jobRoutes?: Parameters<typeof createJobRoutes>[0]
+  dataFileRoutes?: Partial<DataFileRouteDeps>
 }
 
 let db: AppDatabase | null = null
@@ -124,6 +36,7 @@ function getOrCreateDb() {
 
 function createApp(deps: AppDeps = {}) {
   const getDb = deps.getDb ?? (() => deps.db ?? getOrCreateDb())
+  const dataFileDeps = deps.dataFileRoutes ?? {}
 
   const app = new Hono<{
     Variables: {
@@ -139,7 +52,7 @@ function createApp(deps: AppDeps = {}) {
 
   return app
     .get('/static/*', serveStatic({ root: './dist' }))
-    .get('/data/*', serveDataFile)
+    .route('/', createDataFileRoutes(dataFileDeps))
     .route('/api/videos', createVideoRoutes(deps.videoRoutes))
     .route('/api/projects', createProjectRoutes(deps.projectRoutes))
     .route('/api/templates', createTemplateRoutes(deps.templateRoutes))

--- a/projects/edit-vid2/src/server/features/http/byte-range.ts
+++ b/projects/edit-vid2/src/server/features/http/byte-range.ts
@@ -1,0 +1,50 @@
+export type ByteRange =
+  | { ok: true; start: number; end: number; length: number }
+  | { ok: false; reason: 'invalid' | 'unsatisfiable' }
+
+export function parseByteRange(rangeHeader: string, size: number): ByteRange {
+  const match = rangeHeader.trim().match(/^bytes=(\d*)-(\d*)$/)
+  if (!match) {
+    return { ok: false, reason: 'invalid' }
+  }
+
+  const [, startStr, endStr] = match
+
+  if (startStr === '' && endStr === '') {
+    return { ok: false, reason: 'invalid' }
+  }
+
+  if (startStr === '') {
+    const suffixLength = Number.parseInt(endStr, 10)
+    if (Number.isNaN(suffixLength) || suffixLength <= 0) {
+      return { ok: false, reason: 'invalid' }
+    }
+    if (size === 0) {
+      return { ok: false, reason: 'unsatisfiable' }
+    }
+    const start = Math.max(0, size - suffixLength)
+    const end = size - 1
+    return { ok: true, start, end, length: end - start + 1 }
+  }
+
+  const start = Number.parseInt(startStr, 10)
+  if (Number.isNaN(start) || start < 0) {
+    return { ok: false, reason: 'invalid' }
+  }
+
+  const endExplicit = endStr !== ''
+  let end = endExplicit ? Number.parseInt(endStr, 10) : size - 1
+  if (Number.isNaN(end) || (endExplicit && end < 0)) {
+    return { ok: false, reason: 'invalid' }
+  }
+
+  if (end >= size) {
+    end = size - 1
+  }
+
+  if (start > end || start >= size) {
+    return { ok: false, reason: 'unsatisfiable' }
+  }
+
+  return { ok: true, start, end, length: end - start + 1 }
+}

--- a/projects/edit-vid2/src/server/routes/data-files.ts
+++ b/projects/edit-vid2/src/server/routes/data-files.ts
@@ -51,12 +51,16 @@ function isWithinRoot(root: string, target: string): boolean {
   return target === resolvedRoot || target.startsWith(prefix)
 }
 
-function resolveRelativePath(c: Context): string {
-  return decodeURIComponent(c.req.path.replace(PUBLIC_DATA_PREFIX, ''))
+function resolveRelativePath(c: Context): string | null {
+  const raw = c.req.path.replace(PUBLIC_DATA_PREFIX, '')
+  try {
+    return decodeURIComponent(raw)
+  } catch {
+    return null
+  }
 }
 
-function serveFile(c: Context, root: string, fs: FileSystemLike) {
-  const relativePath = resolveRelativePath(c)
+function serveFile(c: Context, root: string, fs: FileSystemLike, relativePath: string) {
   const filePath = resolve(root, relativePath)
 
   if (!isWithinRoot(root, filePath)) {
@@ -107,10 +111,20 @@ export function createDataFileRoutes(deps: Partial<DataFileRouteDeps> = {}) {
   const resolvedDeps = { ...defaultDataFileRouteDeps, ...deps }
   const routes = new Hono<HonoEnv>()
 
-  routes.get('/data/videos/:path{.*}', (c) => serveFile(c, resolvedDeps.videoRoot, resolvedDeps.fs))
-  routes.get('/data/projects/:projectId/previews/:path{.*}', (c) =>
-    serveFile(c, resolvedDeps.projectRoot, resolvedDeps.fs)
-  )
+  routes.get('/data/videos/:path{.*}', (c) => {
+    const relativePath = resolveRelativePath(c)
+    if (relativePath === null) {
+      return c.text('bad request', 400)
+    }
+    return serveFile(c, resolvedDeps.videoRoot, resolvedDeps.fs, relativePath)
+  })
+
+  routes.get('/data/projects/:projectId/previews/:path{.*}', (c) => {
+    const projectId = c.req.param('projectId')
+    const projectPreviewRoot = resolve(resolvedDeps.projectRoot, projectId, 'previews')
+    const relativePath = c.req.param('path')
+    return serveFile(c, projectPreviewRoot, resolvedDeps.fs, relativePath)
+  })
 
   return routes
 }

--- a/projects/edit-vid2/src/server/routes/data-files.ts
+++ b/projects/edit-vid2/src/server/routes/data-files.ts
@@ -1,0 +1,118 @@
+import { createReadStream, existsSync, statSync } from 'node:fs'
+import { extname, resolve } from 'node:path'
+import { Readable } from 'node:stream'
+import type { Context } from 'hono'
+import { Hono } from 'hono'
+import { parseByteRange } from '#/server/features/http/byte-range'
+import type { HonoEnv } from '#/server/routes/shared'
+
+const MIME_TYPES: Record<string, string> = {
+  '.mp4': 'video/mp4',
+  '.webm': 'video/webm',
+  '.ogv': 'video/ogg',
+  '.mov': 'video/quicktime',
+  '.avi': 'video/x-msvideo',
+  '.mkv': 'video/x-matroska',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.png': 'image/png',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.svg': 'image/svg+xml',
+}
+
+type FileSystemLike = {
+  exists: (path: string) => boolean
+  stat: (path: string) => { isFile: () => boolean; size: number }
+  createReadStream: (path: string, options?: { start?: number; end?: number }) => Readable
+}
+
+export type DataFileRouteDeps = {
+  videoRoot: string
+  projectRoot: string
+  fs: FileSystemLike
+}
+
+const defaultDataFileRouteDeps: DataFileRouteDeps = {
+  videoRoot: 'data/videos',
+  projectRoot: 'data/projects',
+  fs: {
+    exists: existsSync,
+    stat: statSync,
+    createReadStream,
+  },
+}
+
+const PUBLIC_DATA_PREFIX = /^\/data\/(?:videos|projects)\//
+
+function isWithinRoot(root: string, target: string): boolean {
+  const resolvedRoot = resolve(root)
+  const prefix = `${resolvedRoot}/`
+  return target === resolvedRoot || target.startsWith(prefix)
+}
+
+function resolveRelativePath(c: Context): string {
+  return decodeURIComponent(c.req.path.replace(PUBLIC_DATA_PREFIX, ''))
+}
+
+function serveFile(c: Context, root: string, fs: FileSystemLike) {
+  const relativePath = resolveRelativePath(c)
+  const filePath = resolve(root, relativePath)
+
+  if (!isWithinRoot(root, filePath)) {
+    return c.notFound()
+  }
+
+  if (!fs.exists(filePath)) {
+    return c.notFound()
+  }
+
+  const stats = fs.stat(filePath)
+  if (!stats.isFile()) {
+    return c.notFound()
+  }
+
+  const { size } = stats
+  const ext = extname(filePath).toLowerCase()
+  const contentType = MIME_TYPES[ext] || 'application/octet-stream'
+  const rangeHeader = c.req.header('range')
+
+  if (!rangeHeader) {
+    const stream = fs.createReadStream(filePath)
+    return c.body(Readable.toWeb(stream) as unknown as ReadableStream, 200, {
+      'Content-Type': contentType,
+      'Content-Length': String(size),
+      'Accept-Ranges': 'bytes',
+    })
+  }
+
+  const range = parseByteRange(rangeHeader, size)
+  if (!range.ok) {
+    return c.body('range not satisfiable', 416, {
+      'Content-Range': `bytes */${size}`,
+    })
+  }
+
+  const { start, end, length } = range
+  const stream = fs.createReadStream(filePath, { start, end })
+  return c.body(Readable.toWeb(stream) as unknown as ReadableStream, 206, {
+    'Content-Type': contentType,
+    'Content-Range': `bytes ${start}-${end}/${size}`,
+    'Content-Length': String(length),
+    'Accept-Ranges': 'bytes',
+  })
+}
+
+export function createDataFileRoutes(deps: Partial<DataFileRouteDeps> = {}) {
+  const resolvedDeps = { ...defaultDataFileRouteDeps, ...deps }
+  const routes = new Hono<HonoEnv>()
+
+  routes.get('/data/videos/:path{.*}', (c) => serveFile(c, resolvedDeps.videoRoot, resolvedDeps.fs))
+  routes.get('/data/projects/:projectId/previews/:path{.*}', (c) =>
+    serveFile(c, resolvedDeps.projectRoot, resolvedDeps.fs)
+  )
+
+  return routes
+}
+
+export { MIME_TYPES }

--- a/projects/edit-vid2/src/server/routes/exports.ts
+++ b/projects/edit-vid2/src/server/routes/exports.ts
@@ -17,6 +17,7 @@ import {
   updateExportJob,
 } from '#/server/features/export/export-repository'
 import { exportWorker } from '#/server/features/export/export-worker'
+import { parseByteRange } from '#/server/features/http/byte-range'
 import { getProjectById, getProjects } from '#/server/features/projects/project-repository'
 import { getVideoAssetById } from '#/server/features/videos/video-repository'
 import type { HonoEnv } from '#/server/routes/shared'
@@ -304,19 +305,14 @@ function createJobRoutes(deps: Partial<ExportRouteDeps> = {}) {
       })
     }
 
-    const match = rangeHeader.match(/^bytes=(\d+)-(\d*)$/)
-    if (!match) {
-      return c.json({ error: 'range not satisfiable' }, 416)
+    const range = parseByteRange(rangeHeader, size)
+    if (!range.ok) {
+      return c.json({ error: 'range not satisfiable' }, 416, {
+        'Content-Range': `bytes */${size}`,
+      })
     }
 
-    const start = Number.parseInt(match[1], 10)
-    const end = match[2] ? Number.parseInt(match[2], 10) : size - 1
-
-    if (Number.isNaN(start) || Number.isNaN(end) || start >= size || end >= size || start > end) {
-      return c.json({ error: 'range not satisfiable' }, 416)
-    }
-
-    const length = end - start + 1
+    const { start, end, length } = range
     const stream = resolvedDeps.createReadStream(job.outputPath, { start, end })
     return c.body(Readable.toWeb(stream) as unknown as ReadableStream, 206, {
       ...baseHeaders,

--- a/projects/edit-vid2/tests/features/byte-range.test.ts
+++ b/projects/edit-vid2/tests/features/byte-range.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from 'bun:test'
+import { parseByteRange } from '#/server/features/http/byte-range'
+
+describe('parseByteRange', () => {
+  const size = 100
+
+  test('returns invalid for missing or malformed header', () => {
+    expect(parseByteRange('', size)).toEqual({ ok: false, reason: 'invalid' })
+    expect(parseByteRange('bytes=', size)).toEqual({ ok: false, reason: 'invalid' })
+    expect(parseByteRange('bytes=-', size)).toEqual({ ok: false, reason: 'invalid' })
+    expect(parseByteRange('bytes=0-1,2-3', size)).toEqual({ ok: false, reason: 'invalid' })
+    expect(parseByteRange('bytes=0-1-2', size)).toEqual({ ok: false, reason: 'invalid' })
+    expect(parseByteRange('items=0-1', size)).toEqual({ ok: false, reason: 'invalid' })
+    expect(parseByteRange('bytes=0--1', size)).toEqual({ ok: false, reason: 'invalid' })
+  })
+
+  test('returns full range when no range header is not applicable', () => {
+    expect(parseByteRange('bytes=0-99', size)).toEqual({ ok: true, start: 0, end: 99, length: 100 })
+  })
+
+  test('normalizes closed range', () => {
+    expect(parseByteRange('bytes=0-3', size)).toEqual({ ok: true, start: 0, end: 3, length: 4 })
+  })
+
+  test('normalizes open-ended range to file end', () => {
+    expect(parseByteRange('bytes=4-', size)).toEqual({ ok: true, start: 4, end: 99, length: 96 })
+  })
+
+  test('normalizes suffix range to last N bytes', () => {
+    expect(parseByteRange('bytes=-4', size)).toEqual({ ok: true, start: 96, end: 99, length: 4 })
+  })
+
+  test('clamps end beyond size to file end', () => {
+    expect(parseByteRange('bytes=0-999999999', size)).toEqual({ ok: true, start: 0, end: 99, length: 100 })
+  })
+
+  test('clamps suffix larger than size to full file', () => {
+    expect(parseByteRange('bytes=-999999999', size)).toEqual({ ok: true, start: 0, end: 99, length: 100 })
+  })
+
+  test('rejects suffix of zero bytes', () => {
+    expect(parseByteRange('bytes=-0', size)).toEqual({ ok: false, reason: 'invalid' })
+  })
+
+  test('rejects start equal to size', () => {
+    expect(parseByteRange('bytes=100-', size)).toEqual({ ok: false, reason: 'unsatisfiable' })
+    expect(parseByteRange('bytes=100-100', size)).toEqual({ ok: false, reason: 'unsatisfiable' })
+  })
+
+  test('rejects start greater than end', () => {
+    expect(parseByteRange('bytes=5-3', size)).toEqual({ ok: false, reason: 'unsatisfiable' })
+  })
+
+  test('rejects start beyond size', () => {
+    expect(parseByteRange('bytes=101-105', size)).toEqual({ ok: false, reason: 'unsatisfiable' })
+  })
+
+  test('rejects negative start', () => {
+    expect(parseByteRange('bytes=-1-5', size)).toEqual({ ok: false, reason: 'invalid' })
+  })
+
+  test('handles empty file as unsatisfiable for any range', () => {
+    expect(parseByteRange('bytes=0-', 0)).toEqual({ ok: false, reason: 'unsatisfiable' })
+    expect(parseByteRange('bytes=-1', 0)).toEqual({ ok: false, reason: 'unsatisfiable' })
+  })
+
+  test('returns full range when suffix equals size', () => {
+    expect(parseByteRange('bytes=-100', size)).toEqual({ ok: true, start: 0, end: 99, length: 100 })
+  })
+
+  test('trims whitespace around header', () => {
+    expect(parseByteRange('  bytes=0-3  ', size)).toEqual({ ok: true, start: 0, end: 3, length: 4 })
+  })
+})

--- a/projects/edit-vid2/tests/features/data-files.test.ts
+++ b/projects/edit-vid2/tests/features/data-files.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createDataFileRoutes } from '#/server/routes/data-files'
+import { createTestServer } from './server-test-helper'
+
+function setupTempRoot() {
+  const root = join(tmpdir(), `edit-vid2-data-files-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+  mkdirSync(root, { recursive: true })
+  return root
+}
+
+describe('data file API', () => {
+  test('returns 200 with full content and headers without range', async () => {
+    const root = setupTempRoot()
+    const { app, cleanup } = createTestServer({ dataFileRoutes: { videoRoot: root, projectRoot: root } })
+    try {
+      const dir = join(root, 'video-1')
+      mkdirSync(dir)
+      writeFileSync(join(dir, 'source.mp4'), 'hello world')
+
+      const res = await app.request('/data/videos/video-1/source.mp4')
+      expect(res.status).toBe(200)
+      expect(res.headers.get('content-type')).toBe('video/mp4')
+      expect(res.headers.get('content-length')).toBe('11')
+      expect(res.headers.get('accept-ranges')).toBe('bytes')
+      expect(await res.text()).toBe('hello world')
+    } finally {
+      cleanup()
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('returns 206 for closed range', async () => {
+    const root = setupTempRoot()
+    const { app, cleanup } = createTestServer({ dataFileRoutes: { videoRoot: root, projectRoot: root } })
+    try {
+      const dir = join(root, 'video-1')
+      mkdirSync(dir)
+      writeFileSync(join(dir, 'source.mp4'), 'hello world')
+
+      const res = await app.request('/data/videos/video-1/source.mp4', {
+        headers: { Range: 'bytes=0-3' },
+      })
+      expect(res.status).toBe(206)
+      expect(res.headers.get('content-range')).toBe('bytes 0-3/11')
+      expect(res.headers.get('content-length')).toBe('4')
+      expect(await res.text()).toBe('hell')
+    } finally {
+      cleanup()
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('returns 206 for open-ended range', async () => {
+    const root = setupTempRoot()
+    const { app, cleanup } = createTestServer({ dataFileRoutes: { videoRoot: root, projectRoot: root } })
+    try {
+      const dir = join(root, 'video-1')
+      mkdirSync(dir)
+      writeFileSync(join(dir, 'source.mp4'), 'hello world')
+
+      const res = await app.request('/data/videos/video-1/source.mp4', {
+        headers: { Range: 'bytes=6-' },
+      })
+      expect(res.status).toBe(206)
+      expect(res.headers.get('content-range')).toBe('bytes 6-10/11')
+      expect(await res.text()).toBe('world')
+    } finally {
+      cleanup()
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('returns 206 for suffix range', async () => {
+    const root = setupTempRoot()
+    const { app, cleanup } = createTestServer({ dataFileRoutes: { videoRoot: root, projectRoot: root } })
+    try {
+      const dir = join(root, 'video-1')
+      mkdirSync(dir)
+      writeFileSync(join(dir, 'source.mp4'), 'hello world')
+
+      const res = await app.request('/data/videos/video-1/source.mp4', {
+        headers: { Range: 'bytes=-5' },
+      })
+      expect(res.status).toBe(206)
+      expect(res.headers.get('content-range')).toBe('bytes 6-10/11')
+      expect(await res.text()).toBe('world')
+    } finally {
+      cleanup()
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('clamps end beyond size to file end', async () => {
+    const root = setupTempRoot()
+    const { app, cleanup } = createTestServer({ dataFileRoutes: { videoRoot: root, projectRoot: root } })
+    try {
+      const dir = join(root, 'video-1')
+      mkdirSync(dir)
+      writeFileSync(join(dir, 'source.mp4'), 'hello world')
+
+      const res = await app.request('/data/videos/video-1/source.mp4', {
+        headers: { Range: 'bytes=0-999999999' },
+      })
+      expect(res.status).toBe(206)
+      expect(res.headers.get('content-range')).toBe('bytes 0-10/11')
+      expect(await res.text()).toBe('hello world')
+    } finally {
+      cleanup()
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('returns 416 with content-range header for invalid range', async () => {
+    const root = setupTempRoot()
+    const { app, cleanup } = createTestServer({ dataFileRoutes: { videoRoot: root, projectRoot: root } })
+    try {
+      const dir = join(root, 'video-1')
+      mkdirSync(dir)
+      writeFileSync(join(dir, 'source.mp4'), 'hello world')
+
+      const res = await app.request('/data/videos/video-1/source.mp4', {
+        headers: { Range: 'bytes=11-11' },
+      })
+      expect(res.status).toBe(416)
+      expect(res.headers.get('content-range')).toBe('bytes */11')
+    } finally {
+      cleanup()
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('returns 416 for empty file range request', async () => {
+    const root = setupTempRoot()
+    const { app, cleanup } = createTestServer({ dataFileRoutes: { videoRoot: root, projectRoot: root } })
+    try {
+      const dir = join(root, 'video-1')
+      mkdirSync(dir)
+      writeFileSync(join(dir, 'source.mp4'), '')
+
+      const res = await app.request('/data/videos/video-1/source.mp4', {
+        headers: { Range: 'bytes=0-' },
+      })
+      expect(res.status).toBe(416)
+      expect(res.headers.get('content-range')).toBe('bytes */0')
+    } finally {
+      cleanup()
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('returns 404 for missing file', async () => {
+    const root = setupTempRoot()
+    const { app, cleanup } = createTestServer({ dataFileRoutes: { videoRoot: root, projectRoot: root } })
+    try {
+      const res = await app.request('/data/videos/video-1/missing.mp4')
+      expect(res.status).toBe(404)
+    } finally {
+      cleanup()
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('returns 404 for directory', async () => {
+    const root = setupTempRoot()
+    const { app, cleanup } = createTestServer({ dataFileRoutes: { videoRoot: root, projectRoot: root } })
+    try {
+      mkdirSync(join(root, 'video-1'))
+      const res = await app.request('/data/videos/video-1')
+      expect(res.status).toBe(404)
+    } finally {
+      cleanup()
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('returns 404 for encoded path traversal', async () => {
+    const root = setupTempRoot()
+    const { app, cleanup } = createTestServer({ dataFileRoutes: { videoRoot: root, projectRoot: root } })
+    try {
+      writeFileSync(join(root, 'secret.txt'), 'secret')
+      const res = await app.request('/data/videos/%2e%2e%2fsecret.txt')
+      expect(res.status).toBe(404)
+    } finally {
+      cleanup()
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('returns octet-stream for unknown extension', async () => {
+    const root = setupTempRoot()
+    const { app, cleanup } = createTestServer({ dataFileRoutes: { videoRoot: root, projectRoot: root } })
+    try {
+      const dir = join(root, 'video-1')
+      mkdirSync(dir)
+      writeFileSync(join(dir, 'data.unknown'), 'binary')
+
+      const res = await app.request('/data/videos/video-1/data.unknown')
+      expect(res.status).toBe(200)
+      expect(res.headers.get('content-type')).toBe('application/octet-stream')
+    } finally {
+      cleanup()
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('serves project preview files under nested route', async () => {
+    const root = setupTempRoot()
+    const { app, cleanup } = createTestServer({ dataFileRoutes: { videoRoot: root, projectRoot: root } })
+    try {
+      const dir = join(root, 'project-1', 'previews')
+      mkdirSync(dir, { recursive: true })
+      writeFileSync(join(dir, 'preview.jpg'), 'image')
+
+      const res = await app.request('/data/projects/project-1/previews/preview.jpg')
+      expect(res.status).toBe(200)
+      expect(res.headers.get('content-type')).toBe('image/jpeg')
+      expect(await res.text()).toBe('image')
+    } finally {
+      cleanup()
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('does not serve files outside allowed data roots', async () => {
+    const root = setupTempRoot()
+    const { app, cleanup } = createTestServer({ dataFileRoutes: { videoRoot: root, projectRoot: root } })
+    try {
+      const exportsDir = join(root, 'exports', 'job-1')
+      mkdirSync(exportsDir, { recursive: true })
+      writeFileSync(join(exportsDir, 'output.mp4'), 'video')
+
+      const res = await app.request('/data/exports/job-1/output.mp4')
+      expect(res.headers.get('content-type')).toBe('text/html; charset=UTF-8')
+    } finally {
+      cleanup()
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('data file route security', () => {
+  test('rejects encoded path traversal at route level', async () => {
+    const root = setupTempRoot()
+    const routes = createDataFileRoutes({ videoRoot: root, projectRoot: root })
+    try {
+      const res = await routes.request('/%2e%2e%2foutside.txt')
+      expect(res.status).toBe(404)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+})

--- a/projects/edit-vid2/tests/features/data-files.test.ts
+++ b/projects/edit-vid2/tests/features/data-files.test.ts
@@ -176,6 +176,18 @@ describe('data file API', () => {
     }
   })
 
+  test('returns 400 for malformed percent encoding on video route', async () => {
+    const root = setupTempRoot()
+    const { app, cleanup } = createTestServer({ dataFileRoutes: { videoRoot: root, projectRoot: root } })
+    try {
+      const res = await app.request('/data/videos/%E0%A4%A')
+      expect(res.status).toBe(400)
+    } finally {
+      cleanup()
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
   test('returns 404 for encoded path traversal', async () => {
     const root = setupTempRoot()
     const { app, cleanup } = createTestServer({ dataFileRoutes: { videoRoot: root, projectRoot: root } })
@@ -224,6 +236,26 @@ describe('data file API', () => {
     }
   })
 
+  test('project preview is scoped to its own project directory', async () => {
+    const root = setupTempRoot()
+    const { app, cleanup } = createTestServer({ dataFileRoutes: { videoRoot: root, projectRoot: root } })
+    try {
+      const ownDir = join(root, 'project-1', 'previews')
+      const otherDir = join(root, 'project-2', 'previews')
+      mkdirSync(ownDir, { recursive: true })
+      mkdirSync(otherDir, { recursive: true })
+      writeFileSync(join(ownDir, 'preview.jpg'), 'image')
+      writeFileSync(join(otherDir, 'preview.jpg'), 'other')
+
+      const res = await app.request(
+        '/data/projects/project-1/previews/' + encodeURIComponent('../project-2/previews/preview.jpg')
+      )
+      expect(res.status).toBe(404)
+    } finally {
+      cleanup()
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
   test('does not serve files outside allowed data roots', async () => {
     const root = setupTempRoot()
     const { app, cleanup } = createTestServer({ dataFileRoutes: { videoRoot: root, projectRoot: root } })


### PR DESCRIPTION
## Issues

- Close #1082

## Why

`app.tsx` に Range 解析やファイル I/O の詳細実装が混在しており、`/data/*` と export preview で Range 処理の挙動が重複していた。また専用 server テストがなく、suffix range、境界条件、パス逸脱などの回帰を直接検出できなかった。

## Summary

HTTP Range ファイル配信を `app.tsx` から分離し、Range 解析を再利用可能な純粋関数に切り出した。公開パスを `/data/videos/*` と `/data/projects/:projectId/previews/*` に限定し、server テストで正常系・境界値・異常系・セキュリティを固定した。

## Changes

- `src/server/features/http/byte-range.ts` を追加 — 単一 Range 解析の純粋関数 `parseByteRange`
- `src/server/routes/data-files.ts` を追加 — ファイル配信専用 route、パス制約・MIME 判定・依存注入対応
- `src/server/app.tsx` を route 登録中心の構成に戻す（`videoRoot` / `projectRoot` 注入）
- `src/server/routes/exports.ts` の export preview で `parseByteRange` を再利用
- `tests/features/byte-range.test.ts` を追加 — Range 解析の unit test（正常系・境界値・異常系 15 cases）
- `tests/features/data-files.test.ts` を追加 — ファイル配信の integration test（14 cases、encoded traversal 含む）

## Checklist

- [x] フォーマット（`bun run format:check`）
- [x] リント・型チェック（`bun run lint`）
- [x] テスト（`bun run test:unit` → 85 pass）
- [x] ビルド（`bun run build`）
