### PR TITLE
feat(file-server): add copy-all button to text preview dialog (#1090)

### DIFF
--- a/projects/file-server/src/components/file-viewer/FileViewerModal.tsx
+++ b/projects/file-server/src/components/file-viewer/FileViewerModal.tsx
@@ -132,12 +132,15 @@ export const FileViewerModal: FC<FileViewerModalProps> = ({
               }
               doCopy().then(() => showCopyFeedback('Copied')).catch(() => showCopyFeedback('Copy failed'));
             }
+            let copyFeedbackTimer = null;
+            let originalBtnHTML = null;
             function showCopyFeedback(message) {
               const btn = document.getElementById('file-viewer-copy-button');
               if (!btn) return;
-              const original = btn.innerHTML;
+              if (copyFeedbackTimer) clearTimeout(copyFeedbackTimer);
+              if (!originalBtnHTML) originalBtnHTML = btn.innerHTML;
               btn.innerHTML = '<span class=\\'text-xs font-semibold px-1\\'>' + message + '</span>';
-              setTimeout(() => { btn.innerHTML = original; }, 1500);
+              copyFeedbackTimer = setTimeout(function() { btn.innerHTML = originalBtnHTML; copyFeedbackTimer = null; }, 1500);
             }
           `,
           }}

--- a/projects/file-server/src/components/file-viewer/FileViewerModal.tsx
+++ b/projects/file-server/src/components/file-viewer/FileViewerModal.tsx
@@ -4,6 +4,7 @@ import {
   secondaryIconButtonClassName,
 } from "../buttonStyles"
 import { CloseIcon } from "../icons/CloseIcon"
+import { CopyIcon } from "../icons/CopyIcon"
 import { DownloadIcon } from "../icons/DownloadIcon"
 import { EditIcon } from "../icons/EditIcon"
 import { ExternalLinkIcon } from "../icons/ExternalLinkIcon"
@@ -16,6 +17,7 @@ interface FileViewerModalProps {
   animation?: string
   isEditing?: boolean
   showEdit?: boolean
+  showCopy?: boolean
   layout?: "default" | "pdf"
   children: Child
 }
@@ -28,6 +30,7 @@ export const FileViewerModal: FC<FileViewerModalProps> = ({
   animation,
   isEditing = false,
   showEdit = false,
+  showCopy = false,
   layout = "default",
   children,
 }) => {
@@ -69,6 +72,19 @@ export const FileViewerModal: FC<FileViewerModalProps> = ({
       </button>
     ) : null
 
+  const copyButton = showCopy ? (
+    <button
+      type="button"
+      id="file-viewer-copy-button"
+      title="Copy all"
+      aria-label="Copy all"
+      onclick="copyFileContent()"
+      className={secondaryIconButtonClassName}
+    >
+      <CopyIcon />
+    </button>
+  ) : null
+
   const closeButton = (
     <button
       type="button"
@@ -91,6 +107,42 @@ export const FileViewerModal: FC<FileViewerModalProps> = ({
           __html: "document.body.style.overflow = 'hidden';",
         }}
       />
+      {showCopy ? (
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+            function copyFileContent() {
+              const target = document.querySelector('[data-copy-source]');
+              const content = target instanceof HTMLTextAreaElement ? target.value : (target?.textContent ?? '');
+              async function doCopy() {
+                if (navigator.clipboard && navigator.clipboard.writeText) {
+                  await navigator.clipboard.writeText(content);
+                } else {
+                  const textarea = document.createElement('textarea');
+                  textarea.value = content;
+                  textarea.style.position = 'fixed';
+                  textarea.style.left = '-9999px';
+                  document.body.appendChild(textarea);
+                  textarea.focus();
+                  textarea.select();
+                  const ok = document.execCommand('copy');
+                  document.body.removeChild(textarea);
+                  if (!ok) throw new Error('copy failed');
+                }
+              }
+              doCopy().then(() => showCopyFeedback('Copied')).catch(() => showCopyFeedback('Copy failed'));
+            }
+            function showCopyFeedback(message) {
+              const btn = document.getElementById('file-viewer-copy-button');
+              if (!btn) return;
+              const original = btn.innerHTML;
+              btn.innerHTML = '<span class=\\'text-xs font-semibold px-1\\'>' + message + '</span>';
+              setTimeout(() => { btn.innerHTML = original; }, 1500);
+            }
+          `,
+          }}
+        />
+      ) : null}
       <div
         className="fixed inset-0 bg-black/30 backdrop-blur-sm flex items-center justify-center z-50"
         hx-on:click={closeScript}
@@ -103,6 +155,7 @@ export const FileViewerModal: FC<FileViewerModalProps> = ({
             <div className="flex items-center gap-2">
               {downloadButton}
               {publicUrlButton}
+              {copyButton}
               {editButton}
               {closeButton}
             </div>

--- a/projects/file-server/src/components/file-viewer/TextEditor.tsx
+++ b/projects/file-server/src/components/file-viewer/TextEditor.tsx
@@ -18,6 +18,7 @@ export const TextEditor: FC<TextEditorProps> = ({ content, path }) => {
     >
       <input type="hidden" name="path" value={path} />
       <textarea
+        data-copy-source
         name="content"
         placeholder="This file is empty. Start typing..."
         className="flex-1 w-full bg-gradient-to-br from-indigo-50 to-purple-50 p-4 rounded-xl border-2 border-indigo-200 resize-none font-mono text-sm leading-relaxed focus:outline-none focus:border-indigo-400 focus:ring-2 focus:ring-indigo-200"

--- a/projects/file-server/src/components/file-viewer/TextViewer.tsx
+++ b/projects/file-server/src/components/file-viewer/TextViewer.tsx
@@ -7,14 +7,20 @@ interface TextViewerProps {
 export const TextViewer: FC<TextViewerProps> = ({ content }) => {
   if (content.length === 0) {
     return (
-      <div className="flex flex-1 items-center justify-center rounded-xl border-2 border-dashed border-indigo-200 bg-gradient-to-br from-indigo-50 to-purple-50 p-6 text-center text-sm text-slate-600">
+      <div
+        data-copy-source
+        className="flex flex-1 items-center justify-center rounded-xl border-2 border-dashed border-indigo-200 bg-gradient-to-br from-indigo-50 to-purple-50 p-6 text-center text-sm text-slate-600"
+      >
         This file is empty.
       </div>
     )
   }
 
   return (
-    <pre className="bg-gradient-to-br from-indigo-50 to-purple-50 p-4 rounded-xl overflow-auto whitespace-pre-wrap break-words border-2 border-indigo-200 flex-1">
+    <pre
+      data-copy-source
+      className="bg-gradient-to-br from-indigo-50 to-purple-50 p-4 rounded-xl overflow-auto whitespace-pre-wrap break-words border-2 border-indigo-200 flex-1"
+    >
       {content}
     </pre>
   )

--- a/projects/file-server/src/components/file-viewer/TextViewer.tsx
+++ b/projects/file-server/src/components/file-viewer/TextViewer.tsx
@@ -7,11 +7,9 @@ interface TextViewerProps {
 export const TextViewer: FC<TextViewerProps> = ({ content }) => {
   if (content.length === 0) {
     return (
-      <div
-        data-copy-source
-        className="flex flex-1 items-center justify-center rounded-xl border-2 border-dashed border-indigo-200 bg-gradient-to-br from-indigo-50 to-purple-50 p-6 text-center text-sm text-slate-600"
-      >
+      <div className="flex flex-1 items-center justify-center rounded-xl border-2 border-dashed border-indigo-200 bg-gradient-to-br from-indigo-50 to-purple-50 p-6 text-center text-sm text-slate-600">
         This file is empty.
+        <span data-copy-source style="display:none" />
       </div>
     )
   }

--- a/projects/file-server/src/components/file-viewer/index.tsx
+++ b/projects/file-server/src/components/file-viewer/index.tsx
@@ -40,6 +40,7 @@ export const FileViewer: FC<FileViewerProps> = ({
           borderColor="indigo-300"
           isEditing={true}
           showEdit={allowEdit}
+          showCopy={true}
         >
           <TextEditor content={content} path={path} />
         </FileViewerModal>
@@ -52,6 +53,7 @@ export const FileViewer: FC<FileViewerProps> = ({
         publicUrl={publicUrl}
         borderColor="indigo-300"
         showEdit={allowEdit}
+        showCopy={true}
       >
         <TextViewer content={content} />
       </FileViewerModal>

--- a/projects/file-server/src/components/icons/CopyIcon.tsx
+++ b/projects/file-server/src/components/icons/CopyIcon.tsx
@@ -1,0 +1,17 @@
+import type { FC } from "hono/jsx"
+
+export const CopyIcon: FC = () => (
+  <svg
+    width="20"
+    height="20"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    aria-hidden="true"
+  >
+    <title>Copy</title>
+    <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+  </svg>
+)

--- a/projects/file-server/tests/read.test.ts
+++ b/projects/file-server/tests/read.test.ts
@@ -312,6 +312,58 @@ describe("file endpoint /file", () => {
     expect(data.success).toBe(false)
     expect(data.error.name).toBe("NotAFile")
   })
+
+  it("should show copy button for text files", async () => {
+    await Bun.write(
+      path.join(UPLOAD_DIR, "public", "copy-test.txt"),
+      "copy target content",
+    )
+
+    const res = await app.request(
+      new Request("http://localhost/file?path=public%2Fcopy-test.txt", {
+        headers: { "HX-Request": "true" },
+      }),
+    )
+    expect(res.status).toBe(200)
+    const text = await res.text()
+    expect(text).toContain('id="file-viewer-copy-button"')
+    expect(text).toContain('aria-label="Copy all"')
+    expect(text).toContain('title="Copy all"')
+    expect(text).toContain('onclick="copyFileContent()"')
+    expect(text).toContain("data-copy-source")
+    expect(text).toContain("copy target content")
+  })
+
+  it("should show copy button for empty text files", async () => {
+    await Bun.write(path.join(UPLOAD_DIR, "public", "empty-copy.txt"), "")
+
+    const res = await app.request(
+      new Request("http://localhost/file?path=public%2Fempty-copy.txt", {
+        headers: { "HX-Request": "true" },
+      }),
+    )
+    expect(res.status).toBe(200)
+    const text = await res.text()
+    expect(text).toContain('id="file-viewer-copy-button"')
+    expect(text).toContain("data-copy-source")
+  })
+
+  it("should not show copy button for image files", async () => {
+    const pngBytes = new Uint8Array([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+    ])
+    await Bun.write(path.join(UPLOAD_DIR, "public", "photo.png"), pngBytes)
+
+    const res = await app.request(
+      new Request("http://localhost/file?path=public%2Fphoto.png", {
+        headers: { "HX-Request": "true" },
+      }),
+    )
+    expect(res.status).toBe(200)
+    const text = await res.text()
+    expect(text).not.toContain('id="file-viewer-copy-button"')
+    expect(text).not.toContain("data-copy-source")
+  })
 })
 
 describe("file archive endpoint /file/archive", () => {

--- a/projects/file-server/tests/read.test.ts
+++ b/projects/file-server/tests/read.test.ts
@@ -346,6 +346,9 @@ describe("file endpoint /file", () => {
     const text = await res.text()
     expect(text).toContain('id="file-viewer-copy-button"')
     expect(text).toContain("data-copy-source")
+    expect(text).toMatch(
+      /<span[^>]*data-copy-source[^>]*>\s*<\/span>/,
+    )
   })
 
   it("should not show copy button for image files", async () => {

--- a/projects/file-server/tests/update.test.ts
+++ b/projects/file-server/tests/update.test.ts
@@ -151,4 +151,25 @@ describe("update", () => {
     const saved = await readFile(testFilePath, "utf-8")
     expect(saved).toBe("Updated nested content!")
   })
+
+  it("should show copy button in text editor", async () => {
+    const testFilePath = path.join(UPLOAD_DIR, "public", "edit-copy.txt")
+    await writeFile(testFilePath, "edit copy content", "utf-8")
+
+    const res = await app.request(
+      new Request(
+        "http://localhost/file?path=public%2Fedit-copy.txt&edit=true",
+        {
+          headers: { "HX-Request": "true" },
+        },
+      ),
+    )
+    expect(res.status).toBe(200)
+    const text = await res.text()
+    expect(text).toContain('id="file-viewer-copy-button"')
+    expect(text).toContain('aria-label="Copy all"')
+    expect(text).toContain('onclick="copyFileContent()"')
+    expect(text).toContain("data-copy-source")
+    expect(text).toContain("edit copy content")
+  })
 })


### PR DESCRIPTION
## Issues

- Close #1090

## Why

テキストファイルのプレビューダイアログでは内容を閲覧・編集できるが、全文をクリップボードにコピーする操作がなかった。閲覧時・編集時それぞれで表示中または未保存の全文をワンクリックでコピーできるようにすることで、操作性を向上させる。

## Summary

テキストファイルのプレビューダイアログに SVG アイコンのコピーボタンを追加する。閲覧中は `<pre>` の全文、編集中は `<textarea>` の現在値をクリップボードへコピーし、成功・失敗を短時間フィードバック表示する。画像・動画・PDF などのバイナリファイルには表示しない。

## Changes

- `CopyIcon` コンポーネントを追加
- `TextViewer` / `TextEditor` のコピー対象要素に `data-copy-source` を設定
- `FileViewerModal` に `showCopy` prop とコピーボタンを追加
- Clipboard API を優先し、未対応環境では `execCommand('copy')` フォールバックを使用
- コピー成功時は `Copied`、失敗時は `Copy failed` をボタン内に短時間表示
- `FileViewer` からテキストファイルの場合のみ `showCopy={true}` を渡す
- テキスト閲覧・編集・空ファイル・画像ファイルの表示条件を検証するテストを追加

## Checklist

- [x] フォーマット (`bunx biome format --write`)
- [x] リント / 型チェック (`bun run lint`)
- [x] テスト (`bun test`)
