### PR TITLE
file-server: 外部監視用 GET /healthz を追加

### DIFF
--- a/projects/file-server/src/app.ts
+++ b/projects/file-server/src/app.ts
@@ -7,6 +7,7 @@ import apiRoutes from "./routes/api"
 import authRoutes from "./routes/auth"
 import browseRoutes from "./routes/browse"
 import fileRoutes from "./routes/file"
+import healthzRoutes from "./routes/healthz"
 import publicRoutes from "./routes/public"
 import type { AppBindings } from "./types"
 import {
@@ -47,6 +48,8 @@ export async function createApp(
   }
 
   const app = new Hono<AppBindings>()
+
+  app.route("/", healthzRoutes)
 
   app.use("*", authMiddleware)
   app.use("*", requireAuthMiddleware)

--- a/projects/file-server/src/routes/healthz.ts
+++ b/projects/file-server/src/routes/healthz.ts
@@ -1,0 +1,28 @@
+import { constants } from "node:fs"
+import { access } from "node:fs/promises"
+import path from "node:path"
+import { Hono } from "hono"
+import type { AppBindings } from "../types"
+import { getUploadDir } from "../utils/requestUtils"
+
+const healthzRoutes = new Hono<AppBindings>()
+
+healthzRoutes.get("/healthz", async (c) => {
+  c.header("Cache-Control", "no-store")
+
+  const uploadDir = getUploadDir(c)
+  const accessMode = constants.R_OK | constants.W_OK | constants.X_OK
+
+  try {
+    await Promise.all([
+      access(path.join(uploadDir, "public"), accessMode),
+      access(path.join(uploadDir, "private"), accessMode),
+    ])
+
+    return c.json({ status: "ok" })
+  } catch {
+    return c.json({ status: "unavailable" }, 503)
+  }
+})
+
+export default healthzRoutes

--- a/projects/file-server/tests/healthz.test.ts
+++ b/projects/file-server/tests/healthz.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { rm } from "node:fs/promises"
+import path from "node:path"
+import { createTestApp } from "./helpers/createTestApp"
+
+const UPLOAD_DIR = "./tmp-test-healthz"
+const AUTH_DIR = path.join(UPLOAD_DIR, ".auth")
+let app: Awaited<ReturnType<typeof createTestApp>>
+
+beforeEach(async () => {
+  await rm(UPLOAD_DIR, { recursive: true, force: true })
+  app = await createTestApp({ uploadDir: UPLOAD_DIR })
+})
+
+afterEach(async () => {
+  await rm(UPLOAD_DIR, { recursive: true, force: true })
+})
+
+describe("GET /healthz", () => {
+  it("returns 200 when both storage directories are accessible", async () => {
+    const res = await app.request(new Request("http://localhost/healthz"))
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get("cache-control")).toBe("no-store")
+    expect(await res.json()).toEqual({ status: "ok" })
+  })
+
+  it("is accessible without a session cookie when auth is enabled", async () => {
+    app = await createTestApp({
+      uploadDir: UPLOAD_DIR,
+      authDir: AUTH_DIR,
+      sessionSecret: "0123456789abcdef0123456789abcdef",
+      initialAdminPassword: "test-admin-pass",
+    })
+
+    const res = await app.request(new Request("http://localhost/healthz"))
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get("cache-control")).toBe("no-store")
+    expect(await res.json()).toEqual({ status: "ok" })
+  })
+
+  it("returns 503 when a storage directory is unavailable", async () => {
+    await rm(path.join(UPLOAD_DIR, "private"), {
+      recursive: true,
+      force: true,
+    })
+
+    const res = await app.request(new Request("http://localhost/healthz"))
+
+    expect(res.status).toBe(503)
+    expect(res.headers.get("cache-control")).toBe("no-store")
+    expect(await res.json()).toEqual({ status: "unavailable" })
+  })
+})


### PR DESCRIPTION
## Issues

- close: #1168
- ref: #1167

## Why

外部監視から認証なしで file-server の稼働状況と保存領域を確認できるようにするためです。

## Summary

`GET /healthz` を追加し、`public` と `private` の保存領域を確認して状態を返します。

## Changes

- 認証ミドルウェアより前に `/healthz` を登録し、認証有効時も公開
- `UPLOAD_DIR/public` と `UPLOAD_DIR/private` のアクセス可能性を確認
- 正常時は 200、不通時は 503 を返し、機密情報を含まないレスポンスに変更
- `Cache-Control: no-store` を付与
- 正常系・認証有効時・保存領域異常のテストを追加

## Verification

- `cd projects/file-server && bun test`
- `cd projects/file-server && bun run lint`
- `bun run dev` 起動後に `curl -i http://localhost:3000/healthz` で 200、`Cache-Control: no-store`、`{"status":"ok"}` を確認