### PR TITLE
refactor(portfolio): Diff画面からuseEffectを除去

### DIFF
--- a/projects/portfolio/src/client/features/diff/page.tsx
+++ b/projects/portfolio/src/client/features/diff/page.tsx
@@ -129,6 +129,12 @@ type DiffProps = {
   initialState: DiffStatePayload
 }
 
+function persistDiffState(state: DiffStatePayload) {
+  void saveDiffState(state).catch((error) => {
+    console.error('Failed to save diff state:', error)
+  })
+}
+
 export function Diff({ initialState }: DiffProps) {
   const [mode, setMode] = useState<'view' | 'edit'>('view')
   const [beforeCode, setBeforeCode] = useState(initialState.beforeCode)
@@ -143,14 +149,14 @@ export function Diff({ initialState }: DiffProps) {
     const nextBeforeCode = value ?? ''
     beforeCodeRef.current = nextBeforeCode
     setBeforeCode(nextBeforeCode)
-    void saveDiffState({ beforeCode: nextBeforeCode, afterCode: afterCodeRef.current }).catch(() => undefined)
+    persistDiffState({ beforeCode: nextBeforeCode, afterCode: afterCodeRef.current })
   }
 
   const handleAfterCodeChange = (value: string | undefined) => {
     const nextAfterCode = value ?? ''
     afterCodeRef.current = nextAfterCode
     setAfterCode(nextAfterCode)
-    void saveDiffState({ beforeCode: beforeCodeRef.current, afterCode: nextAfterCode }).catch(() => undefined)
+    persistDiffState({ beforeCode: beforeCodeRef.current, afterCode: nextAfterCode })
   }
 
   return (

--- a/projects/portfolio/src/client/features/diff/page.tsx
+++ b/projects/portfolio/src/client/features/diff/page.tsx
@@ -1,9 +1,11 @@
 import './monaco'
 import Editor from '@monaco-editor/react'
 import type { ComponentType } from 'react'
-import { useEffect, useState } from 'react'
+import { useRef, useState } from 'react'
 import ReactDiffViewerModule from 'react-diff-viewer'
-import { loadDiffState, saveDiffState } from '#/client/shared/storage/diff-state'
+import { useDarkMode } from '#/client/shared/hooks/use-dark-mode'
+import { useMobileLayout } from '#/client/shared/hooks/use-mobile-layout'
+import { type DiffStatePayload, saveDiffState } from '#/client/shared/storage/diff-state'
 
 const reactDiffViewerImport = ReactDiffViewerModule as ComponentType<any> | { default: ComponentType<any> }
 const ReactDiffViewer =
@@ -46,12 +48,6 @@ const LANGUAGE_OPTIONS: string[] = [
   'markdown',
 ]
 
-const defaultBefore = `line 1
-line 2
-line 3`
-const defaultAfter = `line 1
-modified line 2
-line 3`
 const diffViewerStyles = {
   variables: {
     light: {
@@ -129,102 +125,33 @@ const diffViewerStyles = {
   },
 }
 
-export function Diff() {
+type DiffProps = {
+  initialState: DiffStatePayload
+}
+
+export function Diff({ initialState }: DiffProps) {
   const [mode, setMode] = useState<'view' | 'edit'>('view')
-  const [beforeCode, setBeforeCode] = useState(defaultBefore)
-  const [afterCode, setAfterCode] = useState(defaultAfter)
+  const [beforeCode, setBeforeCode] = useState(initialState.beforeCode)
+  const [afterCode, setAfterCode] = useState(initialState.afterCode)
   const [language, setLanguage] = useState('')
-  const [isHydrated, setIsHydrated] = useState(false)
-  const [isMobile, setIsMobile] = useState(false)
-  const [isDarkTheme, setIsDarkTheme] = useState(() => {
-    if (typeof window === 'undefined') {
-      return false
-    }
-    const saved = localStorage.getItem('theme')
-    if (saved === 'dark') {
-      return true
-    }
-    if (saved === 'light') {
-      return false
-    }
-    return document.documentElement.classList.contains('dark')
-  })
+  const beforeCodeRef = useRef(beforeCode)
+  const afterCodeRef = useRef(afterCode)
+  const isMobile = useMobileLayout()
+  const isDarkTheme = useDarkMode()
 
-  useEffect(() => {
-    const syncTheme = () => {
-      const saved = localStorage.getItem('theme')
-      if (saved === 'dark') {
-        setIsDarkTheme(true)
-        return
-      }
-      if (saved === 'light') {
-        setIsDarkTheme(false)
-        return
-      }
-      setIsDarkTheme(document.documentElement.classList.contains('dark'))
-    }
+  const handleBeforeCodeChange = (value: string | undefined) => {
+    const nextBeforeCode = value ?? ''
+    beforeCodeRef.current = nextBeforeCode
+    setBeforeCode(nextBeforeCode)
+    void saveDiffState({ beforeCode: nextBeforeCode, afterCode: afterCodeRef.current }).catch(() => undefined)
+  }
 
-    syncTheme()
-
-    const observer = new MutationObserver(syncTheme)
-    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] })
-    window.addEventListener('storage', syncTheme)
-
-    return () => {
-      observer.disconnect()
-      window.removeEventListener('storage', syncTheme)
-    }
-  }, [])
-
-  useEffect(() => {
-    const checkMobile = () => setIsMobile(window.innerWidth < 768)
-    checkMobile()
-    window.addEventListener('resize', checkMobile)
-    return () => window.removeEventListener('resize', checkMobile)
-  }, [])
-
-  useEffect(() => {
-    let isMounted = true
-
-    const hydrate = async () => {
-      try {
-        const saved = await loadDiffState()
-        if (!isMounted) {
-          return
-        }
-        if (saved) {
-          setBeforeCode(saved.beforeCode)
-          setAfterCode(saved.afterCode)
-        }
-      } catch {
-        if (!isMounted) {
-          return
-        }
-      } finally {
-        if (isMounted) {
-          setIsHydrated(true)
-        }
-      }
-    }
-
-    hydrate()
-
-    return () => {
-      isMounted = false
-    }
-  }, [])
-
-  useEffect(() => {
-    if (!isHydrated) {
-      return
-    }
-
-    const persist = async () => {
-      await saveDiffState({ beforeCode, afterCode })
-    }
-
-    persist()
-  }, [beforeCode, afterCode, isHydrated])
+  const handleAfterCodeChange = (value: string | undefined) => {
+    const nextAfterCode = value ?? ''
+    afterCodeRef.current = nextAfterCode
+    setAfterCode(nextAfterCode)
+    void saveDiffState({ beforeCode: beforeCodeRef.current, afterCode: nextAfterCode }).catch(() => undefined)
+  }
 
   return (
     <div className='h-screen flex flex-col bg-white p-4 dark:bg-gray-900 overflow-hidden'>
@@ -271,7 +198,7 @@ export function Diff() {
               <div className='flex-1 min-h-0'>
                 <Editor
                   value={beforeCode}
-                  onChange={(value) => setBeforeCode(value || '')}
+                  onChange={handleBeforeCodeChange}
                   theme={isDarkTheme ? 'vs-dark' : 'light'}
                   height='100%'
                   language={language}
@@ -287,7 +214,7 @@ export function Diff() {
               <div className='flex-1 min-h-0'>
                 <Editor
                   value={afterCode}
-                  onChange={(value) => setAfterCode(value || '')}
+                  onChange={handleAfterCodeChange}
                   theme={isDarkTheme ? 'vs-dark' : 'light'}
                   height='100%'
                   language={language}

--- a/projects/portfolio/src/client/routes/diff.tsx
+++ b/projects/portfolio/src/client/routes/diff.tsx
@@ -1,12 +1,22 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { lazy } from 'react'
+import { DEFAULT_DIFF_STATE, loadDiffState } from '#/client/shared/storage/diff-state'
 
 const Diff = lazy(() => import('#/client/features/diff/page').then((module) => ({ default: module.Diff })))
 
 export const Route = createFileRoute('/diff')({
   component: RouteComponent,
+  loader: async () => {
+    try {
+      return (await loadDiffState()) ?? DEFAULT_DIFF_STATE
+    } catch {
+      return DEFAULT_DIFF_STATE
+    }
+  },
 })
 
 function RouteComponent() {
-  return <Diff />
+  const initialState = Route.useLoaderData()
+
+  return <Diff initialState={initialState} />
 }

--- a/projects/portfolio/src/client/shared/hooks/use-dark-mode.ts
+++ b/projects/portfolio/src/client/shared/hooks/use-dark-mode.ts
@@ -1,19 +1,31 @@
-import { useEffect, useState } from 'react'
+import { useSyncExternalStore } from 'react'
+
+function getDarkModeSnapshot() {
+  if (typeof window === 'undefined') {
+    return false
+  }
+
+  const saved = localStorage.getItem('theme')
+  if (saved === 'dark') {
+    return true
+  }
+  if (saved === 'light') {
+    return false
+  }
+  return document.documentElement.classList.contains('dark')
+}
+
+function subscribeToDarkMode(onStoreChange: () => void) {
+  const observer = new MutationObserver(onStoreChange)
+  observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] })
+  window.addEventListener('storage', onStoreChange)
+
+  return () => {
+    observer.disconnect()
+    window.removeEventListener('storage', onStoreChange)
+  }
+}
 
 export function useDarkMode(): boolean {
-  const [isDark, setIsDark] = useState(() => {
-    const saved = localStorage.getItem('theme')
-    if (saved === 'dark') return true
-    if (saved === 'light') return false
-    return document.documentElement.classList.contains('dark')
-  })
-
-  useEffect(() => {
-    const sync = () => setIsDark(document.documentElement.classList.contains('dark'))
-    const observer = new MutationObserver(sync)
-    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] })
-    return () => observer.disconnect()
-  }, [])
-
-  return isDark
+  return useSyncExternalStore(subscribeToDarkMode, getDarkModeSnapshot, () => false)
 }

--- a/projects/portfolio/src/client/shared/hooks/use-mobile-layout.ts
+++ b/projects/portfolio/src/client/shared/hooks/use-mobile-layout.ts
@@ -1,0 +1,18 @@
+import { useSyncExternalStore } from 'react'
+
+const mobileMediaQuery = '(max-width: 767px)'
+
+function getMobileLayoutSnapshot() {
+  return window.matchMedia(mobileMediaQuery).matches
+}
+
+function subscribeToMobileLayout(onStoreChange: () => void) {
+  const mediaQueryList = window.matchMedia(mobileMediaQuery)
+  mediaQueryList.addEventListener('change', onStoreChange)
+
+  return () => mediaQueryList.removeEventListener('change', onStoreChange)
+}
+
+export function useMobileLayout(): boolean {
+  return useSyncExternalStore(subscribeToMobileLayout, getMobileLayoutSnapshot, () => false)
+}

--- a/projects/portfolio/src/client/shared/storage/diff-state.ts
+++ b/projects/portfolio/src/client/shared/storage/diff-state.ts
@@ -1,6 +1,15 @@
-type DiffStatePayload = {
+export type DiffStatePayload = {
   beforeCode: string
   afterCode: string
+}
+
+export const DEFAULT_DIFF_STATE: DiffStatePayload = {
+  beforeCode: `line 1
+line 2
+line 3`,
+  afterCode: `line 1
+modified line 2
+line 3`,
 }
 
 const databaseName = 'portfolio'

--- a/projects/portfolio/tests/client/hooks/use-external-layout.test.tsx
+++ b/projects/portfolio/tests/client/hooks/use-external-layout.test.tsx
@@ -5,8 +5,20 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useDarkMode } from '#/client/shared/hooks/use-dark-mode'
 import { useMobileLayout } from '#/client/shared/hooks/use-mobile-layout'
 
+const createLocalStorageMock = () => {
+  const store = new Map<string, string>()
+
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => store.set(key, value),
+    removeItem: (key: string) => store.delete(key),
+    clear: () => store.clear(),
+  }
+}
+
 describe('external layout hooks', () => {
   beforeEach(() => {
+    vi.stubGlobal('localStorage', createLocalStorageMock())
     localStorage.clear()
     document.documentElement.classList.remove('dark')
   })

--- a/projects/portfolio/tests/client/hooks/use-external-layout.test.tsx
+++ b/projects/portfolio/tests/client/hooks/use-external-layout.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useDarkMode } from '#/client/shared/hooks/use-dark-mode'
+import { useMobileLayout } from '#/client/shared/hooks/use-mobile-layout'
+
+describe('external layout hooks', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    document.documentElement.classList.remove('dark')
+  })
+
+  it('テーマ変更を反映する', async () => {
+    const { result } = renderHook(() => useDarkMode())
+
+    expect(result.current).toBe(false)
+
+    await act(async () => {
+      localStorage.setItem('theme', 'dark')
+      window.dispatchEvent(new StorageEvent('storage', { key: 'theme', newValue: 'dark' }))
+    })
+
+    expect(result.current).toBe(true)
+  })
+
+  it('モバイル向けメディアクエリの変更を反映する', () => {
+    let matches = false
+    const listeners = new Set<() => void>()
+    vi.stubGlobal('matchMedia', () => ({
+      matches,
+      addEventListener: (_type: string, listener: () => void) => listeners.add(listener),
+      removeEventListener: (_type: string, listener: () => void) => listeners.delete(listener),
+    }))
+
+    const { result } = renderHook(() => useMobileLayout())
+    expect(result.current).toBe(false)
+
+    act(() => {
+      matches = true
+      listeners.forEach((listener) => listener())
+    })
+
+    expect(result.current).toBe(true)
+  })
+})

--- a/projects/portfolio/tests/client/pages/diff.test.tsx
+++ b/projects/portfolio/tests/client/pages/diff.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+const saveDiffStateMock = vi.fn()
+
+vi.mock('@monaco-editor/react', () => ({
+  default: ({ onChange, value }: { onChange: (value: string) => void; value: string }) => (
+    <textarea value={value} onChange={(event) => onChange(event.target.value)} />
+  ),
+}))
+
+vi.mock('react-diff-viewer', () => ({
+  default: ({ newValue, oldValue }: { newValue: string; oldValue: string }) => (
+    <div>
+      <span>{oldValue}</span>
+      <span>{newValue}</span>
+    </div>
+  ),
+}))
+
+vi.mock('#/client/shared/hooks/use-dark-mode', () => ({
+  useDarkMode: () => false,
+}))
+
+vi.mock('#/client/shared/hooks/use-mobile-layout', () => ({
+  useMobileLayout: () => false,
+}))
+
+vi.mock('#/client/shared/storage/diff-state', () => ({
+  saveDiffState: (...args: unknown[]) => saveDiffStateMock(...args),
+}))
+
+import { Diff } from '#/client/features/diff/page'
+
+const initialState = {
+  beforeCode: 'saved before',
+  afterCode: 'saved after',
+}
+
+describe('Diff page', () => {
+  it('保存済みコードを初期表示する', () => {
+    render(<Diff initialState={initialState} />)
+
+    expect(screen.getByText('saved before')).toBeTruthy()
+    expect(screen.getByText('saved after')).toBeTruthy()
+  })
+
+  it('編集時に最新のBeforeとAfterを保存する', () => {
+    saveDiffStateMock.mockResolvedValue(undefined)
+    const { container } = render(<Diff initialState={initialState} />)
+
+    fireEvent.click(container.querySelector('button')!)
+    const editors = screen.getAllByRole('textbox')
+
+    fireEvent.change(editors[0], { target: { value: 'updated before' } })
+    fireEvent.change(editors[1], { target: { value: 'updated after' } })
+
+    expect(saveDiffStateMock).toHaveBeenNthCalledWith(1, {
+      beforeCode: 'updated before',
+      afterCode: 'saved after',
+    })
+    expect(saveDiffStateMock).toHaveBeenNthCalledWith(2, {
+      beforeCode: 'updated before',
+      afterCode: 'updated after',
+    })
+  })
+})

--- a/projects/portfolio/tests/client/pages/diff.test.tsx
+++ b/projects/portfolio/tests/client/pages/diff.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
-import { fireEvent, render, screen } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const saveDiffStateMock = vi.fn()
 
@@ -40,6 +40,14 @@ const initialState = {
 }
 
 describe('Diff page', () => {
+  beforeEach(() => {
+    saveDiffStateMock.mockReset()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
   it('保存済みコードを初期表示する', () => {
     render(<Diff initialState={initialState} />)
 
@@ -64,6 +72,20 @@ describe('Diff page', () => {
     expect(saveDiffStateMock).toHaveBeenNthCalledWith(2, {
       beforeCode: 'updated before',
       afterCode: 'updated after',
+    })
+  })
+
+  it('保存失敗をコンソールへ出力する', async () => {
+    const error = new Error('storage unavailable')
+    const consoleErrorMock = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    saveDiffStateMock.mockRejectedValue(error)
+    const { container } = render(<Diff initialState={initialState} />)
+
+    fireEvent.click(container.querySelector('button')!)
+    fireEvent.change(screen.getAllByRole('textbox')[0], { target: { value: 'updated before' } })
+
+    await waitFor(() => {
+      expect(consoleErrorMock).toHaveBeenCalledWith('Failed to save diff state:', error)
     })
   })
 })

--- a/projects/portfolio/tests/client/pages/diff.test.tsx
+++ b/projects/portfolio/tests/client/pages/diff.test.tsx
@@ -5,6 +5,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const saveDiffStateMock = vi.fn()
 
+vi.mock('#/client/features/diff/monaco', () => ({}))
+
 vi.mock('@monaco-editor/react', () => ({
   default: ({ onChange, value }: { onChange: (value: string) => void; value: string }) => (
     <textarea value={value} onChange={(event) => onChange(event.target.value)} />


### PR DESCRIPTION
## Why

Diff画面の初期化・外部状態監視・永続化が複数の`useEffect`に分散していたため、各責務に適した仕組みへ移し、状態同期を明確にします。

## Summary

Diff画面から`useEffect`を除去しました。初期データはルートローダーで取得し、テーマと画面幅は外部ストアとして購読し、コード変更時にイベント駆動で保存します。

## Changes

- IndexedDBの初期読込をTanStack Routerのローダーへ移動
- テーマとモバイルレイアウトの監視を`useSyncExternalStore`へ変更
- Monaco Editorの変更イベントから最新のDiff状態を保存
- 初期表示・保存・外部状態購読の回帰テストを追加

## Checklist

- [x] フォーマット
- [x] リント / 型チェック
- [x] テスト（299件成功）
