### PR TITLE
fix: HTTP環境でログインCookieを有効化

### DIFF
--- a/projects/portfolio/.env.example
+++ b/projects/portfolio/.env.example
@@ -5,6 +5,7 @@ SERVER_PORT=3000
 COOKIE_SECRET=test
 COOKIE_NAME=sid
 COOKIE_EXPIRES=1d
+COOKIE_SECURE=false
 DATABASE_URL=postgresql://{{ user }}:{{ password }}@localhost:5432/{{ database }}
 CHAT_CONVERSATION_ENABLED=TRUE
 CHAT_CACHE_URL=

--- a/projects/portfolio/DEVELOPMENT.md
+++ b/projects/portfolio/DEVELOPMENT.md
@@ -159,4 +159,5 @@ order by display_order, id;
 
 - サインイン時は `users.password_hash` を使ってパスワードを検証します
 - `db:user:add` は平文パスワードを対話入力または標準入力で受け取り、ハッシュ化して登録します
+- `COOKIE_SECURE` は認証Cookieの `Secure` 属性を制御します。HTTPで直接公開する場合は `false`、HTTPSまたはTLS終端プロキシ経由で公開する場合は `true` に設定します。未設定時は `false` です
 - チャット設定の `apiKey` はブラウザの `localStorage` に保存されます。安全な秘密情報ストアではありません

--- a/projects/portfolio/src/server/features/cookie/cookie.ts
+++ b/projects/portfolio/src/server/features/cookie/cookie.ts
@@ -8,14 +8,14 @@ interface CookieOptions {
 }
 
 interface Cookie {
-  createOptions(duration: string): CookieOptions
+  createOptions(duration: string, secure: boolean): CookieOptions
 }
 export const cookie: Cookie = {
-  createOptions(duration: string): CookieOptions {
+  createOptions(duration: string, secure: boolean): CookieOptions {
     const cookieExpiresSec = parseDurationToSeconds(duration)
     return {
       path: '/',
-      secure: process.env.NODE_ENV === 'production',
+      secure,
       httpOnly: true,
       maxAge: cookieExpiresSec,
       expires: new Date(Date.now() + cookieExpiresSec * 1000),

--- a/projects/portfolio/src/server/routes/auth.ts
+++ b/projects/portfolio/src/server/routes/auth.ts
@@ -16,10 +16,16 @@ const SignInBodySchema = z.object({
 const authRoutes = new Hono<HonoEnv>()
   .post('/api/signin', sValidator('json', SignInBodySchema), signinRateLimit, async (c) => {
     const { email, password } = c.req.valid('json')
-    const { DATABASE_URL = '', COOKIE_SECRET = '', COOKIE_NAME = '', COOKIE_EXPIRES = '1d' } = getServerEnv(c)
+    const {
+      DATABASE_URL = '',
+      COOKIE_SECRET = '',
+      COOKIE_NAME = '',
+      COOKIE_EXPIRES = '1d',
+      COOKIE_SECURE = 'false',
+    } = getServerEnv(c)
 
     await auth.login(DATABASE_URL, email, password)
-    const secure = new URL(c.req.url).protocol === 'https:'
+    const secure = COOKIE_SECURE.toLowerCase() === 'true'
     await setSignedCookie(c, COOKIE_NAME, email, COOKIE_SECRET, cookie.createOptions(COOKIE_EXPIRES, secure))
 
     return c.json({})

--- a/projects/portfolio/src/server/routes/auth.ts
+++ b/projects/portfolio/src/server/routes/auth.ts
@@ -19,7 +19,8 @@ const authRoutes = new Hono<HonoEnv>()
     const { DATABASE_URL = '', COOKIE_SECRET = '', COOKIE_NAME = '', COOKIE_EXPIRES = '1d' } = getServerEnv(c)
 
     await auth.login(DATABASE_URL, email, password)
-    await setSignedCookie(c, COOKIE_NAME, email, COOKIE_SECRET, cookie.createOptions(COOKIE_EXPIRES))
+    const secure = new URL(c.req.url).protocol === 'https:'
+    await setSignedCookie(c, COOKIE_NAME, email, COOKIE_SECRET, cookie.createOptions(COOKIE_EXPIRES, secure))
 
     return c.json({})
   })

--- a/projects/portfolio/src/server/routes/shared.ts
+++ b/projects/portfolio/src/server/routes/shared.ts
@@ -11,6 +11,7 @@ export type Env = Partial<{
   COOKIE_SECRET: string
   COOKIE_NAME: string
   COOKIE_EXPIRES: string
+  COOKIE_SECURE: string
   LOG_LEVEL: string
   LOG_FILE: string
   FILE_SERVER_URL: string

--- a/projects/portfolio/tests/features/cookie/cookie.test.ts
+++ b/projects/portfolio/tests/features/cookie/cookie.test.ts
@@ -41,7 +41,7 @@ describe('cookie.createOptions', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-03-16T00:00:00.000Z'))
 
-    const options = cookie.createOptions('1d')
+    const options = cookie.createOptions('1d', false)
 
     expect(options).toMatchObject({
       path: '/',
@@ -53,10 +53,8 @@ describe('cookie.createOptions', () => {
     expect(options.expires.toISOString()).toBe('2026-03-17T00:00:00.000Z')
   })
 
-  it('production では secure を有効にする', () => {
-    vi.stubEnv('NODE_ENV', 'production')
-
-    const options = cookie.createOptions('1d')
+  it('HTTPS 用の options では secure を有効にする', () => {
+    const options = cookie.createOptions('1d', true)
 
     expect(options.secure).toBe(true)
   })

--- a/projects/portfolio/tests/routes/auth.test.ts
+++ b/projects/portfolio/tests/routes/auth.test.ts
@@ -44,6 +44,7 @@ describe('authRoutes', () => {
     vi.stubEnv('COOKIE_SECRET', 'secret')
     vi.stubEnv('COOKIE_NAME', 'session')
     vi.stubEnv('COOKIE_EXPIRES', '1d')
+    vi.stubEnv('COOKIE_SECURE', 'false')
 
     const res = await authRoutes.request(
       '/api/signin',
@@ -74,14 +75,15 @@ describe('authRoutes', () => {
     )
   })
 
-  it('HTTPS の認証成功時は secure cookie を設定する', async () => {
+  it('TLS 終端プロキシ経由では COOKIE_SECURE に従って secure cookie を設定する', async () => {
     vi.stubEnv('DATABASE_URL', 'postgres://db')
     vi.stubEnv('COOKIE_SECRET', 'secret')
     vi.stubEnv('COOKIE_NAME', 'session')
     vi.stubEnv('COOKIE_EXPIRES', '1d')
+    vi.stubEnv('COOKIE_SECURE', 'true')
 
     const res = await authRoutes.request(
-      'https://example.com/api/signin',
+      'http://internal.example/api/signin',
       {
         method: 'POST',
         headers: {

--- a/projects/portfolio/tests/routes/auth.test.ts
+++ b/projects/portfolio/tests/routes/auth.test.ts
@@ -69,6 +69,40 @@ describe('authRoutes', () => {
       'secret',
       expect.objectContaining({
         maxAge: 86400,
+        secure: false,
+      })
+    )
+  })
+
+  it('HTTPS の認証成功時は secure cookie を設定する', async () => {
+    vi.stubEnv('DATABASE_URL', 'postgres://db')
+    vi.stubEnv('COOKIE_SECRET', 'secret')
+    vi.stubEnv('COOKIE_NAME', 'session')
+    vi.stubEnv('COOKIE_EXPIRES', '1d')
+
+    const res = await authRoutes.request(
+      'https://example.com/api/signin',
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          email: 'test@example.com',
+          password: 'testexample',
+        }),
+      },
+      createNodeEnv('192.0.2.10')
+    )
+
+    expect(res.status).toBe(200)
+    expect(setSignedCookieMock).toHaveBeenCalledWith(
+      expect.anything(),
+      'session',
+      'test@example.com',
+      'secret',
+      expect.objectContaining({
+        secure: true,
       })
     )
   })


### PR DESCRIPTION
## 概要

HTTP環境で、正しい認証情報でサインインしてもホーム画面がログイン済みにならない問題を修正します。

## 原因

本番環境では接続方式にかかわらず認証Cookieへ`Secure`属性を付けていました。HTTPではブラウザがそのCookieを送信しないため、次のリクエストで認証状態を復元できませんでした。

また、TLS終端プロキシ配下ではアプリケーションから見える接続がHTTPになるため、バックエンドのリクエストURLだけでは外部のHTTPSを判定できません。

## 変更内容

- `COOKIE_SECURE`で認証Cookieの`Secure`属性を明示的に設定できるようにする
- HTTP直結は`false`、HTTPSまたはTLS終端プロキシ経由は`true`に設定する運用をドキュメント化する
- HTTPバックエンド＋`COOKIE_SECURE=true`の構成を回帰テストで検証する

## 確認

- `bun run test`（70ファイル、395テスト成功）
- `bun run lint`
- `bun run format:check`
