### PR TITLE
[portfolio] 画像生成モードで共通チャット設定を利用できるようにする

### DIFF
--- a/projects/portfolio/src/client/features/chat/components/chat-main.tsx
+++ b/projects/portfolio/src/client/features/chat/components/chat-main.tsx
@@ -11,6 +11,7 @@ import { IconButton } from '#/client/shared/components/icon-button/icon-button'
 import { ArrowDownIcon } from '#/client/shared/icons/arrow-down-icon'
 import type { Settings } from '#/client/shared/storage/remote-storage-settings'
 import type { Conversation } from '#/types'
+import type { ChatError } from '#/types/chat-api'
 
 interface Props {
   initTrigger?: number
@@ -22,6 +23,7 @@ interface Props {
   onSessionCompleted?: (conversation: Conversation) => Promise<void> | void
   onDeleteMessages?: (messageIds: string[], isConversationEmpty: boolean) => void
   onUpdateSetting?: <K extends keyof Settings>(key: K, value: Settings[K]) => Settings
+  onSettingsError?: (error: ChatError) => void
 }
 
 export function ChatMain({
@@ -34,6 +36,7 @@ export function ChatMain({
   onSessionCompleted,
   onDeleteMessages,
   onUpdateSetting,
+  onSettingsError,
 }: Props) {
   const formRef = useRef<HTMLFormElement>(null)
   const prevConversationIdRef = useRef<string | null>(null)
@@ -83,11 +86,16 @@ export function ChatMain({
       onConversationChange,
       onSessionCompleted,
       onDeleteMessages,
+      onSettingsError,
     },
   })
 
   const toggleImageGenerationMode = useCallback(() => {
-    onUpdateSetting?.('imageGenerationMode', !settings.imageGenerationMode)
+    const nextImageGenerationMode = !settings.imageGenerationMode
+    if (nextImageGenerationMode) {
+      onUpdateSetting?.('fakeMode', false)
+    }
+    onUpdateSetting?.('imageGenerationMode', nextImageGenerationMode)
   }, [onUpdateSetting, settings.imageGenerationMode])
 
   const toggleChatHistory = useCallback(() => {

--- a/projects/portfolio/src/client/features/chat/components/chat-settings/chat-settings-form.tsx
+++ b/projects/portfolio/src/client/features/chat/components/chat-settings/chat-settings-form.tsx
@@ -16,7 +16,13 @@ function SectionHeading({ children }: { children: string }) {
   )
 }
 
-export function ChatSettingsForm({ settingsError }: { settingsError?: ChatError | null }) {
+export function ChatSettingsForm({
+  imageGenerationMode = false,
+  settingsError,
+}: {
+  imageGenerationMode?: boolean
+  settingsError?: ChatError | null
+}) {
   const {
     settings,
     apiMode,
@@ -48,24 +54,26 @@ export function ChatSettingsForm({ settingsError }: { settingsError?: ChatError 
         </div>
       )}
 
-      {/* Model Section */}
-      <section className='space-y-3'>
-        <SectionHeading>Model</SectionHeading>
-        <div className='space-y-3'>
-          {/* Model Selection */}
-          <div className='space-y-2'>
-            <label
-              className={`block text-sm font-medium ${fakeMode ? 'text-gray-400' : 'text-gray-700 dark:text-gray-300'}`}
-            >
-              Model
-            </label>
-            <ModelSelector />
-          </div>
+      {!imageGenerationMode && (
+        /* Model Section */
+        <section className='space-y-3'>
+          <SectionHeading>Model</SectionHeading>
+          <div className='space-y-3'>
+            {/* Model Selection */}
+            <div className='space-y-2'>
+              <label
+                className={`block text-sm font-medium ${fakeMode ? 'text-gray-400' : 'text-gray-700 dark:text-gray-300'}`}
+              >
+                Model
+              </label>
+              <ModelSelector />
+            </div>
 
-          {/* Auto Model Toggle */}
-          <AutoModelToggle />
-        </div>
-      </section>
+            {/* Auto Model Toggle */}
+            <AutoModelToggle />
+          </div>
+        </section>
+      )}
 
       {/* API Configuration */}
       <section className='space-y-3'>
@@ -124,45 +132,49 @@ export function ChatSettingsForm({ settingsError }: { settingsError?: ChatError 
         </div>
       </section>
 
-      {/* Parameters */}
-      <section className='space-y-3'>
-        <SectionHeading>Parameters</SectionHeading>
-        <div className='space-y-4'>
-          <TemperatureSlider />
+      {!imageGenerationMode && (
+        /* Parameters */
+        <section className='space-y-3'>
+          <SectionHeading>Parameters</SectionHeading>
+          <div className='space-y-4'>
+            <TemperatureSlider />
 
-          <TextInput
-            name='maxTokens'
-            label='Max Tokens'
-            type='number'
-            min={1}
-            max={4096}
-            defaultValue={settings.maxTokens?.toString()}
-            placeholder='Max tokens'
-            onChange={handleChangeMaxTokens}
-          />
+            <TextInput
+              name='maxTokens'
+              label='Max Tokens'
+              type='number'
+              min={1}
+              max={4096}
+              defaultValue={settings.maxTokens?.toString()}
+              placeholder='Max tokens'
+              onChange={handleChangeMaxTokens}
+            />
 
-          <ReasoningEffort />
-        </div>
-      </section>
+            <ReasoningEffort />
+          </div>
+        </section>
+      )}
 
-      {/* Display Options */}
-      <section className='space-y-3'>
-        <SectionHeading>Display Options</SectionHeading>
-        <div className='space-y-3'>
-          <ToggleInput
-            label='Markdown Preview'
-            labelClassName='text-sm font-medium text-gray-700 dark:text-gray-300'
-            value={markdownPreview}
-            onClick={handleToggleMarkdownPreview}
-          />
-          <ToggleInput
-            label='Stream Mode'
-            labelClassName='text-sm font-medium text-gray-700 dark:text-gray-300'
-            value={streamMode}
-            onClick={handleToggleStreamMode}
-          />
-        </div>
-      </section>
+      {!imageGenerationMode && (
+        /* Display Options */
+        <section className='space-y-3'>
+          <SectionHeading>Display Options</SectionHeading>
+          <div className='space-y-3'>
+            <ToggleInput
+              label='Markdown Preview'
+              labelClassName='text-sm font-medium text-gray-700 dark:text-gray-300'
+              value={markdownPreview}
+              onClick={handleToggleMarkdownPreview}
+            />
+            <ToggleInput
+              label='Stream Mode'
+              labelClassName='text-sm font-medium text-gray-700 dark:text-gray-300'
+              value={streamMode}
+              onClick={handleToggleStreamMode}
+            />
+          </div>
+        </section>
+      )}
 
       {/* Context Options */}
       <section className='space-y-3'>
@@ -179,34 +191,40 @@ export function ChatSettingsForm({ settingsError }: { settingsError?: ChatError 
             <br />
             OFF の場合、今回の入力のみを送信します。
           </p>
-          <ToggleInput
-            label='Send attached images only once'
-            labelClassName='text-sm font-medium text-gray-700 dark:text-gray-300'
-            value={sendImagesOnlyOnce}
-            onClick={handleToggleSendImagesOnlyOnce}
-          />
-          <p className='text-xs text-gray-500 dark:text-gray-400'>
-            ON の場合、保存済み履歴の画像は次回以降の API コンテキストから除外します。
-          </p>
-        </div>
-      </section>
-
-      {/* Debug Options */}
-      <section className='space-y-3'>
-        <SectionHeading>Debug Options</SectionHeading>
-        <div className='space-y-2'>
-          <ToggleInput
-            label='Fake Mode'
-            labelClassName={`text-sm font-medium ${apiMode === 'responses' ? 'text-gray-400 dark:text-gray-500' : 'text-gray-700 dark:text-gray-300'}`}
-            value={fakeMode}
-            disabled={apiMode === 'responses'}
-            onClick={handleToggleFakeMode}
-          />
-          {apiMode === 'responses' && (
-            <p className='text-xs text-gray-500 dark:text-gray-400'>Responses では Fake Mode を利用できません。</p>
+          {!imageGenerationMode && (
+            <>
+              <ToggleInput
+                label='Send attached images only once'
+                labelClassName='text-sm font-medium text-gray-700 dark:text-gray-300'
+                value={sendImagesOnlyOnce}
+                onClick={handleToggleSendImagesOnlyOnce}
+              />
+              <p className='text-xs text-gray-500 dark:text-gray-400'>
+                ON の場合、保存済み履歴の画像は次回以降の API コンテキストから除外します。
+              </p>
+            </>
           )}
         </div>
       </section>
+
+      {!imageGenerationMode && (
+        /* Debug Options */
+        <section className='space-y-3'>
+          <SectionHeading>Debug Options</SectionHeading>
+          <div className='space-y-2'>
+            <ToggleInput
+              label='Fake Mode'
+              labelClassName={`text-sm font-medium ${apiMode === 'responses' ? 'text-gray-400 dark:text-gray-500' : 'text-gray-700 dark:text-gray-300'}`}
+              value={fakeMode}
+              disabled={apiMode === 'responses'}
+              onClick={handleToggleFakeMode}
+            />
+            {apiMode === 'responses' && (
+              <p className='text-xs text-gray-500 dark:text-gray-400'>Responses では Fake Mode を利用できません。</p>
+            )}
+          </div>
+        </section>
+      )}
 
       {/* Bottom spacing for safe area */}
       <div className='h-6' />

--- a/projects/portfolio/src/client/features/chat/components/chat-settings/chat-settings-form.tsx
+++ b/projects/portfolio/src/client/features/chat/components/chat-settings/chat-settings-form.tsx
@@ -79,27 +79,29 @@ export function ChatSettingsForm({
       <section className='space-y-3'>
         <SectionHeading>API Configuration</SectionHeading>
         <div className='space-y-3'>
-          <div className='space-y-2'>
-            <label className='block text-sm font-medium text-gray-700 dark:text-gray-300'>API Mode</label>
-            <div className='relative'>
-              <select
-                value={apiMode}
-                onChange={handleChangeApiMode}
-                className='w-full appearance-none rounded-md border border-gray-300 bg-white px-3 py-2 pr-9 text-sm text-gray-900 outline-none transition-all duration-200 hover:border-gray-400 focus:border-blue-500 focus:ring-2 focus:ring-blue-200 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:focus:ring-blue-800'
-              >
-                <option value='chat_completions'>Chat Completions</option>
-                <option value='responses'>Responses</option>
-              </select>
-              <svg
-                viewBox='0 0 20 20'
-                aria-hidden='true'
-                className='pointer-events-none absolute top-1/2 right-3 h-4 w-4 -translate-y-1/2 stroke-gray-600 dark:stroke-gray-300'
-                fill='none'
-              >
-                <path d='M5 7.5L10 12.5L15 7.5' strokeWidth='1.8' strokeLinecap='round' strokeLinejoin='round' />
-              </svg>
+          {!imageGenerationMode && (
+            <div className='space-y-2'>
+              <label className='block text-sm font-medium text-gray-700 dark:text-gray-300'>API Mode</label>
+              <div className='relative'>
+                <select
+                  value={apiMode}
+                  onChange={handleChangeApiMode}
+                  className='w-full appearance-none rounded-md border border-gray-300 bg-white px-3 py-2 pr-9 text-sm text-gray-900 outline-none transition-all duration-200 hover:border-gray-400 focus:border-blue-500 focus:ring-2 focus:ring-blue-200 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:focus:ring-blue-800'
+                >
+                  <option value='chat_completions'>Chat Completions</option>
+                  <option value='responses'>Responses</option>
+                </select>
+                <svg
+                  viewBox='0 0 20 20'
+                  aria-hidden='true'
+                  className='pointer-events-none absolute top-1/2 right-3 h-4 w-4 -translate-y-1/2 stroke-gray-600 dark:stroke-gray-300'
+                  fill='none'
+                >
+                  <path d='M5 7.5L10 12.5L15 7.5' strokeWidth='1.8' strokeLinecap='round' strokeLinejoin='round' />
+                </svg>
+              </div>
             </div>
-          </div>
+          )}
 
           <TextInput
             name='baseURL'

--- a/projects/portfolio/src/client/features/chat/components/chat-settings/chat-settings-form.tsx
+++ b/projects/portfolio/src/client/features/chat/components/chat-settings/chat-settings-form.tsx
@@ -1,4 +1,5 @@
 import { ToggleInput } from '#/client/shared/components/input/toggle-input'
+import type { ChatError } from '#/types/chat-api'
 import { useChatSettingsContext } from './chat-settings-context'
 import { ModelSelector } from './model-selector'
 import { AutoModelToggle } from './settings/auto-model-toggle'
@@ -15,7 +16,7 @@ function SectionHeading({ children }: { children: string }) {
   )
 }
 
-export function ChatSettingsForm() {
+export function ChatSettingsForm({ settingsError }: { settingsError?: ChatError | null }) {
   const {
     settings,
     apiMode,
@@ -37,6 +38,16 @@ export function ChatSettingsForm() {
 
   return (
     <div className='flex flex-col gap-5'>
+      {settingsError && (
+        <div
+          role='alert'
+          aria-live='assertive'
+          className='rounded-md border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-700 dark:bg-red-900/30 dark:text-red-200'
+        >
+          {settingsError.message}
+        </div>
+      )}
+
       {/* Model Section */}
       <section className='space-y-3'>
         <SectionHeading>Model</SectionHeading>
@@ -85,8 +96,7 @@ export function ChatSettingsForm() {
           <TextInput
             name='baseURL'
             label='Base URL'
-            defaultValue={settings.baseURL || 'https://api.openai.com/v1'}
-            placeholder='https://api.openai.com/v1'
+            defaultValue={settings.baseURL}
             disabled={fakeMode}
             onChange={handleChangeBaseURL}
           />

--- a/projects/portfolio/src/client/features/chat/components/chat-settings/chat-settings.tsx
+++ b/projects/portfolio/src/client/features/chat/components/chat-settings/chat-settings.tsx
@@ -100,7 +100,7 @@ export function ChatSettings({
       {/* Settings Panel */}
       <ChatSettingsProvider value={contextValue}>
         <ChatSettingsPanel show={showPopup ?? false} onClose={onHidePopup ?? (() => {})}>
-          <ChatSettingsForm settingsError={settingsError} />
+          <ChatSettingsForm imageGenerationMode={imageGenerationMode} settingsError={settingsError} />
         </ChatSettingsPanel>
       </ChatSettingsProvider>
     </>

--- a/projects/portfolio/src/client/features/chat/components/chat-settings/chat-settings.tsx
+++ b/projects/portfolio/src/client/features/chat/components/chat-settings/chat-settings.tsx
@@ -3,6 +3,7 @@ import { GearIcon } from '#/client/shared/icons/gear-icon'
 import { NewChatIcon } from '#/client/shared/icons/new-chat-icon'
 import { SidebarIcon } from '#/client/shared/icons/sidebar-icon'
 import type { Settings } from '#/client/shared/storage/remote-storage-settings'
+import type { ChatError } from '#/types/chat-api'
 import { ChatSettingsProvider } from './chat-settings-context'
 import { ChatSettingsForm } from './chat-settings-form'
 import { ChatSettingsPanel } from './chat-settings-panel'
@@ -21,6 +22,7 @@ interface Props {
   onChange?: (settings: Settings) => void
   onHidePopup?: () => void
   imageGenerationMode?: boolean
+  settingsError?: ChatError | null
   settings: Settings
 }
 
@@ -37,6 +39,7 @@ export function ChatSettings({
   onChange,
   onHidePopup,
   imageGenerationMode = false,
+  settingsError,
   settings,
 }: Props) {
   const contextValue = useChatSettings({ showPopup, onChange, settings })
@@ -82,15 +85,13 @@ export function ChatSettings({
                     ? 'Fake Mode'
                     : contextValue.settings.model}
               </span>
-              {!imageGenerationMode && (
-                <IconButton
-                  label='Settings'
-                  onClick={onShowMenu}
-                  className='rounded-md p-2 text-gray-600 transition hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700'
-                >
-                  <GearIcon className='text-[#5D5D5D] dark:text-gray-300' />
-                </IconButton>
-              )}
+              <IconButton
+                label='Settings'
+                onClick={onShowMenu}
+                className='rounded-md p-2 text-gray-600 transition hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700'
+              >
+                <GearIcon className='text-[#5D5D5D] dark:text-gray-300' />
+              </IconButton>
             </div>
           </>
         )}
@@ -98,8 +99,8 @@ export function ChatSettings({
 
       {/* Settings Panel */}
       <ChatSettingsProvider value={contextValue}>
-        <ChatSettingsPanel show={!imageGenerationMode && (showPopup ?? false)} onClose={onHidePopup ?? (() => {})}>
-          <ChatSettingsForm />
+        <ChatSettingsPanel show={showPopup ?? false} onClose={onHidePopup ?? (() => {})}>
+          <ChatSettingsForm settingsError={settingsError} />
         </ChatSettingsPanel>
       </ChatSettingsProvider>
     </>

--- a/projects/portfolio/src/client/features/chat/hooks/use-chat-actions.ts
+++ b/projects/portfolio/src/client/features/chat/hooks/use-chat-actions.ts
@@ -9,6 +9,7 @@ import {
   createImageGenerationAssistantMessage,
   resolveChatRequestSettings,
 } from '#/client/features/chat/lib/chat-message-factory'
+import { validateChatSettings } from '#/client/features/chat/lib/chat-settings-validation'
 import {
   buildEditedHistory,
   buildEditedSendMessages,
@@ -44,6 +45,7 @@ interface UseChatActionsParams {
     onConversationChange?: (conversation: Conversation) => Promise<void> | void
     onSessionCompleted?: (conversation: Conversation) => Promise<void> | void
     onDeleteMessages?: (messageIds: string[], isConversationEmpty: boolean) => void
+    onSettingsError?: (error: ChatError) => void
   }
 }
 
@@ -69,12 +71,18 @@ export function useChatActions({
   const { loading, stream, submitChatCompletion, submitImageGeneration } = streamProcessor
   const { canSaveGeneratedFile, currentConversation, onConversationChange, onSessionCompleted, onDeleteMessages } =
     callbacks
+  const { onSettingsError } = callbacks
 
   const handleSubmit = useCallback(
     (event: FormEvent<HTMLFormElement>) => {
       event.preventDefault()
       if (settings.imageGenerationMode) {
         void handleImageGenerationSubmit()
+        return
+      }
+      const settingsError = validateChatSettings(settings, { allowFakeMode: !settings.imageGenerationMode })
+      if (settingsError) {
+        onSettingsError?.(settingsError)
         return
       }
       const requestSettings = resolveChatRequestSettings(settings)
@@ -187,6 +195,7 @@ export function useChatActions({
       setStreamMessageId,
       setGenerationError,
       settings,
+      onSettingsError,
       submitChatCompletion,
     ]
   )
@@ -194,6 +203,12 @@ export function useChatActions({
   async function handleImageGenerationSubmit() {
     const prompt = buildImageGenerationPrompt(messages, formState.input, settings.includeChatHistory)
     if (!prompt || !submitImageGeneration) {
+      return
+    }
+
+    const settingsError = validateChatSettings(settings)
+    if (settingsError) {
+      onSettingsError?.(settingsError)
       return
     }
 
@@ -325,6 +340,12 @@ export function useChatActions({
         return
       }
 
+      const settingsError = validateChatSettings(settings, { allowFakeMode: !settings.imageGenerationMode })
+      if (settingsError) {
+        onSettingsError?.(settingsError)
+        return
+      }
+
       const editedMessages = buildEditedHistory(messages, index, nextText)
       const editedUserMessage = editedMessages?.at(-1)
       if (!editedMessages || !editedUserMessage || editedUserMessage.role !== 'user') {
@@ -419,6 +440,7 @@ export function useChatActions({
       messages,
       onConversationChange,
       onSessionCompleted,
+      onSettingsError,
       setConversationId,
       setIsSavingConversation,
       setMessages,

--- a/projects/portfolio/src/client/features/chat/hooks/use-chat-page-state.ts
+++ b/projects/portfolio/src/client/features/chat/hooks/use-chat-page-state.ts
@@ -4,18 +4,21 @@ import {
   saveToLocalStorage,
   type Settings,
 } from '#/client/shared/storage/remote-storage-settings'
+import type { ChatError } from '#/types/chat-api'
 
 export function useChatPageState(selectedConversationId: string | null) {
   const [isSettingsPopupOpen, setIsSettingsPopupOpen] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [newChatTrigger, setNewChatTrigger] = useState(Date.now())
   const [settings, setSettings] = useState<Settings>(() => readFromLocalStorage())
+  const [settingsError, setSettingsError] = useState<ChatError | null>(null)
   const [isSidebarOpen, setIsSidebarOpen] = useState(() => readFromLocalStorage().sidebarOpen)
   const previousConversationIdRef = useRef<string | null>(selectedConversationId)
 
   useEffect(() => {
     if (previousConversationIdRef.current !== null && selectedConversationId === null) {
       setIsSettingsPopupOpen(false)
+      setSettingsError(null)
       setNewChatTrigger(Date.now())
     }
 
@@ -24,6 +27,7 @@ export function useChatPageState(selectedConversationId: string | null) {
 
   const startNewConversation = useCallback(() => {
     setIsSettingsPopupOpen(false)
+    setSettingsError(null)
     setNewChatTrigger(Date.now())
   }, [])
 
@@ -48,13 +52,20 @@ export function useChatPageState(selectedConversationId: string | null) {
   }, [])
 
   const updateSettings = useCallback((nextSettings: Settings) => {
+    setSettingsError(null)
     setSettings(nextSettings)
   }, [])
 
   const updateSetting = useCallback(<K extends keyof Settings>(key: K, value: Settings[K]) => {
+    setSettingsError(null)
     const nextSettings = saveToLocalStorage({ [key]: value })
     setSettings(nextSettings)
     return nextSettings
+  }, [])
+
+  const showSettingsError = useCallback((error: ChatError) => {
+    setSettingsError(error)
+    setIsSettingsPopupOpen(true)
   }, [])
 
   return {
@@ -64,6 +75,7 @@ export function useChatPageState(selectedConversationId: string | null) {
     isSidebarOpen,
     newChatTrigger,
     settings,
+    settingsError,
     showSettingsActions: !isSubmitting,
     startNewConversation,
     toggleSidebar,
@@ -72,5 +84,6 @@ export function useChatPageState(selectedConversationId: string | null) {
     setSubmitting,
     updateSettings,
     updateSetting,
+    showSettingsError,
   }
 }

--- a/projects/portfolio/src/client/features/chat/lib/chat-settings-validation.ts
+++ b/projects/portfolio/src/client/features/chat/lib/chat-settings-validation.ts
@@ -1,0 +1,35 @@
+import type { Settings } from '#/client/shared/storage/remote-storage-settings'
+import type { ChatError } from '#/types/chat-api'
+
+interface ValidateChatSettingsOptions {
+  allowFakeMode?: boolean
+}
+
+export function validateChatSettings(
+  settings: Pick<Settings, 'baseURL' | 'apiKey' | 'fakeMode'>,
+  { allowFakeMode = false }: ValidateChatSettingsOptions = {}
+): ChatError | null {
+  if (allowFakeMode && settings.fakeMode) {
+    return null
+  }
+
+  if (!settings.baseURL.trim() || !settings.apiKey.trim()) {
+    return {
+      code: 'VALIDATION_ERROR',
+      message: 'Base URL と API Key を設定してください。',
+      retryable: false,
+    }
+  }
+
+  try {
+    new URL(settings.baseURL.trim())
+  } catch {
+    return {
+      code: 'VALIDATION_ERROR',
+      message: '有効な Base URL を設定してください。',
+      retryable: false,
+    }
+  }
+
+  return null
+}

--- a/projects/portfolio/src/client/features/chat/page.tsx
+++ b/projects/portfolio/src/client/features/chat/page.tsx
@@ -25,6 +25,8 @@ export function Chat() {
     isSidebarOpen,
     newChatTrigger,
     settings,
+    settingsError,
+    showSettingsError,
     showSettingsActions,
     startNewConversation,
     toggleSidebar,
@@ -219,6 +221,7 @@ export function Chat() {
         onChange={updateSettings}
         onHidePopup={closeSettingsPopup}
         imageGenerationMode={settings.imageGenerationMode}
+        settingsError={settingsError}
         settings={settings}
       />
       {isResolvingConversation ? (
@@ -237,6 +240,7 @@ export function Chat() {
           onSessionCompleted={handleSessionCompleted}
           onDeleteMessages={handleDeleteConversationMessage}
           onUpdateSetting={updateSetting}
+          onSettingsError={showSettingsError}
         />
       )}
     </ChatLayout>

--- a/projects/portfolio/src/client/shared/storage/remote-storage-settings.ts
+++ b/projects/portfolio/src/client/shared/storage/remote-storage-settings.ts
@@ -125,13 +125,15 @@ function mergeSettings(
   const includeChatHistory =
     rest.includeChatHistory ??
     (typeof interactiveMode === 'boolean' ? interactiveMode : defaultSettings.includeChatHistory)
+  const imageGenerationMode = rest.imageGenerationMode ?? defaultSettings.imageGenerationMode
 
   return {
     ...defaultSettings,
     ...rest,
     includeChatHistory,
     apiMode,
-    fakeMode: apiMode === 'responses' ? false : (rest.fakeMode ?? defaultSettings.fakeMode),
+    imageGenerationMode,
+    fakeMode: apiMode === 'responses' || imageGenerationMode ? false : (rest.fakeMode ?? defaultSettings.fakeMode),
     schemaVersion: SCHEMA_VERSION,
   }
 }
@@ -171,6 +173,7 @@ function shouldPersistNormalizedSettings(
     settings.schemaVersion !== SCHEMA_VERSION ||
     !ApiModeSchema.safeParse(settings.apiMode).success ||
     (normalized.apiMode === 'responses' && settings.fakeMode === true) ||
+    (normalized.imageGenerationMode && settings.fakeMode === true) ||
     settings.includeChatHistory !== normalized.includeChatHistory ||
     'interactiveMode' in settings ||
     settings.sendImagesOnlyOnce !== normalized.sendImagesOnlyOnce ||

--- a/projects/portfolio/tests/client/components/chat-main.test.tsx
+++ b/projects/portfolio/tests/client/components/chat-main.test.tsx
@@ -134,8 +134,8 @@ const imageGenerationResult: ImageGenerationResponse = {
 const settings: Settings = {
   schemaVersion: '1.4.0',
   model: 'gpt-4.1-mini',
-  baseURL: '',
-  apiKey: '',
+  baseURL: 'https://example.com',
+  apiKey: 'api-key',
   apiMode: 'chat_completions',
   temperature: 0.7,
   temperatureEnabled: false,
@@ -511,6 +511,10 @@ describe('ChatMain', () => {
     await waitFor(() => expect(onConversationChange).toHaveBeenCalledTimes(1))
     expect(submitImageGenerationMock).toHaveBeenCalledWith(
       expect.objectContaining({
+        header: {
+          apiKey: 'api-key',
+          baseURL: 'https://example.com',
+        },
         prompt: '白い背景に青い円を1つ',
         conversationId: 'conversation-1',
       })
@@ -531,6 +535,80 @@ describe('ChatMain', () => {
         ],
       })
     )
+  })
+
+  it('設定不備では画像生成 API を呼ばず prompt を保持し、設定後に同じ prompt を再送できる', async () => {
+    chatFormInputMock = '設定後に再送する画像 prompt'
+    const onSettingsError = vi.fn()
+    const { ChatMain } = await import('#/client/features/chat/components/chat-main')
+    const view = render(
+      <ChatMain
+        settings={{ ...settings, baseURL: '', apiKey: '', imageGenerationMode: true }}
+        onSettingsError={onSettingsError}
+      />
+    )
+
+    fireEvent.submit(view.container.querySelector('form')!)
+
+    await waitFor(() =>
+      expect(onSettingsError).toHaveBeenCalledWith(expect.objectContaining({ code: 'VALIDATION_ERROR' }))
+    )
+    expect(submitImageGenerationMock).not.toHaveBeenCalled()
+    expect(resetAfterSubmitMock).not.toHaveBeenCalled()
+
+    view.rerender(<ChatMain settings={{ ...settings, imageGenerationMode: true }} onSettingsError={onSettingsError} />)
+    fireEvent.submit(view.container.querySelector('form')!)
+
+    await waitFor(() => expect(submitImageGenerationMock).toHaveBeenCalledTimes(1))
+    expect(submitImageGenerationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        header: {
+          apiKey: 'api-key',
+          baseURL: 'https://example.com',
+        },
+        prompt: '設定後に再送する画像 prompt',
+      })
+    )
+  })
+
+  it('通常対話も設定不備では completion API を呼ばず設定エラーを通知する', async () => {
+    buildChatMessagesMock.mockReturnValue({
+      model: 'gpt-test',
+      apiMessages: [{ role: 'user', content: '設定不備の質問' }],
+      draftUserMessage: createUserMessage('message-user-3', '設定不備の質問'),
+      imageContext: { policy: 'send_once', sent: 0, historyOnly: 0 },
+    })
+    const onSettingsError = vi.fn()
+    const { ChatMain } = await import('#/client/features/chat/components/chat-main')
+    const { container } = render(
+      <ChatMain settings={{ ...settings, baseURL: '', apiKey: '' }} onSettingsError={onSettingsError} />
+    )
+
+    fireEvent.submit(container.querySelector('form')!)
+
+    await waitFor(() =>
+      expect(onSettingsError).toHaveBeenCalledWith(expect.objectContaining({ code: 'VALIDATION_ERROR' }))
+    )
+    expect(buildChatMessagesMock).not.toHaveBeenCalled()
+    expect(submitChatCompletionMock).not.toHaveBeenCalled()
+    expect(resetAfterSubmitMock).not.toHaveBeenCalled()
+  })
+
+  it('画像生成モードへ切り替えると Fake Mode を解除して保存する', async () => {
+    const onUpdateSetting = vi.fn()
+    const { ChatMain } = await import('#/client/features/chat/components/chat-main')
+
+    render(
+      <ChatMain
+        settings={{ ...settings, fakeMode: true, imageGenerationMode: false }}
+        onUpdateSetting={onUpdateSetting}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: '画像生成モード On/Off' }))
+
+    expect(onUpdateSetting).toHaveBeenNthCalledWith(1, 'fakeMode', false)
+    expect(onUpdateSetting).toHaveBeenNthCalledWith(2, 'imageGenerationMode', true)
   })
 
   it('共有履歴設定が Off の画像生成では過去の画像 prompt を送らない', async () => {

--- a/projects/portfolio/tests/client/components/chat-settings-form.test.tsx
+++ b/projects/portfolio/tests/client/components/chat-settings-form.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Settings } from '#/client/shared/storage/remote-storage-settings'
+
+const useChatSettingsContextMock = vi.hoisted(() => vi.fn())
+
+vi.mock('#/client/features/chat/components/chat-settings/chat-settings-context', () => ({
+  useChatSettingsContext: useChatSettingsContextMock,
+}))
+
+vi.mock('#/client/features/chat/components/chat-settings/model-selector', () => ({
+  ModelSelector: () => null,
+}))
+
+vi.mock('#/client/features/chat/components/chat-settings/settings/auto-model-toggle', () => ({
+  AutoModelToggle: () => null,
+}))
+
+vi.mock('#/client/features/chat/components/chat-settings/settings/reasoning-effort', () => ({
+  ReasoningEffort: () => null,
+}))
+
+vi.mock('#/client/features/chat/components/chat-settings/settings/temperature-slider', () => ({
+  TemperatureSlider: () => null,
+}))
+
+const settings: Settings = {
+  schemaVersion: '1.4.0',
+  model: 'gpt-4.1-mini',
+  baseURL: '',
+  apiKey: '',
+  apiMode: 'chat_completions',
+  temperature: 0.7,
+  temperatureEnabled: false,
+  maxTokens: undefined,
+  reasoningEffort: 'medium',
+  reasoningEffortEnabled: false,
+  fakeMode: false,
+  autoModel: false,
+  markdownPreview: true,
+  streamMode: true,
+  includeChatHistory: true,
+  sendImagesOnlyOnce: true,
+  imageGenerationMode: true,
+  sidebarOpen: true,
+  templateModels: {},
+}
+
+describe('ChatSettingsForm', () => {
+  beforeEach(() => {
+    useChatSettingsContextMock.mockReturnValue({
+      settings,
+      apiMode: settings.apiMode,
+      fakeMode: settings.fakeMode,
+      markdownPreview: settings.markdownPreview,
+      streamMode: settings.streamMode,
+      includeChatHistory: settings.includeChatHistory,
+      sendImagesOnlyOnce: settings.sendImagesOnlyOnce,
+      handleChangeBaseURL: vi.fn(),
+      handleChangeApiKey: vi.fn(),
+      handleChangeApiMode: vi.fn(),
+      handleChangeMaxTokens: vi.fn(),
+      handleToggleFakeMode: vi.fn(),
+      handleToggleMarkdownPreview: vi.fn(),
+      handleToggleStreamMode: vi.fn(),
+      handleToggleIncludeChatHistory: vi.fn(),
+      handleToggleSendImagesOnlyOnce: vi.fn(),
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('空の baseURL は既定 URL に置き換えず、設定エラーをパネル内に表示する', async () => {
+    const { ChatSettingsForm } = await import('#/client/features/chat/components/chat-settings/chat-settings-form')
+    const { container } = render(
+      <ChatSettingsForm
+        settingsError={{
+          code: 'VALIDATION_ERROR',
+          message: 'Base URL と API Key を設定してください。',
+          retryable: false,
+        }}
+      />
+    )
+
+    const baseUrlInput = container.querySelector<HTMLInputElement>("input[name='baseURL']")
+    expect(baseUrlInput?.value).toBe('')
+    expect(baseUrlInput?.placeholder).not.toContain('api.openai.com')
+    expect(screen.getByRole('alert').textContent).toBe('Base URL と API Key を設定してください。')
+  })
+})

--- a/projects/portfolio/tests/client/components/chat-settings-form.test.tsx
+++ b/projects/portfolio/tests/client/components/chat-settings-form.test.tsx
@@ -75,21 +75,53 @@ describe('ChatSettingsForm', () => {
     vi.clearAllMocks()
   })
 
-  it('空の baseURL は既定 URL に置き換えず、設定エラーをパネル内に表示する', async () => {
-    const { ChatSettingsForm } = await import('#/client/features/chat/components/chat-settings/chat-settings-form')
-    const { container } = render(
-      <ChatSettingsForm
-        settingsError={{
-          code: 'VALIDATION_ERROR',
-          message: 'Base URL と API Key を設定してください。',
-          retryable: false,
-        }}
-      />
-    )
+  describe('設定エラー', () => {
+    it('空の baseURL は既定 URL に置き換えず、設定エラーをパネル内に表示する', async () => {
+      const { ChatSettingsForm } = await import('#/client/features/chat/components/chat-settings/chat-settings-form')
+      const { container } = render(
+        <ChatSettingsForm
+          settingsError={{
+            code: 'VALIDATION_ERROR',
+            message: 'Base URL と API Key を設定してください。',
+            retryable: false,
+          }}
+        />
+      )
 
-    const baseUrlInput = container.querySelector<HTMLInputElement>("input[name='baseURL']")
-    expect(baseUrlInput?.value).toBe('')
-    expect(baseUrlInput?.placeholder).not.toContain('api.openai.com')
-    expect(screen.getByRole('alert').textContent).toBe('Base URL と API Key を設定してください。')
+      const baseUrlInput = container.querySelector<HTMLInputElement>("input[name='baseURL']")
+      expect(baseUrlInput?.value).toBe('')
+      expect(baseUrlInput?.placeholder).not.toContain('api.openai.com')
+      expect(screen.getByRole('alert').textContent).toBe('Base URL と API Key を設定してください。')
+    })
+  })
+
+  describe('セクション表示', () => {
+    it('画像生成モードではAPI設定とContext Optionsだけを表示する', async () => {
+      const { ChatSettingsForm } = await import('#/client/features/chat/components/chat-settings/chat-settings-form')
+      render(<ChatSettingsForm imageGenerationMode />)
+
+      expect(screen.queryByRole('heading', { name: 'Model' })).toBeNull()
+      expect(screen.getByRole('heading', { name: 'API Configuration' })).toBeTruthy()
+      expect(screen.queryByRole('heading', { name: 'Parameters' })).toBeNull()
+      expect(screen.queryByRole('heading', { name: 'Display Options' })).toBeNull()
+      expect(screen.getByRole('heading', { name: 'Context Options' })).toBeTruthy()
+      expect(screen.getByText('Include chat history')).toBeTruthy()
+      expect(screen.queryByText('Send attached images only once')).toBeNull()
+      expect(screen.queryByRole('heading', { name: 'Debug Options' })).toBeNull()
+    })
+
+    it('通常対話モードでは全セクションとContext Optionsの項目を表示する', async () => {
+      const { ChatSettingsForm } = await import('#/client/features/chat/components/chat-settings/chat-settings-form')
+      render(<ChatSettingsForm />)
+
+      expect(screen.getByRole('heading', { name: 'Model' })).toBeTruthy()
+      expect(screen.getByRole('heading', { name: 'API Configuration' })).toBeTruthy()
+      expect(screen.getByRole('heading', { name: 'Parameters' })).toBeTruthy()
+      expect(screen.getByRole('heading', { name: 'Display Options' })).toBeTruthy()
+      expect(screen.getByRole('heading', { name: 'Context Options' })).toBeTruthy()
+      expect(screen.getByText('Include chat history')).toBeTruthy()
+      expect(screen.getByText('Send attached images only once')).toBeTruthy()
+      expect(screen.getByRole('heading', { name: 'Debug Options' })).toBeTruthy()
+    })
   })
 })

--- a/projects/portfolio/tests/client/components/chat-settings-form.test.tsx
+++ b/projects/portfolio/tests/client/components/chat-settings-form.test.tsx
@@ -1,10 +1,11 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Settings } from '#/client/shared/storage/remote-storage-settings'
 
 const useChatSettingsContextMock = vi.hoisted(() => vi.fn())
+const handleChangeApiModeMock = vi.hoisted(() => vi.fn())
 
 vi.mock('#/client/features/chat/components/chat-settings/chat-settings-context', () => ({
   useChatSettingsContext: useChatSettingsContextMock,
@@ -60,7 +61,7 @@ describe('ChatSettingsForm', () => {
       sendImagesOnlyOnce: settings.sendImagesOnlyOnce,
       handleChangeBaseURL: vi.fn(),
       handleChangeApiKey: vi.fn(),
-      handleChangeApiMode: vi.fn(),
+      handleChangeApiMode: handleChangeApiModeMock,
       handleChangeMaxTokens: vi.fn(),
       handleToggleFakeMode: vi.fn(),
       handleToggleMarkdownPreview: vi.fn(),
@@ -98,10 +99,13 @@ describe('ChatSettingsForm', () => {
   describe('セクション表示', () => {
     it('画像生成モードではAPI設定とContext Optionsだけを表示する', async () => {
       const { ChatSettingsForm } = await import('#/client/features/chat/components/chat-settings/chat-settings-form')
-      render(<ChatSettingsForm imageGenerationMode />)
+      const { container } = render(<ChatSettingsForm imageGenerationMode />)
 
       expect(screen.queryByRole('heading', { name: 'Model' })).toBeNull()
       expect(screen.getByRole('heading', { name: 'API Configuration' })).toBeTruthy()
+      expect(container.querySelector("input[name='baseURL']")).toBeTruthy()
+      expect(container.querySelector("input[name='apiKey']")).toBeTruthy()
+      expect(screen.queryByRole('combobox')).toBeNull()
       expect(screen.queryByRole('heading', { name: 'Parameters' })).toBeNull()
       expect(screen.queryByRole('heading', { name: 'Display Options' })).toBeNull()
       expect(screen.getByRole('heading', { name: 'Context Options' })).toBeTruthy()
@@ -122,6 +126,11 @@ describe('ChatSettingsForm', () => {
       expect(screen.getByText('Include chat history')).toBeTruthy()
       expect(screen.getByText('Send attached images only once')).toBeTruthy()
       expect(screen.getByRole('heading', { name: 'Debug Options' })).toBeTruthy()
+      const apiModeSelect = screen.getByRole('combobox') as HTMLSelectElement
+      expect(apiModeSelect.value).toBe('chat_completions')
+
+      fireEvent.change(apiModeSelect, { target: { value: 'responses' } })
+      expect(handleChangeApiModeMock).toHaveBeenCalled()
     })
   })
 })

--- a/projects/portfolio/tests/client/components/chat-settings.test.tsx
+++ b/projects/portfolio/tests/client/components/chat-settings.test.tsx
@@ -38,7 +38,11 @@ vi.mock('#/client/features/chat/components/chat-settings/chat-settings-form', ()
 }))
 
 vi.mock('#/client/features/chat/components/chat-settings/chat-settings-panel', () => ({
-  ChatSettingsPanel: ({ children }: { children: ReactNode }) => <>{children}</>,
+  ChatSettingsPanel: ({ children, show }: { children: ReactNode; show: boolean }) => (
+    <div data-testid='settings-panel' data-show={show}>
+      {children}
+    </div>
+  ),
 }))
 
 import { ChatSettings } from '#/client/features/chat/components/chat-settings/chat-settings'
@@ -69,5 +73,21 @@ describe('ChatSettings', () => {
 
     expect(screen.getByText('gpt-image-2')).toBeTruthy()
     expect(screen.queryByText('画像生成モード')).toBeNull()
+  })
+
+  it('画像生成モード時も Settings ボタンから既存パネルを開ける', () => {
+    render(
+      <ChatSettings
+        settings={settings}
+        showActions={true}
+        showPopup={true}
+        showNewChat={false}
+        showSidebarToggle={false}
+        imageGenerationMode={true}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'Settings' })).toBeTruthy()
+    expect(screen.getByTestId('settings-panel').dataset.show).toBe('true')
   })
 })

--- a/projects/portfolio/tests/client/components/chat-settings.test.tsx
+++ b/projects/portfolio/tests/client/components/chat-settings.test.tsx
@@ -34,7 +34,9 @@ vi.mock('#/client/features/chat/components/chat-settings/hooks/use-chat-settings
 }))
 
 vi.mock('#/client/features/chat/components/chat-settings/chat-settings-form', () => ({
-  ChatSettingsForm: () => null,
+  ChatSettingsForm: ({ imageGenerationMode }: { imageGenerationMode?: boolean }) => (
+    <div data-testid='settings-form' data-image-generation-mode={String(!!imageGenerationMode)} />
+  ),
 }))
 
 vi.mock('#/client/features/chat/components/chat-settings/chat-settings-panel', () => ({
@@ -89,5 +91,6 @@ describe('ChatSettings', () => {
 
     expect(screen.getByRole('button', { name: 'Settings' })).toBeTruthy()
     expect(screen.getByTestId('settings-panel').dataset.show).toBe('true')
+    expect(screen.getByTestId('settings-form').dataset.imageGenerationMode).toBe('true')
   })
 })

--- a/projects/portfolio/tests/client/hooks/use-chat-page-state.test.ts
+++ b/projects/portfolio/tests/client/hooks/use-chat-page-state.test.ts
@@ -158,4 +158,27 @@ describe('useChatPageState', () => {
     expect(result.current.isSettingsPopupOpen).toBe(false)
     expect(result.current.newChatTrigger).toBe(300)
   })
+
+  it('設定エラーを保存して設定パネルを開き、設定変更時に消去する', async () => {
+    const useChatPageState = await importHook()
+    const { result } = renderHook(() => useChatPageState(null))
+    const error = {
+      code: 'VALIDATION_ERROR' as const,
+      message: 'Base URL と API Key を設定してください。',
+      retryable: false,
+    }
+
+    act(() => {
+      result.current.showSettingsError(error)
+    })
+
+    expect(result.current.isSettingsPopupOpen).toBe(true)
+    expect(result.current.settingsError).toEqual(error)
+
+    act(() => {
+      result.current.updateSetting('apiKey', 'api-key')
+    })
+
+    expect(result.current.settingsError).toBeNull()
+  })
 })

--- a/projects/portfolio/tests/client/lib/chat-settings-validation.test.ts
+++ b/projects/portfolio/tests/client/lib/chat-settings-validation.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { validateChatSettings } from '#/client/features/chat/lib/chat-settings-validation'
+
+describe('chat-settings-validation', () => {
+  describe('通常の API 接続', () => {
+    it('baseURL と apiKey が空なら送信を拒否する', () => {
+      expect(validateChatSettings({ baseURL: '', apiKey: '', fakeMode: false })).toMatchObject({
+        code: 'VALIDATION_ERROR',
+      })
+    })
+
+    it('有効な URL と apiKey なら送信を許可する', () => {
+      expect(validateChatSettings({ baseURL: 'https://example.com/v1', apiKey: 'api-key', fakeMode: false })).toBeNull()
+    })
+
+    it('URL 形式が不正なら送信を拒否する', () => {
+      expect(validateChatSettings({ baseURL: 'not-a-url', apiKey: 'api-key', fakeMode: false })).toMatchObject({
+        code: 'VALIDATION_ERROR',
+      })
+    })
+  })
+
+  describe('Fake Mode', () => {
+    it('通常対話では Fake Mode の接続情報検証を省略する', () => {
+      expect(validateChatSettings({ baseURL: '', apiKey: '', fakeMode: true }, { allowFakeMode: true })).toBeNull()
+    })
+
+    it('画像生成では Fake Mode でも接続情報検証を行う', () => {
+      expect(validateChatSettings({ baseURL: '', apiKey: '', fakeMode: true })).toMatchObject({
+        code: 'VALIDATION_ERROR',
+      })
+    })
+  })
+})

--- a/projects/portfolio/tests/client/pages/chat.test.tsx
+++ b/projects/portfolio/tests/client/pages/chat.test.tsx
@@ -55,6 +55,7 @@ const clearActiveChatSessionMock = vi.fn()
 let hasActiveChatSessionMock = false
 
 let chatMainProps: Record<string, unknown> | null = null
+let chatSettingsProps: Record<string, unknown> | null = null
 let conversationHistoryProps: Record<string, unknown> | null = null
 
 const createDeferred = <T,>() => {
@@ -106,7 +107,10 @@ vi.mock('#/client/features/chat/components/chat-layout', () => ({
 }))
 
 vi.mock('#/client/features/chat/components/chat-settings', () => ({
-  ChatSettings: () => null,
+  ChatSettings: (props: Record<string, unknown>) => {
+    chatSettingsProps = props
+    return null
+  },
 }))
 
 vi.mock('#/client/features/chat/components/chat-main', () => ({
@@ -157,6 +161,7 @@ describe('Chat page', () => {
     vi.clearAllMocks()
     hasActiveChatSessionMock = false
     chatMainProps = null
+    chatSettingsProps = null
     conversationHistoryProps = null
     useMetaPropsMock.mockReturnValue({ email: 'test@example.com' })
     useSearchMock.mockReturnValue({})
@@ -334,6 +339,28 @@ describe('Chat page', () => {
       to: '/chat',
       search: { conversationId: undefined },
       replace: true,
+    })
+  })
+
+  it('設定エラー通知時は既存設定パネルを自動表示してエラーを渡す', async () => {
+    const { Chat } = await import('#/client/features/chat/page')
+    render(<Chat />)
+
+    const error = {
+      code: 'VALIDATION_ERROR',
+      message: 'Base URL と API Key を設定してください。',
+      retryable: false,
+    }
+    const onSettingsError = chatMainProps?.onSettingsError as ((nextError: typeof error) => void) | undefined
+    expect(onSettingsError).toBeTypeOf('function')
+
+    onSettingsError?.(error)
+
+    await waitFor(() => {
+      expect(chatSettingsProps).toMatchObject({
+        showPopup: true,
+        settingsError: error,
+      })
     })
   })
 })

--- a/projects/portfolio/tests/client/storage/remote-storage-settings.test.ts
+++ b/projects/portfolio/tests/client/storage/remote-storage-settings.test.ts
@@ -205,4 +205,26 @@ describe('remote-storage-settings', () => {
     expect(settings.apiMode).toBe('responses')
     expect(settings.fakeMode).toBe(false)
   })
+
+  it('画像生成モードでは fakeMode を false に正規化して保存する', async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        schemaVersion: '1.4.0',
+        model: 'gpt-4.1-mini',
+        apiMode: 'chat_completions',
+        fakeMode: true,
+        imageGenerationMode: true,
+      })
+    )
+
+    const { readFromLocalStorage } = await import('#/client/shared/storage/remote-storage-settings')
+    const settings = readFromLocalStorage()
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}')
+
+    expect(settings.imageGenerationMode).toBe(true)
+    expect(settings.fakeMode).toBe(false)
+    expect(stored.imageGenerationMode).toBe(true)
+    expect(stored.fakeMode).toBe(false)
+  })
 })


### PR DESCRIPTION
## 概要

画像生成モードでも既存の共通 Chat Settings を開けるようにし、通常対話と同じ baseURL / apiKey と localStorage を利用するようにしました。

- 画像生成モードの設定ボタンと既存パネルを有効化
- 通常対話・画像生成・通常メッセージ編集の送信前設定検証を共通化
- 設定エラー時は API を呼ばず、prompt を保持したままパネルを自動表示
- 設定完了後に同じ prompt を再送可能化
- 画像生成モードへの切り替え時に Fake Mode を解除して保存
- 空の baseURL を既定 URL に置き換えず空欄表示

## 検証

- `bun run test`（70 files / 391 tests）
- `bun run lint`
- `bun run format:check`
- `bun run build`

Refs #1162