### PR TITLE
[portfolio] Chatbotアイコンの描画定義とアニメーションを分離する

### DIFF
--- a/projects/portfolio/src/client/shared/icons/chatbot-icon.tsx
+++ b/projects/portfolio/src/client/shared/icons/chatbot-icon.tsx
@@ -1,81 +1,10 @@
+import { ChatbotOutline } from './chatbot-outline'
 import { type IconProps, SvgIcon } from './icon-base'
 
 export function ChatbotIcon({ size = 24, label, className, ...rest }: IconProps) {
   return (
     <SvgIcon size={size} viewBox='0 0 400 400' label={label} className={className} {...rest}>
-      <g stroke='currentColor'>
-        <path
-          d='M97.8357 54.6682C177.199 59.5311 213.038 52.9891 238.043 52.9891C261.298 52.9891 272.24 129.465 262.683 152.048C253.672 173.341 100.331 174.196 93.1919 165.763C84.9363 156.008 89.7095 115.275 89.7095 101.301'
-          strokeWidth='16'
-          strokeLinecap='round'
-        />
-        <path
-          d='M98.3318 190.694C-10.6597 291.485 121.25 273.498 148.233 295.083'
-          strokeWidth='16'
-          strokeLinecap='round'
-        />
-        <path
-          d='M98.3301 190.694C99.7917 213.702 101.164 265.697 100.263 272.898'
-          strokeWidth='16'
-          strokeLinecap='round'
-        />
-        <path
-          d='M208.308 136.239C208.308 131.959 208.308 127.678 208.308 123.396'
-          strokeWidth='16'
-          strokeLinecap='round'
-        />
-        <path d='M177.299 137.271C177.035 133.883 177.3 126.121 177.3 123.396' strokeWidth='16' strokeLinecap='round' />
-        <path
-          d='M203.398 241.72C352.097 239.921 374.881 226.73 312.524 341.851'
-          strokeWidth='16'
-          strokeLinecap='round'
-        />
-        <path
-          d='M285.55 345.448C196.81 341.85 136.851 374.229 178.223 264.504'
-          strokeWidth='16'
-          strokeLinecap='round'
-        />
-        <path
-          d='M180.018 345.448C160.77 331.385 139.302 320.213 120.658 304.675'
-          strokeWidth='16'
-          strokeLinecap='round'
-        />
-        <path
-          d='M218.395 190.156C219.024 205.562 219.594 220.898 219.594 236.324'
-          strokeWidth='16'
-          strokeLinecap='round'
-        />
-        <path
-          d='M218.395 190.156C225.896 202.037 232.97 209.77 241.777 230.327'
-          strokeWidth='16'
-          strokeLinecap='round'
-        />
-        <path
-          d='M80.1174 119.041C75.5996 120.222 71.0489 119.99 66.4414 120.41'
-          strokeWidth='16'
-          strokeLinecap='round'
-        />
-        <path
-          d='M59.5935 109.469C59.6539 117.756 59.5918 125.915 58.9102 134.086'
-          strokeWidth='16'
-          strokeLinecap='round'
-        />
-        <path
-          d='M277.741 115.622C281.155 115.268 284.589 114.823 287.997 114.255'
-          strokeWidth='16'
-          strokeLinecap='round'
-        />
-        <path
-          d='M291.412 104.682C292.382 110.109 292.095 115.612 292.095 121.093'
-          strokeWidth='16'
-          strokeLinecap='round'
-        />
-        <path
-          d='M225.768 116.466C203.362 113.993 181.657 115.175 160.124 118.568'
-          strokeWidth='16'
-          strokeLinecap='round'
-        />
-      </g>
+      <ChatbotOutline />
     </SvgIcon>
   )
 }

--- a/projects/portfolio/src/client/shared/icons/chatbot-outline.tsx
+++ b/projects/portfolio/src/client/shared/icons/chatbot-outline.tsx
@@ -1,0 +1,47 @@
+export const CHATBOT_PATHS = {
+  head: [
+    'M97.8357 54.6682C177.199 59.5311 213.038 52.9891 238.043 52.9891C261.298 52.9891 272.24 129.465 262.683 152.048C253.672 173.341 100.331 174.196 93.1919 165.763C84.9363 156.008 89.7095 115.275 89.7095 101.301',
+    'M80.1174 119.041C75.5996 120.222 71.0489 119.99 66.4414 120.41',
+    'M59.5935 109.469C59.6539 117.756 59.5918 125.915 58.9102 134.086',
+    'M277.741 115.622C281.155 115.268 284.589 114.823 287.997 114.255',
+    'M291.412 104.682C292.382 110.109 292.095 115.612 292.095 121.093',
+    'M225.768 116.466C203.362 113.993 181.657 115.175 160.124 118.568',
+  ],
+  armLeft: [
+    'M98.3318 190.694C-10.6597 291.485 121.25 273.498 148.233 295.083',
+    'M98.3301 190.694C99.7917 213.702 101.164 265.697 100.263 272.898',
+  ],
+  body: [
+    'M203.398 241.72C352.097 239.921 374.881 226.73 312.524 341.851',
+    'M285.55 345.448C196.81 341.85 136.851 374.229 178.223 264.504',
+    'M180.018 345.448C160.77 331.385 139.302 320.213 120.658 304.675',
+  ],
+  arm1: ['M218.395 190.156C219.024 205.562 219.594 220.898 219.594 236.324'],
+  arm2: ['M218.395 190.156C225.896 202.037 232.97 209.77 241.777 230.327'],
+  eyes: [
+    'M208.308 136.239C208.308 131.959 208.308 127.678 208.308 123.396',
+    'M177.299 137.271C177.035 133.883 177.3 126.121 177.3 123.396',
+  ],
+} as const
+
+export function ChatbotOutline() {
+  return (
+    <g stroke='currentColor'>
+      <path d={CHATBOT_PATHS.head[0]} strokeWidth='16' strokeLinecap='round' />
+      <path d={CHATBOT_PATHS.armLeft[0]} strokeWidth='16' strokeLinecap='round' />
+      <path d={CHATBOT_PATHS.armLeft[1]} strokeWidth='16' strokeLinecap='round' />
+      <path d={CHATBOT_PATHS.eyes[0]} strokeWidth='16' strokeLinecap='round' />
+      <path d={CHATBOT_PATHS.eyes[1]} strokeWidth='16' strokeLinecap='round' />
+      <path d={CHATBOT_PATHS.body[0]} strokeWidth='16' strokeLinecap='round' />
+      <path d={CHATBOT_PATHS.body[1]} strokeWidth='16' strokeLinecap='round' />
+      <path d={CHATBOT_PATHS.body[2]} strokeWidth='16' strokeLinecap='round' />
+      <path d={CHATBOT_PATHS.arm1[0]} strokeWidth='16' strokeLinecap='round' />
+      <path d={CHATBOT_PATHS.arm2[0]} strokeWidth='16' strokeLinecap='round' />
+      <path d={CHATBOT_PATHS.head[1]} strokeWidth='16' strokeLinecap='round' />
+      <path d={CHATBOT_PATHS.head[2]} strokeWidth='16' strokeLinecap='round' />
+      <path d={CHATBOT_PATHS.head[3]} strokeWidth='16' strokeLinecap='round' />
+      <path d={CHATBOT_PATHS.head[4]} strokeWidth='16' strokeLinecap='round' />
+      <path d={CHATBOT_PATHS.head[5]} strokeWidth='16' strokeLinecap='round' />
+    </g>
+  )
+}

--- a/projects/portfolio/src/client/shared/icons/chatbot-typing-icon.css
+++ b/projects/portfolio/src/client/shared/icons/chatbot-typing-icon.css
@@ -1,0 +1,145 @@
+.bot-root {
+  transform-origin: center;
+  animation: botBob 0.8s ease-in-out infinite;
+}
+.bot-head {
+  transform-origin: 190px 150px;
+  animation: botHeadSwing 0.52s ease-in-out infinite;
+}
+.bot-arm-left {
+  transform-origin: 100px 191px;
+  animation: botTapLeft 0.18s ease-in-out infinite 0.06s;
+}
+.bot-arm-1 {
+  transform-origin: 219px 236px;
+  animation: botTap1 0.14s ease-in-out infinite;
+}
+.bot-arm-2 {
+  transform-origin: 219px 190px;
+  animation: botTap2 0.14s ease-in-out infinite;
+}
+.bot-eye {
+  transform-origin: center;
+  animation: botBlink 2.1s ease-in-out infinite;
+}
+.spark-1 {
+  animation: spark1 0.35s ease-in-out infinite;
+}
+.spark-2 {
+  animation: spark2 0.28s ease-in-out infinite;
+}
+.spark-3 {
+  animation: spark3 0.31s ease-in-out infinite;
+}
+
+@keyframes botBob {
+  0%,
+  100% {
+    transform: translateY(0px);
+  }
+  50% {
+    transform: translate(-2px, -5px) rotate(-1deg);
+  }
+}
+
+@keyframes botTap1 {
+  0%,
+  100% {
+    transform: rotate(0deg) translateY(0px);
+  }
+  50% {
+    transform: rotate(6deg) translate(2px, 10px);
+  }
+}
+
+@keyframes botTap2 {
+  0%,
+  100% {
+    transform: rotate(0deg) translateY(0px);
+  }
+  50% {
+    transform: rotate(8deg) translate(5px, 12px);
+  }
+}
+
+@keyframes botTapLeft {
+  0%,
+  100% {
+    transform: rotate(0deg) translate(0px, 0px);
+  }
+  50% {
+    transform: rotate(-7deg) translate(-4px, 10px);
+  }
+}
+
+@keyframes botHeadSwing {
+  0%,
+  100% {
+    transform: rotate(0deg) translate(0px, 0px);
+  }
+  50% {
+    transform: rotate(2.2deg) translate(1px, -1px);
+  }
+}
+
+@keyframes botBlink {
+  0%,
+  45%,
+  100% {
+    transform: scaleY(1);
+  }
+  48%,
+  52% {
+    transform: scaleY(0.2);
+  }
+}
+
+@keyframes spark1 {
+  0%,
+  100% {
+    transform: translateY(0);
+    opacity: 0;
+  }
+  50% {
+    transform: translateY(-10px);
+    opacity: 1;
+  }
+}
+
+@keyframes spark2 {
+  0%,
+  100% {
+    transform: translateY(0);
+    opacity: 0;
+  }
+  50% {
+    transform: translateY(-10px);
+    opacity: 1;
+  }
+}
+
+@keyframes spark3 {
+  0%,
+  100% {
+    transform: translateY(0);
+    opacity: 0;
+  }
+  50% {
+    transform: translateY(-12px);
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bot-root,
+  .bot-head,
+  .bot-arm-left,
+  .bot-arm-1,
+  .bot-arm-2,
+  .bot-eye,
+  .spark-1,
+  .spark-2,
+  .spark-3 {
+    animation: none;
+  }
+}

--- a/projects/portfolio/src/client/shared/icons/chatbot-typing-icon.tsx
+++ b/projects/portfolio/src/client/shared/icons/chatbot-typing-icon.tsx
@@ -1,71 +1,10 @@
+import './chatbot-typing-icon.css'
+import { CHATBOT_PATHS } from './chatbot-outline'
 import { type IconProps, SvgIcon } from './icon-base'
 
 export function ChatbotTypingIcon({ size = 24, label, className, ...rest }: IconProps) {
   return (
     <SvgIcon size={size} viewBox='0 0 400 400' label={label} className={className} {...rest}>
-      <style>{`
-        .bot-root { transform-origin: center; animation: botBob 0.8s ease-in-out infinite; }
-        .bot-head { transform-origin: 190px 150px; animation: botHeadSwing 0.52s ease-in-out infinite; }
-        .bot-arm-left { transform-origin: 100px 191px; animation: botTapLeft 0.18s ease-in-out infinite 0.06s; }
-        .bot-arm-1 { transform-origin: 219px 236px; animation: botTap1 0.14s ease-in-out infinite; }
-        .bot-arm-2 { transform-origin: 219px 190px; animation: botTap2 0.14s ease-in-out infinite; }
-        .bot-eye { transform-origin: center; animation: botBlink 2.1s ease-in-out infinite; }
-        .spark-1 { animation: spark1 0.35s ease-in-out infinite; }
-        .spark-2 { animation: spark2 0.28s ease-in-out infinite; }
-        .spark-3 { animation: spark3 0.31s ease-in-out infinite; }
-
-        @keyframes botBob {
-          0%, 100% { transform: translateY(0px); }
-          50% { transform: translate(-2px, -5px) rotate(-1deg); }
-        }
-
-        @keyframes botTap1 {
-          0%, 100% { transform: rotate(0deg) translateY(0px); }
-          50% { transform: rotate(6deg) translate(2px, 10px); }
-        }
-
-        @keyframes botTap2 {
-          0%, 100% { transform: rotate(0deg) translateY(0px); }
-          50% { transform: rotate(8deg) translate(5px, 12px); }
-        }
-
-        @keyframes botTapLeft {
-          0%, 100% { transform: rotate(0deg) translate(0px, 0px); }
-          50% { transform: rotate(-7deg) translate(-4px, 10px); }
-        }
-
-        @keyframes botHeadSwing {
-          0%, 100% { transform: rotate(0deg) translate(0px, 0px); }
-          50% { transform: rotate(2.2deg) translate(1px, -1px); }
-        }
-
-        @keyframes botBlink {
-          0%, 45%, 100% { transform: scaleY(1); }
-          48%, 52% { transform: scaleY(0.2); }
-        }
-
-        @keyframes spark1 {
-          0%, 100% { transform: translateY(0); opacity: 0; }
-          50% { transform: translateY(-10px); opacity: 1; }
-        }
-
-        @keyframes spark2 {
-          0%, 100% { transform: translateY(0); opacity: 0; }
-          50% { transform: translateY(-10px); opacity: 1; }
-        }
-
-        @keyframes spark3 {
-          0%, 100% { transform: translateY(0); opacity: 0; }
-          50% { transform: translateY(-12px); opacity: 1; }
-        }
-
-        @media (prefers-reduced-motion: reduce) {
-          .bot-root, .bot-head, .bot-arm-left, .bot-arm-1, .bot-arm-2, .bot-eye, .spark-1, .spark-2, .spark-3 {
-            animation: none;
-          }
-        }
-      `}</style>
-
       <g
         fill='none'
         stroke='currentColor'
@@ -75,21 +14,21 @@ export function ChatbotTypingIcon({ size = 24, label, className, ...rest }: Icon
         className='bot-root'
       >
         <g className='bot-head'>
-          <path d='M97.8357 54.6682C177.199 59.5311 213.038 52.9891 238.043 52.9891C261.298 52.9891 272.24 129.465 262.683 152.048C253.672 173.341 100.331 174.196 93.1919 165.763C84.9363 156.008 89.7095 115.275 89.7095 101.301' />
-          <path d='M80.1174 119.041C75.5996 120.222 71.0489 119.99 66.4414 120.41' />
-          <path d='M59.5935 109.469C59.6539 117.756 59.5918 125.915 58.9102 134.086' />
-          <path d='M277.741 115.622C281.155 115.268 284.589 114.823 287.997 114.255' />
-          <path d='M291.412 104.682C292.382 110.109 292.095 115.612 292.095 121.093' />
-          <path d='M225.768 116.466C203.362 113.993 181.657 115.175 160.124 118.568' />
+          <path d={CHATBOT_PATHS.head[0]} />
+          <path d={CHATBOT_PATHS.head[1]} />
+          <path d={CHATBOT_PATHS.head[2]} />
+          <path d={CHATBOT_PATHS.head[3]} />
+          <path d={CHATBOT_PATHS.head[4]} />
+          <path d={CHATBOT_PATHS.head[5]} />
         </g>
 
-        <path className='bot-arm-left' d='M98.3318 190.694C-10.6597 291.485 121.25 273.498 148.233 295.083' />
-        <path className='bot-arm-left' d='M98.3301 190.694C99.7917 213.702 101.164 265.697 100.263 272.898' />
-        <path d='M203.398 241.72C352.097 239.921 374.881 226.73 312.524 341.851' />
-        <path d='M285.55 345.448C196.81 341.85 136.851 374.229 178.223 264.504' />
-        <path d='M180.018 345.448C160.77 331.385 139.302 320.213 120.658 304.675' />
-        <path className='bot-arm-1' d='M218.395 190.156C219.024 205.562 219.594 220.898 219.594 236.324' />
-        <path className='bot-arm-2' d='M218.395 190.156C225.896 202.037 232.97 209.77 241.777 230.327' />
+        <path className='bot-arm-left' d={CHATBOT_PATHS.armLeft[0]} />
+        <path className='bot-arm-left' d={CHATBOT_PATHS.armLeft[1]} />
+        <path d={CHATBOT_PATHS.body[0]} />
+        <path d={CHATBOT_PATHS.body[1]} />
+        <path d={CHATBOT_PATHS.body[2]} />
+        <path className='bot-arm-1' d={CHATBOT_PATHS.arm1[0]} />
+        <path className='bot-arm-2' d={CHATBOT_PATHS.arm2[0]} />
       </g>
 
       <ellipse className='bot-eye' cx='177' cy='130' rx='7' ry='5' fill='currentColor' />

--- a/projects/portfolio/tests/client/shared/icons/chatbot-icon.test.tsx
+++ b/projects/portfolio/tests/client/shared/icons/chatbot-icon.test.tsx
@@ -1,0 +1,25 @@
+// @vitest-environment jsdom
+
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { ChatbotIcon } from '#/client/shared/icons/chatbot-icon'
+
+describe('ChatbotIcon', () => {
+  it('レンダリングされること', () => {
+    const { container } = render(<ChatbotIcon />)
+    const svg = container.querySelector('svg')
+    expect(svg).toBeTruthy()
+  })
+
+  it('label 指定時は aria-label が設定される', () => {
+    const { container } = render(<ChatbotIcon label='チャットボット' />)
+    const svg = container.querySelector('svg')
+    expect(svg?.getAttribute('aria-label')).toBe('チャットボット')
+  })
+
+  it('className が SVG 要素に適用される', () => {
+    const { container } = render(<ChatbotIcon className='text-green-500' />)
+    const svg = container.querySelector('svg')
+    expect(svg?.getAttribute('class')).toContain('text-green-500')
+  })
+})

--- a/projects/portfolio/tests/client/shared/icons/chatbot-typing-icon.test.tsx
+++ b/projects/portfolio/tests/client/shared/icons/chatbot-typing-icon.test.tsx
@@ -1,14 +1,40 @@
 // @vitest-environment jsdom
 
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { render } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 import { ChatbotTypingIcon } from '#/client/shared/icons/chatbot-typing-icon'
 
 describe('ChatbotTypingIcon', () => {
-  it('prefers-reduced-motion 時にアニメーションを無効化する', () => {
-    const { container } = render(<ChatbotTypingIcon />)
-    const style = container.querySelector('style')?.textContent ?? ''
-    expect(style).toContain('@media (prefers-reduced-motion: reduce)')
-    expect(style).toContain('animation: none')
+  describe('SVG 公開props', () => {
+    it('レンダリングされること', () => {
+      const { container } = render(<ChatbotTypingIcon />)
+      const svg = container.querySelector('svg')
+      expect(svg).toBeTruthy()
+    })
+
+    it('label 未指定時は aria-hidden が設定される', () => {
+      const { container } = render(<ChatbotTypingIcon />)
+      const svg = container.querySelector('svg')
+      expect(svg?.getAttribute('aria-hidden')).toBe('true')
+    })
+
+    it('className が SVG 要素に適用される', () => {
+      const { container } = render(<ChatbotTypingIcon className='text-blue-500' />)
+      const svg = container.querySelector('svg')
+      expect(svg?.getAttribute('class')).toContain('text-blue-500')
+    })
+  })
+
+  describe('CSS', () => {
+    it('prefers-reduced-motion の無効化が含まれる', () => {
+      const css = readFileSync(
+        resolve(import.meta.dirname, '../../../../src/client/shared/icons/chatbot-typing-icon.css'),
+        'utf-8'
+      )
+      expect(css).toContain('@media (prefers-reduced-motion: reduce)')
+      expect(css).toContain('animation: none')
+    })
   })
 })


### PR DESCRIPTION
Closes #1147

## 変更内容

- chatbot-outline.tsx を新規作成し、共通の SVG 描画定義を集約
- chatbot-icon.tsx を ChatbotOutline 使用に簡略化
- chatbot-typing-icon.tsx から inline style を削除し、CSS import に変更
- chatbot-typing-icon.css を co-location で新規作成
- テストでは CSS ファイルの読み取り方式に変更