### PR TITLE
[portfolio] IconButtonでアイコン専用ボタンを共通化 (#1145)

### DIFF
--- a/projects/portfolio/src/client/app/app-layout.tsx
+++ b/projects/portfolio/src/client/app/app-layout.tsx
@@ -1,6 +1,7 @@
 import { Link } from '@tanstack/react-router'
 import type { FC, ReactNode } from 'react'
 import { useState } from 'react'
+import { IconButton } from '#/client/shared/components/icon-button/icon-button'
 import { HamburgerIcon } from '#/client/shared/icons/hamburger-icon'
 import { ThemeToggle } from './theme-toggle'
 
@@ -50,15 +51,14 @@ export const AppLayout: FC<Props> = ({ version, menuItems, children }: Props) =>
 
       {/* モバイルトップヘッダー */}
       <div className='md:hidden fixed top-0 left-0 right-0 h-14 bg-gray-100 dark:bg-gray-800 border-b dark:border-gray-700 z-50 flex items-center justify-between px-4'>
-        <button
+        <IconButton
+          label={isMobileMenuOpen ? 'メニューを閉じる' : 'メニューを開く'}
           onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
-          aria-label={isMobileMenuOpen ? 'メニューを閉じる' : 'メニューを開く'}
           aria-expanded={isMobileMenuOpen}
           className='p-2 rounded text-gray-900 hover:bg-gray-200 dark:text-white dark:hover:bg-gray-700'
         >
-          {/* ハンバーガーアイコン */}
           <HamburgerIcon />
-        </button>
+        </IconButton>
         <span className='text-lg font-semibold text-gray-900 dark:text-white'>Portfolio</span>
         <ThemeToggle size='sm' />
       </div>

--- a/projects/portfolio/src/client/app/theme-toggle.tsx
+++ b/projects/portfolio/src/client/app/theme-toggle.tsx
@@ -1,4 +1,5 @@
 import { useTheme } from '#/client/app/hooks/use-theme'
+import { IconButton } from '#/client/shared/components/icon-button/icon-button'
 import { MoonIcon } from '#/client/shared/icons/moon-icon'
 import { SunIcon } from '#/client/shared/icons/sun-icon'
 
@@ -19,13 +20,12 @@ export function ThemeToggle({ className = '', size = 'md' }: ThemeToggleProps) {
   const iconSize = { sm: 14, md: 16, lg: 20 }
 
   return (
-    <button
-      type='button'
+    <IconButton
+      label={isDark ? 'ライトモードに切り替え' : 'ダークモードに切り替え'}
       onClick={toggleDarkMode}
-      aria-label={isDark ? 'ライトモードに切り替え' : 'ダークモードに切り替え'}
-      className={`flex items-center justify-center rounded bg-gray-200 text-gray-700 transition-colors hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600 ${sizeClasses[size]} ${className}`}
+      className={`rounded bg-gray-200 text-gray-700 transition-colors hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600 ${sizeClasses[size]} ${className}`}
     >
       {isDark ? <SunIcon size={iconSize[size]} /> : <MoonIcon size={iconSize[size]} />}
-    </button>
+    </IconButton>
   )
 }

--- a/projects/portfolio/src/client/features/chat-compare/components/compare-column.tsx
+++ b/projects/portfolio/src/client/features/chat-compare/components/compare-column.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState } from 'react'
 import type { ModelStreamState } from '#/client/features/chat-compare/hooks/use-compare-state'
+import { IconButton } from '#/client/shared/components/icon-button/icon-button'
 import { CheckIcon } from '#/client/shared/icons/check-icon'
 import { CopyIcon } from '#/client/shared/icons/copy-icon'
 import { RefreshIcon } from '#/client/shared/icons/refresh-icon'
@@ -46,16 +47,15 @@ interface CopyMessageButtonProps {
 
 function CopyMessageButton({ copied, onClick }: CopyMessageButtonProps) {
   return (
-    <button
-      type='button'
-      className={`relative flex h-8 w-8 cursor-pointer items-center justify-center rounded-full text-gray-500 transition-[background-color,color,transform] duration-200 ease-out focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 dark:text-gray-300 dark:focus-visible:ring-gray-500 disabled:cursor-default ${
+    <IconButton
+      label={copied ? 'Copied' : 'Copy message'}
+      onClick={onClick}
+      disabled={copied}
+      className={`relative h-8 w-8 rounded-full text-gray-500 transition-[background-color,color,transform] duration-200 ease-out dark:text-gray-300 disabled:opacity-100 ${
         copied
           ? 'text-emerald-600 dark:text-emerald-400'
           : 'hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-700 dark:hover:text-white'
       }`}
-      onClick={onClick}
-      disabled={copied}
-      aria-label={copied ? 'Copied' : 'Copy message'}
     >
       <span
         aria-hidden='true'
@@ -73,7 +73,7 @@ function CopyMessageButton({ copied, onClick }: CopyMessageButtonProps) {
       >
         <CheckIcon size={20} className='stroke-current' />
       </span>
-    </button>
+    </IconButton>
   )
 }
 
@@ -136,24 +136,22 @@ export function CompareColumn({ state, onCancelModel, onRetryModel }: CompareCol
         </span>
         <span className='flex shrink-0 items-center gap-1'>
           {isActive && onCancelModel && (
-            <button
-              type='button'
+            <IconButton
+              label={`Stop ${model}`}
               onClick={() => onCancelModel(model)}
-              aria-label={`Stop ${model}`}
-              className='flex h-7 w-7 cursor-pointer items-center justify-center rounded-md text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-700 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-white'
+              className='h-7 w-7 rounded-md text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-700 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-white'
             >
               <StopIcon size={14} className='fill-current' />
-            </button>
+            </IconButton>
           )}
           {isStopped && onRetryModel && (
-            <button
-              type='button'
+            <IconButton
+              label={`Retry ${model}`}
               onClick={() => onRetryModel(model)}
-              aria-label={`Retry ${model}`}
-              className='flex h-7 w-7 cursor-pointer items-center justify-center rounded-md text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-700 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-white'
+              className='h-7 w-7 rounded-md text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-700 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-white'
             >
               <RefreshIcon size={14} className='fill-current' />
-            </button>
+            </IconButton>
           )}
         </span>
       </div>

--- a/projects/portfolio/src/client/features/chat-compare/components/compare-composer.tsx
+++ b/projects/portfolio/src/client/features/chat-compare/components/compare-composer.tsx
@@ -1,4 +1,5 @@
 import { type ChangeEvent, type KeyboardEvent, useCallback, useState } from 'react'
+import { IconButton } from '#/client/shared/components/icon-button/icon-button'
 import { ArrowUpIcon } from '#/client/shared/icons/arrow-up-icon'
 import { StopIcon } from '#/client/shared/icons/stop-icon'
 
@@ -64,24 +65,22 @@ export function CompareComposer({
           className='min-h-0 flex-1 resize-none overflow-y-auto rounded-xl border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:border-primary-700 focus:outline-none focus:ring-0.5 disabled:opacity-40 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-500'
         />
         {loading ? (
-          <button
-            type='button'
+          <IconButton
+            label='Stop'
             onClick={onCancel}
-            aria-label='Stop'
-            className='flex h-10 w-10 shrink-0 cursor-pointer items-center justify-center rounded-full bg-primary-800 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-gray-400 dark:bg-primary-700 dark:hover:bg-primary-600'
+            className='h-10 w-10 shrink-0 rounded-full bg-primary-800 focus:ring-2 focus:ring-gray-400 hover:bg-primary-700 dark:bg-primary-700 dark:hover:bg-primary-600'
           >
             <StopIcon className='text-white' size={18} />
-          </button>
+          </IconButton>
         ) : (
-          <button
-            type='button'
+          <IconButton
+            label='Send'
             onClick={onSubmit}
             disabled={submitDisabled || value.trim().length === 0}
-            aria-label='Send'
-            className='flex h-10 w-10 shrink-0 cursor-pointer items-center justify-center rounded-full bg-primary-800 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-gray-400 disabled:cursor-default disabled:opacity-40 dark:bg-primary-700 dark:hover:bg-primary-600 dark:disabled:hover:bg-primary-700'
+            className='h-10 w-10 shrink-0 rounded-full bg-primary-800 focus:ring-2 focus:ring-gray-400 disabled:opacity-40 hover:bg-primary-700 dark:bg-primary-700 dark:hover:bg-primary-600 dark:disabled:hover:bg-primary-700'
           >
             <ArrowUpIcon className='text-white' size={22} />
-          </button>
+          </IconButton>
         )}
       </div>
     </div>

--- a/projects/portfolio/src/client/features/chat-compare/page.tsx
+++ b/projects/portfolio/src/client/features/chat-compare/page.tsx
@@ -5,6 +5,7 @@ import { CompareSettings } from '#/client/features/chat-compare/components/compa
 import { ModelChangeConfirmDialog } from '#/client/features/chat-compare/components/model-change-confirm-dialog'
 import { ModelCheckboxList } from '#/client/features/chat-compare/components/model-checkbox-list'
 import { useChatComparePage } from '#/client/features/chat-compare/hooks/use-chat-compare-page'
+import { IconButton } from '#/client/shared/components/icon-button/icon-button'
 import { CloseIcon } from '#/client/shared/icons/close-icon'
 import { GearIcon } from '#/client/shared/icons/gear-icon'
 import { NewChatIcon } from '#/client/shared/icons/new-chat-icon'
@@ -48,15 +49,14 @@ export function ChatCompare() {
           <div className='flex shrink-0 items-center justify-between border-b border-gray-200 bg-gray-50 px-4 py-2 dark:border-gray-700 dark:bg-gray-800'>
             <div className='flex items-center gap-2'>
               <h1 className='font-semibold text-gray-800 text-sm dark:text-gray-200'>Chat Compare</h1>
-              <button
-                type='button'
+              <IconButton
+                label='New chat'
                 onClick={handleNewChat}
                 disabled={!hasConversation || isSubmitting}
-                aria-label='New chat'
-                className='flex h-8 w-8 items-center justify-center rounded-md text-gray-500 transition-colors enabled:cursor-pointer enabled:hover:bg-gray-200 disabled:cursor-not-allowed disabled:opacity-40 dark:text-gray-400 dark:enabled:hover:bg-gray-700'
+                className='h-8 w-8 rounded-md text-gray-500 transition-colors enabled:hover:bg-gray-200 dark:text-gray-400 dark:enabled:hover:bg-gray-700'
               >
                 <NewChatIcon size={18} className='fill-current' />
-              </button>
+              </IconButton>
             </div>
             <div className='flex items-center gap-2'>
               <button

--- a/projects/portfolio/src/client/features/chat/components/chat-composer.tsx
+++ b/projects/portfolio/src/client/features/chat/components/chat-composer.tsx
@@ -1,5 +1,6 @@
 import { type ChangeEvent, type KeyboardEvent, useMemo } from 'react'
 import { ChatInput } from '#/client/features/chat/components/chat-input'
+import { IconButton } from '#/client/shared/components/icon-button/icon-button'
 import { FileImageInput, FileImagePreview } from '#/client/shared/components/input/file-image-input'
 import { ArrowUpIcon } from '#/client/shared/icons/arrow-up-icon'
 import { StopIcon } from '#/client/shared/icons/stop-icon'
@@ -130,22 +131,21 @@ export function SendButton({ color = 'blue', loading, disabled, handleClickStop 
   }, [color])
 
   return loading ? (
-    <button
-      type='button'
+    <IconButton
+      label='Stop sending'
       onClick={handleClickStop}
-      aria-label='Stop sending'
-      className={`flex h-8 w-8 cursor-pointer items-center justify-center rounded-full ${classes} focus:outline-hidden focus:ring-2 focus:ring-gray-400 disabled:cursor-default dark:bg-primary-700 dark:hover:bg-primary-600 dark:disabled:hover:bg-primary-700`}
+      className={`h-8 w-8 rounded-full focus:outline-hidden focus:ring-2 focus:ring-gray-400 dark:bg-primary-700 dark:hover:bg-primary-600 dark:disabled:hover:bg-primary-700 ${classes}`}
     >
       <StopIcon className='text-white' size={18} />
-    </button>
+    </IconButton>
   ) : (
-    <button
+    <IconButton
+      label='Send'
       type='submit'
       disabled={disabled}
-      aria-label='Send'
-      className={`flex h-8 w-8 cursor-pointer items-center justify-center rounded-full ${classes} focus:outline-hidden focus:ring-2 focus:ring-gray-400 disabled:cursor-default dark:bg-primary-700 dark:hover:bg-primary-600 dark:disabled:hover:bg-primary-700`}
+      className={`h-8 w-8 rounded-full focus:outline-hidden focus:ring-2 focus:ring-gray-400 disabled:opacity-100 dark:bg-primary-700 dark:hover:bg-primary-600 dark:disabled:hover:bg-primary-700 ${classes}`}
     >
       <ArrowUpIcon className='text-white' size={22} />
-    </button>
+    </IconButton>
   )
 }

--- a/projects/portfolio/src/client/features/chat/components/chat-main.tsx
+++ b/projects/portfolio/src/client/features/chat/components/chat-main.tsx
@@ -7,6 +7,7 @@ import { useChatConversation } from '#/client/features/chat/hooks/use-chat-conve
 import { useChatForm } from '#/client/features/chat/hooks/use-chat-form'
 import { useMessageCopy } from '#/client/features/chat/hooks/use-message-copy'
 import { useMessageScroll } from '#/client/features/chat/hooks/use-message-scroll'
+import { IconButton } from '#/client/shared/components/icon-button/icon-button'
 import { ArrowDownIcon } from '#/client/shared/icons/arrow-down-icon'
 import type { Settings } from '#/client/shared/storage/remote-storage-settings'
 import type { Conversation } from '#/types'
@@ -183,17 +184,16 @@ export function ChatMain({
                 isPinnedToBottom ? 'pointer-events-none opacity-0' : 'pointer-events-none opacity-100'
               }`}
             >
-              <button
-                type='button'
-                aria-label='最下部へ移動'
+              <IconButton
+                label='最下部へ移動'
                 aria-hidden={isPinnedToBottom}
                 tabIndex={isPinnedToBottom ? -1 : 0}
                 disabled={isPinnedToBottom}
                 onClick={() => scrollToMessageEnd('smooth')}
-                className='pointer-events-auto inline-flex h-8 w-8 items-center justify-center rounded-full border border-gray-200 bg-white/95 text-gray-700 shadow-sm transition-colors hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 dark:border-gray-600 dark:bg-gray-800/95 dark:text-gray-100 dark:hover:bg-gray-700 dark:focus-visible:ring-gray-500'
+                className='pointer-events-auto h-8 w-8 rounded-full border border-gray-200 bg-white/95 text-gray-700 shadow-sm transition-colors hover:bg-gray-100 dark:border-gray-600 dark:bg-gray-800/95 dark:text-gray-100 dark:hover:bg-gray-700'
               >
                 <ArrowDownIcon size={14} className='stroke-current' />
-              </button>
+              </IconButton>
             </div>
             <ChatComposer
               value={input}

--- a/projects/portfolio/src/client/features/chat/components/chat-settings/chat-settings-panel.tsx
+++ b/projects/portfolio/src/client/features/chat/components/chat-settings/chat-settings-panel.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react'
+import { IconButton } from '#/client/shared/components/icon-button/icon-button'
 import { CloseIcon } from '#/client/shared/icons/close-icon'
 
 interface Props {
@@ -33,14 +34,13 @@ export function ChatSettingsPanel({ show, children, onClose }: Props) {
           <h2 id='chat-settings-title' className='text-lg font-semibold text-gray-900 dark:text-gray-100'>
             Chat Settings
           </h2>
-          <button
-            type='button'
+          <IconButton
+            label='Close settings'
             onClick={onClose}
-            className='flex cursor-pointer items-center justify-center rounded-md p-1 text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-400 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200 dark:focus:ring-gray-500'
-            aria-label='Close settings'
+            className='rounded-md p-1 text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200'
           >
             <CloseIcon className='fill-current' />
-          </button>
+          </IconButton>
         </div>
 
         {/* Settings Content - Scrollable */}

--- a/projects/portfolio/src/client/features/chat/components/chat-settings/chat-settings.tsx
+++ b/projects/portfolio/src/client/features/chat/components/chat-settings/chat-settings.tsx
@@ -1,3 +1,4 @@
+import { IconButton } from '#/client/shared/components/icon-button/icon-button'
 import { GearIcon } from '#/client/shared/icons/gear-icon'
 import { NewChatIcon } from '#/client/shared/icons/new-chat-icon'
 import { SidebarIcon } from '#/client/shared/icons/sidebar-icon'
@@ -45,29 +46,27 @@ export function ChatSettings({
             {/* Left side */}
             <div className='flex items-center gap-2'>
               {showSidebarToggle && (
-                <button
-                  type='button'
+                <IconButton
+                  label={isSidebarOpen ? 'Close sidebar' : 'Open sidebar'}
                   onClick={onToggleSidebar}
                   disabled={isSidebarToggleDisabled}
-                  aria-label={isSidebarOpen ? 'Close sidebar' : 'Open sidebar'}
                   aria-expanded={isSidebarOpen}
-                  className='flex items-center justify-center rounded-md p-2 text-gray-600 transition hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-400 enabled:cursor-pointer disabled:cursor-not-allowed disabled:opacity-40 dark:text-gray-300 dark:hover:bg-gray-700 dark:focus:ring-gray-500'
+                  className='rounded-md p-2 text-gray-600 transition hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700'
                 >
                   <SidebarIcon
                     variant={isSidebarOpen ? 'collapse' : 'expand'}
                     className='text-[#5D5D5D] dark:text-gray-300'
                   />
-                </button>
+                </IconButton>
               )}
               {showNewChat && (
-                <button
-                  type='button'
+                <IconButton
+                  label='New chat'
                   onClick={onNewChat}
-                  aria-label='New chat'
-                  className='flex cursor-pointer items-center justify-center rounded-md p-2 text-gray-600 transition hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-400 dark:text-gray-300 dark:hover:bg-gray-700 dark:focus:ring-gray-500'
+                  className='rounded-md p-2 text-gray-600 transition hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700'
                 >
                   <NewChatIcon className='text-[#5D5D5D] dark:text-gray-300' />
-                </button>
+                </IconButton>
               )}
             </div>
             {/* Right side */}
@@ -75,14 +74,13 @@ export function ChatSettings({
               <span className='max-w-48 truncate text-xs font-medium text-gray-500 dark:text-gray-400'>
                 {contextValue.fakeMode ? 'Fake Mode' : contextValue.settings.model}
               </span>
-              <button
-                type='button'
+              <IconButton
+                label='Settings'
                 onClick={onShowMenu}
-                aria-label='Settings'
-                className='flex cursor-pointer items-center justify-center rounded-md p-2 text-gray-600 transition hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-400 dark:text-gray-300 dark:hover:bg-gray-700 dark:focus:ring-gray-500'
+                className='rounded-md p-2 text-gray-600 transition hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700'
               >
                 <GearIcon className='text-[#5D5D5D] dark:text-gray-300' />
-              </button>
+              </IconButton>
             </div>
           </>
         )}

--- a/projects/portfolio/src/client/features/chat/components/code-block-renderer.tsx
+++ b/projects/portfolio/src/client/features/chat/components/code-block-renderer.tsx
@@ -2,6 +2,7 @@ import type { AnchorHTMLAttributes, CSSProperties, HTMLAttributes, MouseEvent, R
 import { createContext, useContext, useState } from 'react'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 import { atomDark } from 'react-syntax-highlighter/dist/cjs/styles/prism'
+import { IconButton } from '#/client/shared/components/icon-button/icon-button'
 import { CheckIcon } from '#/client/shared/icons/check-icon'
 import { ChevronRightIcon } from '#/client/shared/icons/chevron-right-icon'
 import { CopyIcon } from '#/client/shared/icons/copy-icon'
@@ -121,12 +122,11 @@ export interface CodeBlockPreviewButtonProps {
 
 export function CodeBlockPreviewButton({ onClick, pending, disabled }: CodeBlockPreviewButtonProps) {
   return (
-    <button
-      type='button'
+    <IconButton
+      label={pending ? 'Checking preview' : 'Preview code block'}
       onClick={onClick}
       disabled={pending || disabled}
-      aria-label={pending ? 'Checking preview' : 'Preview code block'}
-      className='relative inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-md text-gray-600 transition-[background-color,color] duration-200 ease-out hover:bg-gray-200 hover:text-gray-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 disabled:cursor-default disabled:opacity-60 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white dark:focus-visible:ring-gray-500'
+      className='relative inline-flex h-8 w-8 rounded-md text-gray-600 transition-[background-color,color] duration-200 ease-out hover:bg-gray-200 hover:text-gray-800 disabled:opacity-60 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white'
     >
       {pending ? (
         <svg viewBox='0 0 24 24' aria-hidden='true' fill='none' className='h-[18px] w-[18px] animate-spin'>
@@ -136,7 +136,7 @@ export function CodeBlockPreviewButton({ onClick, pending, disabled }: CodeBlock
       ) : (
         <EyeIcon size={18} className='stroke-current' />
       )}
-    </button>
+    </IconButton>
   )
 }
 
@@ -166,12 +166,11 @@ export interface CodeBlockGenerateButtonProps {
 
 export function CodeBlockGenerateButton({ onClick, pending, disabled }: CodeBlockGenerateButtonProps) {
   return (
-    <button
-      type='button'
+    <IconButton
+      label={pending ? 'Generating preview' : 'Generate preview'}
       onClick={onClick}
       disabled={pending || disabled}
-      aria-label={pending ? 'Generating preview' : 'Generate preview'}
-      className='relative inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-md text-gray-600 transition-[background-color,color] duration-200 ease-out hover:bg-gray-200 hover:text-gray-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 disabled:cursor-default disabled:opacity-60 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white dark:focus-visible:ring-gray-500'
+      className='relative inline-flex h-8 w-8 rounded-md text-gray-600 transition-[background-color,color] duration-200 ease-out hover:bg-gray-200 hover:text-gray-800 disabled:opacity-60 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white'
     >
       {pending ? (
         <svg viewBox='0 0 24 24' aria-hidden='true' fill='none' className='h-[18px] w-[18px] animate-spin'>
@@ -181,7 +180,7 @@ export function CodeBlockGenerateButton({ onClick, pending, disabled }: CodeBloc
       ) : (
         <SparkleIcon size={18} className='stroke-current' />
       )}
-    </button>
+    </IconButton>
   )
 }
 
@@ -193,15 +192,14 @@ interface CodeBlockCopyButtonProps {
 
 function CodeBlockCopyButton({ copied, onClick, disabled }: CodeBlockCopyButtonProps) {
   return (
-    <button
-      type='button'
+    <IconButton
+      label={copied ? 'Copied code block' : 'Copy code block'}
       onClick={onClick}
       disabled={copied || disabled}
-      aria-label={copied ? 'Copied code block' : 'Copy code block'}
-      className={`relative inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-md text-gray-600 transition-[background-color,color] duration-200 ease-out focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 dark:text-gray-300 dark:focus-visible:ring-gray-500 ${
+      className={`relative inline-flex h-8 w-8 rounded-md text-gray-600 transition-[background-color,color] duration-200 ease-out dark:text-gray-300 ${
         copied
-          ? 'text-emerald-600 disabled:cursor-default dark:text-emerald-400'
-          : 'hover:bg-gray-200 hover:text-gray-800 disabled:cursor-not-allowed disabled:opacity-30 disabled:hover:bg-transparent disabled:hover:text-gray-600 dark:hover:bg-gray-700 dark:hover:text-white dark:disabled:hover:bg-transparent dark:disabled:hover:text-gray-300'
+          ? 'text-emerald-600 dark:text-emerald-400'
+          : 'hover:bg-gray-200 hover:text-gray-800 disabled:opacity-30 disabled:hover:bg-transparent disabled:hover:text-gray-600 dark:hover:bg-gray-700 dark:hover:text-white dark:disabled:hover:bg-transparent dark:disabled:hover:text-gray-300'
       }`}
     >
       <span className='relative h-[18px] w-[18px]' aria-hidden='true'>
@@ -220,7 +218,7 @@ function CodeBlockCopyButton({ copied, onClick, disabled }: CodeBlockCopyButtonP
           <CheckIcon size={18} className='stroke-current' />
         </span>
       </span>
-    </button>
+    </IconButton>
   )
 }
 
@@ -306,12 +304,11 @@ export function CodeBlockRenderer({ className, children, actions }: CodeBlockRen
       <div className='flex items-center justify-between border-b border-gray-200 bg-gray-50 px-3 py-1.5 dark:border-gray-600 dark:bg-[#282c34]'>
         <div className='flex items-center gap-1'>
           {canCollapse && (
-            <button
-              type='button'
+            <IconButton
+              label={isOpen ? 'Collapse code block' : 'Expand code block'}
               onClick={toggle}
               aria-expanded={isOpen}
-              aria-label={isOpen ? 'Collapse code block' : 'Expand code block'}
-              className='inline-flex h-6 w-6 cursor-pointer items-center justify-center rounded text-gray-600 transition-colors duration-200 ease-out hover:bg-gray-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 dark:text-gray-300 dark:hover:bg-gray-700 dark:focus-visible:ring-gray-500'
+              className='inline-flex h-6 w-6 rounded text-gray-600 transition-colors duration-200 ease-out hover:bg-gray-200 dark:text-gray-300 dark:hover:bg-gray-700'
             >
               <span
                 className={`inline-flex transition-transform duration-200 ease-out motion-reduce:transition-none ${
@@ -320,7 +317,7 @@ export function CodeBlockRenderer({ className, children, actions }: CodeBlockRen
               >
                 <ChevronRightIcon size={10} />
               </span>
-            </button>
+            </IconButton>
           )}
           <div className='relative'>
             <select

--- a/projects/portfolio/src/client/features/chat/components/code-block-renderer.tsx
+++ b/projects/portfolio/src/client/features/chat/components/code-block-renderer.tsx
@@ -198,7 +198,7 @@ function CodeBlockCopyButton({ copied, onClick, disabled }: CodeBlockCopyButtonP
       disabled={copied || disabled}
       className={`relative inline-flex h-8 w-8 rounded-md text-gray-600 transition-[background-color,color] duration-200 ease-out dark:text-gray-300 ${
         copied
-          ? 'text-emerald-600 dark:text-emerald-400'
+          ? 'text-emerald-600 disabled:opacity-100 dark:text-emerald-400'
           : 'hover:bg-gray-200 hover:text-gray-800 disabled:opacity-30 disabled:hover:bg-transparent disabled:hover:text-gray-600 dark:hover:bg-gray-700 dark:hover:text-white dark:disabled:hover:bg-transparent dark:disabled:hover:text-gray-300'
       }`}
     >

--- a/projects/portfolio/src/client/features/chat/components/message-renderer.tsx
+++ b/projects/portfolio/src/client/features/chat/components/message-renderer.tsx
@@ -18,6 +18,7 @@ import {
 } from '#/client/features/chat/components/code-block-renderer'
 import { ReasoningSection } from '#/client/features/chat/components/reasoning-section'
 import { getUserMessageText } from '#/client/features/chat/lib/edit-message'
+import { IconButton } from '#/client/shared/components/icon-button/icon-button'
 import { ChatbotIcon } from '#/client/shared/icons/chatbot-icon'
 import { CheckIcon } from '#/client/shared/icons/check-icon'
 import { CloseIcon } from '#/client/shared/icons/close-icon'
@@ -95,16 +96,15 @@ function MessageActionBar({ copied, disabled, children, align = 'left' }: Messag
 
 function CopyMessageButton({ copied, onClick }: CopyMessageButtonProps) {
   return (
-    <button
-      type='button'
-      className={`relative flex h-8 w-8 cursor-pointer items-center justify-center rounded-full text-gray-500 transition-[background-color,color,transform] duration-200 ease-out focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 dark:text-gray-300 dark:focus-visible:ring-gray-500 disabled:cursor-default ${
+    <IconButton
+      label={copied ? 'Copied' : 'Copy message'}
+      onClick={onClick}
+      disabled={copied}
+      className={`relative h-8 w-8 rounded-full text-gray-500 transition-[background-color,color,transform] duration-200 ease-out dark:text-gray-300 disabled:opacity-100 ${
         copied
           ? 'text-emerald-600 dark:text-emerald-400'
           : 'hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-700 dark:hover:text-white'
       }`}
-      onClick={onClick}
-      disabled={copied}
-      aria-label={copied ? 'Copied' : 'Copy message'}
     >
       <span
         aria-hidden='true'
@@ -122,7 +122,7 @@ function CopyMessageButton({ copied, onClick }: CopyMessageButtonProps) {
       >
         <CheckIcon size={20} className='stroke-current' />
       </span>
-    </button>
+    </IconButton>
   )
 }
 
@@ -234,44 +234,40 @@ function MessageRendererComponent({
           <MessageActionBar copied={copied} disabled={disabled} align='right'>
             {isEditing ? (
               <>
-                <button
-                  type='button'
-                  className='flex h-8 w-8 cursor-pointer items-center justify-center rounded-full text-gray-500 transition-[background-color,color] duration-200 ease-out hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 disabled:cursor-default disabled:opacity-50 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white dark:focus-visible:ring-gray-500'
+                <IconButton
+                  label='Save edited message'
                   onClick={handleSaveEdit}
                   disabled={!canSaveEdit}
-                  aria-label='Save edited message'
+                  className='h-8 w-8 rounded-full text-gray-500 transition-[background-color,color] duration-200 ease-out hover:bg-gray-100 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white'
                 >
                   <CheckIcon size={20} className='stroke-current' />
-                </button>
-                <button
-                  type='button'
-                  className='flex h-8 w-8 cursor-pointer items-center justify-center rounded-full text-gray-500 transition-[background-color,color] duration-200 ease-out hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 disabled:cursor-default disabled:opacity-50 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white dark:focus-visible:ring-gray-500'
+                </IconButton>
+                <IconButton
+                  label='Cancel editing message'
                   onClick={handleCancelEdit}
                   disabled={isSavingEdit}
-                  aria-label='Cancel editing message'
+                  className='h-8 w-8 rounded-full text-gray-500 transition-[background-color,color] duration-200 ease-out hover:bg-gray-100 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white'
                 >
                   <CloseIcon size={20} className='fill-current' />
-                </button>
+                </IconButton>
               </>
             ) : (
               <>
                 <CopyMessageButton copied={copied} onClick={() => onCopyMessage(userMessageText, index)} />
-                <button
-                  type='button'
-                  className='flex h-8 w-8 cursor-pointer items-center justify-center rounded-full text-gray-500 transition-[background-color,color] duration-200 ease-out hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white dark:focus-visible:ring-gray-500'
+                <IconButton
+                  label='Edit message'
                   onClick={handleStartEdit}
-                  aria-label='Edit message'
+                  className='h-8 w-8 rounded-full text-gray-500 transition-[background-color,color] duration-200 ease-out hover:bg-gray-100 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white'
                 >
                   <EditIcon size={20} className='stroke-current' />
-                </button>
-                <button
-                  type='button'
-                  className='flex h-8 w-8 cursor-pointer items-center justify-center rounded-full text-gray-500 transition-[background-color,color] duration-200 ease-out hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white dark:focus-visible:ring-gray-500'
+                </IconButton>
+                <IconButton
+                  label='Delete message'
                   onClick={() => onDeleteMessage?.(index)}
-                  aria-label='Delete message'
+                  className='h-8 w-8 rounded-full text-gray-500 transition-[background-color,color] duration-200 ease-out hover:bg-gray-100 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white'
                 >
                   <DeleteIcon size={20} />
-                </button>
+                </IconButton>
               </>
             )}
           </MessageActionBar>

--- a/projects/portfolio/src/client/features/chat/components/messages-dump-viewer.tsx
+++ b/projects/portfolio/src/client/features/chat/components/messages-dump-viewer.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { IconButton } from '#/client/shared/components/icon-button/icon-button'
 import { useLockBodyScroll } from '#/client/shared/hooks/use-lock-body-scroll'
 import { CheckIcon } from '#/client/shared/icons/check-icon'
 import { CloseIcon } from '#/client/shared/icons/close-icon'
@@ -56,9 +57,6 @@ export function MessagesDumpViewer({ messages, apiContextMessages, open, onClose
     setCopied(true)
   }
 
-  const iconButtonClass =
-    'flex h-8 w-8 cursor-pointer items-center justify-center rounded-full text-gray-500 transition-[background-color,color] duration-200 ease-out hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white dark:focus-visible:ring-gray-500'
-
   return (
     <div className='fixed inset-0 z-50 flex items-center justify-center p-4'>
       <div className='fixed inset-0 bg-black/50' onClick={onClose} aria-hidden='true' />
@@ -99,12 +97,15 @@ export function MessagesDumpViewer({ messages, apiContextMessages, open, onClose
             )}
           </div>
           <div className='flex items-center gap-1'>
-            <button
-              type='button'
-              className={`${iconButtonClass} ${copied ? 'text-emerald-600 dark:text-emerald-400' : ''}`}
+            <IconButton
+              label={copied ? 'Copied' : 'Copy JSON'}
               onClick={handleCopy}
               disabled={copied}
-              aria-label={copied ? 'Copied' : 'Copy JSON'}
+              className={`relative h-8 w-8 rounded-full text-gray-500 transition-[background-color,color] duration-200 ease-out dark:text-gray-300 disabled:opacity-100 ${
+                copied
+                  ? 'text-emerald-600 dark:text-emerald-400'
+                  : 'hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-700 dark:hover:text-white'
+              }`}
             >
               <span
                 aria-hidden='true'
@@ -122,10 +123,14 @@ export function MessagesDumpViewer({ messages, apiContextMessages, open, onClose
               >
                 <CheckIcon size={18} className='stroke-current' />
               </span>
-            </button>
-            <button type='button' className={iconButtonClass} onClick={onClose} aria-label='Close viewer'>
+            </IconButton>
+            <IconButton
+              label='Close viewer'
+              onClick={onClose}
+              className='h-8 w-8 rounded-full text-gray-500 transition-[background-color,color] duration-200 ease-out hover:bg-gray-100 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white'
+            >
               <CloseIcon size={20} />
-            </button>
+            </IconButton>
           </div>
         </div>
         {hasApiContext && view === 'apiContext' && (

--- a/projects/portfolio/src/client/shared/components/icon-button/icon-button.tsx
+++ b/projects/portfolio/src/client/shared/components/icon-button/icon-button.tsx
@@ -1,6 +1,6 @@
 import type { ButtonHTMLAttributes, ReactNode } from 'react'
 
-interface IconButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+interface IconButtonProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'aria-label'> {
   label: string
   children: ReactNode
 }
@@ -9,9 +9,9 @@ export function IconButton({ label, children, className, type = 'button', ...res
   return (
     <button
       type={type}
-      aria-label={label}
       className={`flex items-center justify-center cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 dark:focus-visible:ring-gray-500 disabled:cursor-default disabled:opacity-50${className ? ` ${className}` : ''}`}
       {...rest}
+      aria-label={label}
     >
       {children}
     </button>

--- a/projects/portfolio/src/client/shared/components/icon-button/icon-button.tsx
+++ b/projects/portfolio/src/client/shared/components/icon-button/icon-button.tsx
@@ -1,0 +1,19 @@
+import type { ButtonHTMLAttributes, ReactNode } from 'react'
+
+interface IconButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  label: string
+  children: ReactNode
+}
+
+export function IconButton({ label, children, className, type = 'button', ...rest }: IconButtonProps) {
+  return (
+    <button
+      type={type}
+      aria-label={label}
+      className={`flex items-center justify-center cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 dark:focus-visible:ring-gray-500 disabled:cursor-default disabled:opacity-50${className ? ` ${className}` : ''}`}
+      {...rest}
+    >
+      {children}
+    </button>
+  )
+}

--- a/projects/portfolio/src/client/shared/components/input/file-image-input.tsx
+++ b/projects/portfolio/src/client/shared/components/input/file-image-input.tsx
@@ -1,4 +1,5 @@
 import { type ReactNode, useEffect, useRef, useState } from 'react'
+import { IconButton } from '#/client/shared/components/icon-button/icon-button'
 import { CloseIcon } from '#/client/shared/icons/close-icon'
 
 interface Props {
@@ -105,14 +106,13 @@ export function FileImagePreview({ maxImages = 3, src, contextLabel, children, o
               className='max-h-[80vh] w-full rounded object-contain shadow-lg'
             />
           </div>
-          <button
-            type='button'
+          <IconButton
+            label='Close preview'
             onClick={handleHideImage}
-            aria-label='Close preview'
             className='absolute top-0 right-0 font-bold text-2xl text-white hover:text-gray-300'
           >
             <CloseIcon size={48} className='text-white' />
-          </button>
+          </IconButton>
         </div>
       )}
     </div>
@@ -139,14 +139,13 @@ function ImagePreview({ src, contextLabel, onImageClick, onCloseClick }: ImagePr
         onClick={onImageClick}
         className='absolute inset-0 h-full w-full cursor-pointer rounded focus:outline-none focus:ring-2 focus:ring-gray-400'
       />
-      <button
-        type='button'
+      <IconButton
+        label='Remove image'
         onClick={onCloseClick}
-        aria-label='Remove image'
-        className='absolute -top-2 left-9.5 flex cursor-pointer items-center justify-center rounded-full border bg-primary-800 hover:bg-primary-700'
+        className='absolute -top-2 left-9.5 rounded-full border bg-primary-800 hover:bg-primary-700'
       >
         <CloseIcon size={16} className='text-white' />
-      </button>
+      </IconButton>
       {contextLabel && (
         <span className='absolute -bottom-2 left-1/2 max-w-24 -translate-x-1/2 whitespace-nowrap rounded-full border border-gray-200 bg-white px-1.5 py-0.5 text-[10px] leading-none text-gray-600 shadow-sm dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300'>
           {contextLabel}

--- a/projects/portfolio/tests/client/shared/components/icon-button.test.tsx
+++ b/projects/portfolio/tests/client/shared/components/icon-button.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { IconButton } from '#/client/shared/components/icon-button/icon-button'
+
+describe('IconButton', () => {
+  afterEach(() => {
+    cleanup()
+  })
+  describe('label', () => {
+    it('必須labelがaria-labelとして設定される', () => {
+      render(
+        <IconButton label='メニューを開く'>
+          <span data-testid='icon' />
+        </IconButton>
+      )
+      expect(screen.getByRole('button', { name: 'メニューを開く' })).toBeTruthy()
+    })
+  })
+
+  describe('type', () => {
+    it('未指定時はデフォルトでtype=buttonになる', () => {
+      render(
+        <IconButton label='test'>
+          <span />
+        </IconButton>
+      )
+      const button = screen.getByRole('button')
+      expect(button.getAttribute('type')).toBe('button')
+    })
+
+    it('明示的にtype=submitを指定できる', () => {
+      render(
+        <IconButton label='test' type='submit'>
+          <span />
+        </IconButton>
+      )
+      const button = screen.getByRole('button')
+      expect(button.getAttribute('type')).toBe('submit')
+    })
+  })
+
+  describe('props forwarding', () => {
+    it('disabledが正しく伝播する', () => {
+      render(
+        <IconButton label='test' disabled>
+          <span />
+        </IconButton>
+      )
+      const button = screen.getByRole('button') as HTMLButtonElement
+      expect(button.disabled).toBe(true)
+    })
+
+    it('classNameが正しく伝播する', () => {
+      render(
+        <IconButton label='test' className='custom-class'>
+          <span />
+        </IconButton>
+      )
+      const button = screen.getByRole('button')
+      expect(button.className).toContain('custom-class')
+    })
+
+    it('標準button propsがforwardされる', () => {
+      render(
+        <IconButton label='test' data-testid='icon-btn' onClick={() => {}}>
+          <span />
+        </IconButton>
+      )
+      const button = screen.getByTestId('icon-btn')
+      expect(button).toBeTruthy()
+      expect(button.tagName).toBe('BUTTON')
+    })
+  })
+})

--- a/projects/portfolio/tests/client/shared/components/icon-button.test.tsx
+++ b/projects/portfolio/tests/client/shared/components/icon-button.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, screen } from '@testing-library/react'
-import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { IconButton } from '#/client/shared/components/icon-button/icon-button'
 
 describe('IconButton', () => {
@@ -62,15 +62,15 @@ describe('IconButton', () => {
       expect(button.className).toContain('custom-class')
     })
 
-    it('標準button propsがforwardされる', () => {
+    it('onClickが正しく発火する', () => {
+      const handleClick = vi.fn()
       render(
-        <IconButton label='test' data-testid='icon-btn' onClick={() => {}}>
+        <IconButton label='test' onClick={handleClick}>
           <span />
         </IconButton>
       )
-      const button = screen.getByTestId('icon-btn')
-      expect(button).toBeTruthy()
-      expect(button.tagName).toBe('BUTTON')
+      fireEvent.click(screen.getByRole('button'))
+      expect(handleClick).toHaveBeenCalledTimes(1)
     })
   })
 })


### PR DESCRIPTION
## 概要

各所でアイコン専用ボタンが `<button>` を直接使って実装されており、aria-label、focus-visible、disabled のスタイルにばらつきがあった。IconButton コンポーネントを共通化し、一貫性とアクセシビリティを向上させる。

## 変更内容

- **IconButton コンポーネントを追加**: `shared/components/icon-button` に配置
  - `label` props 必須（aria-label に使用）
  - デフォルト `type="button"`
  - 標準の `ButtonHTMLAttributes` を forward
  - `focus-visible` / `disabled` 共通スタイルを一元化
- **既存ボタンの移行**: アイコン専用ボタン17箇所を IconButton に置き換え
- **テスト追加**: `tests/client/shared/components/icon-button.test.tsx`

## 確認項目

- [x] `bun run lint` 通過
- [x] `bun run test` 通過 (60 files, 339 tests)
- [x] `bun run format:check` 通過

Closes #1145