### PR TITLE
[portfolio] チャット停止ボタンの位置を調整

### DIFF
--- a/projects/portfolio/src/client/features/chat/components/chat-composer.tsx
+++ b/projects/portfolio/src/client/features/chat/components/chat-composer.tsx
@@ -198,7 +198,7 @@ export function SendButton({ color = 'blue', loading, disabled, handleClickStop 
       onClick={handleClickStop}
       className={`h-8 w-8 rounded-full focus:outline-hidden focus:ring-2 focus:ring-gray-400 dark:bg-primary-700 dark:hover:bg-primary-600 dark:disabled:hover:bg-primary-700 ${classes}`}
     >
-      <StopIcon className='text-white' size={18} />
+      <StopIcon className='-translate-x-[0.5px] translate-y-[0.5px] text-white' size={18} />
     </IconButton>
   ) : (
     <IconButton


### PR DESCRIPTION
## 概要

チャットのメッセージ送信後に表示される停止ボタンの停止記号を、円形ボタンの中央に見えるよう微調整しました。

## 変更内容

- `ChatComposer` の停止記号に小数ピクセル単位の位置調整を追加
- 送信矢印や他の停止アイコンの表示には影響させない構成

## 背景

小さな円形ボタンでは、SVG の停止記号がブラウザの描画スケールによってわずかにずれて見えていました。実際の表示を確認しながら、横方向を 0.5px 左、縦方向を 0.5px 下へ調整しています。

## 検証

- `bun run lint`
- `bun run test`（70ファイル・394テスト）
- `bun run test -- tests/client/components/chat-composer.test.tsx`
- `bun run format:check -- src/client/features/chat/components/chat-composer.tsx`
