### PR TITLE
fix: support message dump copy over HTTP

### DIFF
--- a/projects/portfolio/src/client/features/chat/components/messages-dump-viewer.tsx
+++ b/projects/portfolio/src/client/features/chat/components/messages-dump-viewer.tsx
@@ -3,6 +3,7 @@ import { useLockBodyScroll } from '#/client/shared/hooks/use-lock-body-scroll'
 import { CheckIcon } from '#/client/shared/icons/check-icon'
 import { CloseIcon } from '#/client/shared/icons/close-icon'
 import { CopyIcon } from '#/client/shared/icons/copy-icon'
+import { copyToClipboard } from '#/client/shared/lib/copy-to-clipboard'
 import type { ApiChatMessage, Message } from '#/types'
 
 interface MessagesDumpViewerProps {
@@ -51,7 +52,7 @@ export function MessagesDumpViewer({ messages, apiContextMessages, open, onClose
   const json = JSON.stringify(visibleData, null, 2)
 
   const handleCopy = async () => {
-    await navigator.clipboard.writeText(json)
+    await copyToClipboard(json)
     setCopied(true)
   }
 

--- a/projects/portfolio/tests/client/shared/lib/copy-to-clipboard.test.ts
+++ b/projects/portfolio/tests/client/shared/lib/copy-to-clipboard.test.ts
@@ -1,0 +1,21 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { copyToClipboard } from '#/client/shared/lib/copy-to-clipboard'
+
+describe('copyToClipboard', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('Clipboard APIが利用できない場合もテキストをコピーする', async () => {
+    const execCommand = vi.fn().mockReturnValue(true)
+    Object.defineProperty(navigator, 'clipboard', { configurable: true, value: undefined })
+    Object.defineProperty(document, 'execCommand', { configurable: true, value: execCommand })
+
+    await copyToClipboard('message dump')
+
+    expect(execCommand).toHaveBeenCalledWith('copy')
+    expect(document.querySelector('textarea')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

- Message Dumpのコピー処理を共通の`copyToClipboard`へ統一
- Clipboard APIが利用できないHTTP環境ではtextareaフォールバックを利用
- Clipboard API未提供時の回帰テストを追加

## Root cause

Message Dumpだけが`navigator.clipboard.writeText`を直接呼び出しており、HTTPデプロイ環境で`navigator.clipboard`が未定義のときに例外が発生していました。

## Validation

- `bun run test -- tests/client/shared/lib/copy-to-clipboard.test.ts tests/client/components/chat-results.test.tsx`
- `bun run test`（55 files / 301 tests）
- `bun run lint`（tsc / Oxlint）
- `git diff --check`