### PR TITLE
fix: normalize chat upstream errors

### DIFF
--- a/projects/portfolio/src/client/features/chat-compare/hooks/use-compare-stream.ts
+++ b/projects/portfolio/src/client/features/chat-compare/hooks/use-compare-stream.ts
@@ -1,7 +1,7 @@
 import { hc } from 'hono/client'
 import { useCallback, useRef } from 'react'
 import { readChatError, unavailableChatError } from '#/client/shared/lib/chat-error'
-import { parseChatStreamEvent, updateChatStream } from '#/client/shared/lib/chat-stream'
+import { isChatStreamError, parseChatStreamPayload, updateChatStream } from '#/client/shared/lib/chat-stream'
 import type { AppType } from '#/server/app.d'
 import type { ApiChatMessage, ChatUsage } from '#/types'
 import type { CompareSettings } from './use-compare-settings'
@@ -216,7 +216,14 @@ async function runModelStream(
         }
 
         try {
-          const event = parseChatStreamEvent(jsonStr)
+          const payload = parseChatStreamPayload(jsonStr)
+          if (isChatStreamError(payload)) {
+            clearIdleTimer()
+            onError(payload.message)
+            return
+          }
+
+          const event = payload
           accumulated = updateChatStream(accumulated, event)
 
           if (event.event === 'delta') {

--- a/projects/portfolio/src/client/features/chat-compare/hooks/use-compare-stream.ts
+++ b/projects/portfolio/src/client/features/chat-compare/hooks/use-compare-stream.ts
@@ -1,5 +1,6 @@
 import { hc } from 'hono/client'
 import { useCallback, useRef } from 'react'
+import { readChatError, unavailableChatError } from '#/client/shared/lib/chat-error'
 import { parseChatStreamEvent, updateChatStream } from '#/client/shared/lib/chat-stream'
 import type { AppType } from '#/server/app.d'
 import type { ApiChatMessage, ChatUsage } from '#/types'
@@ -162,8 +163,8 @@ async function runModelStream(
     )
 
     if (!res.ok) {
-      const errorData = (await res.json()) as { error?: string }
-      onError(errorData?.error || `HTTP ${res.status}`)
+      const error = await readChatError(res)
+      onError(error.message)
       return
     }
 
@@ -241,7 +242,7 @@ async function runModelStream(
     clearIdleTimer()
 
     if (timedOut) {
-      onError('Response timed out')
+      onError(unavailableChatError().message)
     } else if (receivedFinish) {
       const responseTimeMs = Date.now() - startTime
       onDone({
@@ -256,6 +257,6 @@ async function runModelStream(
   } catch (error) {
     clearIdleTimer()
     if (error instanceof Error && error.name === 'AbortError') return
-    onError(error instanceof Error ? error.message : 'Unknown error')
+    onError(unavailableChatError().message)
   }
 }

--- a/projects/portfolio/src/client/features/chat/api/chat-completion-client.ts
+++ b/projects/portfolio/src/client/features/chat/api/chat-completion-client.ts
@@ -8,7 +8,7 @@ import {
 } from '#/client/features/chat/lib/receive-session-events'
 import { readChatError, unknownChatError } from '#/client/shared/lib/chat-error'
 import type { ChatStreamState } from '#/client/shared/lib/chat-stream'
-import { parseChatStreamEvent, updateChatStream } from '#/client/shared/lib/chat-stream'
+import { isChatStreamError, parseChatStreamPayload, updateChatStream } from '#/client/shared/lib/chat-stream'
 import type { AppType } from '#/server/app.d'
 import type { ApiChatMessage, ApiMode, Conversation } from '#/types'
 import type { ChatError, ChatResponse, ChatUsage } from '#/types/chat-api'
@@ -80,7 +80,14 @@ export const sendStreamCompletion = async (
   }
 ): Promise<ChatCompletionResult> => {
   if (!req.conversation || !req.assistantMessageId) {
-    return sendLegacyStreamCompletion(req)
+    try {
+      return await sendLegacyStreamCompletion(req)
+    } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        return { result: null, error: null }
+      }
+      return { result: null, error: unknownChatError() }
+    }
   }
 
   try {
@@ -148,6 +155,7 @@ const sendLegacyStreamCompletion = async (
   let finishReason = ''
   let receivedFinish = false
   let usage: ChatUsage | null = null
+  let generationError: ChatError | null = null
 
   const res = await client.api.chat.stream.$post(
     {
@@ -194,7 +202,14 @@ const sendLegacyStreamCompletion = async (
         break
       }
 
-      const event = parseChatStreamEvent(jsonStr)
+      const payload = parseChatStreamPayload(jsonStr)
+      if (isChatStreamError(payload)) {
+        generationError = payload
+        running = false
+        break
+      }
+
+      const event = payload
       accumulated = updateChatStream(accumulated, event)
 
       if (event.event === 'delta') {
@@ -214,6 +229,7 @@ const sendLegacyStreamCompletion = async (
     }
   }
 
+  if (generationError) return { result: null, error: generationError }
   if (!receivedFinish) return { result: null, error: null }
   if (!hasAssistantOutput(accumulated)) return { result: null, error: null }
 

--- a/projects/portfolio/src/client/features/chat/api/chat-completion-client.ts
+++ b/projects/portfolio/src/client/features/chat/api/chat-completion-client.ts
@@ -1,16 +1,17 @@
 import { hc } from 'hono/client'
 import type { MutableRefObject } from 'react'
-import { hasAssistantOutput, makeErrorResponse } from '#/client/features/chat/lib/chat-response-result'
+import { hasAssistantOutput } from '#/client/features/chat/lib/chat-response-result'
 import { saveActiveSession } from '#/client/features/chat/lib/chat-session-storage'
 import {
   receiveSessionEvents,
-  type ResumeChatCompletionResult,
+  type CompletedSessionChatResult,
 } from '#/client/features/chat/lib/receive-session-events'
+import { readChatError, unknownChatError } from '#/client/shared/lib/chat-error'
 import type { ChatStreamState } from '#/client/shared/lib/chat-stream'
 import { parseChatStreamEvent, updateChatStream } from '#/client/shared/lib/chat-stream'
 import type { AppType } from '#/server/app.d'
 import type { ApiChatMessage, ApiMode, Conversation } from '#/types'
-import type { ChatResponse, ChatUsage } from '#/types/chat-api'
+import type { ChatError, ChatResponse, ChatUsage } from '#/types/chat-api'
 
 const client = hc<AppType>('/')
 
@@ -28,7 +29,12 @@ export interface SendCompletionParams {
   reasoningEffort?: 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'
 }
 
-export const sendNonStreamCompletion = async (req: SendCompletionParams): Promise<ChatResponse | null> => {
+export type ChatCompletionResult = {
+  result: ChatResponse | null
+  error: ChatError | null
+}
+
+export const sendNonStreamCompletion = async (req: SendCompletionParams): Promise<ChatCompletionResult> => {
   try {
     const res = await client.api.chat.$post(
       {
@@ -49,17 +55,16 @@ export const sendNonStreamCompletion = async (req: SendCompletionParams): Promis
     )
 
     if (!res.ok) {
-      const error = (await res.json()) as { error?: string }
-      return makeErrorResponse(error?.error || JSON.stringify(error))
+      return { result: null, error: await readChatError(res) }
     }
 
     const data = (await res.json()) as ChatResponse
-    if (!hasAssistantOutput(data.message)) return null
+    if (!hasAssistantOutput(data.message)) return { result: null, error: null }
 
-    return data
+    return { result: data, error: null }
   } catch (error) {
-    if (error instanceof Error && error.name === 'AbortError') return null
-    throw error
+    if (error instanceof Error && error.name === 'AbortError') return { result: null, error: null }
+    return { result: null, error: unknownChatError() }
   }
 }
 
@@ -70,10 +75,10 @@ export const sendStreamCompletion = async (
     eventSourceRef: MutableRefObject<EventSource | null>
     activeSessionIdRef: MutableRefObject<string | null>
     onSessionConversation?: (conversation: Conversation, assistantMessageId: string) => void
-    onSessionResult?: (result: Omit<ResumeChatCompletionResult, 'responseTimeMs'>) => void
+    onSessionResult?: (result: CompletedSessionChatResult) => void
     onStream?: (stream: ChatStreamState) => void
   }
-): Promise<ChatResponse | null> => {
+): Promise<ChatCompletionResult> => {
   if (!req.conversation || !req.assistantMessageId) {
     return sendLegacyStreamCompletion(req)
   }
@@ -97,8 +102,7 @@ export const sendStreamCompletion = async (
     )
 
     if (!res.ok) {
-      const error = (await res.json()) as { error?: string }
-      return makeErrorResponse(error?.error || JSON.stringify(error))
+      return { result: null, error: await readChatError(res) }
     }
 
     const data = (await res.json()) as { sessionId: string }
@@ -115,13 +119,12 @@ export const sendStreamCompletion = async (
       onStream: req.onStream,
     })
 
-    return result.result
+    return { result: result.result, error: result.error }
   } catch (error) {
     if (error instanceof Error && error.name === 'AbortError') {
-      return null
-    } else {
-      throw error
+      return { result: null, error: null }
     }
+    return { result: null, error: unknownChatError() }
   }
 }
 
@@ -137,7 +140,7 @@ export async function cancelChatSession(sessionId: string): Promise<void> {
 
 const sendLegacyStreamCompletion = async (
   req: SendCompletionParams & { onStream?: (stream: ChatStreamState) => void }
-): Promise<ChatResponse | null> => {
+): Promise<ChatCompletionResult> => {
   let accumulated: ChatStreamState = { content: '', reasoningContent: '' }
   let id = ''
   let created = 0
@@ -162,8 +165,7 @@ const sendLegacyStreamCompletion = async (
   )
 
   if (!res.ok) {
-    const error = (await res.json()) as { error?: string }
-    return makeErrorResponse(error?.error || JSON.stringify(error))
+    return { result: null, error: await readChatError(res) }
   }
 
   const reader = res.body?.getReader()
@@ -212,19 +214,22 @@ const sendLegacyStreamCompletion = async (
     }
   }
 
-  if (!receivedFinish) return null
-  if (!hasAssistantOutput(accumulated)) return null
+  if (!receivedFinish) return { result: null, error: null }
+  if (!hasAssistantOutput(accumulated)) return { result: null, error: null }
 
   return {
-    id,
-    created,
-    model,
-    finishReason,
-    message: {
-      content: accumulated.content,
-      reasoningContent: accumulated.reasoningContent,
+    result: {
+      id,
+      created,
+      model,
+      finishReason,
+      message: {
+        content: accumulated.content,
+        reasoningContent: accumulated.reasoningContent,
+      },
+      usage,
     },
-    usage,
+    error: null,
   }
 }
 

--- a/projects/portfolio/src/client/features/chat/components/chat-main.tsx
+++ b/projects/portfolio/src/client/features/chat/components/chat-main.tsx
@@ -18,6 +18,7 @@ interface Props {
   canSaveGeneratedFile?: boolean
   onSubmitting?: (submitting: boolean) => void
   onConversationChange?: (conversation: Conversation) => Promise<void> | void
+  onSessionCompleted?: (conversation: Conversation) => Promise<void> | void
   onDeleteMessages?: (messageIds: string[], isConversationEmpty: boolean) => void
 }
 
@@ -28,6 +29,7 @@ export function ChatMain({
   canSaveGeneratedFile,
   onSubmitting,
   onConversationChange,
+  onSessionCompleted,
   onDeleteMessages,
 }: Props) {
   const formRef = useRef<HTMLFormElement>(null)
@@ -37,9 +39,10 @@ export function ChatMain({
     settings,
     currentConversation,
     onSubmitting,
-    onConversationChange,
+    onSessionCompleted,
   })
-  const { conversationId, messages, isSavingConversation, streamMessageId, streamProcessor } = conversationState
+  const { conversationId, messages, isSavingConversation, streamMessageId, generationError, streamProcessor } =
+    conversationState
   const { loading, stream, cancelStream } = streamProcessor
   const formState = useChatForm({ initTrigger, formRef, submitDisabled: loading || !!stream })
   const {
@@ -75,6 +78,7 @@ export function ChatMain({
       canSaveGeneratedFile,
       currentConversation,
       onConversationChange,
+      onSessionCompleted,
       onDeleteMessages,
     },
   })
@@ -158,6 +162,7 @@ export function ChatMain({
             streamMessageId={streamMessageId}
             copiedId={copiedId}
             savingConversation={isSavingConversation}
+            generationError={generationError}
             messageEndRef={messageEndRef}
             onCopyMessage={copyMessage}
             onDeleteMessage={handleClickDeleteMessage}

--- a/projects/portfolio/src/client/features/chat/components/chat-message-list.tsx
+++ b/projects/portfolio/src/client/features/chat/components/chat-message-list.tsx
@@ -17,6 +17,7 @@ import { ChatbotTypingIcon } from '#/client/shared/icons/chatbot-typing-icon'
 import { SpinnerIcon } from '#/client/shared/icons/spinner-icon'
 import type { ChatStreamState } from '#/client/shared/lib/chat-stream'
 import type { GeneratedCodeFile, Message } from '#/types'
+import type { ChatError } from '#/types/chat-api'
 
 const markdownRemarkPlugins = [remarkGfm]
 const markdownRehypePlugins = [rehypeSanitize]
@@ -37,6 +38,7 @@ interface ChatMessageListProps {
   streamMessageId?: string | null
   copiedId: string
   savingConversation?: boolean
+  generationError?: ChatError | null
   messageEndRef: RefObject<HTMLDivElement | null>
   onCopyMessage: (message: string, index: number) => void
   onDeleteMessage: (index: number) => void
@@ -55,6 +57,7 @@ export function ChatMessageList({
   streamMessageId,
   copiedId,
   savingConversation,
+  generationError,
   messageEndRef,
   onCopyMessage,
   onDeleteMessage,
@@ -99,6 +102,14 @@ export function ChatMessageList({
           codeBlockOpenBlocks={codeBlockOpenBlocks}
           onCodeBlockOpenChange={handleCodeBlockOpenChange}
         />
+        {generationError && (
+          <div
+            role='alert'
+            className='mt-4 rounded-md border border-red-300 bg-red-50 px-3 py-2 text-red-800 text-sm dark:border-red-800 dark:bg-red-950/40 dark:text-red-200'
+          >
+            {generationError.message}
+          </div>
+        )}
         {loading && (
           <div className='flex align-item'>
             <div className='flex h-8 w-8 justify-center rounded-full border border-gray-300 bg-white align-center dark:border-gray-600 dark:bg-gray-800'>

--- a/projects/portfolio/src/client/features/chat/hooks/use-chat-actions.ts
+++ b/projects/portfolio/src/client/features/chat/hooks/use-chat-actions.ts
@@ -14,8 +14,10 @@ import {
   prepareApiMessages,
   summarizeImageContext,
 } from '#/client/features/chat/lib/edit-message'
+import { unknownChatError } from '#/client/shared/lib/chat-error'
 import type { Settings } from '#/client/shared/storage/remote-storage-settings'
 import type { Conversation, GeneratedCodeFile, Message } from '#/types'
+import type { ChatError } from '#/types/chat-api'
 
 interface ConversationState {
   conversationId: string | null
@@ -25,6 +27,7 @@ interface ConversationState {
   setMessages: Dispatch<SetStateAction<Message[]>>
   setIsSavingConversation: Dispatch<SetStateAction<boolean>>
   setStreamMessageId: Dispatch<SetStateAction<string | null>>
+  setGenerationError: Dispatch<SetStateAction<ChatError | null>>
   markSessionOwnedSnapshot: (conversation: Pick<Conversation, 'id' | 'messages'>) => void
 }
 
@@ -37,6 +40,7 @@ interface UseChatActionsParams {
     canSaveGeneratedFile?: boolean
     currentConversation?: Conversation | null
     onConversationChange?: (conversation: Conversation) => Promise<void> | void
+    onSessionCompleted?: (conversation: Conversation) => Promise<void> | void
     onDeleteMessages?: (messageIds: string[], isConversationEmpty: boolean) => void
   }
 }
@@ -57,15 +61,18 @@ export function useChatActions({
     setMessages,
     setIsSavingConversation,
     setStreamMessageId,
+    setGenerationError,
     markSessionOwnedSnapshot,
   } = conversationState
   const { loading, stream, submitChatCompletion } = streamProcessor
-  const { canSaveGeneratedFile, currentConversation, onConversationChange, onDeleteMessages } = callbacks
+  const { canSaveGeneratedFile, currentConversation, onConversationChange, onSessionCompleted, onDeleteMessages } =
+    callbacks
 
   const handleSubmit = useCallback(
     (event: FormEvent<HTMLFormElement>) => {
       event.preventDefault()
       const requestSettings = resolveChatRequestSettings(settings)
+      setGenerationError(null)
       const params = buildChatMessages({
         apiMode: settings.apiMode,
         includeChatHistory: settings.includeChatHistory,
@@ -113,7 +120,12 @@ export function useChatActions({
         maxTokens: requestSettings.maxTokens,
         reasoningEffort: requestSettings.reasoningEffort,
       })
-        .then(async ({ result, responseTimeMs }) => {
+        .then(async ({ result, error, responseTimeMs }) => {
+          if (error) {
+            setGenerationError(error)
+            return
+          }
+
           const assistantMessage = result
             ? createAssistantMessage({
                 assistantMessageId,
@@ -134,14 +146,22 @@ export function useChatActions({
 
           setIsSavingConversation(true)
           try {
-            await onConversationChange?.({
+            const completedConversation = {
               id: currentConversationId,
               title: createConversationTitle(params.draftUserMessage.content),
               messages: finalMessages,
-            })
+            }
+            if (settings.streamMode) {
+              await onSessionCompleted?.(completedConversation)
+            } else {
+              await onConversationChange?.(completedConversation)
+            }
           } finally {
             setIsSavingConversation(false)
           }
+        })
+        .catch(() => {
+          setGenerationError(unknownChatError())
         })
         .finally(() => {
           setStreamMessageId(null)
@@ -153,11 +173,13 @@ export function useChatActions({
       markSessionOwnedSnapshot,
       messages,
       onConversationChange,
+      onSessionCompleted,
       resetAfterSubmit,
       setConversationId,
       setIsSavingConversation,
       setMessages,
       setStreamMessageId,
+      setGenerationError,
       settings,
       submitChatCompletion,
     ]
@@ -226,6 +248,7 @@ export function useChatActions({
       }
 
       const assistantMessageId = uuidv7()
+      setGenerationError(null)
       const sendMessages = buildEditedSendMessages(editedMessages, editedUserMessage.id, settings.includeChatHistory)
       const apiMessages = prepareApiMessages(sendMessages, editedUserMessage.id, settings.sendImagesOnlyOnce)
       const imageContext = summarizeImageContext(sendMessages, editedUserMessage.id, settings.sendImagesOnlyOnce)
@@ -243,7 +266,7 @@ export function useChatActions({
       setStreamMessageId(assistantMessageId)
 
       try {
-        const { result, responseTimeMs } = await submitChatCompletion({
+        const { result, error, responseTimeMs } = await submitChatCompletion({
           header: {
             apiKey: requestSettings.apiKey,
             baseURL: requestSettings.baseURL,
@@ -258,6 +281,11 @@ export function useChatActions({
           maxTokens: requestSettings.maxTokens,
           reasoningEffort: requestSettings.reasoningEffort,
         })
+
+        if (error) {
+          setGenerationError(error)
+          return
+        }
 
         const assistantMessage = result
           ? createAssistantMessage({
@@ -279,14 +307,21 @@ export function useChatActions({
 
         setIsSavingConversation(true)
         try {
-          await onConversationChange?.({
+          const completedConversation = {
             id: draftConversationId,
             title,
             messages: finalMessages,
-          })
+          }
+          if (settings.streamMode) {
+            await onSessionCompleted?.(completedConversation)
+          } else {
+            await onConversationChange?.(completedConversation)
+          }
         } finally {
           setIsSavingConversation(false)
         }
+      } catch {
+        setGenerationError(unknownChatError())
       } finally {
         setStreamMessageId(null)
       }
@@ -299,10 +334,12 @@ export function useChatActions({
       markSessionOwnedSnapshot,
       messages,
       onConversationChange,
+      onSessionCompleted,
       setConversationId,
       setIsSavingConversation,
       setMessages,
       setStreamMessageId,
+      setGenerationError,
       settings,
       stream,
       submitChatCompletion,

--- a/projects/portfolio/src/client/features/chat/hooks/use-chat-conversation.ts
+++ b/projects/portfolio/src/client/features/chat/hooks/use-chat-conversation.ts
@@ -3,14 +3,14 @@ import { hasActiveChatSession, useStreamProcessor } from '#/client/features/chat
 import { createAssistantMessage } from '#/client/features/chat/lib/chat-message-factory'
 import type { Settings } from '#/client/shared/storage/remote-storage-settings'
 import type { Conversation, Message } from '#/types'
-import type { ChatResponse } from '#/types/chat-api'
+import type { ChatError, ChatResponse } from '#/types/chat-api'
 
 interface UseChatConversationParams {
   initTrigger?: number
   settings: Settings
   currentConversation?: Conversation | null
   onSubmitting?: (submitting: boolean) => void
-  onConversationChange?: (conversation: Conversation) => Promise<void> | void
+  onSessionCompleted?: (conversation: Conversation) => Promise<void> | void
 }
 
 export function useChatConversation({
@@ -18,7 +18,7 @@ export function useChatConversation({
   settings,
   currentConversation,
   onSubmitting,
-  onConversationChange,
+  onSessionCompleted,
 }: UseChatConversationParams) {
   const sessionOwnedSnapshotRef = useRef<{ conversationId: string; messageIds: string[] } | null>(null)
   const resumeStartedRef = useRef(false)
@@ -26,6 +26,7 @@ export function useChatConversation({
   const [messages, setMessages] = useState<Message[]>([])
   const [isSavingConversation, setIsSavingConversation] = useState(false)
   const [streamMessageId, setStreamMessageId] = useState<string | null>(null)
+  const [generationError, setGenerationError] = useState<ChatError | null>(null)
 
   const markSessionOwnedSnapshot = useCallback((conversation: Pick<Conversation, 'id' | 'messages'>) => {
     sessionOwnedSnapshotRef.current = {
@@ -91,6 +92,7 @@ export function useChatConversation({
     setMessages([])
     setConversationId(null)
     setStreamMessageId(null)
+    setGenerationError(null)
   }, [initTrigger])
 
   useEffect(() => {
@@ -101,7 +103,14 @@ export function useChatConversation({
     resumeStartedRef.current = true
     let mounted = true
     void resumeActiveChatCompletion().then(async (resumed) => {
-      if (!mounted || !resumed?.conversation) return
+      if (!mounted || !resumed) return
+
+      if (resumed.error) {
+        setGenerationError(resumed.error)
+        return
+      }
+
+      if (!resumed.conversation) return
 
       const assistantMessage = resumed.result
         ? createAssistantMessage({
@@ -122,7 +131,7 @@ export function useChatConversation({
       commitConversationMessages(resumed.conversation.id, finalMessages, null)
 
       if (assistantMessage) {
-        await onConversationChange?.({
+        await onSessionCompleted?.({
           ...resumed.conversation,
           messages: finalMessages,
         })
@@ -135,7 +144,7 @@ export function useChatConversation({
   }, [
     commitConversationMessages,
     markSessionOwnedSnapshot,
-    onConversationChange,
+    onSessionCompleted,
     resumeActiveChatCompletion,
     settings.apiMode,
   ])
@@ -165,10 +174,12 @@ export function useChatConversation({
     messages,
     isSavingConversation,
     streamMessageId,
+    generationError,
     setConversationId,
     setMessages,
     setIsSavingConversation,
     setStreamMessageId,
+    setGenerationError,
     markSessionOwnedSnapshot,
     streamProcessor,
   }

--- a/projects/portfolio/src/client/features/chat/hooks/use-stream-processor.ts
+++ b/projects/portfolio/src/client/features/chat/hooks/use-stream-processor.ts
@@ -6,12 +6,13 @@ import {
 } from '#/client/features/chat/api/chat-completion-client'
 import { clearActiveSession, readActiveSession } from '#/client/features/chat/lib/chat-session-storage'
 import {
+  type CompletedSessionChatResult,
   receiveSessionEvents,
   type ResumeChatCompletionResult,
 } from '#/client/features/chat/lib/receive-session-events'
 import type { ChatStreamState } from '#/client/shared/lib/chat-stream'
 import type { ApiChatMessage, ApiMode, Conversation } from '#/types'
-import type { ChatResponse } from '#/types/chat-api'
+import type { ChatError, ChatResponse } from '#/types/chat-api'
 
 export {
   ACTIVE_SESSION_STORAGE_KEY,
@@ -38,7 +39,7 @@ interface SubmitChatCompletionParams {
 interface UseStreamProcessorParams {
   onSubmitting?: (submitting: boolean) => void
   onSessionConversation?: (conversation: Conversation, assistantMessageId: string) => void
-  onSessionResult?: (result: Omit<ResumeChatCompletionResult, 'responseTimeMs'>) => void
+  onSessionResult?: (result: CompletedSessionChatResult) => void
 }
 
 export function useStreamProcessor({
@@ -77,14 +78,18 @@ export function useStreamProcessor({
       temperature,
       maxTokens,
       reasoningEffort,
-    }: SubmitChatCompletionParams): Promise<{ result: ChatResponse | null; responseTimeMs: number }> => {
+    }: SubmitChatCompletionParams): Promise<{
+      result: ChatResponse | null
+      error: ChatError | null
+      responseTimeMs: number
+    }> => {
       setLoading(true)
       abortControllerRef.current = new AbortController()
       onSubmitting?.(true)
       const requestStartTime = Date.now()
 
       try {
-        const result = streamMode
+        const completion = streamMode
           ? await sendStreamCompletion({
               abortController: abortControllerRef.current,
               eventSourceRef,
@@ -114,7 +119,7 @@ export function useStreamProcessor({
             })
         const responseTimeMs = Date.now() - requestStartTime
 
-        return { result, responseTimeMs }
+        return { ...completion, responseTimeMs }
       } finally {
         abortControllerRef.current = null
         setStream(null)
@@ -146,8 +151,6 @@ export function useStreamProcessor({
         onSessionResult,
         onStream: (stream) => setStream(stream),
       })
-      if (!result.conversation) return null
-
       return {
         ...result,
         responseTimeMs: Date.now() - requestStartTime,

--- a/projects/portfolio/src/client/features/chat/lib/chat-response-result.ts
+++ b/projects/portfolio/src/client/features/chat/lib/chat-response-result.ts
@@ -1,13 +1,4 @@
 import type { ChatResponse } from '#/types/chat-api'
 
-export const makeErrorResponse = (message: string): ChatResponse => ({
-  id: '',
-  created: 0,
-  model: 'N/A',
-  finishReason: '',
-  message: { content: message, reasoningContent: '' },
-  usage: null,
-})
-
 export const hasAssistantOutput = ({ content, reasoningContent }: ChatResponse['message']): boolean =>
   content.length > 0 || reasoningContent.length > 0

--- a/projects/portfolio/src/client/features/chat/lib/receive-session-events.ts
+++ b/projects/portfolio/src/client/features/chat/lib/receive-session-events.ts
@@ -1,17 +1,34 @@
 import type { MutableRefObject } from 'react'
-import { hasAssistantOutput, makeErrorResponse } from '#/client/features/chat/lib/chat-response-result'
-import { saveActiveSession } from '#/client/features/chat/lib/chat-session-storage'
+import { hasAssistantOutput } from '#/client/features/chat/lib/chat-response-result'
+import { clearActiveSession, saveActiveSession } from '#/client/features/chat/lib/chat-session-storage'
+import { unavailableChatError } from '#/client/shared/lib/chat-error'
 import type { ChatStreamState } from '#/client/shared/lib/chat-stream'
 import { updateChatStream } from '#/client/shared/lib/chat-stream'
 import type { Conversation } from '#/types'
-import { ChatSessionEventSchema, type ChatResponse, type ChatSessionEvent, type ChatUsage } from '#/types/chat-api'
+import {
+  ChatSessionEventSchema,
+  ChatSessionMetaSchema,
+  type ChatError,
+  type ChatResponse,
+  type ChatSessionEvent,
+  type ChatUsage,
+} from '#/types/chat-api'
 
 export type ResumeChatCompletionResult = {
-  conversation: Conversation
+  conversation: Conversation | null
   assistantMessageId: string
   result: ChatResponse | null
+  error: ChatError | null
   responseTimeMs: number
 }
+
+export type CompletedSessionChatResult = {
+  conversation: Conversation
+  assistantMessageId: string
+  result: ChatResponse
+}
+
+const EVENT_SOURCE_ERROR_TIMEOUT_MS = 15_000
 
 type ReceiveSessionEventsParams = {
   sessionId: string
@@ -20,7 +37,7 @@ type ReceiveSessionEventsParams = {
   eventSourceRef: MutableRefObject<EventSource | null>
   activeSessionIdRef: MutableRefObject<string | null>
   onSessionConversation?: (conversation: Conversation, assistantMessageId: string) => void
-  onSessionResult?: (result: Omit<ResumeChatCompletionResult, 'responseTimeMs'>) => void
+  onSessionResult?: (result: CompletedSessionChatResult) => void
   onStream?: (stream: ChatStreamState) => void
 }
 
@@ -45,6 +62,7 @@ export const receiveSessionEvents = ({
     let conversation: Conversation | null = null
     let assistantMessageId = ''
     let settled = false
+    let eventSourceErrorTimeout: ReturnType<typeof setTimeout> | null = null
 
     const eventSource = new EventSource(buildChatSessionEventsUrl(sessionId, afterEventId))
     eventSourceRef.current = eventSource
@@ -53,17 +71,23 @@ export const receiveSessionEvents = ({
       eventSource.close()
       eventSourceRef.current = null
       abortSignal?.removeEventListener('abort', handleAbort)
+      if (eventSourceErrorTimeout) {
+        clearTimeout(eventSourceErrorTimeout)
+        eventSourceErrorTimeout = null
+      }
     }
 
-    const finish = (result: ChatResponse | null) => {
+    const finish = (result: ChatResponse | null, error: ChatError | null = null) => {
       if (settled) return
       settled = true
       cleanup()
       activeSessionIdRef.current = null
+      clearActiveSession()
       resolve({
-        conversation: conversation as Conversation,
+        conversation,
         assistantMessageId,
         result,
+        error,
       })
     }
 
@@ -85,6 +109,10 @@ export const receiveSessionEvents = ({
     abortSignal?.addEventListener('abort', handleAbort, { once: true })
 
     const handleSessionEvent = (sessionEvent: ChatSessionEvent) => {
+      if (eventSourceErrorTimeout) {
+        clearTimeout(eventSourceErrorTimeout)
+        eventSourceErrorTimeout = null
+      }
       saveActiveSession({ sessionId, lastEventId: sessionEvent.id })
 
       if (sessionEvent.type === 'user_message') {
@@ -119,8 +147,8 @@ export const receiveSessionEvents = ({
         return
       }
 
-      if (sessionEvent.type === 'error') {
-        finish(makeErrorResponse(sessionEvent.data.message))
+      if (sessionEvent.type === 'generation_error') {
+        finish(null, sessionEvent.data)
         return
       }
 
@@ -142,6 +170,7 @@ export const receiveSessionEvents = ({
           conversation: conversation as Conversation,
           assistantMessageId,
           result,
+          error: null,
         }
         onSessionResult?.(sessionResult)
         finish(sessionResult.result)
@@ -163,7 +192,7 @@ export const receiveSessionEvents = ({
       'usage',
       'done',
       'cancelled',
-      'error',
+      'generation_error',
     ]) {
       eventSource.addEventListener(eventType, (message) => {
         try {
@@ -175,7 +204,31 @@ export const receiveSessionEvents = ({
     }
 
     eventSource.onerror = () => {
-      // EventSource は一時切断時も onerror 後に自動再接続するため、terminal event を待つ。
+      void checkTerminalSession()
+      if (eventSourceErrorTimeout) return
+
+      eventSourceErrorTimeout = setTimeout(() => {
+        finish(null, unavailableChatError())
+      }, EVENT_SOURCE_ERROR_TIMEOUT_MS)
+    }
+
+    async function checkTerminalSession() {
+      try {
+        const response = await fetch(`/api/chat/sessions/${encodeURIComponent(sessionId)}`)
+        if (!response.ok) return
+
+        const payload = (await response.json()) as { session?: unknown }
+        const parsed = ChatSessionMetaSchema.safeParse(payload.session)
+        if (!parsed.success) return
+
+        if (parsed.data.status === 'error') {
+          finish(null, parsed.data.error ?? unavailableChatError())
+        } else if (parsed.data.status === 'cancelled') {
+          finish(null)
+        }
+      } catch {
+        // EventSource の自動再接続と timeout で復旧・終了を判断する。
+      }
     }
   })
 

--- a/projects/portfolio/src/client/features/chat/page.tsx
+++ b/projects/portfolio/src/client/features/chat/page.tsx
@@ -169,6 +169,16 @@ export function Chat() {
     }
   }
 
+  const handleSessionCompleted = async (conversation: Conversation): Promise<void> => {
+    if (!email) return
+
+    const shouldReplace = !selectedConversationId
+    if (conversation.id !== selectedConversationId) {
+      navigateToConversation(conversation.id, shouldReplace)
+    }
+    await query.refetch()
+  }
+
   return (
     <ChatLayout
       isSidebarOpen={isSidebarOpen}
@@ -221,6 +231,7 @@ export function Chat() {
           onSubmitting={setSubmitting}
           currentConversation={currentConversation}
           onConversationChange={handleConversationChange}
+          onSessionCompleted={handleSessionCompleted}
           onDeleteMessages={handleDeleteConversationMessage}
         />
       )}

--- a/projects/portfolio/src/client/shared/lib/chat-error.ts
+++ b/projects/portfolio/src/client/shared/lib/chat-error.ts
@@ -1,0 +1,22 @@
+import { ChatErrorSchema, type ChatError } from '#/types'
+
+export const unknownChatError = (): ChatError => ({
+  code: 'UNKNOWN_UPSTREAM_ERROR',
+  message: 'LLM の応答取得中にエラーが発生しました。しばらく待ってから再試行してください。',
+  retryable: true,
+})
+
+export const unavailableChatError = (): ChatError => ({
+  code: 'UPSTREAM_UNAVAILABLE',
+  message: 'LLM プロバイダーに接続できませんでした。しばらく待ってから再試行してください。',
+  retryable: true,
+})
+
+export async function readChatError(response: Pick<Response, 'json'>): Promise<ChatError> {
+  try {
+    const parsed = ChatErrorSchema.safeParse(await response.json())
+    return parsed.success ? parsed.data : unknownChatError()
+  } catch {
+    return unknownChatError()
+  }
+}

--- a/projects/portfolio/src/client/shared/lib/chat-stream.ts
+++ b/projects/portfolio/src/client/shared/lib/chat-stream.ts
@@ -1,4 +1,4 @@
-import { ChatStreamEventSchema, type ChatStreamEvent } from '#/types/chat-api'
+import { ChatErrorSchema, ChatStreamEventSchema, type ChatError, type ChatStreamEvent } from '#/types/chat-api'
 
 export interface ChatStreamState {
   content: string
@@ -7,6 +7,16 @@ export interface ChatStreamState {
 
 export function parseChatStreamEvent(value: string): ChatStreamEvent {
   return ChatStreamEventSchema.parse(JSON.parse(value))
+}
+
+export function parseChatStreamPayload(value: string): ChatStreamEvent | ChatError {
+  const parsed = JSON.parse(value)
+  const error = ChatErrorSchema.safeParse(parsed)
+  return error.success ? error.data : ChatStreamEventSchema.parse(parsed)
+}
+
+export function isChatStreamError(payload: ChatStreamEvent | ChatError): payload is ChatError {
+  return 'code' in payload
 }
 
 export function updateChatStream(stream: ChatStreamState, event: ChatStreamEvent): ChatStreamState {

--- a/projects/portfolio/src/server/features/chat-sessions/session-manager.ts
+++ b/projects/portfolio/src/server/features/chat-sessions/session-manager.ts
@@ -3,10 +3,11 @@ import { chatConversationRepository } from '#/server/features/chat-conversations
 import { chat } from '#/server/features/chat/chat'
 import { convertStreamChunks } from '#/server/features/chat/converter'
 import type { ResponsesStreamChunk, StreamChunk } from '#/server/features/chat/transport'
-import { getErrorMessage } from '#/server/lib/error-message'
+import { toChatError } from '#/server/lib/chat-error'
 import { logger } from '#/server/lib/logger'
 import type { ApiMode, AssistantMessage, Conversation } from '#/types'
 import type {
+  ChatError,
   ChatSessionEvent,
   ChatSessionMeta,
   ChatSessionStartRequest,
@@ -36,7 +37,7 @@ type SessionRuntime = {
   graceTimer: ReturnType<typeof setTimeout> | null
 }
 
-const TERMINAL_EVENT_TYPES = new Set<ChatSessionEvent['type']>(['done', 'cancelled', 'error'])
+const TERMINAL_EVENT_TYPES = new Set<ChatSessionEvent['type']>(['done', 'cancelled', 'generation_error'])
 
 export class ChatSessionManager {
   private readonly runtimes = new Map<string, SessionRuntime>()
@@ -158,17 +159,15 @@ export class ChatSessionManager {
       }
 
       if ((await this.store.getSession(sessionId))?.status === 'running') {
-        await this.finishSession(sessionId, 'completed')
-        await this.persistIfSignedIn(sessionId, params.databaseUrl, params.ttlSeconds)
+        await this.completeSession(sessionId, params.databaseUrl, params.ttlSeconds)
       }
     } catch (err) {
       if (controller.signal.aborted || runtime.controller?.signal.aborted) return
 
       logger.error({ err, sessionId }, 'Session chat generation failed')
       await this.finishSession(sessionId, 'error', {
-        message: getErrorMessage(err, 'Upstream error'),
+        error: toChatError(err),
       })
-      await this.persistIfSignedIn(sessionId, params.databaseUrl, params.ttlSeconds)
     } finally {
       runtime.controller = null
       await this.store.setSessionTtl(sessionId, params.ttlSeconds)
@@ -201,12 +200,12 @@ export class ChatSessionManager {
   private async finishSession(
     sessionId: string,
     status: Exclude<ChatSessionStatus, 'running'>,
-    data: { reason?: string; message?: string } = {}
+    data: { reason?: string; error?: ChatError } = {}
   ): Promise<void> {
     await this.store.updateSession(sessionId, {
       status,
       completedAt: new Date().toISOString(),
-      error: data.message ?? null,
+      error: data.error ?? null,
     })
 
     if (status === 'completed') {
@@ -225,11 +224,25 @@ export class ChatSessionManager {
     }
 
     await this.appendEvent(sessionId, {
-      type: 'error',
-      data: {
-        message: data.message ?? 'Upstream error',
-      },
+      type: 'generation_error',
+      data: data.error ?? toChatError(new Error('Unknown upstream error')),
     })
+  }
+
+  private async completeSession(sessionId: string, databaseUrl: string | undefined, ttlSeconds: number): Promise<void> {
+    await this.store.updateSession(sessionId, {
+      status: 'completed',
+      completedAt: new Date().toISOString(),
+      error: null,
+    })
+
+    try {
+      await this.persistIfSignedIn(sessionId, databaseUrl, ttlSeconds)
+    } catch (err) {
+      logger.error({ err, sessionId }, 'Session conversation persistence failed')
+    }
+
+    await this.appendEvent(sessionId, { type: 'done', data: {} })
   }
 
   private async appendEvent(sessionId: string, event: Omit<ChatSessionEvent, 'id' | 'sessionId' | 'createdAt'>) {
@@ -270,6 +283,10 @@ export class ChatSessionManager {
 }
 
 export function foldSessionEvents(session: ChatSessionMeta, events: ChatSessionEvent[]): Conversation {
+  if (session.status !== 'completed') {
+    return session.conversation
+  }
+
   let content = ''
   let reasoningContent = ''
   let finishReason = ''

--- a/projects/portfolio/src/server/features/chat-sessions/session-manager.ts
+++ b/projects/portfolio/src/server/features/chat-sessions/session-manager.ts
@@ -3,7 +3,7 @@ import { chatConversationRepository } from '#/server/features/chat-conversations
 import { chat } from '#/server/features/chat/chat'
 import { convertStreamChunks } from '#/server/features/chat/converter'
 import type { ResponsesStreamChunk, StreamChunk } from '#/server/features/chat/transport'
-import { toChatError } from '#/server/lib/chat-error'
+import { conversationPersistenceError, toChatError } from '#/server/lib/chat-error'
 import { logger } from '#/server/lib/logger'
 import type { ApiMode, AssistantMessage, Conversation } from '#/types'
 import type {
@@ -162,7 +162,7 @@ export class ChatSessionManager {
         await this.completeSession(sessionId, params.databaseUrl, params.ttlSeconds)
       }
     } catch (err) {
-      if (controller.signal.aborted || runtime.controller?.signal.aborted) return
+      if (controller.signal.aborted || runtime.controller?.signal?.aborted) return
 
       logger.error({ err, sessionId }, 'Session chat generation failed')
       await this.finishSession(sessionId, 'error', {
@@ -202,47 +202,48 @@ export class ChatSessionManager {
     status: Exclude<ChatSessionStatus, 'running'>,
     data: { reason?: string; error?: ChatError } = {}
   ): Promise<void> {
-    await this.store.updateSession(sessionId, {
-      status,
-      completedAt: new Date().toISOString(),
-      error: data.error ?? null,
-    })
+    const completedAt = new Date().toISOString()
 
     if (status === 'completed') {
       await this.appendEvent(sessionId, { type: 'done', data: {} })
-      return
-    }
-
-    if (status === 'cancelled') {
+    } else if (status === 'cancelled') {
       await this.appendEvent(sessionId, {
         type: 'cancelled',
         data: {
           reason: data.reason ?? 'cancelled',
         },
       })
-      return
+    } else {
+      await this.appendEvent(sessionId, {
+        type: 'generation_error',
+        data: data.error ?? toChatError(new Error('Unknown upstream error')),
+      })
     }
 
-    await this.appendEvent(sessionId, {
-      type: 'generation_error',
-      data: data.error ?? toChatError(new Error('Unknown upstream error')),
+    await this.store.updateSession(sessionId, {
+      status,
+      completedAt,
+      error: data.error ?? null,
     })
   }
 
   private async completeSession(sessionId: string, databaseUrl: string | undefined, ttlSeconds: number): Promise<void> {
+    try {
+      await this.persistIfSignedIn(sessionId, databaseUrl, ttlSeconds)
+    } catch (err) {
+      logger.error({ err, sessionId }, 'Session conversation persistence failed')
+      await this.finishSession(sessionId, 'error', {
+        error: conversationPersistenceError(),
+      })
+      return
+    }
+
+    await this.appendEvent(sessionId, { type: 'done', data: {} })
     await this.store.updateSession(sessionId, {
       status: 'completed',
       completedAt: new Date().toISOString(),
       error: null,
     })
-
-    try {
-      await this.persistIfSignedIn(sessionId, databaseUrl, ttlSeconds)
-    } catch (err) {
-      logger.error({ err, sessionId }, 'Session conversation persistence failed')
-    }
-
-    await this.appendEvent(sessionId, { type: 'done', data: {} })
   }
 
   private async appendEvent(sessionId: string, event: Omit<ChatSessionEvent, 'id' | 'sessionId' | 'createdAt'>) {
@@ -263,7 +264,7 @@ export class ChatSessionManager {
     if (!session || !session.email || !databaseUrl) return
 
     const events = await this.store.readEvents(sessionId)
-    const conversation = foldSessionEvents(session, events)
+    const conversation = foldSessionEvents(session, events, true)
     await chatConversationRepository.upsert(databaseUrl, session.email, conversation)
     await this.store.setSessionTtl(sessionId, ttlSeconds)
   }
@@ -282,8 +283,12 @@ export class ChatSessionManager {
   }
 }
 
-export function foldSessionEvents(session: ChatSessionMeta, events: ChatSessionEvent[]): Conversation {
-  if (session.status !== 'completed') {
+export function foldSessionEvents(
+  session: ChatSessionMeta,
+  events: ChatSessionEvent[],
+  includeCompletedOutput = session.status === 'completed'
+): Conversation {
+  if (!includeCompletedOutput) {
     return session.conversation
   }
 

--- a/projects/portfolio/src/server/features/chat/converter.ts
+++ b/projects/portfolio/src/server/features/chat/converter.ts
@@ -1,3 +1,4 @@
+import { UpstreamChatError } from '#/server/lib/chat-error'
 import type { ApiMode } from '#/types'
 import type { ChatResponse, ChatStreamEvent, ChatUsage } from '#/types/chat-api'
 import type {
@@ -39,6 +40,8 @@ function convertChatCompletionsCompletion(raw: CompletionChunk): ChatResponse {
 }
 
 function convertResponsesCompletion(raw: ResponsesCompletion): ChatResponse {
+  throwIfResponsesFailed(raw)
+
   return {
     id: raw.id,
     created: raw.created_at,
@@ -154,6 +157,8 @@ async function* convertResponsesStreamChunks(raw: ResponsesStreamChunk): AsyncGe
     }
 
     if (event.type === 'response.completed') {
+      throwIfResponsesFailed(event.response)
+
       yield {
         event: 'finish',
         id: lastId,
@@ -172,6 +177,21 @@ async function* convertResponsesStreamChunks(raw: ResponsesStreamChunk): AsyncGe
           usage,
         }
       }
+
+      continue
+    }
+
+    if (event.type === 'response.failed' || event.type === 'response.incomplete') {
+      throwIfResponsesFailed(event.response, true)
+    }
+
+    if (event.type === 'error') {
+      throw new UpstreamChatError({
+        type: 'responses_stream_error',
+        code: event.code ?? undefined,
+        param: event.param ?? undefined,
+        message: event.message,
+      })
     }
   }
 }
@@ -270,4 +290,15 @@ function hasResponseMetadata(
   event: ResponsesStreamEvent
 ): event is Extract<ResponsesStreamEvent, { response: ResponsesCompletion }> {
   return 'response' in event
+}
+
+function throwIfResponsesFailed(raw: Pick<ResponsesCompletion, 'status' | 'error'>, terminalFailure = false): void {
+  if (!terminalFailure && !raw.error && (raw.status === undefined || raw.status === 'completed')) {
+    return
+  }
+
+  throw new UpstreamChatError({
+    code: raw.error?.code ?? raw.status,
+    message: raw.error?.message ?? `Responses API completed with status '${raw.status ?? 'unknown'}'`,
+  })
 }

--- a/projects/portfolio/src/server/lib/chat-error.ts
+++ b/projects/portfolio/src/server/lib/chat-error.ts
@@ -1,0 +1,138 @@
+import { APIConnectionError, APIConnectionTimeoutError, APIError } from 'openai'
+import type { ChatError, ChatErrorCode } from '#/types/chat-api'
+
+const errorDefinitions: Record<Exclude<ChatErrorCode, 'VALIDATION_ERROR'>, Omit<ChatError, 'code'>> = {
+  AUTHENTICATION_FAILED: {
+    message: 'API キーが無効か、利用を許可されていません。設定を確認してください。',
+    retryable: false,
+  },
+  MODEL_ACCESS_DENIED: {
+    message: 'このモデルを利用する権限がありません。モデル名と API キーの権限を確認してください。',
+    retryable: false,
+  },
+  INSUFFICIENT_CREDIT: {
+    message: 'LLM プロバイダーのクレジットが不足しています。API キーの請求状況を確認してください。',
+    retryable: false,
+  },
+  RATE_LIMITED: {
+    message: 'リクエスト数の上限に達しました。しばらく待ってから再試行してください。',
+    retryable: true,
+  },
+  INVALID_REQUEST: {
+    message: 'リクエストを処理できませんでした。入力内容とモデル設定を確認してください。',
+    retryable: false,
+  },
+  UPSTREAM_UNAVAILABLE: {
+    message: 'LLM プロバイダーに接続できませんでした。しばらく待ってから再試行してください。',
+    retryable: true,
+  },
+  UNKNOWN_UPSTREAM_ERROR: {
+    message: 'LLM の応答取得中にエラーが発生しました。しばらく待ってから再試行してください。',
+    retryable: true,
+  },
+}
+
+export const validationError = (message: string): ChatError => ({
+  code: 'VALIDATION_ERROR',
+  message,
+  retryable: false,
+})
+
+export const unavailableChatError = (): ChatError => ({
+  code: 'UPSTREAM_UNAVAILABLE',
+  ...errorDefinitions.UPSTREAM_UNAVAILABLE,
+})
+
+/**
+ * OpenAI SDK が保持する HTTP ステータスと provider のエラー種別だけを使い、
+ * provider の本文を UI 契約へ持ち込まずに分類する。
+ */
+export function toChatError(error: unknown): ChatError {
+  const details = getErrorDetails(error)
+  const code = classifyError(details)
+
+  return {
+    code,
+    ...errorDefinitions[code],
+  }
+}
+
+type ErrorDetails = {
+  status?: number
+  type: string
+  code: string
+  param: string
+  message: string
+  connectionError: boolean
+}
+
+function getErrorDetails(error: unknown): ErrorDetails {
+  const apiError = error instanceof APIError ? error : undefined
+  const body = asRecord(apiError?.error)
+
+  return {
+    status: apiError?.status,
+    type: readString(body?.type),
+    code: readString(body?.code),
+    param: readString(body?.param),
+    message: [readString(body?.message), error instanceof Error ? error.message : '']
+      .filter(Boolean)
+      .join('\n')
+      .toLowerCase(),
+    connectionError: error instanceof APIConnectionError || error instanceof APIConnectionTimeoutError,
+  }
+}
+
+function classifyError({
+  status,
+  type,
+  code,
+  param,
+  message,
+  connectionError,
+}: ErrorDetails): Exclude<ChatErrorCode, 'VALIDATION_ERROR'> {
+  const signals = `${type}\n${code}\n${param}\n${message}`.toLowerCase()
+
+  // LiteLLM は provider の 400 を BadRequestError として返すため、HTTP status より本文の特徴を優先する。
+  if (/credit\s+balance\s+is\s+too\s+low|insufficient\s+credit|credit.*(?:insufficient|too\s+low)/.test(signals)) {
+    return 'INSUFFICIENT_CREDIT'
+  }
+
+  if (
+    status === 401 ||
+    /authentication|invalid[_\s-]?(?:api )?key|invalid.*token|token_not_found|token.*not.*found/.test(signals)
+  ) {
+    return 'AUTHENTICATION_FAILED'
+  }
+
+  if (status === 403 || /model.*(?:access|permission|denied)|(?:access|permission).*model/.test(signals)) {
+    return 'MODEL_ACCESS_DENIED'
+  }
+
+  if (status === 429 || /rate[_\s-]?limit|too many requests/.test(signals)) {
+    return 'RATE_LIMITED'
+  }
+
+  if (
+    connectionError ||
+    status === 408 ||
+    (status !== undefined && status >= 500) ||
+    /connection refused|network error|fetch failed|timed out|timeout/.test(signals)
+  ) {
+    return 'UPSTREAM_UNAVAILABLE'
+  }
+
+  if ((status !== undefined && status >= 400 && status < 500) || /invalid[_\s-]?request|bad request/.test(signals)) {
+    return 'INVALID_REQUEST'
+  }
+
+  return 'UNKNOWN_UPSTREAM_ERROR'
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === 'object' ? (value as Record<string, unknown>) : undefined
+}
+
+function readString(value: unknown): string {
+  return typeof value === 'string' ? value : ''
+}

--- a/projects/portfolio/src/server/lib/chat-error.ts
+++ b/projects/portfolio/src/server/lib/chat-error.ts
@@ -1,6 +1,22 @@
 import { APIConnectionError, APIConnectionTimeoutError, APIError } from 'openai'
 import type { ChatError, ChatErrorCode } from '#/types/chat-api'
 
+export type UpstreamErrorDetails = {
+  status?: number
+  type?: string
+  code?: string
+  param?: string
+  message?: string
+}
+
+/** HTTP 200 の Responses terminal failure など、SDK が例外化しない upstream エラーを表す。 */
+export class UpstreamChatError extends Error {
+  constructor(readonly details: UpstreamErrorDetails) {
+    super(details.message ?? 'Unknown upstream error')
+    this.name = 'UpstreamChatError'
+  }
+}
+
 const errorDefinitions: Record<Exclude<ChatErrorCode, 'VALIDATION_ERROR'>, Omit<ChatError, 'code'>> = {
   AUTHENTICATION_FAILED: {
     message: 'API キーが無効か、利用を許可されていません。設定を確認してください。',
@@ -43,6 +59,12 @@ export const unavailableChatError = (): ChatError => ({
   ...errorDefinitions.UPSTREAM_UNAVAILABLE,
 })
 
+export const conversationPersistenceError = (): ChatError => ({
+  code: 'UPSTREAM_UNAVAILABLE',
+  message: '会話を保存できませんでした。しばらく待ってから再試行してください。',
+  retryable: true,
+})
+
 /**
  * OpenAI SDK が保持する HTTP ステータスと provider のエラー種別だけを使い、
  * provider の本文を UI 契約へ持ち込まずに分類する。
@@ -68,10 +90,11 @@ type ErrorDetails = {
 
 function getErrorDetails(error: unknown): ErrorDetails {
   const apiError = error instanceof APIError ? error : undefined
-  const body = asRecord(apiError?.error)
+  const upstreamError = error instanceof UpstreamChatError ? error.details : undefined
+  const body = asRecord(apiError?.error) ?? upstreamError
 
   return {
-    status: apiError?.status,
+    status: apiError?.status ?? upstreamError?.status,
     type: readString(body?.type),
     code: readString(body?.code),
     param: readString(body?.param),
@@ -117,12 +140,17 @@ function classifyError({
     connectionError ||
     status === 408 ||
     (status !== undefined && status >= 500) ||
-    /connection refused|network error|fetch failed|timed out|timeout/.test(signals)
+    /connection refused|network error|fetch failed|timed out|timeout|server[_\s-]?error|internal[_\s-]?error/.test(
+      signals
+    )
   ) {
     return 'UPSTREAM_UNAVAILABLE'
   }
 
-  if ((status !== undefined && status >= 400 && status < 500) || /invalid[_\s-]?request|bad request/.test(signals)) {
+  if (
+    (status !== undefined && status >= 400 && status < 500) ||
+    /invalid[_\s-]?(?:request|prompt)|bad request/.test(signals)
+  ) {
     return 'INVALID_REQUEST'
   }
 

--- a/projects/portfolio/src/server/routes/chat.ts
+++ b/projects/portfolio/src/server/routes/chat.ts
@@ -303,10 +303,21 @@ const chatRoutes = new Hono<HonoEnv>()
         streamCompletion.controller.abort()
       })
 
-      for await (const event of convertStreamChunks(apiMode, streamCompletion)) {
-        requestLogger.debug({ event }, 'Stream event emitted')
-        await stream.writeSSE({ data: JSON.stringify(event) })
-        await new Promise((resolve) => setTimeout(resolve, 10))
+      try {
+        for await (const event of convertStreamChunks(apiMode, streamCompletion)) {
+          requestLogger.debug({ event }, 'Stream event emitted')
+          await stream.writeSSE({ data: JSON.stringify(event) })
+          await new Promise((resolve) => setTimeout(resolve, 10))
+        }
+      } catch (err) {
+        requestLogger.error({ err }, 'Stream chat iteration failed')
+        if (!aborted) {
+          await stream.writeSSE({
+            event: 'generation_error',
+            data: JSON.stringify(toChatError(err)),
+          })
+        }
+        return
       }
 
       if (!aborted) {
@@ -385,16 +396,22 @@ const chatRoutes = new Hono<HonoEnv>()
       stream.onAbort(close)
 
       let lastEventId = afterEventId
-      for (const event of await chatSessionManager.readEvents(sessionId, afterEventId)) {
-        await writeSessionEvent(stream, event)
-        lastEventId = event.id
-        if (isTerminalSessionEvent(event)) {
-          close()
-          return
+      const replayEvents = async () => {
+        for (const event of await chatSessionManager.readEvents(sessionId, lastEventId)) {
+          await writeSessionEvent(stream, event)
+          lastEventId = event.id
+          if (isTerminalSessionEvent(event)) {
+            close()
+            return true
+          }
         }
+        return false
       }
 
+      if (await replayEvents()) return
+
       if ((await chatSessionManager.getSession(sessionId))?.status !== 'running') {
+        if (await replayEvents()) return
         close()
         return
       }
@@ -412,17 +429,11 @@ const chatRoutes = new Hono<HonoEnv>()
           })
           .then((nextUnsubscribe) => {
             unsubscribe = nextUnsubscribe
-            void chatSessionManager.readEvents(sessionId, lastEventId).then(async (events) => {
-              for (const event of events) {
-                await writeSessionEvent(stream, event)
-                lastEventId = event.id
-                if (isTerminalSessionEvent(event)) {
-                  close()
-                  resolve()
-                  return
-                }
+            void replayEvents().then((isTerminal) => {
+              if (isTerminal) {
+                resolve()
               }
-            })
+            }, reject)
           })
           .catch(reject)
       })

--- a/projects/portfolio/src/server/routes/chat.ts
+++ b/projects/portfolio/src/server/routes/chat.ts
@@ -10,7 +10,7 @@ import { chatStub } from '#/server/features/chat-stub/chat-stub'
 import { chat } from '#/server/features/chat/chat'
 import { convertCompletion, convertStreamChunks } from '#/server/features/chat/converter'
 import type { CompletionChunk, ResponsesStreamChunk, StreamChunk } from '#/server/features/chat/transport'
-import { getErrorMessage } from '#/server/lib/error-message'
+import { toChatError, validationError } from '#/server/lib/chat-error'
 import { logger } from '#/server/lib/logger'
 import { ApiChatMessageSchema, type ApiMode } from '#/types'
 import {
@@ -51,14 +51,14 @@ const chatHeaderValidator = validator('header', (value, c) => {
     const issue = parsed.error.issues[0]
     const headerName = String(issue?.path[0] ?? 'unknown')
 
-    return c.json({ error: `Missing required header '${headerName}'`, code: 'VALIDATION_ERROR' as const }, 400)
+    return c.json(validationError(`Missing required header '${headerName}'`), 400)
   }
 
   const headers = parsed.data
   const fakeMode = headers['api-key'] === 'fakemode'
 
   if (!fakeMode && !z.string().url().safeParse(headers['base-url']).success) {
-    return c.json({ error: `Invalid url 'base-url'`, code: 'VALIDATION_ERROR' as const }, 400)
+    return c.json(validationError(`Invalid url 'base-url'`), 400)
   }
 
   const { SERVER_PORT: port } = getServerEnv(c)
@@ -90,13 +90,7 @@ const chatBodyValidator = sValidator('json', ChatApiRequestSchema, (result, c) =
   const issue = result.error[0]
   const fieldName = formatValidationPath(issue?.path)
 
-  return c.json(
-    {
-      error: `Invalid request body '${fieldName}'`,
-      code: 'VALIDATION_ERROR' as const,
-    },
-    400
-  )
+  return c.json(validationError(`Invalid request body '${fieldName}'`), 400)
 })
 
 const chatSessionStartBodyValidator = sValidator('json', ChatSessionStartRequestSchema, (result, c) => {
@@ -105,13 +99,7 @@ const chatSessionStartBodyValidator = sValidator('json', ChatSessionStartRequest
   const issue = result.error[0]
   const fieldName = formatValidationPath(issue?.path)
 
-  return c.json(
-    {
-      error: `Invalid request body '${fieldName}'`,
-      code: 'VALIDATION_ERROR' as const,
-    },
-    400
-  )
+  return c.json(validationError(`Invalid request body '${fieldName}'`), 400)
 })
 
 function normalizeApiMode(apiMode: ApiMode | undefined): ApiMode {
@@ -259,7 +247,7 @@ const chatRoutes = new Hono<HonoEnv>()
       return c.json(response)
     } catch (err) {
       requestLogger.error({ err }, 'Upstream chat completion failed')
-      return c.json({ error: getErrorMessage(err, 'Upstream error'), code: 'UPSTREAM_ERROR' as const }, 502)
+      return c.json(toChatError(err), 502)
     }
   })
   // SSE ストリーム専用
@@ -302,7 +290,7 @@ const chatRoutes = new Hono<HonoEnv>()
       )
     } catch (err) {
       requestLogger.error({ err }, 'Upstream stream chat failed')
-      return c.json({ error: getErrorMessage(err, 'Upstream error'), code: 'UPSTREAM_ERROR' as const }, 502)
+      return c.json(toChatError(err), 502)
     }
 
     const streamCompletion = completion as StreamChunk | ResponsesStreamChunk
@@ -367,7 +355,7 @@ const chatRoutes = new Hono<HonoEnv>()
     const session = await chatSessionManager.getSession(sessionId)
 
     if (!session) {
-      return c.json({ error: 'Session not found', code: 'VALIDATION_ERROR' as const }, 404)
+      return c.json(validationError('Session not found'), 404)
     }
 
     return c.json({ session })
@@ -377,7 +365,7 @@ const chatRoutes = new Hono<HonoEnv>()
     const session = await chatSessionManager.getSession(sessionId)
 
     if (!session) {
-      return c.json({ error: 'Session not found', code: 'VALIDATION_ERROR' as const }, 404)
+      return c.json(validationError('Session not found'), 404)
     }
 
     const afterEventId = c.req.header('Last-Event-ID') || c.req.query('afterEventId') || undefined
@@ -447,7 +435,7 @@ const chatRoutes = new Hono<HonoEnv>()
     const session = await chatSessionManager.cancelSession(sessionId, 'user_requested')
 
     if (!session) {
-      return c.json({ error: 'Session not found', code: 'VALIDATION_ERROR' as const }, 404)
+      return c.json(validationError('Session not found'), 404)
     }
 
     return c.json({ status: session.status })

--- a/projects/portfolio/src/types/chat-api.ts
+++ b/projects/portfolio/src/types/chat-api.ts
@@ -49,6 +49,32 @@ export const ChatResponseSchema = z.object({
 export type ChatResponse = z.infer<typeof ChatResponseSchema>
 
 // ============================================
+// アプリケーションエラー
+// ============================================
+
+export const ChatErrorCodeSchema = z.enum([
+  'VALIDATION_ERROR',
+  'AUTHENTICATION_FAILED',
+  'MODEL_ACCESS_DENIED',
+  'INSUFFICIENT_CREDIT',
+  'RATE_LIMITED',
+  'INVALID_REQUEST',
+  'UPSTREAM_UNAVAILABLE',
+  'UNKNOWN_UPSTREAM_ERROR',
+])
+
+export type ChatErrorCode = z.infer<typeof ChatErrorCodeSchema>
+
+/** UI に安全に表示できるよう正規化したエラー。provider の生レスポンスは含めない。 */
+export const ChatErrorSchema = z.object({
+  code: ChatErrorCodeSchema,
+  message: z.string(),
+  retryable: z.boolean(),
+})
+
+export type ChatError = z.infer<typeof ChatErrorSchema>
+
+// ============================================
 // SSE ストリームイベント (discriminated union)
 // ============================================
 
@@ -124,7 +150,7 @@ export const ChatSessionMetaSchema = z.object({
   createdAt: z.string(),
   updatedAt: z.string(),
   completedAt: z.string().nullable(),
-  error: z.string().nullable(),
+  error: ChatErrorSchema.nullable(),
 })
 
 export type ChatSessionMeta = z.infer<typeof ChatSessionMetaSchema>
@@ -166,22 +192,17 @@ export const ChatSessionEventSchema = z.discriminatedUnion('type', [
     }),
   }),
   ChatSessionEventBaseSchema.extend({
-    type: z.literal('error'),
-    data: z.object({
-      message: z.string(),
-    }),
+    type: z.literal('generation_error'),
+    data: ChatErrorSchema,
   }),
 ])
 
 export type ChatSessionEvent = z.infer<typeof ChatSessionEventSchema>
 
 // ============================================
-// 統一エラーレスポンス
+// HTTP エラーレスポンス
 // ============================================
 
-export const ChatErrorResponseSchema = z.object({
-  error: z.string(),
-  code: z.enum(['VALIDATION_ERROR', 'UPSTREAM_ERROR', 'INTERNAL_ERROR']),
-})
+export const ChatErrorResponseSchema = ChatErrorSchema
 
-export type ChatErrorResponse = z.infer<typeof ChatErrorResponseSchema>
+export type ChatErrorResponse = ChatError

--- a/projects/portfolio/src/types/index.ts
+++ b/projects/portfolio/src/types/index.ts
@@ -51,6 +51,8 @@ export {
   ChatStreamDeltaEventSchema,
   ChatStreamFinishEventSchema,
   ChatStreamUsageEventSchema,
+  ChatErrorCodeSchema,
+  ChatErrorSchema,
   ChatErrorResponseSchema,
   // Chat API contract types
   type ChatApiRequest,
@@ -60,5 +62,7 @@ export {
   type ChatStreamDeltaEvent,
   type ChatStreamFinishEvent,
   type ChatStreamUsageEvent,
+  type ChatErrorCode,
+  type ChatError,
   type ChatErrorResponse,
 } from './chat-api.js'

--- a/projects/portfolio/tests/client/components/chat-main.test.tsx
+++ b/projects/portfolio/tests/client/components/chat-main.test.tsx
@@ -3,12 +3,14 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Settings } from '#/client/shared/storage/remote-storage-settings'
-import type { AssistantMessage, Conversation, UserMessage } from '#/types'
+import type { AssistantMessage, Conversation, Message, UserMessage } from '#/types'
 
 const useMessageScrollMock = vi.fn()
 const scrollToMessageEndMock = vi.fn()
 const submitChatCompletionMock = vi.fn()
 const resumeActiveChatCompletionMock = vi.fn()
+const buildChatMessagesMock = vi.fn()
+const resetAfterSubmitMock = vi.fn()
 let hasActiveChatSessionMock = false
 let streamProcessorParams: Record<string, unknown> | null = null
 let chatMessageListProps: Record<string, unknown> | null = null
@@ -34,8 +36,8 @@ vi.mock('#/client/features/chat/hooks/use-chat-form', () => ({
     handleChangeInput: vi.fn(),
     handleKeyDown: vi.fn(),
     handleChangeComposition: vi.fn(),
-    buildChatMessages: vi.fn(),
-    resetAfterSubmit: vi.fn(),
+    buildChatMessages: buildChatMessagesMock,
+    resetAfterSubmit: resetAfterSubmitMock,
   }),
 }))
 
@@ -128,8 +130,12 @@ describe('ChatMain', () => {
     chatMessageListProps = null
     streamProcessorParams = null
     hasActiveChatSessionMock = false
+    buildChatMessagesMock.mockReset()
+    buildChatMessagesMock.mockReturnValue(null)
+    resetAfterSubmitMock.mockReset()
     resumeActiveChatCompletionMock.mockResolvedValue(null)
     submitChatCompletionMock.mockResolvedValue({
+      error: null,
       result: {
         message: {
           content: '編集後の回答',
@@ -183,6 +189,48 @@ describe('ChatMain', () => {
       },
       responseTimeMs: 123,
     })
+    const onSessionCompleted = vi.fn()
+    const { ChatMain } = await import('#/client/features/chat/components/chat-main')
+
+    render(
+      <ChatMain settings={settings} currentConversation={currentConversation} onSessionCompleted={onSessionCompleted} />
+    )
+
+    await waitFor(() => {
+      expect(resumeActiveChatCompletionMock).toHaveBeenCalled()
+    })
+    await waitFor(() => {
+      expect(onSessionCompleted).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'conversation-1',
+          messages: [
+            expect.objectContaining({ id: 'message-1' }),
+            expect.objectContaining({ id: 'message-2' }),
+            expect.objectContaining({ id: 'message-3' }),
+            expect.objectContaining({ id: 'message-4', content: '続きの回答' }),
+          ],
+        })
+      )
+    })
+  })
+
+  it('session resume のエラーを assistant message にせず表示状態へ渡す', async () => {
+    hasActiveChatSessionMock = true
+    resumeActiveChatCompletionMock.mockResolvedValue({
+      conversation: {
+        id: 'conversation-1',
+        title: '会話',
+        messages: [...currentConversation.messages, createUserMessage('message-3', '続きの質問')],
+      },
+      assistantMessageId: 'message-4',
+      result: null,
+      error: {
+        code: 'RATE_LIMITED',
+        message: 'リクエスト数の上限に達しました。しばらく待ってから再試行してください。',
+        retryable: true,
+      },
+      responseTimeMs: 123,
+    })
     const onConversationChange = vi.fn()
     const { ChatMain } = await import('#/client/features/chat/components/chat-main')
 
@@ -195,21 +243,9 @@ describe('ChatMain', () => {
     )
 
     await waitFor(() => {
-      expect(resumeActiveChatCompletionMock).toHaveBeenCalled()
+      expect(chatMessageListProps?.generationError).toMatchObject({ code: 'RATE_LIMITED' })
     })
-    await waitFor(() => {
-      expect(onConversationChange).toHaveBeenCalledWith(
-        expect.objectContaining({
-          id: 'conversation-1',
-          messages: [
-            expect.objectContaining({ id: 'message-1' }),
-            expect.objectContaining({ id: 'message-2' }),
-            expect.objectContaining({ id: 'message-3' }),
-            expect.objectContaining({ id: 'message-4', content: '続きの回答' }),
-          ],
-        })
-      )
-    })
+    expect(onConversationChange).not.toHaveBeenCalled()
   })
 
   it('session replay 中に user_message を受けたら入力済みメッセージを即時表示する', async () => {
@@ -392,7 +428,7 @@ describe('ChatMain', () => {
 
     render(
       <ChatMain
-        settings={settings}
+        settings={{ ...settings, streamMode: false }}
         currentConversation={currentConversation}
         onConversationChange={onConversationChange}
       />
@@ -423,6 +459,78 @@ describe('ChatMain', () => {
     })
   })
 
+  it('通常送信のエラーを保存せず専用エラー状態へ渡す', async () => {
+    buildChatMessagesMock.mockReturnValue({
+      model: 'gpt-test',
+      apiMessages: [{ role: 'user', content: '失敗する質問' }],
+      draftUserMessage: createUserMessage('message-user-3', '失敗する質問'),
+      imageContext: { policy: 'send_once', sent: 0, historyOnly: 0 },
+    })
+    submitChatCompletionMock.mockResolvedValue({
+      result: null,
+      error: {
+        code: 'INSUFFICIENT_CREDIT',
+        message: 'LLM プロバイダーのクレジットが不足しています。API キーの請求状況を確認してください。',
+        retryable: false,
+      },
+      responseTimeMs: 123,
+    })
+    const onConversationChange = vi.fn()
+    const { ChatMain } = await import('#/client/features/chat/components/chat-main')
+    const { container } = render(
+      <ChatMain
+        settings={{ ...settings, streamMode: false }}
+        currentConversation={currentConversation}
+        onConversationChange={onConversationChange}
+      />
+    )
+
+    await waitFor(() => expect(chatMessageListProps?.messages).toEqual(currentConversation.messages))
+    fireEvent.submit(container.querySelector('form')!)
+
+    await waitFor(() => {
+      expect(chatMessageListProps?.generationError).toMatchObject({ code: 'INSUFFICIENT_CREDIT' })
+    })
+    const messages = chatMessageListProps?.messages as Message[]
+    expect(messages.at(-1)).toMatchObject({ role: 'user', content: '失敗する質問' })
+    expect(onConversationChange).not.toHaveBeenCalled()
+  })
+
+  it('編集後再送のエラーを保存せず専用エラー状態へ渡す', async () => {
+    submitChatCompletionMock.mockResolvedValue({
+      result: null,
+      error: {
+        code: 'AUTHENTICATION_FAILED',
+        message: 'API キーが無効か、利用を許可されていません。設定を確認してください。',
+        retryable: false,
+      },
+      responseTimeMs: 123,
+    })
+    const onConversationChange = vi.fn()
+    const { ChatMain } = await import('#/client/features/chat/components/chat-main')
+
+    render(
+      <ChatMain
+        settings={settings}
+        currentConversation={currentConversation}
+        onConversationChange={onConversationChange}
+      />
+    )
+
+    await waitFor(() => {
+      expect(chatMessageListProps?.onEditMessage).toBeTypeOf('function')
+    })
+    const onEditMessage = chatMessageListProps?.onEditMessage as (index: number, nextText: string) => Promise<void>
+    await onEditMessage(0, '編集した質問')
+
+    await waitFor(() => {
+      expect(chatMessageListProps?.generationError).toMatchObject({ code: 'AUTHENTICATION_FAILED' })
+    })
+    const messages = chatMessageListProps?.messages as Message[]
+    expect(messages.at(-1)).toMatchObject({ role: 'user', content: '編集した質問' })
+    expect(onConversationChange).not.toHaveBeenCalled()
+  })
+
   it('会話履歴を含めない編集時は送信対象を編集中メッセージに絞る', async () => {
     const conversation: Conversation = {
       ...currentConversation,
@@ -438,7 +546,7 @@ describe('ChatMain', () => {
 
     render(
       <ChatMain
-        settings={{ ...settings, includeChatHistory: false }}
+        settings={{ ...settings, includeChatHistory: false, streamMode: false }}
         currentConversation={conversation}
         onConversationChange={onConversationChange}
       />

--- a/projects/portfolio/tests/client/components/chat-message-list.test.tsx
+++ b/projects/portfolio/tests/client/components/chat-message-list.test.tsx
@@ -96,4 +96,30 @@ describe('ChatMessageList', () => {
       expect(screen.queryByRole('img', { name: 'chatbot-icon' })).toBeNull()
     })
   })
+
+  it('生成エラーを assistant message と分けて表示する', () => {
+    render(
+      <ChatMessageList
+        messages={[]}
+        conversationId='conversation-1'
+        markdownPreview={true}
+        sendImagesOnlyOnce={true}
+        loading={false}
+        stream={null}
+        copiedId=''
+        generationError={{
+          code: 'AUTHENTICATION_FAILED',
+          message: 'API キーが無効か、利用を許可されていません。設定を確認してください。',
+          retryable: false,
+        }}
+        messageEndRef={createRef<HTMLDivElement>()}
+        onCopyMessage={vi.fn()}
+        onDeleteMessage={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('alert').textContent).toContain(
+      'API キーが無効か、利用を許可されていません。設定を確認してください。'
+    )
+  })
 })

--- a/projects/portfolio/tests/client/hooks/use-compare-stream.test.ts
+++ b/projects/portfolio/tests/client/hooks/use-compare-stream.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { renderHook, act } from '@testing-library/react'
+import { act, renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mock$post = vi.fn()
@@ -190,5 +190,45 @@ describe('useCompareStream', () => {
     })
 
     expect(abortSpy).toHaveBeenCalledTimes(callsAfterFirst + 1)
+  })
+
+  it('構造化された upstream エラーの安全な message を返す', async () => {
+    mock$post.mockResolvedValue({
+      ok: false,
+      json: async () => ({
+        code: 'INSUFFICIENT_CREDIT',
+        message: 'LLM プロバイダーのクレジットが不足しています。API キーの請求状況を確認してください。',
+        retryable: false,
+      }),
+    })
+    const { useCompareStream } = await import('#/client/features/chat-compare/hooks/use-compare-stream')
+    const { result } = renderHook(() => useCompareStream())
+    const onStreamError = vi.fn()
+
+    await act(async () => {
+      await result.current.submitModel({
+        settings,
+        modelState: {
+          model: 'model-a',
+          status: 'retrying',
+          messages: [{ role: 'user', content: 'hello' }],
+          content: '',
+          reasoningContent: '',
+          usage: null,
+          finishReason: null,
+          responseTimeMs: null,
+          error: null,
+        },
+        callbacks: {
+          onStreamContent: vi.fn(),
+          onStreamDone: vi.fn(),
+          onStreamError,
+        },
+      })
+    })
+
+    expect(onStreamError).toHaveBeenCalledWith(
+      'LLM プロバイダーのクレジットが不足しています。API キーの請求状況を確認してください。'
+    )
   })
 })

--- a/projects/portfolio/tests/client/hooks/use-compare-stream.test.ts
+++ b/projects/portfolio/tests/client/hooks/use-compare-stream.test.ts
@@ -231,4 +231,58 @@ describe('useCompareStream', () => {
       'LLM プロバイダーのクレジットが不足しています。API キーの請求状況を確認してください。'
     )
   })
+
+  it('direct stream の generation_error を完了扱いにしない', async () => {
+    const encoder = new TextEncoder()
+    mock$post.mockResolvedValue({
+      ok: true,
+      body: {
+        getReader: () => {
+          let sent = false
+          return {
+            read: async () => {
+              if (sent) return { done: true, value: undefined }
+              sent = true
+              return {
+                done: false,
+                value: encoder.encode(
+                  'event: generation_error\ndata: {"code":"RATE_LIMITED","message":"retry later","retryable":true}\n'
+                ),
+              }
+            },
+            cancel: async () => {},
+          }
+        },
+      },
+    })
+    const { useCompareStream } = await import('#/client/features/chat-compare/hooks/use-compare-stream')
+    const { result } = renderHook(() => useCompareStream())
+    const onStreamError = vi.fn()
+    const onStreamDone = vi.fn()
+
+    await act(async () => {
+      await result.current.submitModel({
+        settings,
+        modelState: {
+          model: 'model-a',
+          status: 'retrying',
+          messages: [{ role: 'user', content: 'hello' }],
+          content: '',
+          reasoningContent: '',
+          usage: null,
+          finishReason: null,
+          responseTimeMs: null,
+          error: null,
+        },
+        callbacks: {
+          onStreamContent: vi.fn(),
+          onStreamDone,
+          onStreamError,
+        },
+      })
+    })
+
+    expect(onStreamError).toHaveBeenCalledWith('retry later')
+    expect(onStreamDone).not.toHaveBeenCalled()
+  })
 })

--- a/projects/portfolio/tests/client/hooks/use-stream-processor.test.tsx
+++ b/projects/portfolio/tests/client/hooks/use-stream-processor.test.tsx
@@ -284,6 +284,49 @@ describe('useStreamProcessor', () => {
     })
   })
 
+  it('direct stream の generation_error を assistant 応答にせず返す', async () => {
+    const { useStreamProcessor, chatStreamPostMock } = await importSubject()
+    const encoder = new TextEncoder()
+    const chunks = [
+      encoder.encode(
+        'event: generation_error\ndata: {"code":"RATE_LIMITED","message":"retry later","retryable":true}\n'
+      ),
+    ]
+    chatStreamPostMock.mockResolvedValue({
+      ok: true,
+      body: {
+        getReader() {
+          let index = 0
+          return {
+            read: async () => {
+              if (index >= chunks.length) return { done: true, value: undefined }
+              return { done: false, value: chunks[index++] }
+            },
+          }
+        },
+      },
+    })
+
+    const { result } = renderHook(() => useStreamProcessor())
+    let response: Awaited<ReturnType<typeof result.current.submitChatCompletion>> | undefined
+    await act(async () => {
+      response = await result.current.submitChatCompletion({
+        ...request,
+        streamMode: true,
+      })
+    })
+
+    expect(response).toEqual({
+      error: {
+        code: 'RATE_LIMITED',
+        message: 'retry later',
+        retryable: true,
+      },
+      result: null,
+      responseTimeMs: expect.any(Number),
+    })
+  })
+
   it('session replay の user_message で会話を復元する', async () => {
     const { useStreamProcessor, chatSessionPostMock } = await importSubject()
     const onSessionConversation = vi.fn()

--- a/projects/portfolio/tests/client/hooks/use-stream-processor.test.tsx
+++ b/projects/portfolio/tests/client/hooks/use-stream-processor.test.tsx
@@ -124,6 +124,7 @@ describe('useStreamProcessor', () => {
     })
 
     expect(response).toEqual({
+      error: null,
       result: {
         id: 'chatcmpl-1',
         created: 1700000000,
@@ -221,6 +222,7 @@ describe('useStreamProcessor', () => {
     })
 
     expect(response).toEqual({
+      error: null,
       result: {
         id: 'chunk-1',
         created: 1700000000,
@@ -276,6 +278,7 @@ describe('useStreamProcessor', () => {
     })
 
     expect(response).toEqual({
+      error: null,
       result: null,
       responseTimeMs: expect.any(Number),
     })
@@ -373,7 +376,7 @@ describe('useStreamProcessor', () => {
       },
     })
     expect(onSessionConversation).toHaveBeenCalledWith(conversation, 'message-assistant-1')
-    expect(sessionStorage.getItem('portfolio.chat.activeSession')).toContain('session-1')
+    expect(sessionStorage.getItem('portfolio.chat.activeSession')).toBeNull()
     expect(chatSessionPostMock).toHaveBeenCalledWith(
       expect.objectContaining({
         header: {
@@ -488,6 +491,129 @@ describe('useStreamProcessor', () => {
         },
       },
     })
+  })
+
+  it('generation_error を assistant 応答へ変換せず専用エラーとして返す', async () => {
+    const { useStreamProcessor, chatSessionPostMock } = await importSubject()
+    const conversation = {
+      id: 'conversation-1',
+      title: 'hello',
+      messages: [
+        {
+          id: 'message-user-1',
+          role: 'user' as const,
+          content: 'hello',
+          metadata: { model: 'gpt-test' },
+        },
+      ],
+    }
+    const eventSources = stubEventSource()
+    chatSessionPostMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ sessionId: 'session-1' }),
+    })
+
+    const { result } = renderHook(() => useStreamProcessor())
+    const submitChatCompletion = result.current.submitChatCompletion
+    let responsePromise: ReturnType<typeof submitChatCompletion> | undefined
+    act(() => {
+      responsePromise = submitChatCompletion({
+        ...request,
+        streamMode: true,
+        conversation,
+        assistantMessageId: 'message-assistant-1',
+      })
+    })
+
+    await waitFor(() => expect(eventSources).toHaveLength(1))
+    act(() => {
+      eventSources[0].emit('generation_error', {
+        id: 'event-1',
+        sessionId: 'session-1',
+        type: 'generation_error',
+        createdAt: '2026-05-10T00:00:00.000Z',
+        data: {
+          code: 'INSUFFICIENT_CREDIT',
+          message: 'LLM プロバイダーのクレジットが不足しています。API キーの請求状況を確認してください。',
+          retryable: false,
+        },
+      })
+    })
+
+    await act(async () => {
+      await expect(responsePromise).resolves.toMatchObject({
+        result: null,
+        error: {
+          code: 'INSUFFICIENT_CREDIT',
+        },
+      })
+    })
+    expect(result.current.loading).toBe(false)
+    expect(sessionStorage.getItem('portfolio.chat.activeSession')).toBeNull()
+  })
+
+  it('EventSource の切断時に terminal session のエラーを取得する', async () => {
+    const { useStreamProcessor, chatSessionPostMock } = await importSubject()
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        session: {
+          id: 'session-1',
+          status: 'error',
+          conversation: { id: 'conversation-1', title: 'hello', messages: [] },
+          assistantMessageId: 'message-assistant-1',
+          apiMode: 'chat_completions',
+          model: 'gpt-test',
+          email: null,
+          createdAt: '2026-05-10T00:00:00.000Z',
+          updatedAt: '2026-05-10T00:00:01.000Z',
+          completedAt: '2026-05-10T00:00:01.000Z',
+          error: {
+            code: 'AUTHENTICATION_FAILED',
+            message: 'API キーが無効か、利用を許可されていません。設定を確認してください。',
+            retryable: false,
+          },
+        },
+      }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const eventSources = stubEventSource()
+    chatSessionPostMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ sessionId: 'session-1' }),
+    })
+
+    const { result } = renderHook(() => useStreamProcessor())
+    const submitChatCompletion = result.current.submitChatCompletion
+    let responsePromise: ReturnType<typeof submitChatCompletion> | undefined
+    act(() => {
+      responsePromise = submitChatCompletion({
+        ...request,
+        streamMode: true,
+        conversation: {
+          id: 'conversation-1',
+          title: 'hello',
+          messages: [],
+        },
+        assistantMessageId: 'message-assistant-1',
+      })
+    })
+
+    await waitFor(() => expect(eventSources).toHaveLength(1))
+    act(() => {
+      eventSources[0].onerror?.()
+    })
+
+    await act(async () => {
+      await expect(responsePromise).resolves.toMatchObject({
+        result: null,
+        error: {
+          code: 'AUTHENTICATION_FAILED',
+        },
+      })
+    })
+    expect(fetchMock).toHaveBeenCalledWith('/api/chat/sessions/session-1')
+    expect(result.current.loading).toBe(false)
   })
 
   it('session stream の cancel は RPC で通知し、ローカルでも null 完了する', async () => {

--- a/projects/portfolio/tests/features/chat-sessions/session-manager.test.ts
+++ b/projects/portfolio/tests/features/chat-sessions/session-manager.test.ts
@@ -146,6 +146,88 @@ describe('ChatSessionManager', () => {
     )
   })
 
+  it('会話保存の完了後に done と completed を公開する', async () => {
+    const { manager, completionsMock, upsertMock } = await importSubject()
+    let resolveUpsert: (() => void) | undefined
+    upsertMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveUpsert = resolve
+        })
+    )
+    completionsMock.mockResolvedValue({
+      controller: { abort: vi.fn() },
+      [Symbol.asyncIterator]: createStreamChunk,
+    })
+
+    const session = await manager.startSession({
+      header: {
+        'api-key': 'api-key',
+        'base-url': 'https://example.com',
+      },
+      req: request,
+      apiMode: 'chat_completions',
+      email: 'test@example.com',
+      databaseUrl: 'postgres://example',
+      ttlSeconds: 1800,
+      disconnectGraceMs: 30000,
+    })
+
+    await vi.waitFor(() => expect(upsertMock).toHaveBeenCalledOnce())
+    await expect(manager.getSession(session.id)).resolves.toMatchObject({ status: 'running' })
+    expect((await manager.readEvents(session.id)).some((event) => event.type === 'done')).toBe(false)
+
+    resolveUpsert?.()
+
+    await vi.waitFor(async () => {
+      await expect(manager.getSession(session.id)).resolves.toMatchObject({ status: 'completed' })
+    })
+    expect((await manager.readEvents(session.id)).at(-1)?.type).toBe('done')
+  })
+
+  it('会話保存に失敗した場合は done を配信せず retryable な error session を残す', async () => {
+    const { manager, completionsMock, upsertMock } = await importSubject()
+    upsertMock.mockRejectedValue(new Error('database unavailable'))
+    completionsMock.mockResolvedValue({
+      controller: { abort: vi.fn() },
+      [Symbol.asyncIterator]: createStreamChunk,
+    })
+
+    const session = await manager.startSession({
+      header: {
+        'api-key': 'api-key',
+        'base-url': 'https://example.com',
+      },
+      req: request,
+      apiMode: 'chat_completions',
+      email: 'test@example.com',
+      databaseUrl: 'postgres://example',
+      ttlSeconds: 1800,
+      disconnectGraceMs: 30000,
+    })
+
+    await vi.waitFor(async () => {
+      await expect(manager.getSession(session.id)).resolves.toMatchObject({
+        status: 'error',
+        error: {
+          code: 'UPSTREAM_UNAVAILABLE',
+          message: '会話を保存できませんでした。しばらく待ってから再試行してください。',
+          retryable: true,
+        },
+      })
+    })
+
+    const events = await manager.readEvents(session.id)
+    expect(events.some((event) => event.type === 'done')).toBe(false)
+    expect(events.at(-1)).toMatchObject({
+      type: 'generation_error',
+      data: {
+        code: 'UPSTREAM_UNAVAILABLE',
+        retryable: true,
+      },
+    })
+  })
+
   it('cancel で cancelled event を追加し、terminal event を判定できる', async () => {
     const { store, manager, isTerminalSessionEvent } = await importSubject()
     await store.createSession({

--- a/projects/portfolio/tests/features/chat-sessions/session-manager.test.ts
+++ b/projects/portfolio/tests/features/chat-sessions/session-manager.test.ts
@@ -174,7 +174,7 @@ describe('ChatSessionManager', () => {
     expect(isTerminalSessionEvent(events.at(-1)!)).toBe(true)
   })
 
-  it('production では upstream エラーの詳細を error event に出さない', async () => {
+  it('production では upstream エラーを generation_error として安全に正規化する', async () => {
     vi.stubEnv('NODE_ENV', 'production')
     const { manager, completionsMock } = await importSubject()
     completionsMock.mockRejectedValue(new Error('Connection refused'))
@@ -195,20 +195,26 @@ describe('ChatSessionManager', () => {
     await vi.waitFor(async () => {
       await expect(manager.getSession(session.id)).resolves.toMatchObject({
         status: 'error',
-        error: 'Upstream error',
+        error: {
+          code: 'UPSTREAM_UNAVAILABLE',
+          message: 'LLM プロバイダーに接続できませんでした。しばらく待ってから再試行してください。',
+          retryable: true,
+        },
       })
     })
 
     const events = await manager.readEvents(session.id)
     expect(events.at(-1)).toMatchObject({
-      type: 'error',
+      type: 'generation_error',
       data: {
-        message: 'Upstream error',
+        code: 'UPSTREAM_UNAVAILABLE',
+        message: 'LLM プロバイダーに接続できませんでした。しばらく待ってから再試行してください。',
+        retryable: true,
       },
     })
   })
 
-  it('development では upstream エラーの詳細を error event に残す', async () => {
+  it('development でも upstream エラーの詳細を event に残さない', async () => {
     const { manager, completionsMock } = await importSubject()
     completionsMock.mockRejectedValue(new Error('Connection refused'))
 
@@ -228,9 +234,39 @@ describe('ChatSessionManager', () => {
     await vi.waitFor(async () => {
       await expect(manager.getSession(session.id)).resolves.toMatchObject({
         status: 'error',
-        error: 'Connection refused',
+        error: {
+          code: 'UPSTREAM_UNAVAILABLE',
+          message: 'LLM プロバイダーに接続できませんでした。しばらく待ってから再試行してください。',
+          retryable: true,
+        },
       })
     })
+  })
+
+  it('error session を fold しても空の assistant message を追加しない', async () => {
+    const { foldSessionEvents } = await importSubject()
+    const conversation = foldSessionEvents(
+      {
+        id: 'session-1',
+        status: 'error',
+        conversation: request.conversation,
+        assistantMessageId: 'message-assistant-1',
+        apiMode: 'chat_completions',
+        model: 'gpt-test',
+        email: 'test@example.com',
+        createdAt: '2026-05-10T00:00:00.000Z',
+        updatedAt: '2026-05-10T00:00:01.000Z',
+        completedAt: '2026-05-10T00:00:01.000Z',
+        error: {
+          code: 'INSUFFICIENT_CREDIT',
+          message: 'LLM プロバイダーのクレジットが不足しています。API キーの請求状況を確認してください。',
+          retryable: false,
+        },
+      },
+      []
+    )
+
+    expect(conversation.messages).toEqual(request.conversation.messages)
   })
 
   it('event log を assistant message へ fold する', async () => {

--- a/projects/portfolio/tests/features/chat/converter.test.ts
+++ b/projects/portfolio/tests/features/chat/converter.test.ts
@@ -480,6 +480,19 @@ describe('responses converter', () => {
     })
   })
 
+  it('Responses の failed 応答を空の ChatResponse に変換しない', () => {
+    const raw = {
+      id: 'resp_1',
+      status: 'failed',
+      error: {
+        code: 'rate_limit_exceeded',
+        message: 'raw provider error',
+      },
+    }
+
+    expect(() => convertCompletion('responses', raw as any)).toThrow('raw provider error')
+  })
+
   it('Responses の stream 出力を既存イベント契約に正規化できる', async () => {
     const stream = (async function* () {
       yield {
@@ -566,5 +579,46 @@ describe('responses converter', () => {
         },
       },
     ])
+  })
+
+  it('Responses の failed stream event を例外化する', async () => {
+    const stream = (async function* () {
+      yield {
+        type: 'response.failed',
+        sequence_number: 0,
+        response: {
+          id: 'resp_1',
+          status: 'failed',
+          error: {
+            code: 'server_error',
+            message: 'raw provider error',
+          },
+        },
+      }
+    })() as any
+
+    await expect(async () => {
+      for await (const _event of convertStreamChunks('responses', stream)) {
+        // stream を最後まで消費して terminal failure を検証する。
+      }
+    }).rejects.toThrow('raw provider error')
+  })
+
+  it('Responses の error stream event を例外化する', async () => {
+    const stream = (async function* () {
+      yield {
+        type: 'error',
+        sequence_number: 0,
+        code: 'rate_limit_exceeded',
+        message: 'raw provider error',
+        param: null,
+      }
+    })() as any
+
+    await expect(async () => {
+      for await (const _event of convertStreamChunks('responses', stream)) {
+        // stream を最後まで消費して terminal failure を検証する。
+      }
+    }).rejects.toThrow('raw provider error')
   })
 })

--- a/projects/portfolio/tests/routes/chat.test.ts
+++ b/projects/portfolio/tests/routes/chat.test.ts
@@ -1,3 +1,4 @@
+import { APIError } from 'openai'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { mockLogger } from '../helpers/mock-logger'
 
@@ -86,8 +87,11 @@ describe('chatRoutes', () => {
 
       expect(res.status).toBe(400)
       const body = await res.json()
-      expect(body).toHaveProperty('error')
-      expect(body).toHaveProperty('code', 'VALIDATION_ERROR')
+      expect(body).toEqual({
+        code: 'VALIDATION_ERROR',
+        message: "Missing required header 'api-key'",
+        retryable: false,
+      })
     })
 
     it('fakemode では base-url をローカル endpoint に置き換える', async () => {
@@ -353,12 +357,13 @@ describe('chatRoutes', () => {
 
       expect(res.status).toBe(400)
       await expect(res.json()).resolves.toEqual({
-        error: "Invalid request body 'model'",
         code: 'VALIDATION_ERROR',
+        message: "Invalid request body 'model'",
+        retryable: false,
       })
     })
 
-    it('upstream エラー時は 502 を返す', async () => {
+    it('upstream エラーを安全なアプリケーションエラーへ正規化して 502 を返す', async () => {
       const { chatRoutes, completionsMock } = await importSubject()
       completionsMock.mockRejectedValue(new Error('Connection refused'))
 
@@ -378,12 +383,13 @@ describe('chatRoutes', () => {
       expect(res.status).toBe(502)
       const body = await res.json()
       expect(body).toEqual({
-        error: 'Connection refused',
-        code: 'UPSTREAM_ERROR',
+        code: 'UPSTREAM_UNAVAILABLE',
+        message: 'LLM プロバイダーに接続できませんでした。しばらく待ってから再試行してください。',
+        retryable: true,
       })
     })
 
-    it('production の upstream エラー時は詳細を隠す', async () => {
+    it('production でも provider のエラー詳細を公開しない', async () => {
       vi.stubEnv('NODE_ENV', 'production')
       const { chatRoutes, completionsMock } = await importSubject()
       completionsMock.mockRejectedValue(new Error('Connection refused'))
@@ -403,8 +409,9 @@ describe('chatRoutes', () => {
 
       expect(res.status).toBe(502)
       await expect(res.json()).resolves.toEqual({
-        error: 'Upstream error',
-        code: 'UPSTREAM_ERROR',
+        code: 'UPSTREAM_UNAVAILABLE',
+        message: 'LLM プロバイダーに接続できませんでした。しばらく待ってから再試行してください。',
+        retryable: true,
       })
     })
   })
@@ -573,12 +580,13 @@ describe('chatRoutes', () => {
 
       expect(res.status).toBe(400)
       await expect(res.json()).resolves.toEqual({
-        error: "Invalid request body 'model'",
         code: 'VALIDATION_ERROR',
+        message: "Invalid request body 'model'",
+        retryable: false,
       })
     })
 
-    it('production の upstream エラー時は詳細を隠す', async () => {
+    it('production でも provider のエラー詳細を公開しない', async () => {
       vi.stubEnv('NODE_ENV', 'production')
       const { chatRoutes, completionsMock } = await importSubject()
       completionsMock.mockRejectedValue(new Error('Connection refused'))
@@ -598,8 +606,9 @@ describe('chatRoutes', () => {
 
       expect(res.status).toBe(502)
       await expect(res.json()).resolves.toEqual({
-        error: 'Upstream error',
-        code: 'UPSTREAM_ERROR',
+        code: 'UPSTREAM_UNAVAILABLE',
+        message: 'LLM プロバイダーに接続できませんでした。しばらく待ってから再試行してください。',
+        retryable: true,
       })
     })
   })
@@ -663,6 +672,19 @@ describe('chatRoutes', () => {
         expect(body.session.status).toBe('completed')
       })
     }
+
+    it('存在しない session は公開契約の validation error 形式で返す', async () => {
+      const { chatRoutes } = await importSubject()
+
+      const res = await chatRoutes.request('/api/chat/sessions/not-found')
+
+      expect(res.status).toBe(404)
+      await expect(res.json()).resolves.toEqual({
+        code: 'VALIDATION_ERROR',
+        message: 'Session not found',
+        retryable: false,
+      })
+    })
 
     it('session を作成し、SSE events で replay できる', async () => {
       const { chatRoutes, completionsMock } = await importSubject()
@@ -741,6 +763,53 @@ describe('chatRoutes', () => {
           ]),
         })
       )
+    })
+
+    it('responses モードの upstream 失敗を安全な generation_error event にする', async () => {
+      const { chatRoutes, completionsMock } = await importSubject()
+      completionsMock.mockRejectedValue(
+        new APIError(
+          401,
+          {
+            message: 'Invalid proxy server token passed. Key Hash (Token) = secret-hash',
+            type: 'token_not_found_in_db',
+            param: 'key',
+            code: '401',
+          },
+          undefined,
+          new Headers()
+        )
+      )
+
+      const startRes = await chatRoutes.request('/api/chat/sessions', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'api-key': 'api-key',
+          'base-url': 'https://example.com',
+        },
+        body: JSON.stringify({
+          conversation,
+          assistantMessageId: 'message-assistant-1',
+          model: 'gpt-test',
+          apiMode: 'responses',
+          messages: [{ role: 'user', content: 'hello' }],
+        }),
+      })
+      const { sessionId } = (await startRes.json()) as { sessionId: string }
+
+      await vi.waitFor(async () => {
+        const sessionRes = await chatRoutes.request(`/api/chat/sessions/${sessionId}`)
+        const body = (await sessionRes.json()) as { session: { status: string } }
+        expect(body.session.status).toBe('error')
+      })
+      const eventsRes = await chatRoutes.request(`/api/chat/sessions/${sessionId}/events`)
+      const body = await eventsRes.text()
+
+      expect(body).toContain('event: generation_error')
+      expect(body).toContain('"code":"AUTHENTICATION_FAILED"')
+      expect(body).toContain('API キーが無効か、利用を許可されていません。設定を確認してください。')
+      expect(body).not.toContain('secret-hash')
     })
 
     it('未ログイン時は terminal 後に会話を保存しない', async () => {

--- a/projects/portfolio/tests/routes/chat.test.ts
+++ b/projects/portfolio/tests/routes/chat.test.ts
@@ -339,6 +339,39 @@ describe('chatRoutes', () => {
       })
     })
 
+    it('responses の failed 応答を安全なエラーへ正規化する', async () => {
+      const { chatRoutes, completionsMock } = await importSubject()
+      completionsMock.mockResolvedValue({
+        id: 'resp_1',
+        status: 'failed',
+        error: {
+          code: 'rate_limit_exceeded',
+          message: 'raw provider error',
+        },
+      })
+
+      const res = await chatRoutes.request('/api/chat', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'api-key': 'api-key',
+          'base-url': 'https://example.com',
+        },
+        body: JSON.stringify({
+          model: 'gpt-test',
+          apiMode: 'responses',
+          messages: [],
+        }),
+      })
+
+      expect(res.status).toBe(502)
+      await expect(res.json()).resolves.toEqual({
+        code: 'RATE_LIMITED',
+        message: 'リクエスト数の上限に達しました。しばらく待ってから再試行してください。',
+        retryable: true,
+      })
+    })
+
     it('不正な body は公開契約の validation error 形式で 400 を返す', async () => {
       const { chatRoutes } = await importSubject()
 
@@ -541,6 +574,36 @@ describe('chatRoutes', () => {
       expect(body).toContain('"content":"answer"')
       expect(body).toContain('"event":"finish"')
       expect(body).toContain('"event":"usage"')
+    })
+
+    it('200 応答後の反復例外を generation_error として配信する', async () => {
+      const { chatRoutes, completionsMock } = await importSubject()
+      completionsMock.mockResolvedValue({
+        controller: { abort: vi.fn() },
+        async *[Symbol.asyncIterator]() {
+          yield* createStreamChunk()
+          throw new Error('Connection refused')
+        },
+      })
+
+      const res = await chatRoutes.request('/api/chat/stream', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'api-key': 'api-key',
+          'base-url': 'https://example.com',
+        },
+        body: JSON.stringify({
+          model: 'gpt-test',
+          messages: [],
+        }),
+      })
+      const body = await res.text()
+
+      expect(body).toContain('event: generation_error')
+      expect(body).toContain('"code":"UPSTREAM_UNAVAILABLE"')
+      expect(body).not.toContain('Connection refused')
+      expect(body).not.toContain('data: [DONE]')
     })
 
     it('必須 header がない場合は 400 を返す', async () => {
@@ -810,6 +873,58 @@ describe('chatRoutes', () => {
       expect(body).toContain('"code":"AUTHENTICATION_FAILED"')
       expect(body).toContain('API キーが無効か、利用を許可されていません。設定を確認してください。')
       expect(body).not.toContain('secret-hash')
+    })
+
+    it('responses の failed stream event を成功 session として保存しない', async () => {
+      const { chatRoutes, completionsMock, upsertConversationMock } = await importSubject()
+      completionsMock.mockResolvedValue({
+        controller: { abort: vi.fn() },
+        async *[Symbol.asyncIterator]() {
+          yield {
+            type: 'response.failed',
+            sequence_number: 0,
+            response: {
+              id: 'resp_1',
+              status: 'failed',
+              error: {
+                code: 'server_error',
+                message: 'raw provider error',
+              },
+            },
+          }
+        },
+      })
+
+      const startRes = await chatRoutes.request('/api/chat/sessions', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'api-key': 'api-key',
+          'base-url': 'https://example.com',
+        },
+        body: JSON.stringify({
+          conversation,
+          assistantMessageId: 'message-assistant-1',
+          model: 'gpt-test',
+          apiMode: 'responses',
+          messages: [{ role: 'user', content: 'hello' }],
+        }),
+      })
+      const { sessionId } = (await startRes.json()) as { sessionId: string }
+
+      await vi.waitFor(async () => {
+        const sessionRes = await chatRoutes.request(`/api/chat/sessions/${sessionId}`)
+        const body = (await sessionRes.json()) as { session: { status: string } }
+        expect(body.session.status).toBe('error')
+      })
+      const eventsRes = await chatRoutes.request(`/api/chat/sessions/${sessionId}/events`)
+      const body = await eventsRes.text()
+
+      expect(body).toContain('event: generation_error')
+      expect(body).toContain('"code":"UPSTREAM_UNAVAILABLE"')
+      expect(body).not.toContain('event: done')
+      expect(body).not.toContain('raw provider error')
+      expect(upsertConversationMock).not.toHaveBeenCalled()
     })
 
     it('未ログイン時は terminal 後に会話を保存しない', async () => {

--- a/projects/portfolio/tests/server/lib/chat-error.test.ts
+++ b/projects/portfolio/tests/server/lib/chat-error.test.ts
@@ -1,0 +1,67 @@
+import { APIError } from 'openai'
+import { describe, expect, it } from 'vitest'
+import { toChatError } from '#/server/lib/chat-error'
+
+describe('toChatError', () => {
+  describe('provider error classification', () => {
+    it('クレジット不足を INSUFFICIENT_CREDIT に分類する', () => {
+      const error = createApiError(400, {
+        message: 'AnthropicException: Your credit balance is too low to access the Anthropic API.',
+      })
+
+      expect(toChatError(error)).toEqual({
+        code: 'INSUFFICIENT_CREDIT',
+        message: 'LLM プロバイダーのクレジットが不足しています。API キーの請求状況を確認してください。',
+        retryable: false,
+      })
+    })
+
+    it('LiteLLM の無効トークンを AUTHENTICATION_FAILED に分類する', () => {
+      const error = createApiError(401, {
+        message: 'Invalid proxy server token passed. Key Hash (Token) = secret-hash',
+        type: 'token_not_found_in_db',
+        param: 'key',
+        code: '401',
+      })
+
+      expect(toChatError(error)).toEqual({
+        code: 'AUTHENTICATION_FAILED',
+        message: 'API キーが無効か、利用を許可されていません。設定を確認してください。',
+        retryable: false,
+      })
+    })
+
+    it('モデル権限エラーを MODEL_ACCESS_DENIED に分類する', () => {
+      const error = createApiError(403, {
+        message: 'You do not have access to this model.',
+      })
+
+      expect(toChatError(error)).toEqual({
+        code: 'MODEL_ACCESS_DENIED',
+        message: 'このモデルを利用する権限がありません。モデル名と API キーの権限を確認してください。',
+        retryable: false,
+      })
+    })
+
+    it('rate limit を RATE_LIMITED に分類する', () => {
+      const error = createApiError(429, { message: 'Too many requests' })
+
+      expect(toChatError(error)).toEqual({
+        code: 'RATE_LIMITED',
+        message: 'リクエスト数の上限に達しました。しばらく待ってから再試行してください。',
+        retryable: true,
+      })
+    })
+  })
+
+  it('provider の詳細を公開エラーへ含めない', () => {
+    const rawMessage = 'Invalid proxy server token passed. Key Hash (Token) = secret-hash'
+    const error = createApiError(401, { message: rawMessage, type: 'token_not_found_in_db' })
+
+    expect(JSON.stringify(toChatError(error))).not.toContain(rawMessage)
+  })
+})
+
+function createApiError(status: number, body: Record<string, unknown>): APIError {
+  return new APIError(status, body, undefined, new Headers())
+}


### PR DESCRIPTION
- Closes #1141

## 概要

- LiteLLM / OpenAI 互換 upstream の失敗を、安全な `code`・`message`・`retryable` に正規化
- Chat Completions と Responses、非ストリーム・ストリーム・セッション SSE で同じエラー契約を使用
- セッション失敗は `generation_error` として扱い、assistant メッセージや会話履歴へ誤って保存しない
- ストリーミング成功時の会話保存は BFF に一本化し、フロントエンドは再取得のみを行う

## 確認

- `bun run typegen`
- `bun run lint`
- `bun run test`（56 files / 316 tests）
- 開発サーバーで Chat Completions / Responses の両方について、クレジット不足を `INSUFFICIENT_CREDIT`、無効 API キーを `AUTHENTICATION_FAILED` として確認
- Responses セッション SSE で `generation_error` を確認
