### PR TITLE
feat(browser-auto): add React client foundation

### DIFF
--- a/projects/browser-auto/AGENTS.md
+++ b/projects/browser-auto/AGENTS.md
@@ -3,11 +3,13 @@
 - Bun
 - TypeScript
 - Hono
+- React
 - oxlint
 - oxfmt
 
 # Commands
 
 - `bun run dev`: Start the development server with watch mode.
+- `bun run build`: Bundle the React SPA into `dist/client`.
 - `bun run lint`: Run oxlint and fail on warnings.
 - `bun run format`: Format files with oxfmt.

--- a/projects/browser-auto/Dockerfile
+++ b/projects/browser-auto/Dockerfile
@@ -19,6 +19,17 @@ FROM base AS dependencies
 RUN bun install --frozen-lockfile
 
 # -----------------------------------------------
+# build stage
+# -----------------------------------------------
+FROM base AS build
+
+COPY --from=dependencies /app/node_modules ./node_modules
+COPY tsconfig.json ./
+COPY src ./src
+
+RUN bun run build
+
+# -----------------------------------------------
 # test stage
 # -----------------------------------------------
 FROM base AS test
@@ -59,6 +70,7 @@ WORKDIR /app
 
 COPY --from=base /usr/local/bin/bun /usr/local/bin/bunx /usr/local/bin/
 COPY --from=production-dependencies --chown=pwuser:pwuser /app/node_modules ./node_modules
+COPY --from=build --chown=pwuser:pwuser /app/dist ./dist
 COPY --chown=pwuser:pwuser package.json bun.lock tsconfig.json ./
 COPY --chown=pwuser:pwuser src ./src
 
@@ -73,4 +85,4 @@ EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD node -e "fetch('http://127.0.0.1:3000/').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"
 
-CMD ["bun", "run", "src/index.ts"]
+CMD ["bun", "run", "src/server/bun-server.ts"]

--- a/projects/browser-auto/Dockerfile
+++ b/projects/browser-auto/Dockerfile
@@ -1,5 +1,4 @@
 ARG BUN_VERSION=1.3.10
-ARG PLAYWRIGHT_VERSION=1.61.0
 ARG COMMIT_HASH=""
 
 # -----------------------------------------------
@@ -58,7 +57,8 @@ RUN bun install --frozen-lockfile --production
 # -----------------------------------------------
 # final stage
 # -----------------------------------------------
-FROM mcr.microsoft.com/playwright:v${PLAYWRIGHT_VERSION}-noble AS final
+# TODO: Use the Playwright image when browser automation is implemented.
+FROM oven/bun:${BUN_VERSION} AS final
 
 ARG COMMIT_HASH
 
@@ -68,21 +68,20 @@ ENV PORT=3000
 
 WORKDIR /app
 
-COPY --from=base /usr/local/bin/bun /usr/local/bin/bunx /usr/local/bin/
-COPY --from=production-dependencies --chown=pwuser:pwuser /app/node_modules ./node_modules
-COPY --from=build --chown=pwuser:pwuser /app/dist ./dist
-COPY --chown=pwuser:pwuser package.json bun.lock tsconfig.json ./
-COPY --chown=pwuser:pwuser src ./src
+COPY --from=production-dependencies --chown=bun:bun /app/node_modules ./node_modules
+COPY --from=build --chown=bun:bun /app/dist ./dist
+COPY --chown=bun:bun package.json bun.lock tsconfig.json ./
+COPY --chown=bun:bun src ./src
 
-RUN mkdir -p /data && chown pwuser:pwuser /data
+RUN mkdir -p /data && chown bun:bun /data
 
-USER pwuser
+USER bun
 
 VOLUME ["/data"]
 
 EXPOSE 3000
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD node -e "fetch('http://127.0.0.1:3000/').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"
+    CMD bun -e "fetch('http://127.0.0.1:3000/').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"
 
 CMD ["bun", "run", "src/server/bun-server.ts"]

--- a/projects/browser-auto/bun.lock
+++ b/projects/browser-auto/bun.lock
@@ -9,8 +9,12 @@
       },
       "devDependencies": {
         "@types/bun": "^1.3.14",
+        "@types/react": "^19.2.17",
+        "@types/react-dom": "^19.2.3",
         "oxfmt": "^0.56.0",
         "oxlint": "^1.71.0",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
       },
       "peerDependencies": {
         "typescript": "^6.0.3",
@@ -98,13 +102,25 @@
 
     "@types/node": ["@types/node@26.0.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA=="],
 
+    "@types/react": ["@types/react@19.2.17", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw=="],
+
+    "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
     "hono": ["hono@4.12.27", "", {}, "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q=="],
 
     "oxfmt": ["oxfmt@0.56.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.56.0", "@oxfmt/binding-android-arm64": "0.56.0", "@oxfmt/binding-darwin-arm64": "0.56.0", "@oxfmt/binding-darwin-x64": "0.56.0", "@oxfmt/binding-freebsd-x64": "0.56.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.56.0", "@oxfmt/binding-linux-arm-musleabihf": "0.56.0", "@oxfmt/binding-linux-arm64-gnu": "0.56.0", "@oxfmt/binding-linux-arm64-musl": "0.56.0", "@oxfmt/binding-linux-ppc64-gnu": "0.56.0", "@oxfmt/binding-linux-riscv64-gnu": "0.56.0", "@oxfmt/binding-linux-riscv64-musl": "0.56.0", "@oxfmt/binding-linux-s390x-gnu": "0.56.0", "@oxfmt/binding-linux-x64-gnu": "0.56.0", "@oxfmt/binding-linux-x64-musl": "0.56.0", "@oxfmt/binding-openharmony-arm64": "0.56.0", "@oxfmt/binding-win32-arm64-msvc": "0.56.0", "@oxfmt/binding-win32-ia32-msvc": "0.56.0", "@oxfmt/binding-win32-x64-msvc": "0.56.0" }, "peerDependencies": { "svelte": "^5.0.0", "vite-plus": "*" }, "optionalPeers": ["svelte", "vite-plus"], "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-9Dv0wV3zKiyvhjD7bRKaInKmHQ1sPx3RGOjQkGFJbbdQ16576yf8qhMSO9Q9cvHcs+1NpBsRTkuDDYFFPTJ6gw=="],
 
     "oxlint": ["oxlint@1.71.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.71.0", "@oxlint/binding-android-arm64": "1.71.0", "@oxlint/binding-darwin-arm64": "1.71.0", "@oxlint/binding-darwin-x64": "1.71.0", "@oxlint/binding-freebsd-x64": "1.71.0", "@oxlint/binding-linux-arm-gnueabihf": "1.71.0", "@oxlint/binding-linux-arm-musleabihf": "1.71.0", "@oxlint/binding-linux-arm64-gnu": "1.71.0", "@oxlint/binding-linux-arm64-musl": "1.71.0", "@oxlint/binding-linux-ppc64-gnu": "1.71.0", "@oxlint/binding-linux-riscv64-gnu": "1.71.0", "@oxlint/binding-linux-riscv64-musl": "1.71.0", "@oxlint/binding-linux-s390x-gnu": "1.71.0", "@oxlint/binding-linux-x64-gnu": "1.71.0", "@oxlint/binding-linux-x64-musl": "1.71.0", "@oxlint/binding-openharmony-arm64": "1.71.0", "@oxlint/binding-win32-arm64-msvc": "1.71.0", "@oxlint/binding-win32-ia32-msvc": "1.71.0", "@oxlint/binding-win32-x64-msvc": "1.71.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.22.1", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-U1m1X+C0vDj7DC1e13IoZULzEcPczE7UOMTs8VlZGHUEIUaSTZKo5qkPsQEfzpgnQ29Pea/w3Xntk62UCecxZw=="],
+
+    "react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
+
+    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "tinypool": ["tinypool@2.1.0", "", {}, "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw=="],
 

--- a/projects/browser-auto/package.json
+++ b/projects/browser-auto/package.json
@@ -3,11 +3,12 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "build": "bun build src/client/index.html --production --outdir dist/client",
     "dev": "bun --watch src/server/bun-server.ts",
     "lint": "oxlint . --deny-warnings",
     "lint:fix": "oxlint . --fix",
-    "format": "oxfmt .",
-    "format:check": "oxfmt --check .",
+    "format": "oxfmt . '!src/client/index.html'",
+    "format:check": "oxfmt --check . '!src/client/index.html'",
     "check": "bun run lint && bun run format:check"
   },
   "dependencies": {
@@ -15,8 +16,12 @@
   },
   "devDependencies": {
     "@types/bun": "^1.3.14",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
     "oxfmt": "^0.56.0",
-    "oxlint": "^1.71.0"
+    "oxlint": "^1.71.0",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
   },
   "peerDependencies": {
     "typescript": "^6.0.3"

--- a/projects/browser-auto/package.json
+++ b/projects/browser-auto/package.json
@@ -2,9 +2,8 @@
   "name": "browser-auto",
   "private": true,
   "type": "module",
-  "module": "src/index.ts",
   "scripts": {
-    "dev": "bun --watch src/index.ts",
+    "dev": "bun --watch src/server/bun-server.ts",
     "lint": "oxlint . --deny-warnings",
     "lint:fix": "oxlint . --fix",
     "format": "oxfmt .",

--- a/projects/browser-auto/package.json
+++ b/projects/browser-auto/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "bun build src/client/index.html --production --outdir dist/client",
+    "build": "bun build src/client/index.html --production --public-path / --outdir dist/client",
     "dev": "bun --watch src/server/bun-server.ts",
     "lint": "oxlint . --deny-warnings",
     "lint:fix": "oxlint . --fix",

--- a/projects/browser-auto/src/client/app.tsx
+++ b/projects/browser-auto/src/client/app.tsx
@@ -1,11 +1,16 @@
-import { StrictMode } from "react"
+import { StrictMode, useState } from "react"
 import { createRoot } from "react-dom/client"
 
 export function App() {
+  const [count, setCount] = useState(0)
+
   return (
     <main>
       <h1>Browser Auto</h1>
-      <p>Client foundation is ready.</p>
+      <p>Count: {count}</p>
+      <button type="button" onClick={() => setCount((current) => current + 1)}>
+        Increment
+      </button>
     </main>
   )
 }

--- a/projects/browser-auto/src/client/app.tsx
+++ b/projects/browser-auto/src/client/app.tsx
@@ -1,0 +1,23 @@
+import { StrictMode } from "react"
+import { createRoot } from "react-dom/client"
+
+export function App() {
+  return (
+    <main>
+      <h1>Browser Auto</h1>
+      <p>Client foundation is ready.</p>
+    </main>
+  )
+}
+
+const root = document.getElementById("root")
+
+if (!root) {
+  throw new Error("Root element not found")
+}
+
+createRoot(root).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+)

--- a/projects/browser-auto/src/client/index.html
+++ b/projects/browser-auto/src/client/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Browser Auto</title>
+    <script type="module" src="./app.tsx"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/projects/browser-auto/src/server/app.tsx
+++ b/projects/browser-auto/src/server/app.tsx
@@ -4,4 +4,4 @@ const app = new Hono()
 
 app.get("/", (c) => c.text("Hello, Hono!"))
 
-Bun.serve({ fetch: app.fetch, port: 3000 })
+export default app

--- a/projects/browser-auto/src/server/app.tsx
+++ b/projects/browser-auto/src/server/app.tsx
@@ -1,7 +1,9 @@
 import { Hono } from "hono"
+import { serveStatic } from "hono/bun"
 
 const app = new Hono()
 
-app.get("/", (c) => c.text("Hello, Hono!"))
+app.use("*", serveStatic({ root: "./dist/client" }))
+app.get("*", serveStatic({ path: "./dist/client/index.html" }))
 
 export default app

--- a/projects/browser-auto/src/server/bun-server.ts
+++ b/projects/browser-auto/src/server/bun-server.ts
@@ -1,0 +1,10 @@
+import { Hono } from "hono"
+import app from "./app"
+
+const hono = new Hono()
+hono.route("/", app)
+
+const PORT = 3000
+console.info(`Server running at http://localhost:${PORT}`)
+
+Bun.serve({ fetch: hono.fetch, port: PORT })

--- a/projects/browser-auto/tsconfig.json
+++ b/projects/browser-auto/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     // Environment setup & latest features
-    "lib": ["ESNext"],
+    "lib": ["DOM", "ESNext"],
     "types": ["bun"],
     "target": "ESNext",
     "module": "Preserve",


### PR DESCRIPTION
## Issues

- Refs #1095

## Why

#1096で追加したサーバー基盤に続き、Web管理画面を実装するためのClient基盤を整備する。

## Summary

`projects/browser-auto` にReactの最小SPAとBunによるビルド構成を追加しました。生成したClient成果物はHonoから配信し、クライアントサイドルーティング向けのフォールバックにも対応しています。

## Changes

- ServerエントリーポイントとHonoアプリを分離
- React SPAのHTMLエントリーと最小コンポーネントを追加
- `useState`を使ったカウンターサンプルを追加
- BunでClientを`dist/client`へバンドルするコマンドを追加
- Honoから静的アセットとSPAフォールバックを配信
- Docker buildステージでClientを生成し、finalステージへ配置
- Reactをビルド時のみ必要な開発依存として追加
- `AGENTS.md`へReactとClientビルドコマンドを追記

## Checklist

- [x] フォーマット
- [x] リント
- [x] 型チェック
- [x] Clientビルド
- [x] Docker `test`ステージのビルド
- [x] 静的アセットとSPAフォールバックのHTTP確認

## Details

- 前回PR: #1096
- Issue #1095は後続実装が残るため、このPRではクローズしません。
