### PR TITLE
Issue #1160: /chat に画像生成モードを追加

### DIFF
--- a/projects/portfolio/.env.example
+++ b/projects/portfolio/.env.example
@@ -11,7 +11,7 @@ CHAT_CACHE_URL=
 CHAT_SESSION_TTL_SECONDS=1800
 CHAT_DISCONNECT_GRACE_MS=30000
 
-# File-server 連携（assistant 生成コードの保存先）。
+# File-server 連携（assistant が生成したコード・画像の保存先）。
 # AUTH_DIR 有効時のみ動作。空なら連携を無効化する。
 # FILE_SERVER_URL は portfolio サーバーから到達する内部向け URL。
 # FILE_SERVER_PUBLIC_URL はブラウザが開く公開向け URL。

--- a/projects/portfolio/plans/2026-08-10_portfolio-image-generation-mode.md
+++ b/projects/portfolio/plans/2026-08-10_portfolio-image-generation-mode.md
@@ -1,0 +1,24 @@
+# /chat 画像生成モード
+
+## Why
+
+`/chat` の会話体験を維持したまま、通常のチャット設定に依存しない text-to-image の導線を追加する。
+
+## What
+
+- composer に会話中も保持される画像生成 On/Off badge と prompt 履歴 On/Off を表示する
+- 専用 API で画像生成対応モデルを自動選択し、固定の `gpt-image-2` / `1024x1024` / PNG 設定で生成する
+- 履歴 On の場合も、同一会話内の画像生成 user prompt だけを入力に含める
+- file server への upload 成功後にだけ conversation を保存し、assistant metadata の `generatedImages` に公開パス等を保存する
+- 再読込後も public URL から画像を表示し、preview・拡大・download を可能にする
+
+## Constraints
+
+- edit / variation / 参照画像は MVP の対象外
+- 生成画像の Base64 は DB に保存しない。既存の upload image の Base64 保存は変更しない
+- 画像表示の data boundary は `GeneratedImage` に切り出し、将来の upload image 共用を妨げない
+- metadata は既存 JSONB を利用するため DB schema migration は不要
+
+## API / file server
+
+`POST /api/image/generations` が生成と file server upload を一連で扱う。file server が未設定、login 失敗、upload 失敗の場合は生成成功を返さず、conversation も保存しない。認証情報は既存の `FILE_SERVER_URL`、`FILE_SERVER_PUBLIC_URL`、`FILE_SERVER_ADMIN_USERNAME`、`FILE_SERVER_ADMIN_PASSWORD` を利用する。

--- a/projects/portfolio/src/client/features/chat/api/image-generation-client.ts
+++ b/projects/portfolio/src/client/features/chat/api/image-generation-client.ts
@@ -1,0 +1,51 @@
+import { readChatError, unknownChatError } from '#/client/shared/lib/chat-error'
+import { ImageGenerationResponseSchema } from '#/types/image-generation-api'
+import type { ImageGenerationResponse } from '#/types/image-generation-api'
+
+export interface SendImageGenerationParams {
+  abortController: AbortController
+  header: {
+    apiKey: string
+    baseURL: string
+  }
+  prompt: string
+  conversationId: string
+  assistantMessageId: string
+}
+
+export async function sendImageGeneration(
+  req: SendImageGenerationParams
+): Promise<{ result: ImageGenerationResponse | null; error: ReturnType<typeof unknownChatError> | null }> {
+  try {
+    const response = await fetch('/api/image/generations', {
+      method: 'POST',
+      headers: {
+        'api-key': req.header.apiKey,
+        'base-url': req.header.baseURL,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        prompt: req.prompt,
+        conversationId: req.conversationId,
+        assistantMessageId: req.assistantMessageId,
+      }),
+      signal: req.abortController.signal,
+    })
+
+    if (!response.ok) {
+      return { result: null, error: await readChatError(response) }
+    }
+
+    const parsed = ImageGenerationResponseSchema.safeParse(await response.json())
+    if (!parsed.success) {
+      return { result: null, error: unknownChatError() }
+    }
+
+    return { result: parsed.data, error: null }
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      return { result: null, error: null }
+    }
+    return { result: null, error: unknownChatError() }
+  }
+}

--- a/projects/portfolio/src/client/features/chat/components/chat-composer.tsx
+++ b/projects/portfolio/src/client/features/chat/components/chat-composer.tsx
@@ -17,7 +17,6 @@ interface ChatComposerProps {
   includeChatHistory: boolean
   sendImagesOnlyOnce: boolean
   imageGenerationMode?: boolean
-  includeImageGenerationHistory?: boolean
   uploadImages: string[]
   onCancelStream: () => void
   onImageChange: (src: string, index?: number) => void
@@ -25,7 +24,7 @@ interface ChatComposerProps {
   onKeyDown: (event: KeyboardEvent<HTMLTextAreaElement>) => void
   onChangeComposition: (composition: boolean) => void
   onToggleImageGenerationMode?: () => void
-  onToggleImageGenerationHistory?: () => void
+  onToggleChatHistory?: () => void
 }
 
 export function ChatComposer({
@@ -39,7 +38,6 @@ export function ChatComposer({
   includeChatHistory,
   sendImagesOnlyOnce,
   imageGenerationMode = false,
-  includeImageGenerationHistory = true,
   uploadImages,
   onCancelStream,
   onImageChange,
@@ -47,7 +45,7 @@ export function ChatComposer({
   onKeyDown,
   onChangeComposition,
   onToggleImageGenerationMode,
-  onToggleImageGenerationHistory,
+  onToggleChatHistory,
 }: ChatComposerProps) {
   return (
     <ChatInput
@@ -68,10 +66,10 @@ export function ChatComposer({
         <div className='flex items-center gap-1'>
           <ImageGenerationModeAction
             enabled={imageGenerationMode}
-            includeHistory={includeImageGenerationHistory}
+            includeHistory={includeChatHistory}
             disabled={loading || streamActive}
             onToggleMode={onToggleImageGenerationMode}
-            onToggleHistory={onToggleImageGenerationHistory}
+            onToggleHistory={onToggleChatHistory}
           />
           {!imageGenerationMode && (
             <ImageUploadAction

--- a/projects/portfolio/src/client/features/chat/components/chat-composer.tsx
+++ b/projects/portfolio/src/client/features/chat/components/chat-composer.tsx
@@ -16,12 +16,16 @@ interface ChatComposerProps {
   streamActive: boolean
   includeChatHistory: boolean
   sendImagesOnlyOnce: boolean
+  imageGenerationMode?: boolean
+  includeImageGenerationHistory?: boolean
   uploadImages: string[]
   onCancelStream: () => void
   onImageChange: (src: string, index?: number) => void
   onChangeInput: (event: ChangeEvent<HTMLTextAreaElement>) => void
   onKeyDown: (event: KeyboardEvent<HTMLTextAreaElement>) => void
   onChangeComposition: (composition: boolean) => void
+  onToggleImageGenerationMode?: () => void
+  onToggleImageGenerationHistory?: () => void
 }
 
 export function ChatComposer({
@@ -34,12 +38,16 @@ export function ChatComposer({
   streamActive,
   includeChatHistory,
   sendImagesOnlyOnce,
+  imageGenerationMode = false,
+  includeImageGenerationHistory = true,
   uploadImages,
   onCancelStream,
   onImageChange,
   onChangeInput,
   onKeyDown,
   onChangeComposition,
+  onToggleImageGenerationMode,
+  onToggleImageGenerationHistory,
 }: ChatComposerProps) {
   return (
     <ChatInput
@@ -57,17 +65,73 @@ export function ChatComposer({
         />
       }
       leftBottom={
-        <ImageUploadAction
-          uploadImages={uploadImages}
-          disabled={loading || streamActive}
-          contextLabel={sendImagesOnlyOnce ? 'この送信に含む' : '履歴でも継続'}
-          onImageChange={onImageChange}
-        />
+        <div className='flex items-center gap-1'>
+          <ImageGenerationModeAction
+            enabled={imageGenerationMode}
+            includeHistory={includeImageGenerationHistory}
+            disabled={loading || streamActive}
+            onToggleMode={onToggleImageGenerationMode}
+            onToggleHistory={onToggleImageGenerationHistory}
+          />
+          {!imageGenerationMode && (
+            <ImageUploadAction
+              uploadImages={uploadImages}
+              disabled={loading || streamActive}
+              contextLabel={sendImagesOnlyOnce ? 'この送信に含む' : '履歴でも継続'}
+              onImageChange={onImageChange}
+            />
+          )}
+        </div>
       }
       onChangeInput={onChangeInput}
       onKeyDown={onKeyDown}
       onChangeComposition={onChangeComposition}
     />
+  )
+}
+
+function ImageGenerationModeAction({
+  enabled,
+  includeHistory,
+  disabled,
+  onToggleMode,
+  onToggleHistory,
+}: {
+  enabled: boolean
+  includeHistory: boolean
+  disabled: boolean
+  onToggleMode?: () => void
+  onToggleHistory?: () => void
+}) {
+  return (
+    <div className='flex items-center gap-1'>
+      <button
+        type='button'
+        onClick={onToggleMode}
+        disabled={disabled}
+        aria-label='画像生成モード On/Off'
+        className={`rounded-3xl border px-2 py-1 text-xs transition-colors disabled:opacity-50 ${
+          enabled
+            ? 'border-emerald-300 bg-emerald-50 text-emerald-700 hover:bg-emerald-100 dark:border-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-200 dark:hover:bg-emerald-900/60'
+            : 'border-gray-300 bg-gray-50 text-gray-600 hover:bg-gray-100 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700'
+        }`}
+      >
+        画像生成 {enabled ? 'On' : 'Off'}
+      </button>
+      <button
+        type='button'
+        onClick={onToggleHistory}
+        disabled={disabled}
+        aria-label='画像生成 prompt 履歴 On/Off'
+        className={`rounded-3xl border px-2 py-1 text-xs transition-colors disabled:opacity-50 ${
+          includeHistory
+            ? 'border-blue-300 bg-blue-50 text-blue-700 hover:bg-blue-100 dark:border-blue-700 dark:bg-blue-900/40 dark:text-blue-200 dark:hover:bg-blue-900/60'
+            : 'border-gray-300 bg-gray-50 text-gray-600 hover:bg-gray-100 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700'
+        }`}
+      >
+        履歴 {includeHistory ? 'On' : 'Off'}
+      </button>
+    </div>
   )
 }
 

--- a/projects/portfolio/src/client/features/chat/components/chat-main.tsx
+++ b/projects/portfolio/src/client/features/chat/components/chat-main.tsx
@@ -21,6 +21,7 @@ interface Props {
   onConversationChange?: (conversation: Conversation) => Promise<void> | void
   onSessionCompleted?: (conversation: Conversation) => Promise<void> | void
   onDeleteMessages?: (messageIds: string[], isConversationEmpty: boolean) => void
+  onUpdateSetting?: <K extends keyof Settings>(key: K, value: Settings[K]) => Settings
 }
 
 export function ChatMain({
@@ -32,6 +33,7 @@ export function ChatMain({
   onConversationChange,
   onSessionCompleted,
   onDeleteMessages,
+  onUpdateSetting,
 }: Props) {
   const formRef = useRef<HTMLFormElement>(null)
   const prevConversationIdRef = useRef<string | null>(null)
@@ -84,6 +86,14 @@ export function ChatMain({
     },
   })
 
+  const toggleImageGenerationMode = useCallback(() => {
+    onUpdateSetting?.('imageGenerationMode', !settings.imageGenerationMode)
+  }, [onUpdateSetting, settings.imageGenerationMode])
+
+  const toggleImageGenerationHistory = useCallback(() => {
+    onUpdateSetting?.('includeImageGenerationHistory', !settings.includeImageGenerationHistory)
+  }, [onUpdateSetting, settings.includeImageGenerationHistory])
+
   useEffect(() => {
     if (!currentConversation || prevConversationIdRef.current === currentConversation.id) {
       return
@@ -118,13 +128,15 @@ export function ChatMain({
               >
                 お手伝いできることはありますか？
               </div>
-              <div className='hidden md:block'>
-                <PromptTemplate
-                  autoModel={settings.autoModel}
-                  placeholder={settings.model}
-                  onSubmit={handleTemplateSubmit}
-                />
-              </div>
+              {!settings.imageGenerationMode && (
+                <div className='hidden md:block'>
+                  <PromptTemplate
+                    autoModel={settings.autoModel}
+                    placeholder={settings.model}
+                    onSubmit={handleTemplateSubmit}
+                  />
+                </div>
+              )}
               <ChatComposer
                 value={input}
                 textAreaRows={textAreaRows}
@@ -134,12 +146,16 @@ export function ChatMain({
                 streamActive={!!stream}
                 includeChatHistory={settings.includeChatHistory}
                 sendImagesOnlyOnce={settings.sendImagesOnlyOnce}
+                imageGenerationMode={settings.imageGenerationMode}
+                includeImageGenerationHistory={settings.includeImageGenerationHistory}
                 uploadImages={uploadImages}
                 onCancelStream={cancelStream}
                 onImageChange={handleUploadImageChange}
                 onChangeInput={handleChangeInput}
                 onKeyDown={handleKeyDown}
                 onChangeComposition={handleChangeComposition}
+                onToggleImageGenerationMode={toggleImageGenerationMode}
+                onToggleImageGenerationHistory={toggleImageGenerationHistory}
               />
               <div className='py-4' />
             </div>
@@ -203,12 +219,16 @@ export function ChatMain({
               streamActive={!!stream}
               includeChatHistory={settings.includeChatHistory}
               sendImagesOnlyOnce={settings.sendImagesOnlyOnce}
+              imageGenerationMode={settings.imageGenerationMode}
+              includeImageGenerationHistory={settings.includeImageGenerationHistory}
               uploadImages={uploadImages}
               onCancelStream={cancelStream}
               onImageChange={handleUploadImageChange}
               onChangeInput={handleChangeInput}
               onKeyDown={handleKeyDown}
               onChangeComposition={handleChangeComposition}
+              onToggleImageGenerationMode={toggleImageGenerationMode}
+              onToggleImageGenerationHistory={toggleImageGenerationHistory}
             />
             <div className='h-4' />
           </>

--- a/projects/portfolio/src/client/features/chat/components/chat-main.tsx
+++ b/projects/portfolio/src/client/features/chat/components/chat-main.tsx
@@ -90,9 +90,9 @@ export function ChatMain({
     onUpdateSetting?.('imageGenerationMode', !settings.imageGenerationMode)
   }, [onUpdateSetting, settings.imageGenerationMode])
 
-  const toggleImageGenerationHistory = useCallback(() => {
-    onUpdateSetting?.('includeImageGenerationHistory', !settings.includeImageGenerationHistory)
-  }, [onUpdateSetting, settings.includeImageGenerationHistory])
+  const toggleChatHistory = useCallback(() => {
+    onUpdateSetting?.('includeChatHistory', !settings.includeChatHistory)
+  }, [onUpdateSetting, settings.includeChatHistory])
 
   useEffect(() => {
     if (!currentConversation || prevConversationIdRef.current === currentConversation.id) {
@@ -147,7 +147,6 @@ export function ChatMain({
                 includeChatHistory={settings.includeChatHistory}
                 sendImagesOnlyOnce={settings.sendImagesOnlyOnce}
                 imageGenerationMode={settings.imageGenerationMode}
-                includeImageGenerationHistory={settings.includeImageGenerationHistory}
                 uploadImages={uploadImages}
                 onCancelStream={cancelStream}
                 onImageChange={handleUploadImageChange}
@@ -155,7 +154,7 @@ export function ChatMain({
                 onKeyDown={handleKeyDown}
                 onChangeComposition={handleChangeComposition}
                 onToggleImageGenerationMode={toggleImageGenerationMode}
-                onToggleImageGenerationHistory={toggleImageGenerationHistory}
+                onToggleChatHistory={toggleChatHistory}
               />
               <div className='py-4' />
             </div>
@@ -220,7 +219,6 @@ export function ChatMain({
               includeChatHistory={settings.includeChatHistory}
               sendImagesOnlyOnce={settings.sendImagesOnlyOnce}
               imageGenerationMode={settings.imageGenerationMode}
-              includeImageGenerationHistory={settings.includeImageGenerationHistory}
               uploadImages={uploadImages}
               onCancelStream={cancelStream}
               onImageChange={handleUploadImageChange}
@@ -228,7 +226,7 @@ export function ChatMain({
               onKeyDown={handleKeyDown}
               onChangeComposition={handleChangeComposition}
               onToggleImageGenerationMode={toggleImageGenerationMode}
-              onToggleImageGenerationHistory={toggleImageGenerationHistory}
+              onToggleChatHistory={toggleChatHistory}
             />
             <div className='h-4' />
           </>

--- a/projects/portfolio/src/client/features/chat/components/chat-settings/chat-settings.tsx
+++ b/projects/portfolio/src/client/features/chat/components/chat-settings/chat-settings.tsx
@@ -20,6 +20,7 @@ interface Props {
   onToggleSidebar?: () => void
   onChange?: (settings: Settings) => void
   onHidePopup?: () => void
+  imageGenerationMode?: boolean
 }
 
 export function ChatSettings({
@@ -34,6 +35,7 @@ export function ChatSettings({
   onToggleSidebar,
   onChange,
   onHidePopup,
+  imageGenerationMode = false,
 }: Props) {
   const contextValue = useChatSettings({ showPopup, onChange })
 
@@ -72,15 +74,21 @@ export function ChatSettings({
             {/* Right side */}
             <div className='flex items-center gap-2'>
               <span className='max-w-48 truncate text-xs font-medium text-gray-500 dark:text-gray-400'>
-                {contextValue.fakeMode ? 'Fake Mode' : contextValue.settings.model}
+                {imageGenerationMode
+                  ? '画像生成モード'
+                  : contextValue.fakeMode
+                    ? 'Fake Mode'
+                    : contextValue.settings.model}
               </span>
-              <IconButton
-                label='Settings'
-                onClick={onShowMenu}
-                className='rounded-md p-2 text-gray-600 transition hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700'
-              >
-                <GearIcon className='text-[#5D5D5D] dark:text-gray-300' />
-              </IconButton>
+              {!imageGenerationMode && (
+                <IconButton
+                  label='Settings'
+                  onClick={onShowMenu}
+                  className='rounded-md p-2 text-gray-600 transition hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700'
+                >
+                  <GearIcon className='text-[#5D5D5D] dark:text-gray-300' />
+                </IconButton>
+              )}
             </div>
           </>
         )}
@@ -88,7 +96,7 @@ export function ChatSettings({
 
       {/* Settings Panel */}
       <ChatSettingsProvider value={contextValue}>
-        <ChatSettingsPanel show={showPopup ?? false} onClose={onHidePopup ?? (() => {})}>
+        <ChatSettingsPanel show={!imageGenerationMode && (showPopup ?? false)} onClose={onHidePopup ?? (() => {})}>
           <ChatSettingsForm />
         </ChatSettingsPanel>
       </ChatSettingsProvider>

--- a/projects/portfolio/src/client/features/chat/components/chat-settings/chat-settings.tsx
+++ b/projects/portfolio/src/client/features/chat/components/chat-settings/chat-settings.tsx
@@ -75,7 +75,7 @@ export function ChatSettings({
             <div className='flex items-center gap-2'>
               <span className='max-w-48 truncate text-xs font-medium text-gray-500 dark:text-gray-400'>
                 {imageGenerationMode
-                  ? '画像生成モード'
+                  ? 'gpt-image-2'
                   : contextValue.fakeMode
                     ? 'Fake Mode'
                     : contextValue.settings.model}

--- a/projects/portfolio/src/client/features/chat/components/chat-settings/chat-settings.tsx
+++ b/projects/portfolio/src/client/features/chat/components/chat-settings/chat-settings.tsx
@@ -21,6 +21,7 @@ interface Props {
   onChange?: (settings: Settings) => void
   onHidePopup?: () => void
   imageGenerationMode?: boolean
+  settings: Settings
 }
 
 export function ChatSettings({
@@ -36,8 +37,9 @@ export function ChatSettings({
   onChange,
   onHidePopup,
   imageGenerationMode = false,
+  settings,
 }: Props) {
-  const contextValue = useChatSettings({ showPopup, onChange })
+  const contextValue = useChatSettings({ showPopup, onChange, settings })
 
   return (
     <>

--- a/projects/portfolio/src/client/features/chat/components/chat-settings/hooks/use-chat-settings.ts
+++ b/projects/portfolio/src/client/features/chat/components/chat-settings/hooks/use-chat-settings.ts
@@ -6,17 +6,16 @@ import { useModelFetching } from './use-model-fetching'
 import { useSettingsHandlers } from './use-settings-handlers'
 
 interface UseChatSettingsOptions {
+  settings: Settings
   showPopup?: boolean
   onChange?: (settings: Settings) => void
 }
 
-export function useChatSettings(options: UseChatSettingsOptions = {}): ChatSettingsContextValue {
-  const { showPopup, onChange } = options
-
+export function useChatSettings({ settings, showPopup, onChange }: UseChatSettingsOptions): ChatSettingsContextValue {
   useLockBodyScroll(showPopup ?? false)
 
   const storage = useLocalStorageSettings({ onChange })
-  const models = useModelFetching({ autoModel: storage.autoModel })
+  const models = useModelFetching({ autoModel: settings.autoModel })
   const handlers = useSettingsHandlers({
     setModel: storage.setModel,
     setTemperature: storage.setTemperature,
@@ -30,31 +29,31 @@ export function useChatSettings(options: UseChatSettingsOptions = {}): ChatSetti
     setSendImagesOnlyOnce: storage.setSendImagesOnlyOnce,
     setReasoningEffort: storage.setReasoningEffort,
     setReasoningEffortEnabled: storage.setReasoningEffortEnabled,
-    temperatureEnabled: storage.temperatureEnabled,
-    autoModel: storage.autoModel,
-    apiMode: storage.apiMode,
-    fakeMode: storage.fakeMode,
-    markdownPreview: storage.markdownPreview,
-    streamMode: storage.streamMode,
-    includeChatHistory: storage.includeChatHistory,
-    sendImagesOnlyOnce: storage.sendImagesOnlyOnce,
-    reasoningEffortEnabled: storage.reasoningEffortEnabled,
+    temperatureEnabled: settings.temperatureEnabled,
+    autoModel: settings.autoModel,
+    apiMode: settings.apiMode,
+    fakeMode: settings.fakeMode,
+    markdownPreview: settings.markdownPreview,
+    streamMode: settings.streamMode,
+    includeChatHistory: settings.includeChatHistory,
+    sendImagesOnlyOnce: settings.sendImagesOnlyOnce,
+    reasoningEffortEnabled: settings.reasoningEffortEnabled,
     updateSetting: storage.updateSetting,
   })
 
   return {
-    settings: storage.settings,
-    temperature: storage.temperature,
-    temperatureEnabled: storage.temperatureEnabled,
-    autoModel: storage.autoModel,
-    apiMode: storage.apiMode,
-    fakeMode: storage.fakeMode,
-    markdownPreview: storage.markdownPreview,
-    streamMode: storage.streamMode,
-    includeChatHistory: storage.includeChatHistory,
-    sendImagesOnlyOnce: storage.sendImagesOnlyOnce,
-    reasoningEffort: storage.reasoningEffort,
-    reasoningEffortEnabled: storage.reasoningEffortEnabled,
+    settings,
+    temperature: settings.temperature,
+    temperatureEnabled: settings.temperatureEnabled,
+    autoModel: settings.autoModel,
+    apiMode: settings.apiMode,
+    fakeMode: settings.fakeMode,
+    markdownPreview: settings.markdownPreview,
+    streamMode: settings.streamMode,
+    includeChatHistory: settings.includeChatHistory,
+    sendImagesOnlyOnce: settings.sendImagesOnlyOnce,
+    reasoningEffort: settings.reasoningEffort,
+    reasoningEffortEnabled: settings.reasoningEffortEnabled,
     ...models,
     ...handlers,
   }

--- a/projects/portfolio/src/client/features/chat/components/image-asset-preview.tsx
+++ b/projects/portfolio/src/client/features/chat/components/image-asset-preview.tsx
@@ -1,0 +1,82 @@
+import { useState } from 'react'
+import type { GeneratedImage } from '#/types'
+
+export interface ImageAsset {
+  fileName: string
+  publicPath: string
+  previewUrl?: string
+  contentType: string
+  createdAt: string
+}
+
+interface ImageAssetPreviewProps {
+  images: readonly ImageAsset[]
+  label?: string
+}
+
+export function ImageAssetPreview({ images, label = 'Generated images' }: ImageAssetPreviewProps) {
+  const [selectedImage, setSelectedImage] = useState<ImageAsset | null>(null)
+  const visibleImages = images.filter((image): image is GeneratedImage => Boolean(image.previewUrl))
+
+  if (visibleImages.length === 0) {
+    return null
+  }
+
+  return (
+    <div className='mt-2 flex flex-wrap gap-3' aria-label={label}>
+      {visibleImages.map((image) => (
+        <div key={image.publicPath} className='flex max-w-sm flex-col gap-1'>
+          <button
+            type='button'
+            className='cursor-zoom-in overflow-hidden rounded-lg border border-gray-200 bg-gray-50 text-left dark:border-gray-700 dark:bg-gray-900'
+            onClick={() => setSelectedImage(image)}
+            aria-label={`画像を拡大表示: ${image.fileName}`}
+          >
+            <img src={image.previewUrl} alt={image.fileName} className='block max-h-80 max-w-full object-contain' />
+          </button>
+          <a
+            href={image.previewUrl}
+            download={image.fileName}
+            className='self-start text-xs text-gray-500 underline hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'
+          >
+            画像をダウンロード
+          </a>
+        </div>
+      ))}
+
+      {selectedImage?.previewUrl && (
+        <div
+          role='dialog'
+          aria-modal='true'
+          aria-label={`画像を拡大表示: ${selectedImage.fileName}`}
+          className='fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4'
+          onClick={() => setSelectedImage(null)}
+        >
+          <div className='relative max-h-full max-w-full' onClick={(event) => event.stopPropagation()}>
+            <img
+              src={selectedImage.previewUrl}
+              alt={selectedImage.fileName}
+              className='max-h-[85vh] max-w-[90vw] object-contain'
+            />
+            <div className='mt-2 flex justify-end gap-2'>
+              <a
+                href={selectedImage.previewUrl}
+                download={selectedImage.fileName}
+                className='rounded-md bg-white px-3 py-1.5 text-sm text-gray-800 hover:bg-gray-100'
+              >
+                ダウンロード
+              </a>
+              <button
+                type='button'
+                onClick={() => setSelectedImage(null)}
+                className='rounded-md bg-white px-3 py-1.5 text-sm text-gray-800 hover:bg-gray-100'
+              >
+                閉じる
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/projects/portfolio/src/client/features/chat/components/message-renderer.tsx
+++ b/projects/portfolio/src/client/features/chat/components/message-renderer.tsx
@@ -16,6 +16,7 @@ import {
   type CodeBlockOpenBlocks,
   type CodeBlockOpenChangeHandler,
 } from '#/client/features/chat/components/code-block-renderer'
+import { ImageAssetPreview } from '#/client/features/chat/components/image-asset-preview'
 import { ReasoningSection } from '#/client/features/chat/components/reasoning-section'
 import { getUserMessageText } from '#/client/features/chat/lib/edit-message'
 import { IconButton } from '#/client/shared/components/icon-button/icon-button'
@@ -170,7 +171,8 @@ function MessageRendererComponent({
   }
 
   if (message.role === 'user') {
-    const canSaveEdit = editText.trim().length > 0 && !disabled && !isSavingEdit
+    const canEditImagePrompt = message.metadata.imageGenerationMode !== true
+    const canSaveEdit = canEditImagePrompt && editText.trim().length > 0 && !disabled && !isSavingEdit
     const userMessageText = getUserMessageText(message)
 
     const handleStartEdit = () => {
@@ -254,13 +256,15 @@ function MessageRendererComponent({
             ) : (
               <>
                 <CopyMessageButton copied={copied} onClick={() => onCopyMessage(userMessageText, index)} />
-                <IconButton
-                  label='Edit message'
-                  onClick={handleStartEdit}
-                  className='h-8 w-8 rounded-full text-gray-500 transition-[background-color,color] duration-200 ease-out hover:bg-gray-100 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white'
-                >
-                  <EditIcon size={20} className='stroke-current' />
-                </IconButton>
+                {canEditImagePrompt && (
+                  <IconButton
+                    label='Edit message'
+                    onClick={handleStartEdit}
+                    className='h-8 w-8 rounded-full text-gray-500 transition-[background-color,color] duration-200 ease-out hover:bg-gray-100 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white'
+                  >
+                    <EditIcon size={20} className='stroke-current' />
+                  </IconButton>
+                )}
                 <IconButton
                   label='Delete message'
                   onClick={() => onDeleteMessage?.(index)}
@@ -277,6 +281,7 @@ function MessageRendererComponent({
   }
 
   const generatedFiles = message.role === 'assistant' ? (message.metadata.generatedFiles ?? []) : []
+  const generatedImages = message.role === 'assistant' ? (message.metadata.generatedImages ?? []) : []
   const assistantContextValue =
     message.role === 'assistant' && message.id && conversationId && onSaveGeneratedFile
       ? {
@@ -334,6 +339,7 @@ function MessageRendererComponent({
             </p>
           </div>
         )}
+        <ImageAssetPreview images={generatedImages} />
         <MessageActionBar copied={copied}>
           <CopyMessageButton copied={copied} onClick={() => onCopyMessage(message.content, index)} />
         </MessageActionBar>

--- a/projects/portfolio/src/client/features/chat/hooks/use-chat-actions.ts
+++ b/projects/portfolio/src/client/features/chat/hooks/use-chat-actions.ts
@@ -224,7 +224,7 @@ export function useChatActions({
     resetAfterSubmit()
 
     try {
-      const { result, error } = await submitImageGeneration({
+      const { result, error, responseTimeMs } = await submitImageGeneration({
         header: {
           apiKey: settings.apiKey,
           baseURL: settings.baseURL,
@@ -242,6 +242,7 @@ export function useChatActions({
       const assistantMessage = createImageGenerationAssistantMessage({
         assistantMessageId,
         result,
+        responseTimeMs,
       })
       const finalMessages = [...nextMessages, assistantMessage]
       const completedConversation = {

--- a/projects/portfolio/src/client/features/chat/hooks/use-chat-actions.ts
+++ b/projects/portfolio/src/client/features/chat/hooks/use-chat-actions.ts
@@ -6,6 +6,7 @@ import type { useStreamProcessor } from '#/client/features/chat/hooks/use-stream
 import {
   createAssistantMessage,
   createConversationTitle,
+  createImageGenerationAssistantMessage,
   resolveChatRequestSettings,
 } from '#/client/features/chat/lib/chat-message-factory'
 import {
@@ -14,6 +15,7 @@ import {
   prepareApiMessages,
   summarizeImageContext,
 } from '#/client/features/chat/lib/edit-message'
+import { buildImageGenerationPrompt } from '#/client/features/chat/lib/image-generation'
 import { unknownChatError } from '#/client/shared/lib/chat-error'
 import type { Settings } from '#/client/shared/storage/remote-storage-settings'
 import type { Conversation, GeneratedCodeFile, Message } from '#/types'
@@ -64,13 +66,17 @@ export function useChatActions({
     setGenerationError,
     markSessionOwnedSnapshot,
   } = conversationState
-  const { loading, stream, submitChatCompletion } = streamProcessor
+  const { loading, stream, submitChatCompletion, submitImageGeneration } = streamProcessor
   const { canSaveGeneratedFile, currentConversation, onConversationChange, onSessionCompleted, onDeleteMessages } =
     callbacks
 
   const handleSubmit = useCallback(
     (event: FormEvent<HTMLFormElement>) => {
       event.preventDefault()
+      if (settings.imageGenerationMode) {
+        void handleImageGenerationSubmit()
+        return
+      }
       const requestSettings = resolveChatRequestSettings(settings)
       setGenerationError(null)
       const params = buildChatMessages({
@@ -185,6 +191,80 @@ export function useChatActions({
     ]
   )
 
+  async function handleImageGenerationSubmit() {
+    const prompt = buildImageGenerationPrompt(messages, formState.input, settings.includeImageGenerationHistory)
+    if (!prompt || !submitImageGeneration) {
+      return
+    }
+
+    const assistantMessageId = uuidv7()
+    const currentConversationId = conversationId || uuidv7()
+    const draftUserMessage: Message = {
+      id: uuidv7(),
+      role: 'user',
+      content: prompt.currentPrompt,
+      metadata: {
+        model: '',
+        imageGenerationMode: true,
+        includeImageGenerationHistory: settings.includeImageGenerationHistory,
+      },
+    }
+    const nextMessages = [...messages, draftUserMessage]
+    const draftConversation = {
+      id: currentConversationId,
+      title: createConversationTitle(draftUserMessage.content),
+      messages: nextMessages,
+    }
+
+    setGenerationError(null)
+    markSessionOwnedSnapshot(draftConversation)
+    setConversationId(currentConversationId)
+    setMessages(nextMessages)
+    setStreamMessageId(assistantMessageId)
+    resetAfterSubmit()
+
+    try {
+      const { result, error } = await submitImageGeneration({
+        header: {
+          apiKey: settings.apiKey,
+          baseURL: settings.baseURL,
+        },
+        prompt: prompt.prompt,
+        conversationId: currentConversationId,
+        assistantMessageId,
+      })
+
+      if (error || !result) {
+        setGenerationError(error ?? unknownChatError())
+        return
+      }
+
+      const assistantMessage = createImageGenerationAssistantMessage({
+        assistantMessageId,
+        result,
+      })
+      const finalMessages = [...nextMessages, assistantMessage]
+      const completedConversation = {
+        id: currentConversationId,
+        title: createConversationTitle(draftUserMessage.content),
+        messages: finalMessages,
+      }
+      markSessionOwnedSnapshot(completedConversation)
+      setMessages(finalMessages)
+
+      setIsSavingConversation(true)
+      try {
+        await onConversationChange?.(completedConversation)
+      } finally {
+        setIsSavingConversation(false)
+      }
+    } catch {
+      setGenerationError(unknownChatError())
+    } finally {
+      setStreamMessageId(null)
+    }
+  }
+
   const handleSaveGeneratedFile = useCallback(
     async (messageIndex: number, params: SaveGeneratedFileRequest): Promise<GeneratedCodeFile | null> => {
       if (!canSaveGeneratedFile) {
@@ -238,6 +318,10 @@ export function useChatActions({
   const handleEditMessage = useCallback(
     async (index: number, nextText: string): Promise<void> => {
       if (loading || stream || isSavingConversation) {
+        return
+      }
+
+      if (messages[index]?.role === 'user' && messages[index].metadata.imageGenerationMode === true) {
         return
       }
 

--- a/projects/portfolio/src/client/features/chat/hooks/use-chat-actions.ts
+++ b/projects/portfolio/src/client/features/chat/hooks/use-chat-actions.ts
@@ -192,7 +192,7 @@ export function useChatActions({
   )
 
   async function handleImageGenerationSubmit() {
-    const prompt = buildImageGenerationPrompt(messages, formState.input, settings.includeImageGenerationHistory)
+    const prompt = buildImageGenerationPrompt(messages, formState.input, settings.includeChatHistory)
     if (!prompt || !submitImageGeneration) {
       return
     }
@@ -206,7 +206,6 @@ export function useChatActions({
       metadata: {
         model: '',
         imageGenerationMode: true,
-        includeImageGenerationHistory: settings.includeImageGenerationHistory,
       },
     }
     const nextMessages = [...messages, draftUserMessage]

--- a/projects/portfolio/src/client/features/chat/hooks/use-chat-page-state.ts
+++ b/projects/portfolio/src/client/features/chat/hooks/use-chat-page-state.ts
@@ -51,6 +51,12 @@ export function useChatPageState(selectedConversationId: string | null) {
     setSettings(nextSettings)
   }, [])
 
+  const updateSetting = useCallback(<K extends keyof Settings>(key: K, value: Settings[K]) => {
+    const nextSettings = saveToLocalStorage({ [key]: value })
+    setSettings(nextSettings)
+    return nextSettings
+  }, [])
+
   return {
     selectedConversationId,
     isSettingsPopupOpen,
@@ -65,5 +71,6 @@ export function useChatPageState(selectedConversationId: string | null) {
     closeSettingsPopup,
     setSubmitting,
     updateSettings,
+    updateSetting,
   }
 }

--- a/projects/portfolio/src/client/features/chat/hooks/use-stream-processor.ts
+++ b/projects/portfolio/src/client/features/chat/hooks/use-stream-processor.ts
@@ -43,6 +43,10 @@ interface UseStreamProcessorParams {
   onSessionResult?: (result: CompletedSessionChatResult) => void
 }
 
+type ImageGenerationSubmissionResult = Awaited<ReturnType<typeof sendImageGeneration>> & {
+  responseTimeMs?: number
+}
+
 export function useStreamProcessor({
   onSubmitting,
   onSessionConversation,
@@ -168,14 +172,23 @@ export function useStreamProcessor({
   }, [onSessionConversation, onSessionResult, onSubmitting])
 
   const submitImageGeneration = useCallback(
-    async (params: Omit<SendImageGenerationParams, 'abortController'>) => {
+    async (params: Omit<SendImageGenerationParams, 'abortController'>): Promise<ImageGenerationSubmissionResult> => {
       setImageLoading(true)
       const abortController = new AbortController()
       abortControllerRef.current = abortController
       onSubmitting?.(true)
+      const requestStartTime = Date.now()
 
       try {
-        return await sendImageGeneration({ ...params, abortController })
+        const generation = await sendImageGeneration({ ...params, abortController })
+        if (generation.error || !generation.result) {
+          return generation
+        }
+
+        return {
+          ...generation,
+          responseTimeMs: Date.now() - requestStartTime,
+        }
       } finally {
         if (abortControllerRef.current === abortController) {
           abortControllerRef.current = null

--- a/projects/portfolio/src/client/features/chat/hooks/use-stream-processor.ts
+++ b/projects/portfolio/src/client/features/chat/hooks/use-stream-processor.ts
@@ -4,6 +4,7 @@ import {
   sendNonStreamCompletion,
   sendStreamCompletion,
 } from '#/client/features/chat/api/chat-completion-client'
+import { sendImageGeneration, type SendImageGenerationParams } from '#/client/features/chat/api/image-generation-client'
 import { clearActiveSession, readActiveSession } from '#/client/features/chat/lib/chat-session-storage'
 import {
   type CompletedSessionChatResult,
@@ -51,6 +52,7 @@ export function useStreamProcessor({
   const eventSourceRef = useRef<EventSource | null>(null)
   const activeSessionIdRef = useRef<string | null>(null)
   const [loading, setLoading] = useState(false)
+  const [imageLoading, setImageLoading] = useState(false)
   const [stream, setStream] = useState<ChatStreamState | null>(null)
 
   const cancelStream = useCallback(() => {
@@ -165,11 +167,32 @@ export function useStreamProcessor({
     }
   }, [onSessionConversation, onSessionResult, onSubmitting])
 
+  const submitImageGeneration = useCallback(
+    async (params: Omit<SendImageGenerationParams, 'abortController'>) => {
+      setImageLoading(true)
+      const abortController = new AbortController()
+      abortControllerRef.current = abortController
+      onSubmitting?.(true)
+
+      try {
+        return await sendImageGeneration({ ...params, abortController })
+      } finally {
+        if (abortControllerRef.current === abortController) {
+          abortControllerRef.current = null
+        }
+        setImageLoading(false)
+        onSubmitting?.(false)
+      }
+    },
+    [onSubmitting]
+  )
+
   return {
-    loading,
+    loading: loading || imageLoading,
     stream,
     cancelStream,
     submitChatCompletion,
     resumeActiveChatCompletion,
+    submitImageGeneration,
   }
 }

--- a/projects/portfolio/src/client/features/chat/lib/chat-message-factory.ts
+++ b/projects/portfolio/src/client/features/chat/lib/chat-message-factory.ts
@@ -1,6 +1,7 @@
 import type { Settings } from '#/client/shared/storage/remote-storage-settings'
 import type { ApiChatMessage, ImageContextSummary, Message } from '#/types'
 import type { ChatResponse } from '#/types/chat-api'
+import type { ImageGenerationResponse } from '#/types/image-generation-api'
 
 const CONVERSATION_TITLE_MAX_LENGTH = 10
 
@@ -41,7 +42,7 @@ export function createAssistantMessage({
   assistantMessageId: string
   result: ChatResponse
   apiMode: Settings['apiMode']
-  responseTimeMs: number
+  responseTimeMs?: number
   imageContext?: ImageContextSummary
   apiContextMessages?: ApiChatMessage[]
 }): Message {
@@ -54,7 +55,7 @@ export function createAssistantMessage({
       model: result.model,
       apiMode,
       finishReason: result.finishReason,
-      responseTimeMs,
+      responseTimeMs: responseTimeMs ?? 0,
       usage: {
         promptTokens: result.usage?.promptTokens || 0,
         completionTokens: result.usage?.completionTokens || 0,
@@ -63,6 +64,33 @@ export function createAssistantMessage({
       },
       imageContext,
       apiContextMessages,
+    },
+  }
+}
+
+export function createImageGenerationAssistantMessage({
+  assistantMessageId,
+  result,
+  responseTimeMs,
+}: {
+  assistantMessageId: string
+  result: ImageGenerationResponse
+  responseTimeMs?: number
+}): Message {
+  return {
+    id: assistantMessageId,
+    role: 'assistant',
+    content: '',
+    metadata: {
+      model: result.model,
+      finishReason: 'stop',
+      responseTimeMs: responseTimeMs ?? 0,
+      usage: {
+        promptTokens: result.usage.inputTokens ?? 0,
+        completionTokens: result.usage.outputTokens ?? 0,
+        totalTokens: result.usage.totalTokens ?? 0,
+      },
+      generatedImages: [result.image],
     },
   }
 }

--- a/projects/portfolio/src/client/features/chat/lib/image-generation.ts
+++ b/projects/portfolio/src/client/features/chat/lib/image-generation.ts
@@ -1,0 +1,32 @@
+import type { Message } from '#/types'
+
+export function buildImageGenerationPrompt(
+  messages: Message[],
+  currentPrompt: string,
+  includeHistory: boolean
+): { currentPrompt: string; prompt: string } | null {
+  const trimmedPrompt = currentPrompt.trim()
+  if (!trimmedPrompt) {
+    return null
+  }
+
+  const history = includeHistory
+    ? messages
+        .filter((message) => message.role === 'user' && message.metadata.imageGenerationMode === true)
+        .map((message) =>
+          typeof message.content === 'string'
+            ? message.content
+            : message.content
+                .filter((part) => part.type === 'text')
+                .map((part) => part.text)
+                .join('')
+        )
+        .map((prompt) => prompt.trim())
+        .filter(Boolean)
+    : []
+
+  return {
+    currentPrompt: trimmedPrompt,
+    prompt: [...history, trimmedPrompt].join('\n\n'),
+  }
+}

--- a/projects/portfolio/src/client/features/chat/page.tsx
+++ b/projects/portfolio/src/client/features/chat/page.tsx
@@ -219,6 +219,7 @@ export function Chat() {
         onChange={updateSettings}
         onHidePopup={closeSettingsPopup}
         imageGenerationMode={settings.imageGenerationMode}
+        settings={settings}
       />
       {isResolvingConversation ? (
         <div className='flex min-h-0 flex-1 items-center justify-center gap-2'>

--- a/projects/portfolio/src/client/features/chat/page.tsx
+++ b/projects/portfolio/src/client/features/chat/page.tsx
@@ -32,6 +32,7 @@ export function Chat() {
     closeSettingsPopup,
     setSubmitting,
     updateSettings,
+    updateSetting,
   } = useChatPageState(conversationId ?? null)
 
   const { email } = useMetaProps()
@@ -217,6 +218,7 @@ export function Chat() {
         onToggleSidebar={toggleSidebar}
         onChange={updateSettings}
         onHidePopup={closeSettingsPopup}
+        imageGenerationMode={settings.imageGenerationMode}
       />
       {isResolvingConversation ? (
         <div className='flex min-h-0 flex-1 items-center justify-center gap-2'>
@@ -233,6 +235,7 @@ export function Chat() {
           onConversationChange={handleConversationChange}
           onSessionCompleted={handleSessionCompleted}
           onDeleteMessages={handleDeleteConversationMessage}
+          onUpdateSetting={updateSetting}
         />
       )}
     </ChatLayout>

--- a/projects/portfolio/src/client/shared/storage/remote-storage-settings.ts
+++ b/projects/portfolio/src/client/shared/storage/remote-storage-settings.ts
@@ -21,6 +21,8 @@ export interface Settings {
   streamMode: boolean
   includeChatHistory: boolean
   sendImagesOnlyOnce: boolean
+  imageGenerationMode: boolean
+  includeImageGenerationHistory: boolean
   sidebarOpen: boolean
   templateModels: {
     [key: string]: {
@@ -51,6 +53,8 @@ const defaultSettings: Settings = {
   streamMode: true,
   includeChatHistory: true,
   sendImagesOnlyOnce: true,
+  imageGenerationMode: false,
+  includeImageGenerationHistory: true,
   sidebarOpen: true,
   templateModels: {},
 }
@@ -160,6 +164,8 @@ function shouldPersistNormalizedSettings(
     settings.includeChatHistory !== normalized.includeChatHistory ||
     'interactiveMode' in settings ||
     settings.sendImagesOnlyOnce !== normalized.sendImagesOnlyOnce ||
+    settings.imageGenerationMode !== normalized.imageGenerationMode ||
+    settings.includeImageGenerationHistory !== normalized.includeImageGenerationHistory ||
     'mcpServerURLs' in settings
   )
 }

--- a/projects/portfolio/src/client/shared/storage/remote-storage-settings.ts
+++ b/projects/portfolio/src/client/shared/storage/remote-storage-settings.ts
@@ -22,7 +22,6 @@ export interface Settings {
   includeChatHistory: boolean
   sendImagesOnlyOnce: boolean
   imageGenerationMode: boolean
-  includeImageGenerationHistory: boolean
   sidebarOpen: boolean
   templateModels: {
     [key: string]: {
@@ -34,6 +33,7 @@ export interface Settings {
 type StoredSettings = Partial<Settings> & {
   schemaVersion?: string
   interactiveMode?: boolean
+  includeImageGenerationHistory?: unknown
 }
 
 const defaultSettings: Settings = {
@@ -54,7 +54,6 @@ const defaultSettings: Settings = {
   includeChatHistory: true,
   sendImagesOnlyOnce: true,
   imageGenerationMode: false,
-  includeImageGenerationHistory: true,
   sidebarOpen: true,
   templateModels: {},
 }
@@ -109,8 +108,19 @@ function parseStoredSettings(value: string | null): StoredSettings | null {
   }
 }
 
-function mergeSettings(settings: Partial<Settings> & { interactiveMode?: unknown; mcpServerURLs?: unknown }): Settings {
-  const { interactiveMode, mcpServerURLs: _dropped, ...rest } = settings
+function mergeSettings(
+  settings: Partial<Settings> & {
+    interactiveMode?: unknown
+    mcpServerURLs?: unknown
+    includeImageGenerationHistory?: unknown
+  }
+): Settings {
+  const {
+    interactiveMode,
+    mcpServerURLs: _dropped,
+    includeImageGenerationHistory: _legacyImageGenerationHistory,
+    ...rest
+  } = settings
   const apiMode = normalizeApiMode(rest.apiMode)
   const includeChatHistory =
     rest.includeChatHistory ??
@@ -165,7 +175,7 @@ function shouldPersistNormalizedSettings(
     'interactiveMode' in settings ||
     settings.sendImagesOnlyOnce !== normalized.sendImagesOnlyOnce ||
     settings.imageGenerationMode !== normalized.imageGenerationMode ||
-    settings.includeImageGenerationHistory !== normalized.includeImageGenerationHistory ||
+    'includeImageGenerationHistory' in settings ||
     'mcpServerURLs' in settings
   )
 }

--- a/projects/portfolio/src/server/app.tsx
+++ b/projects/portfolio/src/server/app.tsx
@@ -3,6 +3,7 @@ import { Hono } from 'hono'
 import type { MiddlewareHandler } from 'hono'
 import { requestId } from 'hono/request-id'
 import type pino from 'pino'
+import { resolveFileServerPublicOrigin } from './features/chat-conversations/file-server-client'
 import { getErrorMessage } from './lib/error-message'
 import { logger } from './lib/logger'
 import { AuthenticationError, authRoutes } from './routes/auth'
@@ -12,19 +13,25 @@ import { htmlRoutes } from './routes/html'
 import { modelsRoutes } from './routes/models'
 import { promptTemplatesRoutes } from './routes/prompt-templates'
 import type { HonoEnv } from './routes/shared'
+import { getServerEnv } from './routes/shared'
 
 const securityHeaders = {
-  'Content-Security-Policy':
-    "base-uri 'self'; default-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; script-src 'self' 'unsafe-inline'; worker-src 'self'; img-src 'self' data: https:; connect-src 'self'; frame-src 'self'",
   'X-Content-Type-Options': 'nosniff',
   'X-Frame-Options': 'DENY',
   'Referrer-Policy': 'strict-origin-when-cross-origin',
   'Permissions-Policy': 'camera=(), microphone=(), geolocation=(), payment=(), usb=(), display-capture=()',
 } as const
 
+function buildContentSecurityPolicy(fileServerPublicOrigin: string | null): string {
+  const imageOrigin = fileServerPublicOrigin ? ` ${fileServerPublicOrigin}` : ''
+
+  return `base-uri 'self'; default-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; script-src 'self' 'unsafe-inline'; worker-src 'self'; img-src 'self' data: https:${imageOrigin}; connect-src 'self'; frame-src 'self'`
+}
+
 const applySecurityHeaders: MiddlewareHandler<HonoEnv> = async (c, next) => {
   await next()
 
+  c.header('Content-Security-Policy', buildContentSecurityPolicy(resolveFileServerPublicOrigin(getServerEnv(c))))
   for (const [name, value] of Object.entries(securityHeaders)) {
     c.header(name, value)
   }

--- a/projects/portfolio/src/server/features/chat-conversations/file-server-client.ts
+++ b/projects/portfolio/src/server/features/chat-conversations/file-server-client.ts
@@ -38,6 +38,31 @@ export function resolveFileServerPublicBaseUrl(env: Pick<FileServerEnv, 'FILE_SE
   return baseUrl.replace(/\/$/, '')
 }
 
+export function resolveFileServerPublicOrigin(env: Pick<FileServerEnv, 'FILE_SERVER_PUBLIC_URL'>): string | null {
+  const baseUrl = resolveFileServerPublicBaseUrl(env)
+
+  if (!baseUrl) {
+    return null
+  }
+
+  try {
+    const url = new URL(baseUrl)
+
+    if (!['http:', 'https:'].includes(url.protocol) || url.username || url.password) {
+      return null
+    }
+
+    const origin = url.origin
+    if (!/^https?:\/\/(?:[a-z\d.-]+|\[[0-9a-f:.]+\])(?::\d+)?$/i.test(origin)) {
+      return null
+    }
+
+    return origin
+  } catch {
+    return null
+  }
+}
+
 export function buildFileServerPreviewUrl(publicBaseUrl: string, publicPath: string): string {
   return `${publicBaseUrl}${publicPath}`
 }

--- a/projects/portfolio/src/server/features/chat-conversations/read-conversations.ts
+++ b/projects/portfolio/src/server/features/chat-conversations/read-conversations.ts
@@ -7,6 +7,7 @@ import type {
   AssistantMetadata,
   Conversation,
   GeneratedCodeFile,
+  GeneratedImage,
   ImageContent,
   Message,
   TextContent,
@@ -72,17 +73,44 @@ function normalizeGeneratedFiles(
   })
 }
 
+function normalizeGeneratedImages(
+  images: unknown,
+  fileServerPublicBaseUrl?: string | null
+): GeneratedImage[] | undefined {
+  if (!Array.isArray(images)) {
+    return undefined
+  }
+
+  return images.map((image) => {
+    if (!image || typeof image !== 'object') {
+      return image as GeneratedImage
+    }
+
+    const generatedImage = image as GeneratedImage
+    if (!fileServerPublicBaseUrl || !generatedImage.publicPath) {
+      return generatedImage
+    }
+
+    return {
+      ...generatedImage,
+      previewUrl: buildFileServerPreviewUrl(fileServerPublicBaseUrl, generatedImage.publicPath),
+    }
+  })
+}
+
 function normalizeAssistantMetadata(metadata: unknown, fileServerPublicBaseUrl?: string | null): AssistantMetadata {
   const base = (metadata ?? {}) as AssistantMetadata
   const generatedFiles = normalizeGeneratedFiles(base.generatedFiles, fileServerPublicBaseUrl)
+  const generatedImages = normalizeGeneratedImages(base.generatedImages, fileServerPublicBaseUrl)
 
-  if (!generatedFiles) {
+  if (!generatedFiles && !generatedImages) {
     return base
   }
 
   return {
     ...base,
-    generatedFiles,
+    ...(generatedFiles ? { generatedFiles } : {}),
+    ...(generatedImages ? { generatedImages } : {}),
   }
 }
 

--- a/projects/portfolio/src/server/features/chat-conversations/save-generated-image.ts
+++ b/projects/portfolio/src/server/features/chat-conversations/save-generated-image.ts
@@ -1,0 +1,57 @@
+import {
+  buildFileServerPreviewUrl,
+  loginToFileServer,
+  type FileServerConfig,
+  uploadFileToFileServer,
+} from '#/server/features/chat-conversations/file-server-client'
+import { logger } from '#/server/lib/logger'
+import type { GeneratedImage } from '#/types'
+
+export type SaveGeneratedImageResult =
+  | { ok: true; image: GeneratedImage }
+  | { ok: false; reason: 'file-server-unavailable' | 'upload-failed' }
+
+interface SaveGeneratedImageParams {
+  conversationId: string
+  assistantMessageId: string
+  content: ArrayBuffer
+  contentType: 'image/png'
+  createdAt: string
+}
+
+export async function saveGeneratedImage(
+  params: SaveGeneratedImageParams,
+  fileServerConfig: FileServerConfig | null
+): Promise<SaveGeneratedImageResult> {
+  if (!fileServerConfig) {
+    return { ok: false, reason: 'file-server-unavailable' }
+  }
+
+  const fileName = `${params.assistantMessageId}-image-0.png`
+  const publicPath = `/public/portfolio/${params.conversationId}/${fileName}`
+  const virtualPath = publicPath.slice(1)
+
+  try {
+    const session = await loginToFileServer(fileServerConfig)
+    await uploadFileToFileServer(fileServerConfig, session, {
+      fileName,
+      content: params.content,
+      contentType: params.contentType,
+      path: virtualPath,
+    })
+  } catch (error) {
+    logger.error({ err: error }, 'failed to upload generated image to file-server')
+    return { ok: false, reason: 'upload-failed' }
+  }
+
+  return {
+    ok: true,
+    image: {
+      fileName,
+      publicPath,
+      previewUrl: buildFileServerPreviewUrl(fileServerConfig.publicBaseUrl, publicPath),
+      contentType: params.contentType,
+      createdAt: params.createdAt,
+    },
+  }
+}

--- a/projects/portfolio/src/server/features/image-generation/image-generation.ts
+++ b/projects/portfolio/src/server/features/image-generation/image-generation.ts
@@ -3,6 +3,7 @@ import type { ImageGenerationUsage } from '#/types/image-generation-api'
 
 export const IMAGE_GENERATION_MODEL = 'gpt-image-2'
 export const IMAGE_GENERATION_SIZE = '1024x1024'
+export const IMAGE_GENERATION_OUTPUT_FORMAT = 'png' as const
 export const IMAGE_GENERATION_CONTENT_TYPE = 'image/png' as const
 
 export interface GeneratedImagePayload {
@@ -28,7 +29,7 @@ export async function generateImage({
     prompt,
     n: 1,
     size: IMAGE_GENERATION_SIZE,
-    output_format: 'png',
+    output_format: IMAGE_GENERATION_OUTPUT_FORMAT,
   })
 
   const image = response.data?.[0]

--- a/projects/portfolio/src/server/features/image-generation/image-generation.ts
+++ b/projects/portfolio/src/server/features/image-generation/image-generation.ts
@@ -1,0 +1,53 @@
+import OpenAI from 'openai'
+import type { ImageGenerationUsage } from '#/types/image-generation-api'
+
+export const IMAGE_GENERATION_MODEL = 'gpt-image-2'
+export const IMAGE_GENERATION_SIZE = '1024x1024'
+export const IMAGE_GENERATION_CONTENT_TYPE = 'image/png' as const
+
+export interface GeneratedImagePayload {
+  id: string
+  created: number
+  model: string
+  content: ArrayBuffer
+  usage: ImageGenerationUsage
+}
+
+export async function generateImage({
+  apiKey,
+  baseURL,
+  prompt,
+}: {
+  apiKey: string
+  baseURL: string
+  prompt: string
+}): Promise<GeneratedImagePayload> {
+  const openai = new OpenAI({ apiKey, baseURL })
+  const response = await openai.images.generate({
+    model: IMAGE_GENERATION_MODEL,
+    prompt,
+    n: 1,
+    size: IMAGE_GENERATION_SIZE,
+    output_format: 'png',
+  })
+
+  const image = response.data?.[0]
+  if (!image?.b64_json) {
+    throw new Error('Image provider returned no image data')
+  }
+
+  const bytes = Buffer.from(image.b64_json, 'base64')
+  const content = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer
+
+  return {
+    id: `image_${response.created}`,
+    created: response.created,
+    model: IMAGE_GENERATION_MODEL,
+    content,
+    usage: {
+      inputTokens: response.usage?.input_tokens,
+      outputTokens: response.usage?.output_tokens,
+      totalTokens: response.usage?.total_tokens,
+    },
+  }
+}

--- a/projects/portfolio/src/server/lib/chat-error.ts
+++ b/projects/portfolio/src/server/lib/chat-error.ts
@@ -6,6 +6,7 @@ export type UpstreamErrorDetails = {
   type?: string
   code?: string
   param?: string
+  requestId?: string
   message?: string
 }
 
@@ -56,6 +57,21 @@ const errorDefinitions: Record<Exclude<ChatErrorCode, 'VALIDATION_ERROR'>, Omit<
       '生成画像を保存できませんでした。file-server のログイン・アップロード設定と接続状態を確認して再試行してください。',
     retryable: true,
   },
+  IMAGE_MODEL_ENDPOINT_INCOMPATIBLE: {
+    message:
+      '画像生成プロバイダーがモデルまたはエンドポイントに対応していません。base URL の /images/generations 対応と gpt-image-2 の利用可否を確認してください。',
+    retryable: false,
+  },
+  IMAGE_REQUEST_INVALID: {
+    message:
+      '画像生成リクエストのパラメータが受け付けられませんでした。プロバイダーが受け付ける model・size・output format・n・prompt を確認してください。',
+    retryable: false,
+  },
+  IMAGE_PROVIDER_REJECTED: {
+    message:
+      '画像生成プロバイダーにリクエストを拒否されました。prompt の内容とプロバイダーの安全基準・利用制限を確認してください。',
+    retryable: false,
+  },
 }
 
 export const validationError = (message: string): ChatError => ({
@@ -78,6 +94,39 @@ export const imageStorageFailedError = (): ChatError => ({
   code: 'IMAGE_STORAGE_FAILED',
   ...errorDefinitions.IMAGE_STORAGE_FAILED,
 })
+
+export function toImageGenerationChatError(error: unknown): ChatError {
+  const details = getErrorDetails(error)
+  const code = classifyImageGenerationError(details)
+
+  return {
+    code,
+    ...errorDefinitions[code],
+  }
+}
+
+export function getSafeUpstreamErrorLogFields(error: unknown): Record<string, string | number | boolean> {
+  const details = getErrorDetails(error)
+  const fields: Record<string, string | number | boolean> = {}
+
+  if (isHttpStatus(details.status)) fields.status = details.status
+
+  const code = readSafeDiagnosticValue(details.code)
+  if (code) fields.code = code
+
+  const type = readSafeDiagnosticValue(details.type)
+  if (type) fields.type = type
+
+  const param = readSafeDiagnosticValue(details.param)
+  if (param) fields.param = param
+
+  const requestId = readSafeDiagnosticValue(details.requestId)
+  if (requestId) fields.requestId = requestId
+
+  if (details.connectionError) fields.connectionError = true
+
+  return fields
+}
 
 export const conversationPersistenceError = (): ChatError => ({
   code: 'UPSTREAM_UNAVAILABLE',
@@ -104,6 +153,7 @@ type ErrorDetails = {
   type: string
   code: string
   param: string
+  requestId: string
   message: string
   connectionError: boolean
 }
@@ -115,15 +165,74 @@ function getErrorDetails(error: unknown): ErrorDetails {
 
   return {
     status: apiError?.status ?? upstreamError?.status,
-    type: readString(body?.type),
-    code: readString(body?.code),
-    param: readString(body?.param),
+    type: readString(apiError?.type) || readString(body?.type),
+    code: readString(apiError?.code) || readString(body?.code),
+    param: readString(apiError?.param) || readString(body?.param),
+    requestId: readString(apiError?.requestID) || readString(upstreamError?.requestId),
     message: [readString(body?.message), error instanceof Error ? error.message : '']
       .filter(Boolean)
       .join('\n')
       .toLowerCase(),
     connectionError: error instanceof APIConnectionError || error instanceof APIConnectionTimeoutError,
   }
+}
+
+function classifyImageGenerationError(details: ErrorDetails): Exclude<ChatErrorCode, 'VALIDATION_ERROR'> {
+  const genericCode = classifyError(details)
+
+  if (!['INVALID_REQUEST', 'UNKNOWN_UPSTREAM_ERROR'].includes(genericCode)) {
+    return genericCode
+  }
+
+  if (isImageProviderRejection(details)) {
+    return 'IMAGE_PROVIDER_REJECTED'
+  }
+
+  if (isImageModelEndpointIncompatible(details)) {
+    return 'IMAGE_MODEL_ENDPOINT_INCOMPATIBLE'
+  }
+
+  return genericCode === 'INVALID_REQUEST' ? 'IMAGE_REQUEST_INVALID' : genericCode
+}
+
+function isImageProviderRejection({ type, code, message }: ErrorDetails): boolean {
+  const structuredSignals = `${type}\n${code}`.toLowerCase()
+  if (
+    /moderation[_\s-]?blocked|content[_\s-]?(?:policy|filter)|policy[_\s-]?violation|image[_\s-]?generation[_\s-]?user[_\s-]?error|safety[_\s-]?(?:violation|blocked|filter)|(?:^|\n)blocked(?:$|\n)/.test(
+      structuredSignals
+    )
+  ) {
+    return true
+  }
+
+  const messageSignals = message.toLowerCase()
+  return /(?:prompt|content|image|moderation).*(?:blocked|rejected|filtered|policy|safety|violation)|(?:blocked|rejected|filtered).*(?:prompt|content|image)/.test(
+    messageSignals
+  )
+}
+
+function isImageModelEndpointIncompatible({ status, type, code, param, message }: ErrorDetails): boolean {
+  if (status === 404 || status === 405) return true
+
+  const signals = `${type}\n${code}\n${param}\n${message}`.toLowerCase()
+  const normalizedParam = param.toLowerCase()
+
+  return (
+    normalizedParam === 'model' ||
+    normalizedParam === 'endpoint' ||
+    /(?:model|endpoint|route|path).*(?:not found|not supported|unsupported|unavailable)|(?:not found|not supported|unsupported|unavailable).*(?:model|endpoint|route|path)|does not support.*(?:model|image|endpoint)|image.*(?:not supported|unsupported)/.test(
+      signals
+    )
+  )
+}
+
+function isHttpStatus(value: number | undefined): value is number {
+  return value !== undefined && Number.isInteger(value) && value >= 100 && value <= 599
+}
+
+function readSafeDiagnosticValue(value: unknown): string | undefined {
+  const normalized = readString(value).trim()
+  return /^[A-Za-z0-9][A-Za-z0-9._:/-]{0,119}$/.test(normalized) ? normalized : undefined
 }
 
 function classifyError({

--- a/projects/portfolio/src/server/lib/chat-error.ts
+++ b/projects/portfolio/src/server/lib/chat-error.ts
@@ -46,6 +46,16 @@ const errorDefinitions: Record<Exclude<ChatErrorCode, 'VALIDATION_ERROR'>, Omit<
     message: 'LLM の応答取得中にエラーが発生しました。しばらく待ってから再試行してください。',
     retryable: true,
   },
+  IMAGE_STORAGE_NOT_CONFIGURED: {
+    message:
+      '生成画像の保存先が未設定です。file-server の接続先・公開 URL・管理者ユーザー名・パスワードを確認してください。',
+    retryable: false,
+  },
+  IMAGE_STORAGE_FAILED: {
+    message:
+      '生成画像を保存できませんでした。file-server のログイン・アップロード設定と接続状態を確認して再試行してください。',
+    retryable: true,
+  },
 }
 
 export const validationError = (message: string): ChatError => ({
@@ -57,6 +67,16 @@ export const validationError = (message: string): ChatError => ({
 export const unavailableChatError = (): ChatError => ({
   code: 'UPSTREAM_UNAVAILABLE',
   ...errorDefinitions.UPSTREAM_UNAVAILABLE,
+})
+
+export const imageStorageNotConfiguredError = (): ChatError => ({
+  code: 'IMAGE_STORAGE_NOT_CONFIGURED',
+  ...errorDefinitions.IMAGE_STORAGE_NOT_CONFIGURED,
+})
+
+export const imageStorageFailedError = (): ChatError => ({
+  code: 'IMAGE_STORAGE_FAILED',
+  ...errorDefinitions.IMAGE_STORAGE_FAILED,
 })
 
 export const conversationPersistenceError = (): ChatError => ({

--- a/projects/portfolio/src/server/routes/chat.ts
+++ b/projects/portfolio/src/server/routes/chat.ts
@@ -12,11 +12,19 @@ import { chatStub } from '#/server/features/chat-stub/chat-stub'
 import { chat } from '#/server/features/chat/chat'
 import { convertCompletion, convertStreamChunks } from '#/server/features/chat/converter'
 import type { CompletionChunk, ResponsesStreamChunk, StreamChunk } from '#/server/features/chat/transport'
-import { generateImage, IMAGE_GENERATION_CONTENT_TYPE } from '#/server/features/image-generation/image-generation'
 import {
+  generateImage,
+  IMAGE_GENERATION_CONTENT_TYPE,
+  IMAGE_GENERATION_MODEL,
+  IMAGE_GENERATION_OUTPUT_FORMAT,
+  IMAGE_GENERATION_SIZE,
+} from '#/server/features/image-generation/image-generation'
+import {
+  getSafeUpstreamErrorLogFields,
   imageStorageFailedError,
   imageStorageNotConfiguredError,
   toChatError,
+  toImageGenerationChatError,
   validationError,
 } from '#/server/lib/chat-error'
 import { logger } from '#/server/lib/logger'
@@ -267,8 +275,21 @@ const chatRoutes = new Hono<HonoEnv>()
         usage: generated.usage,
       })
     } catch (error) {
-      const chatError = toChatError(error)
-      requestLogger.error({ code: chatError.code }, 'Image generation failed')
+      const chatError = toImageGenerationChatError(error)
+      requestLogger.error(
+        {
+          errorCode: chatError.code,
+          provider: getSafeUpstreamErrorLogFields(error),
+          request: {
+            endpoint: '/images/generations',
+            model: IMAGE_GENERATION_MODEL,
+            size: IMAGE_GENERATION_SIZE,
+            outputFormat: IMAGE_GENERATION_OUTPUT_FORMAT,
+            count: 1,
+          },
+        },
+        'Image generation failed'
+      )
       return c.json(chatError, 502)
     }
   })

--- a/projects/portfolio/src/server/routes/chat.ts
+++ b/projects/portfolio/src/server/routes/chat.ts
@@ -13,7 +13,12 @@ import { chat } from '#/server/features/chat/chat'
 import { convertCompletion, convertStreamChunks } from '#/server/features/chat/converter'
 import type { CompletionChunk, ResponsesStreamChunk, StreamChunk } from '#/server/features/chat/transport'
 import { generateImage, IMAGE_GENERATION_CONTENT_TYPE } from '#/server/features/image-generation/image-generation'
-import { toChatError, unavailableChatError, validationError } from '#/server/lib/chat-error'
+import {
+  imageStorageFailedError,
+  imageStorageNotConfiguredError,
+  toChatError,
+  validationError,
+} from '#/server/lib/chat-error'
 import { logger } from '#/server/lib/logger'
 import { ApiChatMessageSchema, type ApiMode } from '#/types'
 import {
@@ -226,7 +231,7 @@ const chatRoutes = new Hono<HonoEnv>()
     const requestLogger = c.var.logger ?? logger
 
     if (!fileServerConfig) {
-      return c.json(unavailableChatError(), 503)
+      return c.json(imageStorageNotConfiguredError(), 503)
     }
 
     try {
@@ -248,7 +253,10 @@ const chatRoutes = new Hono<HonoEnv>()
 
       if (!saved.ok) {
         requestLogger.error({ reason: saved.reason }, 'Generated image was not persisted')
-        return c.json(unavailableChatError(), 502)
+        if (saved.reason === 'file-server-unavailable') {
+          return c.json(imageStorageNotConfiguredError(), 503)
+        }
+        return c.json(imageStorageFailedError(), 502)
       }
 
       return c.json({
@@ -259,8 +267,9 @@ const chatRoutes = new Hono<HonoEnv>()
         usage: generated.usage,
       })
     } catch (error) {
-      requestLogger.error({ err: error }, 'Image generation failed')
-      return c.json(toChatError(error), 502)
+      const chatError = toChatError(error)
+      requestLogger.error({ code: chatError.code }, 'Image generation failed')
+      return c.json(chatError, 502)
     }
   })
   // 非ストリーム専用

--- a/projects/portfolio/src/server/routes/chat.ts
+++ b/projects/portfolio/src/server/routes/chat.ts
@@ -5,12 +5,15 @@ import { Hono } from 'hono'
 import { streamSSE } from 'hono/streaming'
 import { validator } from 'hono/validator'
 import { z } from 'zod'
+import { resolveFileServerConfig } from '#/server/features/chat-conversations/file-server-client'
+import { saveGeneratedImage } from '#/server/features/chat-conversations/save-generated-image'
 import { chatSessionManager, isTerminalSessionEvent } from '#/server/features/chat-sessions/session-manager'
 import { chatStub } from '#/server/features/chat-stub/chat-stub'
 import { chat } from '#/server/features/chat/chat'
 import { convertCompletion, convertStreamChunks } from '#/server/features/chat/converter'
 import type { CompletionChunk, ResponsesStreamChunk, StreamChunk } from '#/server/features/chat/transport'
-import { toChatError, validationError } from '#/server/lib/chat-error'
+import { generateImage, IMAGE_GENERATION_CONTENT_TYPE } from '#/server/features/image-generation/image-generation'
+import { toChatError, unavailableChatError, validationError } from '#/server/lib/chat-error'
 import { logger } from '#/server/lib/logger'
 import { ApiChatMessageSchema, type ApiMode } from '#/types'
 import {
@@ -19,6 +22,7 @@ import {
   type ChatApiRequest,
   type ChatSessionEvent,
 } from '#/types/chat-api'
+import { ImageGenerationRequestSchema } from '#/types/image-generation-api'
 import type { HonoEnv } from './shared'
 import { getServerEnv, getSignedInEmail } from './shared'
 
@@ -85,6 +89,15 @@ const formatValidationPath = (path: unknown): string => {
 }
 
 const chatBodyValidator = sValidator('json', ChatApiRequestSchema, (result, c) => {
+  if (result.success) return
+
+  const issue = result.error[0]
+  const fieldName = formatValidationPath(issue?.path)
+
+  return c.json(validationError(`Invalid request body '${fieldName}'`), 400)
+})
+
+const imageGenerationBodyValidator = sValidator('json', ImageGenerationRequestSchema, (result, c) => {
   if (result.success) return
 
   const issue = result.error[0]
@@ -206,6 +219,50 @@ const streamStubCompletion = (
   })
 
 const chatRoutes = new Hono<HonoEnv>()
+  .post('/api/image/generations', chatHeaderValidator, imageGenerationBodyValidator, async (c) => {
+    const header = c.req.valid('header')
+    const req = c.req.valid('json')
+    const fileServerConfig = resolveFileServerConfig(getServerEnv(c))
+    const requestLogger = c.var.logger ?? logger
+
+    if (!fileServerConfig) {
+      return c.json(unavailableChatError(), 503)
+    }
+
+    try {
+      const generated = await generateImage({
+        apiKey: header['api-key'],
+        baseURL: header['base-url'],
+        prompt: req.prompt,
+      })
+      const saved = await saveGeneratedImage(
+        {
+          conversationId: req.conversationId,
+          assistantMessageId: req.assistantMessageId,
+          content: generated.content,
+          contentType: IMAGE_GENERATION_CONTENT_TYPE,
+          createdAt: new Date(generated.created * 1000).toISOString(),
+        },
+        fileServerConfig
+      )
+
+      if (!saved.ok) {
+        requestLogger.error({ reason: saved.reason }, 'Generated image was not persisted')
+        return c.json(unavailableChatError(), 502)
+      }
+
+      return c.json({
+        id: generated.id,
+        created: generated.created,
+        model: generated.model,
+        image: saved.image,
+        usage: generated.usage,
+      })
+    } catch (error) {
+      requestLogger.error({ err: error }, 'Image generation failed')
+      return c.json(toChatError(error), 502)
+    }
+  })
   // 非ストリーム専用
   .post('/api/chat', chatHeaderValidator, chatBodyValidator, async (c) => {
     const header = c.req.valid('header')

--- a/projects/portfolio/src/server/routes/conversations.ts
+++ b/projects/portfolio/src/server/routes/conversations.ts
@@ -7,7 +7,7 @@ import {
 } from '#/server/features/chat-conversations/file-server-client'
 import { chatConversationRepository } from '#/server/features/chat-conversations/repository'
 import { requireAuth } from '#/server/middleware/auth'
-import { ApiModeSchema, ConversationSchema, GeneratedCodeFileSchema } from '#/types'
+import { ApiModeSchema, ConversationSchema, GeneratedCodeFileSchema, GeneratedImageSchema } from '#/types'
 import type { HonoEnv } from './shared'
 import { getServerEnv } from './shared'
 
@@ -30,6 +30,7 @@ const AssistantMetadataPatchSchema = z
       })
       .optional(),
     generatedFiles: z.array(GeneratedCodeFileSchema).optional(),
+    generatedImages: z.array(GeneratedImageSchema).optional(),
   })
   .strict()
 

--- a/projects/portfolio/src/types/chat-api.ts
+++ b/projects/portfolio/src/types/chat-api.ts
@@ -63,6 +63,9 @@ export const ChatErrorCodeSchema = z.enum([
   'UNKNOWN_UPSTREAM_ERROR',
   'IMAGE_STORAGE_NOT_CONFIGURED',
   'IMAGE_STORAGE_FAILED',
+  'IMAGE_MODEL_ENDPOINT_INCOMPATIBLE',
+  'IMAGE_REQUEST_INVALID',
+  'IMAGE_PROVIDER_REJECTED',
 ])
 
 export type ChatErrorCode = z.infer<typeof ChatErrorCodeSchema>

--- a/projects/portfolio/src/types/chat-api.ts
+++ b/projects/portfolio/src/types/chat-api.ts
@@ -61,6 +61,8 @@ export const ChatErrorCodeSchema = z.enum([
   'INVALID_REQUEST',
   'UPSTREAM_UNAVAILABLE',
   'UNKNOWN_UPSTREAM_ERROR',
+  'IMAGE_STORAGE_NOT_CONFIGURED',
+  'IMAGE_STORAGE_FAILED',
 ])
 
 export type ChatErrorCode = z.infer<typeof ChatErrorCodeSchema>

--- a/projects/portfolio/src/types/chat.ts
+++ b/projects/portfolio/src/types/chat.ts
@@ -74,7 +74,6 @@ export const UserMetadataSchema = z
     reasoningEffort: ReasoningEffortSchema.optional(),
     sendImagesOnlyOnce: z.boolean().optional(),
     imageGenerationMode: z.boolean().optional(),
-    includeImageGenerationHistory: z.boolean().optional(),
   })
   .catch({ model: '' })
 

--- a/projects/portfolio/src/types/chat.ts
+++ b/projects/portfolio/src/types/chat.ts
@@ -73,6 +73,8 @@ export const UserMetadataSchema = z
     maxTokens: z.number().optional(),
     reasoningEffort: ReasoningEffortSchema.optional(),
     sendImagesOnlyOnce: z.boolean().optional(),
+    imageGenerationMode: z.boolean().optional(),
+    includeImageGenerationHistory: z.boolean().optional(),
   })
   .catch({ model: '' })
 
@@ -101,6 +103,17 @@ export const GeneratedCodeFileSchema = z.object({
 
 export type GeneratedCodeFile = z.infer<typeof GeneratedCodeFileSchema>
 
+/** file-server に保存した生成画像の公開メタデータ。画像本体は含めない。 */
+export const GeneratedImageSchema = z.object({
+  fileName: z.string(),
+  publicPath: z.string(),
+  previewUrl: z.string().optional(),
+  contentType: z.string(),
+  createdAt: z.string(),
+})
+
+export type GeneratedImage = z.infer<typeof GeneratedImageSchema>
+
 export const AssistantMetadataSchema = z
   .object({
     model: z.string().catch(''),
@@ -116,6 +129,7 @@ export const AssistantMetadataSchema = z
       })
       .catch({}),
     generatedFiles: z.array(GeneratedCodeFileSchema).optional(),
+    generatedImages: z.array(GeneratedImageSchema).optional(),
     imageContext: ImageContextSummarySchema.optional(),
     apiContextMessages: z.array(ApiChatMessageSchema).optional(),
   })

--- a/projects/portfolio/src/types/image-generation-api.ts
+++ b/projects/portfolio/src/types/image-generation-api.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod'
+import { GeneratedImageSchema } from './chat'
+
+export const ImageGenerationRequestSchema = z.object({
+  prompt: z.string().trim().min(1).max(32000),
+  conversationId: z.string().regex(/^[A-Za-z0-9_-]+$/),
+  assistantMessageId: z.string().regex(/^[A-Za-z0-9_-]+$/),
+})
+
+export type ImageGenerationRequest = z.infer<typeof ImageGenerationRequestSchema>
+
+export const ImageGenerationUsageSchema = z.object({
+  inputTokens: z.number().int().nonnegative().optional(),
+  outputTokens: z.number().int().nonnegative().optional(),
+  totalTokens: z.number().int().nonnegative().optional(),
+})
+
+export type ImageGenerationUsage = z.infer<typeof ImageGenerationUsageSchema>
+
+export const ImageGenerationResponseSchema = z.object({
+  id: z.string(),
+  created: z.number(),
+  model: z.string(),
+  image: GeneratedImageSchema,
+  usage: ImageGenerationUsageSchema,
+})
+
+export type ImageGenerationResponse = z.infer<typeof ImageGenerationResponseSchema>

--- a/projects/portfolio/src/types/index.ts
+++ b/projects/portfolio/src/types/index.ts
@@ -9,6 +9,7 @@ export {
   UserMetadataSchema,
   AssistantMetadataSchema,
   GeneratedCodeFileSchema,
+  GeneratedImageSchema,
   ImageContextSummarySchema,
   ApiModeSchema,
   ReasoningEffortSchema,
@@ -26,6 +27,7 @@ export {
   type UserMetadata,
   type AssistantMetadata,
   type GeneratedCodeFile,
+  type GeneratedImage,
   type ImageContextSummary,
   type ApiMode,
   type ReasoningEffort,
@@ -66,3 +68,12 @@ export {
   type ChatError,
   type ChatErrorResponse,
 } from './chat-api.js'
+
+export {
+  ImageGenerationRequestSchema,
+  ImageGenerationResponseSchema,
+  ImageGenerationUsageSchema,
+  type ImageGenerationRequest,
+  type ImageGenerationResponse,
+  type ImageGenerationUsage,
+} from './image-generation-api.js'

--- a/projects/portfolio/tests/app.test.tsx
+++ b/projects/portfolio/tests/app.test.tsx
@@ -105,4 +105,59 @@ describe('app', () => {
     expect(res.status).toBe(200)
     expectSecurityHeaders(res)
   })
+
+  describe('Content-Security-Policy img-src', () => {
+    it('FILE_SERVER_PUBLIC_URL の http originだけを追加し、pathとqueryを含めない', async () => {
+      vi.stubEnv('FILE_SERVER_PUBLIC_URL', 'http://files.example.com/public/portfolio?cache=1')
+      const { app } = await importSubject()
+      const res = await app.request('/auth-ok')
+      const policy = res.headers.get('Content-Security-Policy')
+
+      expect(policy).toContain("img-src 'self' data: https: http://files.example.com;")
+      expect(policy).not.toContain('/public/portfolio')
+      expect(policy).not.toContain('?cache=1')
+      expect(policy).toContain("connect-src 'self'; frame-src 'self'")
+      expect(policy).not.toContain("connect-src 'self' http://files.example.com")
+    })
+
+    it('FILE_SERVER_PUBLIC_URL が空または未設定なら file-server originを追加しない', async () => {
+      const { app: unsetApp } = await importSubject()
+      const unsetResponse = await unsetApp.request('/auth-ok')
+      expect(unsetResponse.headers.get('Content-Security-Policy')).toBe(
+        "base-uri 'self'; default-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; script-src 'self' 'unsafe-inline'; worker-src 'self'; img-src 'self' data: https:; connect-src 'self'; frame-src 'self'"
+      )
+
+      vi.stubEnv('FILE_SERVER_PUBLIC_URL', '')
+      const { app } = await importSubject()
+      const response = await app.request('/auth-ok')
+
+      expect(response.headers.get('Content-Security-Policy')).toBe(
+        "base-uri 'self'; default-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; script-src 'self' 'unsafe-inline'; worker-src 'self'; img-src 'self' data: https:; connect-src 'self'; frame-src 'self'"
+      )
+    })
+
+    it('不正な URL または非 HTTP(S) URLを img-src に追加しない', async () => {
+      vi.stubEnv('FILE_SERVER_PUBLIC_URL', 'not a url')
+      const { app: invalidApp } = await importSubject()
+      const invalidResponse = await invalidApp.request('/auth-ok')
+      expect(invalidResponse.headers.get('Content-Security-Policy')).not.toContain('not a url')
+
+      vi.stubEnv('FILE_SERVER_PUBLIC_URL', 'ftp://files.example.com/public')
+      const { app } = await importSubject()
+      const response = await app.request('/auth-ok')
+
+      expect(response.headers.get('Content-Security-Policy')).not.toContain('ftp://files.example.com')
+      expect(response.headers.get('Content-Security-Policy')).toContain("img-src 'self' data: https:;")
+    })
+
+    it('credentials付きURLを追加せず、既存のsecurity directivesとconnect-srcを維持する', async () => {
+      vi.stubEnv('FILE_SERVER_PUBLIC_URL', 'http://user:password@files.example.com:8010/public')
+      const { app } = await importSubject()
+      const res = await app.request('/auth-ok')
+
+      expect(res.headers.get('Content-Security-Policy')).toBe(
+        "base-uri 'self'; default-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; script-src 'self' 'unsafe-inline'; worker-src 'self'; img-src 'self' data: https:; connect-src 'self'; frame-src 'self'"
+      )
+    })
+  })
 })

--- a/projects/portfolio/tests/client/components/chat-composer.test.tsx
+++ b/projects/portfolio/tests/client/components/chat-composer.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { useState } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { ChatComposer } from '#/client/features/chat/components/chat-composer'
 
@@ -54,5 +55,29 @@ describe('ChatComposer', () => {
     render(<ChatComposer {...defaultProps} imageGenerationMode={true} />)
 
     expect(screen.getByRole('button', { name: '画像生成モード On/Off' }).textContent).toContain('画像生成 On')
+  })
+
+  it('画像モードの履歴バッジは共有 Include chat history の値を表示・更新する', () => {
+    function ComposerWithSharedHistory() {
+      const [includeChatHistory, setIncludeChatHistory] = useState(false)
+
+      return (
+        <ChatComposer
+          {...defaultProps}
+          imageGenerationMode={true}
+          includeChatHistory={includeChatHistory}
+          onToggleChatHistory={() => setIncludeChatHistory((current) => !current)}
+        />
+      )
+    }
+
+    render(<ComposerWithSharedHistory />)
+
+    const historyButton = screen.getByRole('button', { name: '画像生成 prompt 履歴 On/Off' })
+    expect(historyButton.textContent).toContain('履歴 Off')
+
+    fireEvent.click(historyButton)
+
+    expect(historyButton.textContent).toContain('履歴 On')
   })
 })

--- a/projects/portfolio/tests/client/components/chat-composer.test.tsx
+++ b/projects/portfolio/tests/client/components/chat-composer.test.tsx
@@ -49,4 +49,10 @@ describe('ChatComposer', () => {
     expect(buttons.at(-1)?.disabled).toBe(false)
     expect(screen.getByRole('textbox')).toBeTruthy()
   })
+
+  it('画像生成モード時は下部の On バッジを表示する', () => {
+    render(<ChatComposer {...defaultProps} imageGenerationMode={true} />)
+
+    expect(screen.getByRole('button', { name: '画像生成モード On/Off' }).textContent).toContain('画像生成 On')
+  })
 })

--- a/projects/portfolio/tests/client/components/chat-main.test.tsx
+++ b/projects/portfolio/tests/client/components/chat-main.test.tsx
@@ -121,6 +121,8 @@ const settings: Settings = {
   streamMode: true,
   includeChatHistory: true,
   sendImagesOnlyOnce: true,
+  imageGenerationMode: false,
+  includeImageGenerationHistory: true,
   sidebarOpen: true,
   templateModels: {},
 }

--- a/projects/portfolio/tests/client/components/chat-main.test.tsx
+++ b/projects/portfolio/tests/client/components/chat-main.test.tsx
@@ -19,7 +19,12 @@ let streamProcessorParams: Record<string, unknown> | null = null
 let chatMessageListProps: Record<string, unknown> | null = null
 
 vi.mock('#/client/features/chat/components/chat-input', () => ({
-  ChatInput: () => <div data-testid='chat-input' />,
+  ChatInput: ({ leftBottom, rightBottom }: { leftBottom?: React.ReactNode; rightBottom?: React.ReactNode }) => (
+    <div data-testid='chat-input'>
+      {leftBottom}
+      {rightBottom}
+    </div>
+  ),
 }))
 
 vi.mock('#/client/features/chat/components/chat-message-list', () => ({
@@ -144,7 +149,6 @@ const settings: Settings = {
   includeChatHistory: true,
   sendImagesOnlyOnce: true,
   imageGenerationMode: false,
-  includeImageGenerationHistory: true,
   sidebarOpen: true,
   templateModels: {},
 }
@@ -527,6 +531,57 @@ describe('ChatMain', () => {
         ],
       })
     )
+  })
+
+  it('共有履歴設定が Off の画像生成では過去の画像 prompt を送らない', async () => {
+    chatFormInputMock = '現在の画像 prompt'
+    const imageHistoryConversation: Conversation = {
+      ...currentConversation,
+      messages: [
+        {
+          id: 'image-user-1',
+          role: 'user',
+          content: '過去の画像 prompt',
+          metadata: {
+            model: '',
+            imageGenerationMode: true,
+          },
+        },
+      ],
+    }
+    const { ChatMain } = await import('#/client/features/chat/components/chat-main')
+    const { container } = render(
+      <ChatMain
+        settings={{ ...settings, imageGenerationMode: true, includeChatHistory: false }}
+        currentConversation={imageHistoryConversation}
+      />
+    )
+
+    fireEvent.submit(container.querySelector('form')!)
+
+    await waitFor(() => expect(submitImageGenerationMock).toHaveBeenCalledTimes(1))
+    expect(submitImageGenerationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: '現在の画像 prompt',
+      })
+    )
+  })
+
+  it('画像モードの履歴バッジ toggle は共有 Include chat history を更新する', async () => {
+    const onUpdateSetting = vi.fn()
+    const { ChatMain } = await import('#/client/features/chat/components/chat-main')
+
+    render(
+      <ChatMain
+        settings={{ ...settings, imageGenerationMode: true, includeChatHistory: false }}
+        currentConversation={currentConversation}
+        onUpdateSetting={onUpdateSetting}
+      />
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: '画像生成 prompt 履歴 On/Off' }))
+
+    expect(onUpdateSetting).toHaveBeenCalledWith('includeChatHistory', true)
   })
 
   it('画像生成失敗時は assistant message と会話保存を追加しない', async () => {

--- a/projects/portfolio/tests/client/components/chat-main.test.tsx
+++ b/projects/portfolio/tests/client/components/chat-main.test.tsx
@@ -4,13 +4,16 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Settings } from '#/client/shared/storage/remote-storage-settings'
 import type { AssistantMessage, Conversation, Message, UserMessage } from '#/types'
+import type { ImageGenerationResponse } from '#/types/image-generation-api'
 
 const useMessageScrollMock = vi.fn()
 const scrollToMessageEndMock = vi.fn()
 const submitChatCompletionMock = vi.fn()
+const submitImageGenerationMock = vi.fn()
 const resumeActiveChatCompletionMock = vi.fn()
 const buildChatMessagesMock = vi.fn()
 const resetAfterSubmitMock = vi.fn()
+let chatFormInputMock = ''
 let hasActiveChatSessionMock = false
 let streamProcessorParams: Record<string, unknown> | null = null
 let chatMessageListProps: Record<string, unknown> | null = null
@@ -28,7 +31,7 @@ vi.mock('#/client/features/chat/components/chat-message-list', () => ({
 
 vi.mock('#/client/features/chat/hooks/use-chat-form', () => ({
   useChatForm: () => ({
-    input: '',
+    input: chatFormInputMock,
     uploadImages: [],
     textAreaRows: 2,
     setTemplateInput: vi.fn(),
@@ -61,6 +64,7 @@ vi.mock('#/client/features/chat/hooks/use-stream-processor', () => ({
       stream: null,
       cancelStream: vi.fn(),
       submitChatCompletion: submitChatCompletionMock,
+      submitImageGeneration: submitImageGenerationMock,
       resumeActiveChatCompletion: resumeActiveChatCompletionMock,
     }
   },
@@ -104,6 +108,24 @@ const currentConversation: Conversation = {
   messages: [createUserMessage('message-1', 'こんにちは'), createAssistantMessage('message-2', 'こんばんは')],
 }
 
+const imageGenerationResult: ImageGenerationResponse = {
+  id: 'image-1',
+  created: 1700000000,
+  model: 'gpt-image-2',
+  image: {
+    fileName: 'image-1.png',
+    publicPath: '/public/portfolio/conversation-1/image-1.png',
+    previewUrl: 'https://files.example.com/public/portfolio/conversation-1/image-1.png',
+    contentType: 'image/png',
+    createdAt: '2026-08-10T00:00:00.000Z',
+  },
+  usage: {
+    inputTokens: 1,
+    outputTokens: 2,
+    totalTokens: 3,
+  },
+}
+
 const settings: Settings = {
   schemaVersion: '1.4.0',
   model: 'gpt-4.1-mini',
@@ -131,10 +153,17 @@ describe('ChatMain', () => {
   beforeEach(() => {
     chatMessageListProps = null
     streamProcessorParams = null
+    chatFormInputMock = ''
     hasActiveChatSessionMock = false
     buildChatMessagesMock.mockReset()
     buildChatMessagesMock.mockReturnValue(null)
     resetAfterSubmitMock.mockReset()
+    submitImageGenerationMock.mockReset()
+    submitImageGenerationMock.mockResolvedValue({
+      result: imageGenerationResult,
+      error: null,
+      responseTimeMs: 1_345,
+    })
     resumeActiveChatCompletionMock.mockResolvedValue(null)
     submitChatCompletionMock.mockResolvedValue({
       error: null,
@@ -459,6 +488,76 @@ describe('ChatMain', () => {
         })
       )
     })
+  })
+
+  it('画像生成成功時は実測 responseTimeMs を assistant message と保存 payload に伝播する', async () => {
+    chatFormInputMock = '白い背景に青い円を1つ'
+    const onConversationChange = vi.fn()
+    const { ChatMain } = await import('#/client/features/chat/components/chat-main')
+    const { container } = render(
+      <ChatMain
+        settings={{ ...settings, imageGenerationMode: true }}
+        currentConversation={currentConversation}
+        onConversationChange={onConversationChange}
+      />
+    )
+
+    fireEvent.submit(container.querySelector('form')!)
+
+    await waitFor(() => expect(onConversationChange).toHaveBeenCalledTimes(1))
+    expect(submitImageGenerationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: '白い背景に青い円を1つ',
+        conversationId: 'conversation-1',
+      })
+    )
+    expect(onConversationChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'conversation-1',
+        messages: [
+          ...currentConversation.messages,
+          expect.objectContaining({ role: 'user', content: '白い背景に青い円を1つ' }),
+          expect.objectContaining({
+            role: 'assistant',
+            metadata: expect.objectContaining({
+              model: 'gpt-image-2',
+              responseTimeMs: 1_345,
+            }),
+          }),
+        ],
+      })
+    )
+  })
+
+  it('画像生成失敗時は assistant message と会話保存を追加しない', async () => {
+    chatFormInputMock = '保存に失敗する画像'
+    submitImageGenerationMock.mockResolvedValue({
+      result: null,
+      error: {
+        code: 'IMAGE_STORAGE_FAILED',
+        message:
+          '生成画像を保存できませんでした。file-server のログイン・アップロード設定と接続状態を確認して再試行してください。',
+        retryable: true,
+      },
+    })
+    const onConversationChange = vi.fn()
+    const { ChatMain } = await import('#/client/features/chat/components/chat-main')
+    const { container } = render(
+      <ChatMain
+        settings={{ ...settings, imageGenerationMode: true }}
+        currentConversation={currentConversation}
+        onConversationChange={onConversationChange}
+      />
+    )
+
+    fireEvent.submit(container.querySelector('form')!)
+
+    await waitFor(() => expect(chatMessageListProps?.generationError).toMatchObject({ code: 'IMAGE_STORAGE_FAILED' }))
+    expect(onConversationChange).not.toHaveBeenCalled()
+    expect(chatMessageListProps?.messages).toEqual([
+      ...currentConversation.messages,
+      expect.objectContaining({ role: 'user', content: '保存に失敗する画像' }),
+    ])
   })
 
   it('通常送信のエラーを保存せず専用エラー状態へ渡す', async () => {

--- a/projects/portfolio/tests/client/components/chat-message-factory.test.ts
+++ b/projects/portfolio/tests/client/components/chat-message-factory.test.ts
@@ -27,7 +27,6 @@ const settings: Settings = {
   includeChatHistory: true,
   sendImagesOnlyOnce: true,
   imageGenerationMode: false,
-  includeImageGenerationHistory: true,
   sidebarOpen: true,
   templateModels: {},
 }

--- a/projects/portfolio/tests/client/components/chat-message-factory.test.ts
+++ b/projects/portfolio/tests/client/components/chat-message-factory.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from 'vitest'
 import {
   createAssistantMessage,
   createConversationTitle,
+  createImageGenerationAssistantMessage,
   resolveChatRequestSettings,
 } from '#/client/features/chat/lib/chat-message-factory'
 import type { Settings } from '#/client/shared/storage/remote-storage-settings'
 import type { ChatResponse } from '#/types/chat-api'
+import type { ImageGenerationResponse } from '#/types/image-generation-api'
 
 const settings: Settings = {
   schemaVersion: '1.4.0',
@@ -40,6 +42,24 @@ const response: ChatResponse = {
     reasoningContent: 'reasoning',
   },
   usage: null,
+}
+
+const imageResponse: ImageGenerationResponse = {
+  id: 'image-1',
+  created: 1700000000,
+  model: 'gpt-image-2',
+  image: {
+    fileName: 'image-1.png',
+    publicPath: '/public/portfolio/conversation-1/image-1.png',
+    previewUrl: 'https://files.example.com/public/portfolio/conversation-1/image-1.png',
+    contentType: 'image/png',
+    createdAt: '2026-08-10T00:00:00.000Z',
+  },
+  usage: {
+    inputTokens: 1,
+    outputTokens: 2,
+    totalTokens: 3,
+  },
 }
 
 describe('chat-message-factory', () => {
@@ -102,6 +122,26 @@ describe('chat-message-factory', () => {
         },
         imageContext: { policy: 'send_once', sent: 1, historyOnly: 2 },
         apiContextMessages: [{ role: 'user', content: '質問' }],
+      })
+    })
+  })
+
+  describe('createImageGenerationAssistantMessage', () => {
+    it('成功時の実測 responseTimeMs を画像 assistant metadata に保存する', () => {
+      const message = createImageGenerationAssistantMessage({
+        assistantMessageId: 'assistant-image-1',
+        result: imageResponse,
+        responseTimeMs: 1_345,
+      })
+
+      expect(message).toMatchObject({
+        id: 'assistant-image-1',
+        role: 'assistant',
+        metadata: {
+          model: 'gpt-image-2',
+          responseTimeMs: 1_345,
+          generatedImages: [imageResponse.image],
+        },
       })
     })
   })

--- a/projects/portfolio/tests/client/components/chat-message-factory.test.ts
+++ b/projects/portfolio/tests/client/components/chat-message-factory.test.ts
@@ -24,6 +24,8 @@ const settings: Settings = {
   streamMode: true,
   includeChatHistory: true,
   sendImagesOnlyOnce: true,
+  imageGenerationMode: false,
+  includeImageGenerationHistory: true,
   sidebarOpen: true,
   templateModels: {},
 }

--- a/projects/portfolio/tests/client/components/chat-settings.test.tsx
+++ b/projects/portfolio/tests/client/components/chat-settings.test.tsx
@@ -3,8 +3,31 @@
 import { cleanup, render, screen } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Settings } from '#/client/shared/storage/remote-storage-settings'
 
 const useChatSettingsMock = vi.hoisted(() => vi.fn())
+
+const settings = {
+  schemaVersion: '1.4.0',
+  model: 'gpt-4.1-mini',
+  baseURL: '',
+  apiKey: '',
+  apiMode: 'chat_completions',
+  temperature: 0.7,
+  temperatureEnabled: false,
+  maxTokens: undefined,
+  reasoningEffort: 'medium',
+  reasoningEffortEnabled: false,
+  fakeMode: false,
+  autoModel: false,
+  markdownPreview: true,
+  streamMode: true,
+  includeChatHistory: true,
+  sendImagesOnlyOnce: true,
+  imageGenerationMode: true,
+  sidebarOpen: true,
+  templateModels: {},
+} satisfies Settings
 
 vi.mock('#/client/features/chat/components/chat-settings/hooks/use-chat-settings', () => ({
   useChatSettings: useChatSettingsMock,
@@ -34,7 +57,15 @@ describe('ChatSettings', () => {
   })
 
   it('画像生成モード時は右上に固定モデル名を表示する', () => {
-    render(<ChatSettings showActions={true} showNewChat={false} showSidebarToggle={false} imageGenerationMode={true} />)
+    render(
+      <ChatSettings
+        settings={settings}
+        showActions={true}
+        showNewChat={false}
+        showSidebarToggle={false}
+        imageGenerationMode={true}
+      />
+    )
 
     expect(screen.getByText('gpt-image-2')).toBeTruthy()
     expect(screen.queryByText('画像生成モード')).toBeNull()

--- a/projects/portfolio/tests/client/components/chat-settings.test.tsx
+++ b/projects/portfolio/tests/client/components/chat-settings.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const useChatSettingsMock = vi.hoisted(() => vi.fn())
+
+vi.mock('#/client/features/chat/components/chat-settings/hooks/use-chat-settings', () => ({
+  useChatSettings: useChatSettingsMock,
+}))
+
+vi.mock('#/client/features/chat/components/chat-settings/chat-settings-form', () => ({
+  ChatSettingsForm: () => null,
+}))
+
+vi.mock('#/client/features/chat/components/chat-settings/chat-settings-panel', () => ({
+  ChatSettingsPanel: ({ children }: { children: ReactNode }) => <>{children}</>,
+}))
+
+import { ChatSettings } from '#/client/features/chat/components/chat-settings/chat-settings'
+
+describe('ChatSettings', () => {
+  beforeEach(() => {
+    useChatSettingsMock.mockReturnValue({
+      fakeMode: false,
+      settings: { model: 'gpt-4.1-mini' },
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('画像生成モード時は右上に固定モデル名を表示する', () => {
+    render(<ChatSettings showActions={true} showNewChat={false} showSidebarToggle={false} imageGenerationMode={true} />)
+
+    expect(screen.getByText('gpt-image-2')).toBeTruthy()
+    expect(screen.queryByText('画像生成モード')).toBeNull()
+  })
+})

--- a/projects/portfolio/tests/client/components/image-asset-preview.test.tsx
+++ b/projects/portfolio/tests/client/components/image-asset-preview.test.tsx
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { ImageAssetPreview } from '#/client/features/chat/components/image-asset-preview'
+
+describe('画像アセットプレビュー', () => {
+  it('画像を再読込表示し、拡大表示と download link を提供する', () => {
+    render(
+      <ImageAssetPreview
+        images={[
+          {
+            fileName: 'assistant-image-0.png',
+            publicPath: '/public/portfolio/conversation/assistant-image-0.png',
+            previewUrl: 'https://files.example.test/public/portfolio/conversation/assistant-image-0.png',
+            contentType: 'image/png',
+            createdAt: '2026-08-10T00:00:00.000Z',
+          },
+        ]}
+      />
+    )
+
+    expect(screen.getAllByRole('img')).toHaveLength(1)
+    expect(screen.getByRole('link', { name: '画像をダウンロード' }).getAttribute('href')).toBe(
+      'https://files.example.test/public/portfolio/conversation/assistant-image-0.png'
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: '画像を拡大表示: assistant-image-0.png' }))
+    expect(screen.getByRole('dialog')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: '閉じる' }))
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+})

--- a/projects/portfolio/tests/client/hooks/use-chat-settings.test.ts
+++ b/projects/portfolio/tests/client/hooks/use-chat-settings.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from '@testing-library/react'
+import { useState } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Settings } from '#/client/shared/storage/remote-storage-settings'
+
+const STORAGE_KEY = 'portfolio.chat-settings'
+
+const useModelFetchingMock = vi.hoisted(() => vi.fn())
+
+vi.mock('#/client/features/chat/components/chat-settings/hooks/use-model-fetching', () => ({
+  useModelFetching: useModelFetchingMock,
+}))
+
+vi.mock('#/client/shared/hooks/use-lock-body-scroll', () => ({
+  useLockBodyScroll: vi.fn(),
+}))
+
+const createLocalStorageMock = (initialEntries: Record<string, string> = {}) => {
+  const store = new Map(Object.entries(initialEntries))
+
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value)
+    },
+    removeItem: (key: string) => {
+      store.delete(key)
+    },
+    clear: () => {
+      store.clear()
+    },
+  }
+}
+
+const settings: Settings = {
+  schemaVersion: '1.4.0',
+  model: 'gpt-4.1-mini',
+  baseURL: '',
+  apiKey: '',
+  apiMode: 'chat_completions',
+  temperature: 0.7,
+  temperatureEnabled: false,
+  maxTokens: undefined,
+  reasoningEffort: 'medium',
+  reasoningEffortEnabled: false,
+  fakeMode: false,
+  autoModel: false,
+  markdownPreview: true,
+  streamMode: true,
+  includeChatHistory: false,
+  sendImagesOnlyOnce: true,
+  imageGenerationMode: true,
+  sidebarOpen: true,
+  templateModels: {},
+}
+
+describe('useChatSettings', () => {
+  beforeEach(() => {
+    vi.stubGlobal('localStorage', createLocalStorageMock({ [STORAGE_KEY]: JSON.stringify(settings) }))
+    useModelFetchingMock.mockReturnValue({
+      fetchedModels: [],
+      isLoadingModels: false,
+      fetchError: null,
+      refetchModels: vi.fn(),
+    })
+    vi.resetModules()
+  })
+
+  it('ページの共有設定更新を同一画面の通常設定値へ反映する', async () => {
+    const { useChatSettings } = await import('#/client/features/chat/components/chat-settings/hooks/use-chat-settings')
+    const { result, rerender } = renderHook(
+      ({ currentSettings }: { currentSettings: Settings }) => useChatSettings({ settings: currentSettings }),
+      { initialProps: { currentSettings: settings } }
+    )
+
+    expect(result.current.includeChatHistory).toBe(false)
+
+    rerender({ currentSettings: { ...settings, includeChatHistory: true } })
+
+    expect(result.current.includeChatHistory).toBe(true)
+    expect(result.current.settings.includeChatHistory).toBe(true)
+  })
+
+  it('設定パネル側の履歴 toggle も共有設定を更新して永続化する', async () => {
+    const { useChatSettings } = await import('#/client/features/chat/components/chat-settings/hooks/use-chat-settings')
+    const { result } = renderHook(() => {
+      const [currentSettings, setCurrentSettings] = useState(settings)
+      const context = useChatSettings({ settings: currentSettings, onChange: setCurrentSettings })
+      return { context }
+    })
+
+    act(() => {
+      result.current.context.handleToggleIncludeChatHistory()
+    })
+
+    expect(result.current.context.includeChatHistory).toBe(true)
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}')).toMatchObject({ includeChatHistory: true })
+  })
+})

--- a/projects/portfolio/tests/client/hooks/use-stream-processor.test.tsx
+++ b/projects/portfolio/tests/client/hooks/use-stream-processor.test.tsx
@@ -179,6 +179,82 @@ describe('useStreamProcessor', () => {
     )
   })
 
+  it('画像生成成功時は API 成功応答までの responseTimeMs を返す', async () => {
+    const nowMock = vi.spyOn(Date, 'now').mockReturnValueOnce(1_000).mockReturnValueOnce(2_345)
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        id: 'image-1',
+        created: 1700000000,
+        model: 'gpt-image-2',
+        image: {
+          fileName: 'image-1.png',
+          publicPath: '/public/portfolio/conversation-1/image-1.png',
+          previewUrl: 'https://files.example.com/public/portfolio/conversation-1/image-1.png',
+          contentType: 'image/png',
+          createdAt: '2026-08-10T00:00:00.000Z',
+        },
+        usage: {
+          inputTokens: 1,
+          outputTokens: 2,
+          totalTokens: 3,
+        },
+      }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { useStreamProcessor } = await importSubject()
+    const { result } = renderHook(() => useStreamProcessor())
+
+    let response: Awaited<ReturnType<typeof result.current.submitImageGeneration>> | undefined
+    await act(async () => {
+      response = await result.current.submitImageGeneration({
+        header: { apiKey: 'api-key', baseURL: 'https://example.com' },
+        prompt: '青い円を描く',
+        conversationId: 'conversation-1',
+        assistantMessageId: 'assistant-1',
+      })
+    })
+
+    expect(response).toMatchObject({
+      result: {
+        id: 'image-1',
+        model: 'gpt-image-2',
+      },
+      error: null,
+      responseTimeMs: 1_345,
+    })
+    nowMock.mockRestore()
+  })
+
+  it('画像生成失敗時は responseTimeMs を返さない', async () => {
+    const nowMock = vi.spyOn(Date, 'now').mockReturnValue(1_000)
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('upstream failed')))
+
+    const { useStreamProcessor } = await importSubject()
+    const { result } = renderHook(() => useStreamProcessor())
+
+    let response: Awaited<ReturnType<typeof result.current.submitImageGeneration>> | undefined
+    await act(async () => {
+      response = await result.current.submitImageGeneration({
+        header: { apiKey: 'api-key', baseURL: 'https://example.com' },
+        prompt: '青い円を描く',
+        conversationId: 'conversation-1',
+        assistantMessageId: 'assistant-1',
+      })
+    })
+
+    expect(response).toEqual({
+      result: null,
+      error: {
+        code: 'UNKNOWN_UPSTREAM_ERROR',
+        message: 'LLM の応答取得中にエラーが発生しました。しばらく待ってから再試行してください。',
+        retryable: true,
+      },
+    })
+    nowMock.mockRestore()
+  })
+
   it('stream の reasoning-only 応答を保持する', async () => {
     const { useStreamProcessor, chatStreamPostMock } = await importSubject()
     const encoder = new TextEncoder()

--- a/projects/portfolio/tests/client/lib/image-generation.test.ts
+++ b/projects/portfolio/tests/client/lib/image-generation.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { buildImageGenerationPrompt } from '#/client/features/chat/lib/image-generation'
+import type { Message } from '#/types'
+
+const userMessage = (id: string, content: string, imageGenerationMode = false): Message => ({
+  id,
+  role: 'user',
+  content,
+  metadata: {
+    model: 'gpt-4o-mini',
+    ...(imageGenerationMode ? { imageGenerationMode: true } : {}),
+  },
+})
+
+describe('画像生成プロンプトの組み立て', () => {
+  it('同一会話の画像生成 user prompt だけを履歴に含める', () => {
+    const result = buildImageGenerationPrompt(
+      [userMessage('normal', '通常チャットの内容'), userMessage('image', '過去の画像 prompt', true)],
+      '現在の画像 prompt',
+      true
+    )
+
+    expect(result).toEqual({
+      currentPrompt: '現在の画像 prompt',
+      prompt: '過去の画像 prompt\n\n現在の画像 prompt',
+    })
+  })
+
+  it('履歴設定が Off のとき現在の prompt だけを返す', () => {
+    const result = buildImageGenerationPrompt(
+      [userMessage('image', '過去の画像 prompt', true)],
+      '現在の画像 prompt',
+      false
+    )
+
+    expect(result).toEqual({
+      currentPrompt: '現在の画像 prompt',
+      prompt: '現在の画像 prompt',
+    })
+  })
+
+  it('空の prompt は送信対象にしない', () => {
+    expect(buildImageGenerationPrompt([], '  ', true)).toBeNull()
+  })
+})

--- a/projects/portfolio/tests/client/storage/remote-storage-settings.test.ts
+++ b/projects/portfolio/tests/client/storage/remote-storage-settings.test.ts
@@ -168,6 +168,26 @@ describe('remote-storage-settings', () => {
     expect('interactiveMode' in stored).toBe(false)
   })
 
+  it('旧画像専用履歴キーを共有設定へ反映せず読み込み後に除去する', async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        schemaVersion: '1.4.0',
+        includeChatHistory: false,
+        includeImageGenerationHistory: true,
+      })
+    )
+
+    const { readFromLocalStorage } = await import('#/client/shared/storage/remote-storage-settings')
+    const settings = readFromLocalStorage()
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}')
+
+    expect(settings.includeChatHistory).toBe(false)
+    expect('includeImageGenerationHistory' in settings).toBe(false)
+    expect(stored.includeChatHistory).toBe(false)
+    expect('includeImageGenerationHistory' in stored).toBe(false)
+  })
+
   it('responses では fakeMode を false に正規化する', async () => {
     localStorage.setItem(
       STORAGE_KEY,

--- a/projects/portfolio/tests/features/chat-conversations/read-conversations.test.ts
+++ b/projects/portfolio/tests/features/chat-conversations/read-conversations.test.ts
@@ -226,4 +226,49 @@ describe('readConversations', () => {
       ])
     }
   })
+
+  it('画像 assistant の responseTimeMs を再読込時も保持する', async () => {
+    const { readConversations } = await importSubject({
+      users: [{ id: 'user-1', email: 'test@example.com' }],
+      rows: [
+        {
+          conversationId: 'conversation-1',
+          conversationTitle: '画像生成',
+          conversationCreatedAt: new Date(),
+          conversationUpdatedAt: new Date('2026-08-10T00:00:00.000Z'),
+          messageId: 'assistant-1',
+          messageRole: 'assistant',
+          messageContent: '',
+          messageReasoningContent: '',
+          messageMetadata: {
+            model: 'gpt-image-2',
+            responseTimeMs: 1_345,
+            usage: { inputTokens: 1, outputTokens: 2, totalTokens: 3 },
+            generatedImages: [
+              {
+                fileName: 'image-1.png',
+                publicPath: '/public/portfolio/conversation-1/image-1.png',
+                previewUrl: 'http://internal-file-server/public/portfolio/conversation-1/image-1.png',
+                contentType: 'image/png',
+                createdAt: '2026-08-10T00:00:00.000Z',
+              },
+            ],
+          },
+          messageCreatedAt: new Date(),
+        },
+      ],
+    })
+
+    const result = await readConversations('postgres://db', 'test@example.com', 'https://files.example.com')
+    const message = result?.[0].messages[0]
+
+    expect(message?.role).toBe('assistant')
+    if (message?.role === 'assistant') {
+      expect(message.metadata.responseTimeMs).toBe(1_345)
+      expect(message.metadata.generatedImages?.[0]).toMatchObject({
+        publicPath: '/public/portfolio/conversation-1/image-1.png',
+        previewUrl: 'https://files.example.com/public/portfolio/conversation-1/image-1.png',
+      })
+    }
+  })
 })

--- a/projects/portfolio/tests/server/features/image-generation.test.ts
+++ b/projects/portfolio/tests/server/features/image-generation.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  generateImage,
+  IMAGE_GENERATION_MODEL,
+  IMAGE_GENERATION_SIZE,
+} from '#/server/features/image-generation/image-generation'
+
+const mocks = vi.hoisted(() => ({
+  generate: vi.fn(),
+}))
+
+vi.mock('openai', () => ({
+  default: vi.fn(function () {
+    return {
+      images: {
+        generate: mocks.generate,
+      },
+    }
+  }),
+}))
+
+describe('画像生成機能', () => {
+  it('固定のモデル・サイズで生成し Base64 をバイナリに変換する', async () => {
+    mocks.generate.mockResolvedValueOnce({
+      created: 1_700_000_000,
+      data: [{ b64_json: Buffer.from('png-data').toString('base64') }],
+      usage: { input_tokens: 12, output_tokens: 34, total_tokens: 46 },
+    })
+
+    const result = await generateImage({
+      apiKey: 'test-key',
+      baseURL: 'https://example.test/v1',
+      prompt: 'a small blue house',
+    })
+
+    expect(mocks.generate).toHaveBeenCalledWith({
+      model: IMAGE_GENERATION_MODEL,
+      prompt: 'a small blue house',
+      n: 1,
+      size: IMAGE_GENERATION_SIZE,
+      output_format: 'png',
+    })
+    expect(Buffer.from(result.content).toString()).toBe('png-data')
+    expect(result.usage).toEqual({ inputTokens: 12, outputTokens: 34, totalTokens: 46 })
+  })
+})

--- a/projects/portfolio/tests/server/features/save-generated-image.test.ts
+++ b/projects/portfolio/tests/server/features/save-generated-image.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from 'vitest'
+import { saveGeneratedImage } from '#/server/features/chat-conversations/save-generated-image'
+
+const mocks = vi.hoisted(() => ({
+  login: vi.fn(),
+  upload: vi.fn(),
+  preview: vi.fn(),
+  error: vi.fn(),
+}))
+
+vi.mock('#/server/features/chat-conversations/file-server-client', () => ({
+  buildFileServerPreviewUrl: mocks.preview,
+  loginToFileServer: mocks.login,
+  uploadFileToFileServer: mocks.upload,
+}))
+
+vi.mock('#/server/lib/logger', () => ({
+  logger: { error: mocks.error },
+}))
+
+const config = {
+  baseUrl: 'https://files.example.test',
+  publicBaseUrl: 'https://files.example.test',
+  credentials: { username: 'admin', password: 'password' },
+}
+
+describe('生成画像の file-server 保存', () => {
+  it('file server 未設定では保存を実行しない', async () => {
+    const result = await saveGeneratedImage(
+      {
+        conversationId: 'conversation-1',
+        assistantMessageId: 'assistant-1',
+        content: new ArrayBuffer(1),
+        contentType: 'image/png',
+        createdAt: '2026-08-10T00:00:00.000Z',
+      },
+      null
+    )
+
+    expect(result).toEqual({ ok: false, reason: 'file-server-unavailable' })
+    expect(mocks.login).not.toHaveBeenCalled()
+  })
+
+  it('upload 成功後だけ public metadata を返す', async () => {
+    mocks.login.mockResolvedValueOnce('session-1')
+    mocks.upload.mockResolvedValueOnce(undefined)
+    mocks.preview.mockReturnValueOnce('https://files.example.test/public/preview.png')
+
+    const result = await saveGeneratedImage(
+      {
+        conversationId: 'conversation-1',
+        assistantMessageId: 'assistant-1',
+        content: new ArrayBuffer(1),
+        contentType: 'image/png',
+        createdAt: '2026-08-10T00:00:00.000Z',
+      },
+      config
+    )
+
+    expect(mocks.upload).toHaveBeenCalledWith(config, 'session-1', {
+      fileName: 'assistant-1-image-0.png',
+      content: expect.any(ArrayBuffer),
+      contentType: 'image/png',
+      path: 'public/portfolio/conversation-1/assistant-1-image-0.png',
+    })
+    expect(result).toEqual({
+      ok: true,
+      image: {
+        fileName: 'assistant-1-image-0.png',
+        publicPath: '/public/portfolio/conversation-1/assistant-1-image-0.png',
+        previewUrl: 'https://files.example.test/public/preview.png',
+        contentType: 'image/png',
+        createdAt: '2026-08-10T00:00:00.000Z',
+      },
+    })
+  })
+
+  it('upload 失敗では成功 metadata を返さない', async () => {
+    mocks.login.mockResolvedValueOnce('session-1')
+    mocks.upload.mockRejectedValueOnce(new Error('upload failed'))
+
+    const result = await saveGeneratedImage(
+      {
+        conversationId: 'conversation-1',
+        assistantMessageId: 'assistant-1',
+        content: new ArrayBuffer(1),
+        contentType: 'image/png',
+        createdAt: '2026-08-10T00:00:00.000Z',
+      },
+      config
+    )
+
+    expect(result).toEqual({ ok: false, reason: 'upload-failed' })
+    expect(mocks.error).toHaveBeenCalled()
+  })
+})

--- a/projects/portfolio/tests/server/lib/chat-error.test.ts
+++ b/projects/portfolio/tests/server/lib/chat-error.test.ts
@@ -1,6 +1,6 @@
 import { APIError } from 'openai'
 import { describe, expect, it } from 'vitest'
-import { toChatError } from '#/server/lib/chat-error'
+import { getSafeUpstreamErrorLogFields, toChatError } from '#/server/lib/chat-error'
 
 describe('toChatError', () => {
   describe('provider error classification', () => {
@@ -60,8 +60,33 @@ describe('toChatError', () => {
 
     expect(JSON.stringify(toChatError(error))).not.toContain(rawMessage)
   })
+
+  describe('safe upstream diagnostic fields', () => {
+    it('status・code・type・param・request IDだけを抽出し、provider本文を含めない', () => {
+      const rawMessage = 'raw provider body with secret details'
+      const error = createApiError(
+        400,
+        {
+          message: rawMessage,
+          code: 'invalid_request_error',
+          type: 'invalid_request_error',
+          param: 'output_format',
+        },
+        'req_image_123'
+      )
+
+      expect(getSafeUpstreamErrorLogFields(error)).toEqual({
+        status: 400,
+        code: 'invalid_request_error',
+        type: 'invalid_request_error',
+        param: 'output_format',
+        requestId: 'req_image_123',
+      })
+      expect(JSON.stringify(getSafeUpstreamErrorLogFields(error))).not.toContain(rawMessage)
+    })
+  })
 })
 
-function createApiError(status: number, body: Record<string, unknown>): APIError {
-  return new APIError(status, body, undefined, new Headers())
+function createApiError(status: number, body: Record<string, unknown>, requestId?: string): APIError {
+  return new APIError(status, body, undefined, new Headers(requestId ? { 'x-request-id': requestId } : undefined))
 }

--- a/projects/portfolio/tests/server/routes/image-generation.test.ts
+++ b/projects/portfolio/tests/server/routes/image-generation.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it, vi } from 'vitest'
+import { APIError } from 'openai'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { chatRoutes } from '#/server/routes/chat'
 
 const mocks = vi.hoisted(() => ({
@@ -43,66 +44,125 @@ const request = () =>
   })
 
 describe('画像生成専用 API', () => {
-  it('file-server upload 成功時だけ生成 metadata を返す', async () => {
-    mocks.resolveConfig.mockReturnValue({
-      baseUrl: 'https://files.example.test',
-      publicBaseUrl: 'https://files.example.test',
-      credentials: { username: 'admin', password: 'password' },
-    })
-    mocks.generate.mockResolvedValueOnce({
-      id: 'image-1',
-      created: 1_700_000_000,
-      model: 'gpt-image-2',
-      content: new ArrayBuffer(1),
-      usage: { inputTokens: 1, outputTokens: 2, totalTokens: 3 },
-    })
-    mocks.save.mockResolvedValueOnce({
-      ok: true,
-      image: {
-        fileName: 'assistant-1-image-0.png',
-        publicPath: '/public/portfolio/conversation-1/assistant-1-image-0.png',
-        previewUrl: 'https://files.example.test/public/portfolio/conversation-1/assistant-1-image-0.png',
-        contentType: 'image/png',
-        createdAt: '2023-11-14T22:13:20.000Z',
-      },
-    })
-
-    const response = await chatRoutes.request(request(), undefined, env)
-
-    expect(response.status).toBe(200)
-    expect(await response.json()).toMatchObject({
-      id: 'image-1',
-      model: 'gpt-image-2',
-      image: { publicPath: '/public/portfolio/conversation-1/assistant-1-image-0.png' },
-    })
-    expect(mocks.save).toHaveBeenCalledWith(
-      expect.objectContaining({
-        conversationId: 'conversation-1',
-        assistantMessageId: 'assistant-1',
-        contentType: 'image/png',
-      }),
-      expect.any(Object)
-    )
+  beforeEach(() => {
+    mocks.generate.mockReset()
+    mocks.save.mockReset()
+    mocks.resolveConfig.mockReset()
   })
 
-  it('file-server upload 失敗時は成功を返さない', async () => {
-    mocks.resolveConfig.mockReturnValue({
-      baseUrl: 'https://files.example.test',
-      publicBaseUrl: 'https://files.example.test',
-      credentials: { username: 'admin', password: 'password' },
-    })
-    mocks.generate.mockResolvedValueOnce({
-      id: 'image-1',
-      created: 1_700_000_000,
-      model: 'gpt-image-2',
-      content: new ArrayBuffer(1),
-      usage: {},
-    })
-    mocks.save.mockResolvedValueOnce({ ok: false, reason: 'upload-failed' })
+  describe('成功', () => {
+    it('file-server upload 成功時だけ生成 metadata を返す', async () => {
+      mocks.resolveConfig.mockReturnValue({
+        baseUrl: 'https://files.example.test',
+        publicBaseUrl: 'https://files.example.test',
+        credentials: { username: 'admin', password: 'password' },
+      })
+      mocks.generate.mockResolvedValueOnce({
+        id: 'image-1',
+        created: 1_700_000_000,
+        model: 'gpt-image-2',
+        content: new ArrayBuffer(1),
+        usage: { inputTokens: 1, outputTokens: 2, totalTokens: 3 },
+      })
+      mocks.save.mockResolvedValueOnce({
+        ok: true,
+        image: {
+          fileName: 'assistant-1-image-0.png',
+          publicPath: '/public/portfolio/conversation-1/assistant-1-image-0.png',
+          previewUrl: 'https://files.example.test/public/portfolio/conversation-1/assistant-1-image-0.png',
+          contentType: 'image/png',
+          createdAt: '2023-11-14T22:13:20.000Z',
+        },
+      })
 
-    const response = await chatRoutes.request(request(), undefined, env)
+      const response = await chatRoutes.request(request(), undefined, env)
 
-    expect(response.status).toBe(502)
-    expect(mocks.save).toHaveBeenCalled()
+      expect(response.status).toBe(200)
+      expect(await response.json()).toMatchObject({
+        id: 'image-1',
+        model: 'gpt-image-2',
+        image: { publicPath: '/public/portfolio/conversation-1/assistant-1-image-0.png' },
+      })
+      expect(mocks.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          conversationId: 'conversation-1',
+          assistantMessageId: 'assistant-1',
+          contentType: 'image/png',
+        }),
+        expect.any(Object)
+      )
+    })
+  })
+
+  describe('エラー分類', () => {
+    it('file-server 設定が不足している場合は保存先未設定エラーを返す', async () => {
+      mocks.resolveConfig.mockReturnValue(null)
+
+      const response = await chatRoutes.request(request(), undefined, env)
+
+      expect(response.status).toBe(503)
+      await expect(response.json()).resolves.toEqual({
+        code: 'IMAGE_STORAGE_NOT_CONFIGURED',
+        message:
+          '生成画像の保存先が未設定です。file-server の接続先・公開 URL・管理者ユーザー名・パスワードを確認してください。',
+        retryable: false,
+      })
+      expect(mocks.generate).not.toHaveBeenCalled()
+    })
+
+    it('file-server upload 失敗時は保存失敗エラーを返す', async () => {
+      mocks.resolveConfig.mockReturnValue({
+        baseUrl: 'https://files.example.test',
+        publicBaseUrl: 'https://files.example.test',
+        credentials: { username: 'admin', password: 'password' },
+      })
+      mocks.generate.mockResolvedValueOnce({
+        id: 'image-1',
+        created: 1_700_000_000,
+        model: 'gpt-image-2',
+        content: new ArrayBuffer(1),
+        usage: {},
+      })
+      mocks.save.mockResolvedValueOnce({ ok: false, reason: 'upload-failed' })
+
+      const response = await chatRoutes.request(request(), undefined, env)
+
+      expect(response.status).toBe(502)
+      await expect(response.json()).resolves.toEqual({
+        code: 'IMAGE_STORAGE_FAILED',
+        message:
+          '生成画像を保存できませんでした。file-server のログイン・アップロード設定と接続状態を確認して再試行してください。',
+        retryable: true,
+      })
+      expect(mocks.save).toHaveBeenCalled()
+    })
+
+    it('OpenAI image API の失敗は provider 系 error classification を維持する', async () => {
+      mocks.resolveConfig.mockReturnValue({
+        baseUrl: 'https://files.example.test',
+        publicBaseUrl: 'https://files.example.test',
+        credentials: { username: 'admin', password: 'password' },
+      })
+      mocks.generate.mockRejectedValueOnce(
+        new APIError(
+          401,
+          {
+            message: 'Invalid API key',
+          },
+          undefined,
+          new Headers()
+        )
+      )
+
+      const response = await chatRoutes.request(request(), undefined, env)
+
+      expect(response.status).toBe(502)
+      await expect(response.json()).resolves.toEqual({
+        code: 'AUTHENTICATION_FAILED',
+        message: 'API キーが無効か、利用を許可されていません。設定を確認してください。',
+        retryable: false,
+      })
+      expect(mocks.save).not.toHaveBeenCalled()
+    })
   })
 })

--- a/projects/portfolio/tests/server/routes/image-generation.test.ts
+++ b/projects/portfolio/tests/server/routes/image-generation.test.ts
@@ -6,11 +6,15 @@ const mocks = vi.hoisted(() => ({
   generate: vi.fn(),
   save: vi.fn(),
   resolveConfig: vi.fn(),
+  error: vi.fn(),
 }))
 
 vi.mock('#/server/features/image-generation/image-generation', () => ({
   generateImage: mocks.generate,
   IMAGE_GENERATION_CONTENT_TYPE: 'image/png',
+  IMAGE_GENERATION_MODEL: 'gpt-image-2',
+  IMAGE_GENERATION_OUTPUT_FORMAT: 'png',
+  IMAGE_GENERATION_SIZE: '1024x1024',
 }))
 
 vi.mock('#/server/features/chat-conversations/save-generated-image', () => ({
@@ -19,6 +23,10 @@ vi.mock('#/server/features/chat-conversations/save-generated-image', () => ({
 
 vi.mock('#/server/features/chat-conversations/file-server-client', () => ({
   resolveFileServerConfig: mocks.resolveConfig,
+}))
+
+vi.mock('#/server/lib/logger', () => ({
+  logger: { error: mocks.error },
 }))
 
 const env = {
@@ -48,6 +56,7 @@ describe('画像生成専用 API', () => {
     mocks.generate.mockReset()
     mocks.save.mockReset()
     mocks.resolveConfig.mockReset()
+    mocks.error.mockReset()
   })
 
   describe('成功', () => {
@@ -137,32 +146,161 @@ describe('画像生成専用 API', () => {
       expect(mocks.save).toHaveBeenCalled()
     })
 
-    it('OpenAI image API の失敗は provider 系 error classification を維持する', async () => {
-      mocks.resolveConfig.mockReturnValue({
-        baseUrl: 'https://files.example.test',
-        publicBaseUrl: 'https://files.example.test',
-        credentials: { username: 'admin', password: 'password' },
-      })
-      mocks.generate.mockRejectedValueOnce(
-        new APIError(
-          401,
-          {
-            message: 'Invalid API key',
-          },
-          undefined,
-          new Headers()
+    describe('provider error classification', () => {
+      it('OpenAI image API の認証失敗は従来の provider 系分類を維持する', async () => {
+        mocks.resolveConfig.mockReturnValue({
+          baseUrl: 'https://files.example.test',
+          publicBaseUrl: 'https://files.example.test',
+          credentials: { username: 'admin', password: 'password' },
+        })
+        mocks.generate.mockRejectedValueOnce(
+          new APIError(
+            401,
+            {
+              message: 'Invalid API key',
+            },
+            undefined,
+            new Headers()
+          )
         )
-      )
 
-      const response = await chatRoutes.request(request(), undefined, env)
+        const response = await chatRoutes.request(request(), undefined, env)
 
-      expect(response.status).toBe(502)
-      await expect(response.json()).resolves.toEqual({
-        code: 'AUTHENTICATION_FAILED',
-        message: 'API キーが無効か、利用を許可されていません。設定を確認してください。',
-        retryable: false,
+        expect(response.status).toBe(502)
+        await expect(response.json()).resolves.toEqual({
+          code: 'AUTHENTICATION_FAILED',
+          message: 'API キーが無効か、利用を許可されていません。設定を確認してください。',
+          retryable: false,
+        })
+        expect(mocks.save).not.toHaveBeenCalled()
       })
-      expect(mocks.save).not.toHaveBeenCalled()
+
+      it('model または endpoint 非対応を専用エラーに分類し、安全な診断項目だけを記録する', async () => {
+        mocks.resolveConfig.mockReturnValue({
+          baseUrl: 'https://files.example.test',
+          publicBaseUrl: 'https://files.example.test',
+          credentials: { username: 'admin', password: 'password' },
+        })
+        const rawProviderMessage = 'raw provider body with credentials and implementation details'
+        mocks.generate.mockRejectedValueOnce(
+          createApiError(
+            404,
+            {
+              message: rawProviderMessage,
+              code: 'model_not_found',
+              type: 'invalid_request_error',
+              param: 'model',
+            },
+            'req_image_compatibility'
+          )
+        )
+
+        const response = await chatRoutes.request(request(), undefined, env)
+        const body = await response.json()
+
+        expect(response.status).toBe(502)
+        expect(body).toEqual({
+          code: 'IMAGE_MODEL_ENDPOINT_INCOMPATIBLE',
+          message:
+            '画像生成プロバイダーがモデルまたはエンドポイントに対応していません。base URL の /images/generations 対応と gpt-image-2 の利用可否を確認してください。',
+          retryable: false,
+        })
+        expect(JSON.stringify(body)).not.toContain(rawProviderMessage)
+        expect(mocks.error).toHaveBeenCalledWith(
+          expect.objectContaining({
+            errorCode: 'IMAGE_MODEL_ENDPOINT_INCOMPATIBLE',
+            provider: {
+              status: 404,
+              code: 'model_not_found',
+              type: 'invalid_request_error',
+              param: 'model',
+              requestId: 'req_image_compatibility',
+            },
+            request: {
+              endpoint: '/images/generations',
+              model: 'gpt-image-2',
+              size: '1024x1024',
+              outputFormat: 'png',
+              count: 1,
+            },
+          }),
+          'Image generation failed'
+        )
+        expect(JSON.stringify(mocks.error.mock.calls)).not.toContain(rawProviderMessage)
+        expect(mocks.save).not.toHaveBeenCalled()
+      })
+
+      it('parameter 不正を専用エラーに分類し、provider本文を公開しない', async () => {
+        mocks.resolveConfig.mockReturnValue({
+          baseUrl: 'https://files.example.test',
+          publicBaseUrl: 'https://files.example.test',
+          credentials: { username: 'admin', password: 'password' },
+        })
+        const rawProviderMessage = 'raw provider body with unsupported parameter details'
+        mocks.generate.mockRejectedValueOnce(
+          createApiError(
+            400,
+            {
+              message: rawProviderMessage,
+              code: 'invalid_request_error',
+              type: 'invalid_request_error',
+              param: 'output_format',
+            },
+            'req_image_parameter'
+          )
+        )
+
+        const response = await chatRoutes.request(request(), undefined, env)
+        const body = await response.json()
+
+        expect(response.status).toBe(502)
+        expect(body).toEqual({
+          code: 'IMAGE_REQUEST_INVALID',
+          message:
+            '画像生成リクエストのパラメータが受け付けられませんでした。プロバイダーが受け付ける model・size・output format・n・prompt を確認してください。',
+          retryable: false,
+        })
+        expect(JSON.stringify(body)).not.toContain(rawProviderMessage)
+        expect(mocks.save).not.toHaveBeenCalled()
+      })
+
+      it('provider の安全基準による拒否を専用エラーに分類する', async () => {
+        mocks.resolveConfig.mockReturnValue({
+          baseUrl: 'https://files.example.test',
+          publicBaseUrl: 'https://files.example.test',
+          credentials: { username: 'admin', password: 'password' },
+        })
+        const rawProviderMessage = 'raw moderation response details'
+        mocks.generate.mockRejectedValueOnce(
+          createApiError(
+            400,
+            {
+              message: rawProviderMessage,
+              code: 'moderation_blocked',
+              type: 'image_generation_user_error',
+            },
+            'req_image_moderation'
+          )
+        )
+
+        const response = await chatRoutes.request(request(), undefined, env)
+        const body = await response.json()
+
+        expect(response.status).toBe(502)
+        expect(body).toEqual({
+          code: 'IMAGE_PROVIDER_REJECTED',
+          message:
+            '画像生成プロバイダーにリクエストを拒否されました。prompt の内容とプロバイダーの安全基準・利用制限を確認してください。',
+          retryable: false,
+        })
+        expect(JSON.stringify(body)).not.toContain(rawProviderMessage)
+        expect(JSON.stringify(mocks.error.mock.calls)).not.toContain(rawProviderMessage)
+        expect(mocks.save).not.toHaveBeenCalled()
+      })
     })
   })
 })
+
+function createApiError(status: number, body: Record<string, unknown>, requestId: string): APIError {
+  return new APIError(status, body, undefined, new Headers({ 'x-request-id': requestId }))
+}

--- a/projects/portfolio/tests/server/routes/image-generation.test.ts
+++ b/projects/portfolio/tests/server/routes/image-generation.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest'
+import { chatRoutes } from '#/server/routes/chat'
+
+const mocks = vi.hoisted(() => ({
+  generate: vi.fn(),
+  save: vi.fn(),
+  resolveConfig: vi.fn(),
+}))
+
+vi.mock('#/server/features/image-generation/image-generation', () => ({
+  generateImage: mocks.generate,
+  IMAGE_GENERATION_CONTENT_TYPE: 'image/png',
+}))
+
+vi.mock('#/server/features/chat-conversations/save-generated-image', () => ({
+  saveGeneratedImage: mocks.save,
+}))
+
+vi.mock('#/server/features/chat-conversations/file-server-client', () => ({
+  resolveFileServerConfig: mocks.resolveConfig,
+}))
+
+const env = {
+  FILE_SERVER_URL: 'https://files.example.test',
+  FILE_SERVER_PUBLIC_URL: 'https://files.example.test',
+  FILE_SERVER_ADMIN_USERNAME: 'admin',
+  FILE_SERVER_ADMIN_PASSWORD: 'password',
+} as never
+
+const request = () =>
+  new Request('http://localhost/api/image/generations', {
+    method: 'POST',
+    headers: {
+      'api-key': 'test-key',
+      'base-url': 'https://api.example.test/v1',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      prompt: 'a blue house',
+      conversationId: 'conversation-1',
+      assistantMessageId: 'assistant-1',
+    }),
+  })
+
+describe('画像生成専用 API', () => {
+  it('file-server upload 成功時だけ生成 metadata を返す', async () => {
+    mocks.resolveConfig.mockReturnValue({
+      baseUrl: 'https://files.example.test',
+      publicBaseUrl: 'https://files.example.test',
+      credentials: { username: 'admin', password: 'password' },
+    })
+    mocks.generate.mockResolvedValueOnce({
+      id: 'image-1',
+      created: 1_700_000_000,
+      model: 'gpt-image-2',
+      content: new ArrayBuffer(1),
+      usage: { inputTokens: 1, outputTokens: 2, totalTokens: 3 },
+    })
+    mocks.save.mockResolvedValueOnce({
+      ok: true,
+      image: {
+        fileName: 'assistant-1-image-0.png',
+        publicPath: '/public/portfolio/conversation-1/assistant-1-image-0.png',
+        previewUrl: 'https://files.example.test/public/portfolio/conversation-1/assistant-1-image-0.png',
+        contentType: 'image/png',
+        createdAt: '2023-11-14T22:13:20.000Z',
+      },
+    })
+
+    const response = await chatRoutes.request(request(), undefined, env)
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({
+      id: 'image-1',
+      model: 'gpt-image-2',
+      image: { publicPath: '/public/portfolio/conversation-1/assistant-1-image-0.png' },
+    })
+    expect(mocks.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationId: 'conversation-1',
+        assistantMessageId: 'assistant-1',
+        contentType: 'image/png',
+      }),
+      expect.any(Object)
+    )
+  })
+
+  it('file-server upload 失敗時は成功を返さない', async () => {
+    mocks.resolveConfig.mockReturnValue({
+      baseUrl: 'https://files.example.test',
+      publicBaseUrl: 'https://files.example.test',
+      credentials: { username: 'admin', password: 'password' },
+    })
+    mocks.generate.mockResolvedValueOnce({
+      id: 'image-1',
+      created: 1_700_000_000,
+      model: 'gpt-image-2',
+      content: new ArrayBuffer(1),
+      usage: {},
+    })
+    mocks.save.mockResolvedValueOnce({ ok: false, reason: 'upload-failed' })
+
+    const response = await chatRoutes.request(request(), undefined, env)
+
+    expect(response.status).toBe(502)
+    expect(mocks.save).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## Issues
- close: #1160
- ref: #1160

## Why
`/chat` の会話体験を維持したまま、通常の chat 設定と分離した text-to-image 導線を追加します。

## Summary
composer に持続する画像生成 On/Off badge と prompt 履歴設定を追加し、専用 API で生成・file-server upload・conversation 保存・再読込表示までを実装しました。

## Changes
- `POST /api/image/generations` と固定の `gpt-image-2` / `1024x1024` / PNG 生成を追加
- file-server upload 成功後だけ conversation を保存し、`assistant.metadata.generatedImages` に publicPath 等を保存
- image prompt 履歴は同一会話の image-mode user prompt のみを利用
- 通常 chat 設定を image mode 中に非表示・不使用化
- 画像の再読込表示、preview、拡大 modal、download link を追加
- edit / variation / 参照画像は対象外。既存 upload image の Base64 保存は変更なし
- 仕様書と focused tests を追加

## Verification
- `bun run format:check`
- `bun run lint`
- `bun run test`（66 files / 355 tests）
- `bun run build`
- `git diff --check`

DB schema は既存 metadata JSONB を利用するため migration はありません。

## Known risks
- 利用する image-capable model と file-server の設定・対応状況は環境依存です。
- build で既存の chunk-size warning が表示されますが、build 自体は成功しています。

## Screenshot
<img width="1270" height="1157" alt="image" src="https://github.com/user-attachments/assets/b9f26f41-753f-45d1-8bb1-1a679ad9b7ca" />
