### PR TITLE
browser-auto の build/dev スクリプトを Bun ネイティブ API に置換

### DIFF
--- a/projects/browser-auto/scripts/build.mjs
+++ b/projects/browser-auto/scripts/build.mjs
@@ -1,11 +1,3 @@
-import { execSync } from "node:child_process"
-
-execSync("bunx tailwindcss -i src/client/app.css -o dist/client/app.css", {
-  stdio: "inherit",
-})
-execSync("bun build src/client/app.tsx --outdir dist/client --minify --production", {
-  stdio: "inherit",
-})
-execSync("cp src/client/index.html dist/client/index.html", {
-  stdio: "inherit",
-})
+await Bun.$`bunx tailwindcss -i src/client/app.css -o dist/client/app.css`
+await Bun.$`bun build src/client/app.tsx --outdir dist/client --minify --production`
+await Bun.$`cp src/client/index.html dist/client/index.html`

--- a/projects/browser-auto/scripts/dev.mjs
+++ b/projects/browser-auto/scripts/dev.mjs
@@ -16,9 +16,16 @@ async function buildJs() {
 await copyHtml()
 await buildJs()
 
+let buildQueue = Promise.resolve()
+
+function queueBuild() {
+  buildQueue = buildQueue.then(() => buildJs())
+  return buildQueue
+}
+
 watch("src/client", { recursive: true }, (_event, filename) => {
   if (filename?.endsWith(".tsx") || filename?.endsWith(".ts")) {
-    void buildJs()
+    void queueBuild()
   }
   if (filename?.endsWith(".html")) {
     void copyHtml()

--- a/projects/browser-auto/scripts/dev.mjs
+++ b/projects/browser-auto/scripts/dev.mjs
@@ -1,42 +1,40 @@
-import { spawn, execSync } from "node:child_process"
 import { watch, mkdirSync } from "node:fs"
 
-function copyHtml() {
+async function copyHtml() {
   mkdirSync("dist/client", { recursive: true })
-  execSync("cp src/client/index.html dist/client/index.html", { stdio: "inherit" })
+  await Bun.$`cp src/client/index.html dist/client/index.html`
 }
 
-function buildJs() {
+async function buildJs() {
   try {
-    execSync("bun build src/client/app.tsx --outdir dist/client --minify --production", {
-      stdio: "inherit",
-    })
+    await Bun.$`bun build src/client/app.tsx --outdir dist/client --minify --production`
   } catch {
     // build failed, keep watching
   }
 }
 
-copyHtml()
-buildJs()
+await copyHtml()
+await buildJs()
 
 watch("src/client", { recursive: true }, (_event, filename) => {
   if (filename?.endsWith(".tsx") || filename?.endsWith(".ts")) {
-    buildJs()
+    void buildJs()
   }
   if (filename?.endsWith(".html")) {
-    copyHtml()
+    void copyHtml()
   }
 })
 
 const processes = [
-  spawn(
-    "bunx",
-    ["tailwindcss", "-i", "src/client/app.css", "-o", "dist/client/app.css", "--watch"],
+  Bun.spawn(
+    ["bunx", "tailwindcss", "-i", "src/client/app.css", "-o", "dist/client/app.css", "--watch"],
     {
-      stdio: "inherit",
+      stdio: ["inherit", "inherit", "inherit"],
     },
   ),
-  spawn("bun", ["--watch", "src/server/bun-server.ts"], { stdio: "inherit" }),
+  Bun.spawn(["bun", "--watch", "src/server/bun-server.ts"], {
+    stdio: ["inherit", "inherit", "inherit"],
+  }),
 ]
 
 function cleanup() {
@@ -49,8 +47,8 @@ process.on("SIGINT", cleanup)
 process.on("SIGTERM", cleanup)
 
 for (const proc of processes) {
-  proc.on("exit", (code) => {
-    if (code !== null && code !== 0) {
+  void proc.exited.then((code) => {
+    if (proc.signalCode === null && code !== 0) {
       cleanup()
       process.exit(code)
     }


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## Issues

- closes #1176
- ref: #1167

## Why

`bun scripts/...` で実行する browser-auto の build/dev スクリプトが `node:child_process` に依存していたため、Bun 実行環境のネイティブ API に統一します。

## Summary

`node:child_process` を削除し、コマンド実行を `Bun.$`、プロセス起動を `Bun.spawn` に置き換えました。

## Changes

- `scripts/build.mjs` の Tailwind、Bun build、HTML コピーを `Bun.$` に置換
- `scripts/dev.mjs` の HTML コピーと JS build を `Bun.$` に置換
- Tailwind CSS watch と `bun --watch` サーバーを `Bun.spawn` で起動
- Bun subprocess の終了監視と SIGINT/SIGTERM 時の後始末を維持
- `node:fs` の `watch` / `mkdirSync` は変更なし

## Verification

- `cd projects/browser-auto && bun run lint`
- `cd projects/browser-auto && bun run format`
- `cd projects/browser-auto && bun run format:check`
- `cd projects/browser-auto && bun scripts/build.mjs`
- `bun scripts/dev.mjs` の起動、Tailwind watch・`bun --watch` サーバー起動、SIGTERM による子プロセス停止を確認
