### PR TITLE
[portfolio] PostgreSQL/file-serverのヘルスチェックを実装する

### DIFF
--- a/projects/portfolio/src/client/features/home/page.tsx
+++ b/projects/portfolio/src/client/features/home/page.tsx
@@ -2,6 +2,7 @@ import { hc } from 'hono/client'
 import { type FormEvent, useState } from 'react'
 import { useMetaProps } from '#/client/shared/hooks/use-meta-props'
 import type { AppType } from '#/server/app.d'
+import { SystemStatusWidget } from './system-status-widget'
 
 const client = hc<AppType>('/')
 
@@ -60,25 +61,28 @@ export function Home() {
         )}
 
         {email ? (
-          <div className='space-y-4'>
-            <p className='text-center text-gray-700 text-lg dark:text-gray-300'>
-              <span className='font-semibold'>User：</span>
-              <span className='break-all font-mono text-gray-600 dark:text-gray-400'>{email}</span>
-            </p>
-            {loginExpiresLabel && (
-              <p className='text-center text-gray-500 text-sm dark:text-gray-400'>
-                <span className='font-medium'>ログイン有効期限：</span>
-                <span>{loginExpiresLabel}</span>
+          <>
+            <div className='space-y-4'>
+              <p className='text-center text-gray-700 text-lg dark:text-gray-300'>
+                <span className='font-semibold'>User：</span>
+                <span className='break-all font-mono text-gray-600 dark:text-gray-400'>{email}</span>
               </p>
-            )}
-            <button
-              type='button'
-              onClick={handleSignOut}
-              className='w-full cursor-pointer rounded-sm border border-gray-300 p-2 text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700'
-            >
-              Sign Out
-            </button>
-          </div>
+              {loginExpiresLabel && (
+                <p className='text-center text-gray-500 text-sm dark:text-gray-400'>
+                  <span className='font-medium'>ログイン有効期限：</span>
+                  <span>{loginExpiresLabel}</span>
+                </p>
+              )}
+              <button
+                type='button'
+                onClick={handleSignOut}
+                className='w-full cursor-pointer rounded-sm border border-gray-300 p-2 text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700'
+              >
+                Sign Out
+              </button>
+            </div>
+            <SystemStatusWidget />
+          </>
         ) : (
           <form onSubmit={handleSubmit} className='space-y-4'>
             <div>

--- a/projects/portfolio/src/client/features/home/system-status-widget.tsx
+++ b/projects/portfolio/src/client/features/home/system-status-widget.tsx
@@ -1,0 +1,170 @@
+import { hc } from 'hono/client'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { AppType } from '#/server/app.d'
+import type { SystemCheck, SystemStatus } from '#/types'
+
+const client = hc<AppType>('/')
+
+type SystemStatusEndpoint = {
+  $get: (options?: { query?: { refresh?: string } }) => Promise<Response>
+}
+
+const systemStatusEndpoint = (client.api as unknown as { 'system-status'?: SystemStatusEndpoint })['system-status']
+
+const reasonLabels: Record<string, string> = {
+  ok: '応答あり',
+  'not-configured': '設定なし',
+  'connection-failed': '接続失敗',
+  'schema-check-failed': 'スキーマ確認失敗',
+  'schema-incomplete': 'スキーマ不備',
+  'database-unavailable': 'データベース利用不可',
+  timeout: 'タイムアウト',
+  'healthz-unavailable': 'ヘルスチェック失敗',
+  'login-failed': 'ログイン失敗',
+  'read-failed': '読み取り失敗',
+  'file-server-api-unavailable': 'API利用不可',
+  'public-unavailable': '公開配信不可',
+}
+
+function getStatusLabel(status: SystemCheck['status']): string {
+  if (status === 'ok') return '正常'
+  if (status === 'not-configured') return '未設定'
+  return '異常'
+}
+
+function getReasonLabel(reason: string): string {
+  return reasonLabels[reason] ?? '確認失敗'
+}
+
+function formatCheckedAt(value: string): string {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return '不明'
+
+  return new Intl.DateTimeFormat('ja-JP', {
+    dateStyle: 'short',
+    timeStyle: 'medium',
+  }).format(date)
+}
+
+function CheckRow({ label, check }: { label: string; check: SystemCheck }) {
+  const isHealthy = check.status === 'ok'
+  return (
+    <div className='flex items-start justify-between gap-3 text-xs'>
+      <span className='text-gray-700 dark:text-gray-300'>{label}</span>
+      <span
+        className={`text-right ${isHealthy ? 'text-green-700 dark:text-green-400' : 'text-red-700 dark:text-red-400'}`}
+      >
+        {getStatusLabel(check.status)}（{getReasonLabel(check.reason)}）
+      </span>
+    </div>
+  )
+}
+
+export function SystemStatusWidget() {
+  const [status, setStatus] = useState<SystemStatus | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(false)
+  const requestRef = useRef<AbortController | null>(null)
+
+  const loadStatus = useCallback(async (refresh: boolean) => {
+    if (!systemStatusEndpoint) return
+
+    requestRef.current?.abort()
+    const controller = new AbortController()
+    requestRef.current = controller
+    setLoading(true)
+    setError(false)
+
+    try {
+      const response = await systemStatusEndpoint.$get(refresh ? { query: { refresh: '1' } } : undefined)
+      if (!response.ok) {
+        throw new Error('system status request failed')
+      }
+
+      const nextStatus = (await response.json()) as SystemStatus
+      if (!nextStatus || !nextStatus.checks) {
+        throw new Error('system status response is invalid')
+      }
+      setStatus(nextStatus)
+    } catch {
+      if (!controller.signal.aborted) {
+        setError(true)
+      }
+    } finally {
+      if (requestRef.current === controller) {
+        requestRef.current = null
+        setLoading(false)
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    void loadStatus(false)
+    return () => requestRef.current?.abort()
+  }, [loadStatus])
+
+  const isHealthy = status?.status === 'ok'
+  const database = status?.checks.database
+  const fileServerHealth = status?.checks.fileServerHealth
+  const fileServerApi = status?.checks.fileServerApi
+  const fileServerPublic = status?.checks.fileServerPublic
+
+  return (
+    <section
+      aria-label='システム状態'
+      className='fixed right-2 bottom-2 z-40 w-[calc(100%-1rem)] max-w-xs rounded-lg border border-gray-200 bg-white/95 p-3 shadow-lg backdrop-blur dark:border-gray-700 dark:bg-gray-800/95 sm:right-4 sm:bottom-4'
+    >
+      <div className='flex items-center justify-between gap-3'>
+        <div className='flex min-w-0 items-center gap-2'>
+          <span
+            aria-hidden='true'
+            className={`h-2.5 w-2.5 shrink-0 rounded-full ${
+              isHealthy ? 'bg-green-500' : status ? 'bg-red-500' : 'bg-gray-400'
+            }`}
+          />
+          <h2 className='truncate font-semibold text-gray-900 text-sm dark:text-white'>
+            {isHealthy ? 'システム正常' : status ? 'システム要確認' : 'システム状態'}
+          </h2>
+        </div>
+        <button
+          type='button'
+          onClick={() => void loadStatus(true)}
+          disabled={loading || !systemStatusEndpoint}
+          className='shrink-0 rounded border border-gray-300 px-2 py-1 text-gray-700 text-xs hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700'
+        >
+          {loading ? '確認中…' : '再確認'}
+        </button>
+      </div>
+
+      {status ? (
+        <>
+          <p className='mt-2 text-gray-500 text-[11px] dark:text-gray-400'>
+            最終確認：{formatCheckedAt(status.checkedAt)}
+          </p>
+          <div className='mt-2 space-y-1.5 border-t border-gray-100 pt-2 dark:border-gray-700'>
+            {database && <CheckRow label='PostgreSQL' check={database} />}
+            {database && (
+              <div className='ml-3 space-y-1 border-l border-gray-200 pl-2 dark:border-gray-600'>
+                <CheckRow label='接続' check={database.connection} />
+                <CheckRow label='スキーマ' check={database.schema} />
+              </div>
+            )}
+            {fileServerHealth && <CheckRow label='file-server 稼働' check={fileServerHealth} />}
+            {fileServerApi && <CheckRow label='file-server API' check={fileServerApi} />}
+            {fileServerApi && (
+              <div className='ml-3 space-y-1 border-l border-gray-200 pl-2 dark:border-gray-600'>
+                <CheckRow label='ログイン' check={fileServerApi.login} />
+                <CheckRow label='読み取り' check={fileServerApi.read} />
+              </div>
+            )}
+            {fileServerPublic && <CheckRow label='公開URL' check={fileServerPublic} />}
+          </div>
+        </>
+      ) : (
+        <p className='mt-2 text-gray-500 text-xs dark:text-gray-400'>状態を確認しています。</p>
+      )}
+
+      {error && <p className='mt-2 text-red-700 text-xs dark:text-red-400'>状態を取得できませんでした。</p>}
+    </section>
+  )
+}

--- a/projects/portfolio/src/db/index.ts
+++ b/projects/portfolio/src/db/index.ts
@@ -1,6 +1,16 @@
 import { drizzle } from 'drizzle-orm/node-postgres'
+import type { PoolConfig } from 'pg'
 
-export function getDatabase(databaseUrl: string) {
-  const db = drizzle(databaseUrl)
-  return db
+export type DatabasePoolOptions = Pick<
+  PoolConfig,
+  'connectionTimeoutMillis' | 'query_timeout' | 'statement_timeout' | 'max'
+>
+
+export function getDatabase(databaseUrl: string, options: DatabasePoolOptions = {}) {
+  return drizzle({
+    connection: {
+      connectionString: databaseUrl,
+      ...options,
+    },
+  })
 }

--- a/projects/portfolio/src/server/app.d.ts
+++ b/projects/portfolio/src/server/app.d.ts
@@ -1,6 +1,6 @@
-import { HonoEnv } from './routes/shared';
-declare const app: import('hono/hono-base').HonoBase<HonoEnv, import('hono/types').BlankSchema, "/", "*">;
-declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/types').BlankSchema | import('hono/types').MergeSchemaPath<{
+import type { HonoEnv } from './routes/shared';
+declare const app: import("hono/hono-base").HonoBase<HonoEnv, import("hono/types").BlankSchema, "/", "*">;
+declare const routes: import("hono/hono-base").HonoBase<HonoEnv, import("hono/types").BlankSchema | import("hono/types").MergeSchemaPath<{
     "/api/signin": {
         $post: {
             input: {
@@ -25,7 +25,7 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
             };
             output: {};
             outputFormat: "json";
-            status: import('hono/utils/http-status').ContentfulStatusCode;
+            status: import("hono/utils/http-status").ContentfulStatusCode;
         };
     };
 } & {
@@ -34,10 +34,106 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
             input: {};
             output: {};
             outputFormat: "json";
-            status: import('hono/utils/http-status').ContentfulStatusCode;
+            status: import("hono/utils/http-status").ContentfulStatusCode;
         };
     };
-}, "/"> | import('hono/types').MergeSchemaPath<{
+}, "/"> | import("hono/types").MergeSchemaPath<{
+    "/api/image/generations": {
+        $post: {
+            input: {
+                header: {
+                    'api-key': string;
+                    'base-url': string;
+                };
+            } & {
+                json: {
+                    prompt: string;
+                    conversationId: string;
+                    assistantMessageId: string;
+                };
+            };
+            output: {
+                code: "VALIDATION_ERROR" | "AUTHENTICATION_FAILED" | "MODEL_ACCESS_DENIED" | "INSUFFICIENT_CREDIT" | "RATE_LIMITED" | "INVALID_REQUEST" | "UPSTREAM_UNAVAILABLE" | "UNKNOWN_UPSTREAM_ERROR" | "IMAGE_STORAGE_NOT_CONFIGURED" | "IMAGE_STORAGE_FAILED" | "IMAGE_MODEL_ENDPOINT_INCOMPATIBLE" | "IMAGE_REQUEST_INVALID" | "IMAGE_PROVIDER_REJECTED";
+                message: string;
+                retryable: boolean;
+            };
+            outputFormat: "json";
+            status: 400;
+        } | {
+            input: {
+                header: {
+                    'api-key': string;
+                    'base-url': string;
+                };
+            } & {
+                json: {
+                    prompt: string;
+                    conversationId: string;
+                    assistantMessageId: string;
+                };
+            };
+            output: {
+                code: "VALIDATION_ERROR" | "AUTHENTICATION_FAILED" | "MODEL_ACCESS_DENIED" | "INSUFFICIENT_CREDIT" | "RATE_LIMITED" | "INVALID_REQUEST" | "UPSTREAM_UNAVAILABLE" | "UNKNOWN_UPSTREAM_ERROR" | "IMAGE_STORAGE_NOT_CONFIGURED" | "IMAGE_STORAGE_FAILED" | "IMAGE_MODEL_ENDPOINT_INCOMPATIBLE" | "IMAGE_REQUEST_INVALID" | "IMAGE_PROVIDER_REJECTED";
+                message: string;
+                retryable: boolean;
+            };
+            outputFormat: "json";
+            status: 503;
+        } | {
+            input: {
+                header: {
+                    'api-key': string;
+                    'base-url': string;
+                };
+            } & {
+                json: {
+                    prompt: string;
+                    conversationId: string;
+                    assistantMessageId: string;
+                };
+            };
+            output: {
+                code: "VALIDATION_ERROR" | "AUTHENTICATION_FAILED" | "MODEL_ACCESS_DENIED" | "INSUFFICIENT_CREDIT" | "RATE_LIMITED" | "INVALID_REQUEST" | "UPSTREAM_UNAVAILABLE" | "UNKNOWN_UPSTREAM_ERROR" | "IMAGE_STORAGE_NOT_CONFIGURED" | "IMAGE_STORAGE_FAILED" | "IMAGE_MODEL_ENDPOINT_INCOMPATIBLE" | "IMAGE_REQUEST_INVALID" | "IMAGE_PROVIDER_REJECTED";
+                message: string;
+                retryable: boolean;
+            };
+            outputFormat: "json";
+            status: 502;
+        } | {
+            input: {
+                header: {
+                    'api-key': string;
+                    'base-url': string;
+                };
+            } & {
+                json: {
+                    prompt: string;
+                    conversationId: string;
+                    assistantMessageId: string;
+                };
+            };
+            output: {
+                id: string;
+                created: number;
+                model: string;
+                image: {
+                    fileName: string;
+                    publicPath: string;
+                    contentType: string;
+                    createdAt: string;
+                    previewUrl?: string | undefined;
+                };
+                usage: {
+                    inputTokens?: number | undefined;
+                    outputTokens?: number | undefined;
+                    totalTokens?: number | undefined;
+                };
+            };
+            outputFormat: "json";
+            status: import("hono/utils/http-status").ContentfulStatusCode;
+        };
+    };
+} & {
     "/api/chat": {
         $post: {
             input: {
@@ -73,8 +169,9 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                 };
             };
             output: {
-                error: string;
-                code: "VALIDATION_ERROR";
+                code: "VALIDATION_ERROR" | "AUTHENTICATION_FAILED" | "MODEL_ACCESS_DENIED" | "INSUFFICIENT_CREDIT" | "RATE_LIMITED" | "INVALID_REQUEST" | "UPSTREAM_UNAVAILABLE" | "UNKNOWN_UPSTREAM_ERROR" | "IMAGE_STORAGE_NOT_CONFIGURED" | "IMAGE_STORAGE_FAILED" | "IMAGE_MODEL_ENDPOINT_INCOMPATIBLE" | "IMAGE_REQUEST_INVALID" | "IMAGE_PROVIDER_REJECTED";
+                message: string;
+                retryable: boolean;
             };
             outputFormat: "json";
             status: 400;
@@ -112,11 +209,12 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                 };
             };
             output: {
-                error: string;
-                code: "VALIDATION_ERROR";
+                code: "VALIDATION_ERROR" | "AUTHENTICATION_FAILED" | "MODEL_ACCESS_DENIED" | "INSUFFICIENT_CREDIT" | "RATE_LIMITED" | "INVALID_REQUEST" | "UPSTREAM_UNAVAILABLE" | "UNKNOWN_UPSTREAM_ERROR" | "IMAGE_STORAGE_NOT_CONFIGURED" | "IMAGE_STORAGE_FAILED" | "IMAGE_MODEL_ENDPOINT_INCOMPATIBLE" | "IMAGE_REQUEST_INVALID" | "IMAGE_PROVIDER_REJECTED";
+                message: string;
+                retryable: boolean;
             };
             outputFormat: "json";
-            status: 400;
+            status: 502;
         } | {
             input: {
                 header: {
@@ -167,46 +265,7 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                 } | null;
             };
             outputFormat: "json";
-            status: import('hono/utils/http-status').ContentfulStatusCode;
-        } | {
-            input: {
-                header: {
-                    'api-key': string;
-                    'base-url': string;
-                };
-            } & {
-                json: {
-                    messages: ({
-                        role: "user";
-                        content: string | ({
-                            type: "image_url";
-                            image_url: {
-                                url: string;
-                            };
-                        } | {
-                            type: "text";
-                            text: string;
-                        })[];
-                    } | {
-                        role: "assistant";
-                        content: string;
-                    } | {
-                        role: "system";
-                        content: string;
-                    })[];
-                    model: string;
-                    apiMode?: "chat_completions" | "responses" | undefined;
-                    temperature?: number | undefined;
-                    maxTokens?: number | undefined;
-                    reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | undefined;
-                };
-            };
-            output: {
-                error: string;
-                code: "UPSTREAM_ERROR";
-            };
-            outputFormat: "json";
-            status: 502;
+            status: import("hono/utils/http-status").ContentfulStatusCode;
         };
     };
 } & {
@@ -245,47 +304,9 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                 };
             };
             output: {
-                error: string;
-                code: "VALIDATION_ERROR";
-            };
-            outputFormat: "json";
-            status: 400;
-        } | {
-            input: {
-                header: {
-                    'api-key': string;
-                    'base-url': string;
-                };
-            } & {
-                json: {
-                    messages: ({
-                        role: "user";
-                        content: string | ({
-                            type: "image_url";
-                            image_url: {
-                                url: string;
-                            };
-                        } | {
-                            type: "text";
-                            text: string;
-                        })[];
-                    } | {
-                        role: "assistant";
-                        content: string;
-                    } | {
-                        role: "system";
-                        content: string;
-                    })[];
-                    model: string;
-                    apiMode?: "chat_completions" | "responses" | undefined;
-                    temperature?: number | undefined;
-                    maxTokens?: number | undefined;
-                    reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | undefined;
-                };
-            };
-            output: {
-                error: string;
-                code: "VALIDATION_ERROR";
+                code: "VALIDATION_ERROR" | "AUTHENTICATION_FAILED" | "MODEL_ACCESS_DENIED" | "INSUFFICIENT_CREDIT" | "RATE_LIMITED" | "INVALID_REQUEST" | "UPSTREAM_UNAVAILABLE" | "UNKNOWN_UPSTREAM_ERROR" | "IMAGE_STORAGE_NOT_CONFIGURED" | "IMAGE_STORAGE_FAILED" | "IMAGE_MODEL_ENDPOINT_INCOMPATIBLE" | "IMAGE_REQUEST_INVALID" | "IMAGE_PROVIDER_REJECTED";
+                message: string;
+                retryable: boolean;
             };
             outputFormat: "json";
             status: 400;
@@ -324,7 +345,7 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
             };
             output: {};
             outputFormat: string;
-            status: import('hono/utils/http-status').StatusCode;
+            status: import("hono/utils/http-status").StatusCode;
         };
     };
 } & {
@@ -378,6 +399,7 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                                 maxTokens?: number | undefined;
                                 reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | undefined;
                                 sendImagesOnlyOnce?: boolean | undefined;
+                                imageGenerationMode?: boolean | undefined;
                             };
                             id?: string | undefined;
                             reasoningContent?: string | undefined;
@@ -403,6 +425,13 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                                     previewUrl: string;
                                     contentType: string;
                                     createdAt: string;
+                                }[] | undefined;
+                                generatedImages?: {
+                                    fileName: string;
+                                    publicPath: string;
+                                    contentType: string;
+                                    createdAt: string;
+                                    previewUrl?: string | undefined;
                                 }[] | undefined;
                                 imageContext?: {
                                     policy: "send_once" | "full_history";
@@ -447,8 +476,9 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                 };
             };
             output: {
-                error: string;
-                code: "VALIDATION_ERROR";
+                code: "VALIDATION_ERROR" | "AUTHENTICATION_FAILED" | "MODEL_ACCESS_DENIED" | "INSUFFICIENT_CREDIT" | "RATE_LIMITED" | "INVALID_REQUEST" | "UPSTREAM_UNAVAILABLE" | "UNKNOWN_UPSTREAM_ERROR" | "IMAGE_STORAGE_NOT_CONFIGURED" | "IMAGE_STORAGE_FAILED" | "IMAGE_MODEL_ENDPOINT_INCOMPATIBLE" | "IMAGE_REQUEST_INVALID" | "IMAGE_PROVIDER_REJECTED";
+                message: string;
+                retryable: boolean;
             };
             outputFormat: "json";
             status: 400;
@@ -501,6 +531,7 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                                 maxTokens?: number | undefined;
                                 reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | undefined;
                                 sendImagesOnlyOnce?: boolean | undefined;
+                                imageGenerationMode?: boolean | undefined;
                             };
                             id?: string | undefined;
                             reasoningContent?: string | undefined;
@@ -527,128 +558,12 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                                     contentType: string;
                                     createdAt: string;
                                 }[] | undefined;
-                                imageContext?: {
-                                    policy: "send_once" | "full_history";
-                                    sent: number;
-                                    historyOnly: number;
-                                } | undefined;
-                                apiContextMessages?: ({
-                                    role: "user";
-                                    content: string | ({
-                                        type: "image_url";
-                                        image_url: {
-                                            url: string;
-                                        };
-                                    } | {
-                                        type: "text";
-                                        text: string;
-                                    })[];
-                                } | {
-                                    role: "assistant";
-                                    content: string;
-                                } | {
-                                    role: "system";
-                                    content: string;
-                                })[] | undefined;
-                            };
-                            id?: string | undefined;
-                            reasoningContent?: string | undefined;
-                        } | {
-                            role: "system";
-                            content: string;
-                            id?: string | undefined;
-                            reasoningContent?: string | undefined;
-                            metadata?: Record<string, never> | undefined;
-                        })[];
-                        updatedAt?: unknown;
-                    };
-                    assistantMessageId: string;
-                    apiMode?: "chat_completions" | "responses" | undefined;
-                    temperature?: number | undefined;
-                    maxTokens?: number | undefined;
-                    reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | undefined;
-                };
-            };
-            output: {
-                error: string;
-                code: "VALIDATION_ERROR";
-            };
-            outputFormat: "json";
-            status: 400;
-        } | {
-            input: {
-                header: {
-                    'api-key': string;
-                    'base-url': string;
-                };
-            } & {
-                json: {
-                    messages: ({
-                        role: "user";
-                        content: string | ({
-                            type: "image_url";
-                            image_url: {
-                                url: string;
-                            };
-                        } | {
-                            type: "text";
-                            text: string;
-                        })[];
-                    } | {
-                        role: "assistant";
-                        content: string;
-                    } | {
-                        role: "system";
-                        content: string;
-                    })[];
-                    model: string;
-                    conversation: {
-                        id: string;
-                        title: string;
-                        messages: ({
-                            role: "user";
-                            content: string | ({
-                                type: "image_url";
-                                image_url: {
-                                    url: string;
-                                };
-                            } | {
-                                type: "text";
-                                text: string;
-                            })[];
-                            metadata: {
-                                model: string;
-                                apiMode?: "chat_completions" | "responses" | undefined;
-                                stream?: boolean | undefined;
-                                temperature?: number | undefined;
-                                maxTokens?: number | undefined;
-                                reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | undefined;
-                                sendImagesOnlyOnce?: boolean | undefined;
-                            };
-                            id?: string | undefined;
-                            reasoningContent?: string | undefined;
-                        } | {
-                            role: "assistant";
-                            content: string;
-                            metadata: {
-                                model: string;
-                                usage: {
-                                    completionTokens?: number | undefined;
-                                    promptTokens?: number | undefined;
-                                    totalTokens?: number | undefined;
-                                    reasoningTokens?: number | undefined;
-                                };
-                                apiMode?: "chat_completions" | "responses" | undefined;
-                                finishReason?: string | undefined;
-                                responseTimeMs?: number | undefined;
-                                generatedFiles?: {
-                                    blockIndex: number;
-                                    language: string;
+                                generatedImages?: {
                                     fileName: string;
                                     publicPath: string;
-                                    previewUrl: string;
                                     contentType: string;
                                     createdAt: string;
+                                    previewUrl?: string | undefined;
                                 }[] | undefined;
                                 imageContext?: {
                                     policy: "send_once" | "full_history";
@@ -697,7 +612,7 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                 status: "error" | "running" | "completed" | "cancelled";
             };
             outputFormat: "json";
-            status: import('hono/utils/http-status').ContentfulStatusCode;
+            status: import("hono/utils/http-status").ContentfulStatusCode;
         };
     };
 } & {
@@ -709,8 +624,9 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                 };
             };
             output: {
-                error: string;
-                code: "VALIDATION_ERROR";
+                code: "VALIDATION_ERROR" | "AUTHENTICATION_FAILED" | "MODEL_ACCESS_DENIED" | "INSUFFICIENT_CREDIT" | "RATE_LIMITED" | "INVALID_REQUEST" | "UPSTREAM_UNAVAILABLE" | "UNKNOWN_UPSTREAM_ERROR" | "IMAGE_STORAGE_NOT_CONFIGURED" | "IMAGE_STORAGE_FAILED" | "IMAGE_MODEL_ENDPOINT_INCOMPATIBLE" | "IMAGE_REQUEST_INVALID" | "IMAGE_PROVIDER_REJECTED";
+                message: string;
+                retryable: boolean;
             };
             outputFormat: "json";
             status: 404;
@@ -746,6 +662,7 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                                 maxTokens?: number | undefined;
                                 reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | undefined;
                                 sendImagesOnlyOnce?: boolean | undefined;
+                                imageGenerationMode?: boolean | undefined;
                             };
                             id?: string | undefined;
                             reasoningContent?: string | undefined;
@@ -771,6 +688,13 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                                     previewUrl: string;
                                     contentType: string;
                                     createdAt: string;
+                                }[] | undefined;
+                                generatedImages?: {
+                                    fileName: string;
+                                    publicPath: string;
+                                    contentType: string;
+                                    createdAt: string;
+                                    previewUrl?: string | undefined;
                                 }[] | undefined;
                                 imageContext?: {
                                     policy: "send_once" | "full_history";
@@ -814,11 +738,15 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                     createdAt: string;
                     updatedAt: string;
                     completedAt: string | null;
-                    error: string | null;
+                    error: {
+                        code: "VALIDATION_ERROR" | "AUTHENTICATION_FAILED" | "MODEL_ACCESS_DENIED" | "INSUFFICIENT_CREDIT" | "RATE_LIMITED" | "INVALID_REQUEST" | "UPSTREAM_UNAVAILABLE" | "UNKNOWN_UPSTREAM_ERROR" | "IMAGE_STORAGE_NOT_CONFIGURED" | "IMAGE_STORAGE_FAILED" | "IMAGE_MODEL_ENDPOINT_INCOMPATIBLE" | "IMAGE_REQUEST_INVALID" | "IMAGE_PROVIDER_REJECTED";
+                        message: string;
+                        retryable: boolean;
+                    } | null;
                 };
             };
             outputFormat: "json";
-            status: import('hono/utils/http-status').ContentfulStatusCode;
+            status: import("hono/utils/http-status").ContentfulStatusCode;
         };
     };
 } & {
@@ -831,7 +759,7 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
             };
             output: {};
             outputFormat: string;
-            status: import('hono/utils/http-status').StatusCode;
+            status: import("hono/utils/http-status").StatusCode;
         };
     };
 } & {
@@ -843,8 +771,9 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                 };
             };
             output: {
-                error: string;
-                code: "VALIDATION_ERROR";
+                code: "VALIDATION_ERROR" | "AUTHENTICATION_FAILED" | "MODEL_ACCESS_DENIED" | "INSUFFICIENT_CREDIT" | "RATE_LIMITED" | "INVALID_REQUEST" | "UPSTREAM_UNAVAILABLE" | "UNKNOWN_UPSTREAM_ERROR" | "IMAGE_STORAGE_NOT_CONFIGURED" | "IMAGE_STORAGE_FAILED" | "IMAGE_MODEL_ENDPOINT_INCOMPATIBLE" | "IMAGE_REQUEST_INVALID" | "IMAGE_PROVIDER_REJECTED";
+                message: string;
+                retryable: boolean;
             };
             outputFormat: "json";
             status: 404;
@@ -858,7 +787,7 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                 status: "error" | "running" | "completed" | "cancelled";
             };
             outputFormat: "json";
-            status: import('hono/utils/http-status').ContentfulStatusCode;
+            status: import("hono/utils/http-status").ContentfulStatusCode;
         };
     };
 } & {
@@ -932,10 +861,10 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
             };
             output: {};
             outputFormat: string;
-            status: import('hono/utils/http-status').StatusCode;
+            status: import("hono/utils/http-status").StatusCode;
         };
     };
-}, "/"> | import('hono/types').MergeSchemaPath<{
+}, "/"> | import("hono/types").MergeSchemaPath<{
     "/api/conversations": {
         $get: {
             input: {};
@@ -962,6 +891,7 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                             maxTokens?: number | undefined;
                             reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | undefined;
                             sendImagesOnlyOnce?: boolean | undefined;
+                            imageGenerationMode?: boolean | undefined;
                         };
                         id?: string | undefined;
                         reasoningContent?: string | undefined;
@@ -987,6 +917,13 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                                 previewUrl: string;
                                 contentType: string;
                                 createdAt: string;
+                            }[] | undefined;
+                            generatedImages?: {
+                                fileName: string;
+                                publicPath: string;
+                                contentType: string;
+                                createdAt: string;
+                                previewUrl?: string | undefined;
                             }[] | undefined;
                             imageContext?: {
                                 policy: "send_once" | "full_history";
@@ -1025,7 +962,7 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                 }[];
             };
             outputFormat: "json";
-            status: import('hono/utils/http-status').ContentfulStatusCode;
+            status: import("hono/utils/http-status").ContentfulStatusCode;
         };
     };
 } & {
@@ -1054,6 +991,7 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                             maxTokens?: number | undefined;
                             reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | undefined;
                             sendImagesOnlyOnce?: boolean | undefined;
+                            imageGenerationMode?: boolean | undefined;
                         };
                         id?: string | undefined;
                         reasoningContent?: string | undefined;
@@ -1079,6 +1017,13 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                                 previewUrl: string;
                                 contentType: string;
                                 createdAt: string;
+                            }[] | undefined;
+                            generatedImages?: {
+                                fileName: string;
+                                publicPath: string;
+                                contentType: string;
+                                createdAt: string;
+                                previewUrl?: string | undefined;
                             }[] | undefined;
                             imageContext?: {
                                 policy: "send_once" | "full_history";
@@ -1147,6 +1092,7 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                             maxTokens?: number | undefined;
                             reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | undefined;
                             sendImagesOnlyOnce?: boolean | undefined;
+                            imageGenerationMode?: boolean | undefined;
                         };
                         id?: string | undefined;
                         reasoningContent?: string | undefined;
@@ -1172,6 +1118,13 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                                 previewUrl: string;
                                 contentType: string;
                                 createdAt: string;
+                            }[] | undefined;
+                            generatedImages?: {
+                                fileName: string;
+                                publicPath: string;
+                                contentType: string;
+                                createdAt: string;
+                                previewUrl?: string | undefined;
                             }[] | undefined;
                             imageContext?: {
                                 policy: "send_once" | "full_history";
@@ -1213,7 +1166,7 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                 conversationId: string;
             };
             outputFormat: "json";
-            status: import('hono/utils/http-status').ContentfulStatusCode;
+            status: import("hono/utils/http-status").ContentfulStatusCode;
         };
     };
 } & {
@@ -1243,7 +1196,7 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                 failedIds: string[];
             };
             outputFormat: "json";
-            status: import('hono/utils/http-status').ContentfulStatusCode;
+            status: import("hono/utils/http-status").ContentfulStatusCode;
         };
     };
 } & {
@@ -1274,7 +1227,7 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                 deletedConversationIds: string[];
             };
             outputFormat: "json";
-            status: import('hono/utils/http-status').ContentfulStatusCode;
+            status: import("hono/utils/http-status").ContentfulStatusCode;
         };
     };
 } & {
@@ -1304,6 +1257,13 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                             contentType: string;
                             createdAt: string;
                         }[] | undefined;
+                        generatedImages?: {
+                            fileName: string;
+                            publicPath: string;
+                            contentType: string;
+                            createdAt: string;
+                            previewUrl?: string | undefined;
+                        }[] | undefined;
                     };
                 };
             };
@@ -1339,6 +1299,13 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                             contentType: string;
                             createdAt: string;
                         }[] | undefined;
+                        generatedImages?: {
+                            fileName: string;
+                            publicPath: string;
+                            contentType: string;
+                            createdAt: string;
+                            previewUrl?: string | undefined;
+                        }[] | undefined;
                     };
                 };
             };
@@ -1371,6 +1338,13 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                             previewUrl: string;
                             contentType: string;
                             createdAt: string;
+                        }[] | undefined;
+                        generatedImages?: {
+                            fileName: string;
+                            publicPath: string;
+                            contentType: string;
+                            createdAt: string;
+                            previewUrl?: string | undefined;
                         }[] | undefined;
                     };
                 };
@@ -1405,6 +1379,13 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                             contentType: string;
                             createdAt: string;
                         }[] | undefined;
+                        generatedImages?: {
+                            fileName: string;
+                            publicPath: string;
+                            contentType: string;
+                            createdAt: string;
+                            previewUrl?: string | undefined;
+                        }[] | undefined;
                     };
                 };
             };
@@ -1438,6 +1419,13 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                             contentType: string;
                             createdAt: string;
                         }[] | undefined;
+                        generatedImages?: {
+                            fileName: string;
+                            publicPath: string;
+                            contentType: string;
+                            createdAt: string;
+                            previewUrl?: string | undefined;
+                        }[] | undefined;
                     };
                 };
             };
@@ -1461,6 +1449,13 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                         previewUrl: string;
                         contentType: string;
                         createdAt: string;
+                    }[] | undefined;
+                    generatedImages?: {
+                        fileName: string;
+                        publicPath: string;
+                        contentType: string;
+                        createdAt: string;
+                        previewUrl?: string | undefined;
                     }[] | undefined;
                     imageContext?: {
                         policy: "send_once" | "full_history";
@@ -1488,7 +1483,7 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                 };
             };
             outputFormat: "json";
-            status: import('hono/utils/http-status').ContentfulStatusCode;
+            status: import("hono/utils/http-status").ContentfulStatusCode;
         };
     };
 } & {
@@ -1501,6 +1496,7 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                     blockIndex: number;
                     language: string;
                     content: string;
+                    force?: boolean | undefined;
                 };
             };
             output: {
@@ -1518,6 +1514,7 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                     blockIndex: number;
                     language: string;
                     content: string;
+                    force?: boolean | undefined;
                 };
             };
             output: {
@@ -1533,6 +1530,7 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                     blockIndex: number;
                     language: string;
                     content: string;
+                    force?: boolean | undefined;
                 };
             };
             output: {
@@ -1548,6 +1546,7 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                     blockIndex: number;
                     language: string;
                     content: string;
+                    force?: boolean | undefined;
                 };
             };
             output: {
@@ -1563,6 +1562,7 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                     blockIndex: number;
                     language: string;
                     content: string;
+                    force?: boolean | undefined;
                 };
             };
             output: {
@@ -1578,6 +1578,7 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                     blockIndex: number;
                     language: string;
                     content: string;
+                    force?: boolean | undefined;
                 };
             };
             output: {
@@ -1593,6 +1594,7 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                     blockIndex: number;
                     language: string;
                     content: string;
+                    force?: boolean | undefined;
                 };
             };
             output: {
@@ -1608,10 +1610,10 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
                 alreadyExisted: boolean;
             };
             outputFormat: "json";
-            status: import('hono/utils/http-status').ContentfulStatusCode;
+            status: import("hono/utils/http-status").ContentfulStatusCode;
         };
     };
-}, "/"> | import('hono/types').MergeSchemaPath<{
+}, "/"> | import("hono/types").MergeSchemaPath<{
     "/api/fetch-models": {
         $get: {
             input: {
@@ -1634,16 +1636,94 @@ declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/ty
             };
             output: string[];
             outputFormat: "json";
-            status: import('hono/utils/http-status').ContentfulStatusCode;
+            status: import("hono/utils/http-status").ContentfulStatusCode;
         };
     };
-}, "/"> | import('hono/types').MergeSchemaPath<{
+}, "/"> | import("hono/types").MergeSchemaPath<{
+    "/api/prompt-templates": {
+        $get: {
+            input: {};
+            output: {
+                data: {
+                    id: string;
+                    inputType: "text" | "textarea";
+                    title: string;
+                    placeholder: string;
+                    prompt: string;
+                }[];
+            };
+            outputFormat: "json";
+            status: import("hono/utils/http-status").ContentfulStatusCode;
+        };
+    };
+}, "/"> | import("hono/types").MergeSchemaPath<{
+    "/api/system-status": {
+        $get: {
+            input: {};
+            output: {
+                status: "ok" | "degraded";
+                checkedAt: string;
+                checks: {
+                    database: {
+                        connection: {
+                            status: import("../types").SystemCheckStatus;
+                            reason: string;
+                            checkedAt: string;
+                        };
+                        schema: {
+                            status: import("../types").SystemCheckStatus;
+                            reason: string;
+                            checkedAt: string;
+                        };
+                        status: import("../types").SystemCheckStatus;
+                        reason: string;
+                        checkedAt: string;
+                    };
+                    fileServerHealth: {
+                        status: import("../types").SystemCheckStatus;
+                        reason: string;
+                        checkedAt: string;
+                    };
+                    fileServerApi: {
+                        login: {
+                            status: import("../types").SystemCheckStatus;
+                            reason: string;
+                            checkedAt: string;
+                        };
+                        read: {
+                            status: import("../types").SystemCheckStatus;
+                            reason: string;
+                            checkedAt: string;
+                        };
+                        status: import("../types").SystemCheckStatus;
+                        reason: string;
+                        checkedAt: string;
+                    };
+                    fileServerPublic: {
+                        status: import("../types").SystemCheckStatus;
+                        reason: string;
+                        checkedAt: string;
+                    };
+                };
+            };
+            outputFormat: "json";
+            status: import("hono/utils/http-status").ContentfulStatusCode;
+        } | {
+            input: {};
+            output: {
+                error: string;
+            };
+            outputFormat: "json";
+            status: 503;
+        };
+    };
+}, "/"> | import("hono/types").MergeSchemaPath<{
     "*": {
         $get: {
             input: {};
             output: {};
             outputFormat: string;
-            status: import('hono/utils/http-status').StatusCode;
+            status: import("hono/utils/http-status").StatusCode;
         };
     };
 }, "/">, "/", "*">;

--- a/projects/portfolio/src/server/app.tsx
+++ b/projects/portfolio/src/server/app.tsx
@@ -14,6 +14,7 @@ import { modelsRoutes } from './routes/models'
 import { promptTemplatesRoutes } from './routes/prompt-templates'
 import type { HonoEnv } from './routes/shared'
 import { getServerEnv } from './routes/shared'
+import { systemStatusRoutes } from './routes/system-status'
 
 const securityHeaders = {
   'X-Content-Type-Options': 'nosniff',
@@ -104,6 +105,7 @@ const routes = app
   .route('/', conversationsRoutes)
   .route('/', modelsRoutes)
   .route('/', promptTemplatesRoutes)
+  .route('/', systemStatusRoutes)
   .route('/', htmlRoutes)
 
 export type AppType = typeof routes

--- a/projects/portfolio/src/server/features/chat-conversations/file-server-client.ts
+++ b/projects/portfolio/src/server/features/chat-conversations/file-server-client.ts
@@ -18,6 +18,10 @@ export interface FileServerEnv {
   FILE_SERVER_ADMIN_PASSWORD?: string
 }
 
+export interface FileServerRequestOptions {
+  signal?: AbortSignal
+}
+
 export function resolveFileServerBaseUrl(env: Pick<FileServerEnv, 'FILE_SERVER_URL'>): string | null {
   const baseUrl = (env.FILE_SERVER_URL ?? '').trim()
 
@@ -67,8 +71,17 @@ export function buildFileServerPreviewUrl(publicBaseUrl: string, publicPath: str
   return `${publicBaseUrl}${publicPath}`
 }
 
-export async function checkFileExists(publicBaseUrl: string, publicPath: string): Promise<boolean> {
-  const res = await fetch(buildFileServerPreviewUrl(publicBaseUrl, publicPath), { method: 'HEAD' })
+export async function checkFileExists(
+  publicBaseUrl: string,
+  publicPath: string,
+  options: FileServerRequestOptions = {}
+): Promise<boolean> {
+  const request: RequestInit = { method: 'HEAD' }
+  if (options.signal) {
+    request.signal = options.signal
+  }
+
+  const res = await fetch(buildFileServerPreviewUrl(publicBaseUrl, publicPath), request)
   return res.ok
 }
 
@@ -114,18 +127,26 @@ function extractSessionCookie(setCookieHeader: string | null): string | null {
 /**
  * file-server に POST /login して session cookie の値を取得する。
  */
-export async function loginToFileServer(config: FileServerConfig): Promise<string> {
+export async function loginToFileServer(
+  config: FileServerConfig,
+  options: FileServerRequestOptions = {}
+): Promise<string> {
   const form = new URLSearchParams()
   form.set('username', config.credentials.username)
   form.set('password', config.credentials.password)
   form.set('returnTo', '/')
 
-  const res = await fetch(`${config.baseUrl}/login`, {
+  const request: RequestInit = {
     method: 'POST',
     body: form,
     redirect: 'manual',
     headers: { 'content-type': 'application/x-www-form-urlencoded' },
-  })
+  }
+  if (options.signal) {
+    request.signal = options.signal
+  }
+
+  const res = await fetch(`${config.baseUrl}/login`, request)
 
   if (res.status !== 302 && res.status !== 303 && !res.ok) {
     const text = await res.text().catch(() => '')
@@ -138,6 +159,36 @@ export async function loginToFileServer(config: FileServerConfig): Promise<strin
     throw new Error('file-server login did not return session cookie')
   }
   return session
+}
+
+/**
+ * file-server の読み取りAPIに GET して、JSON のファイル一覧を確認する。
+ */
+export async function readFileServerApi(
+  config: FileServerConfig,
+  session: string,
+  options: FileServerRequestOptions = {}
+): Promise<void> {
+  const request: RequestInit = {
+    method: 'GET',
+    headers: {
+      cookie: `${SESSION_COOKIE_NAME}=${session}`,
+      accept: 'application/json',
+    },
+  }
+  if (options.signal) {
+    request.signal = options.signal
+  }
+
+  const res = await fetch(`${config.baseUrl}/api/`, request)
+  if (!res.ok) {
+    throw new Error(`file-server read failed: ${res.status}`)
+  }
+
+  const payload = (await res.json().catch(() => null)) as { files?: unknown } | null
+  if (!payload || !Array.isArray(payload.files)) {
+    throw new Error('file-server read returned an invalid response')
+  }
 }
 
 /**

--- a/projects/portfolio/src/server/features/system-status/system-status.ts
+++ b/projects/portfolio/src/server/features/system-status/system-status.ts
@@ -1,0 +1,360 @@
+import { sql } from 'drizzle-orm'
+import { getDatabase } from '#/db'
+import {
+  checkFileExists,
+  loginToFileServer,
+  readFileServerApi,
+  resolveFileServerBaseUrl,
+  resolveFileServerPublicBaseUrl,
+  type FileServerConfig,
+} from '#/server/features/chat-conversations/file-server-client'
+import type { Env } from '#/server/routes/shared'
+import type {
+  DatabaseSystemStatus,
+  FileServerApiSystemStatus,
+  SystemCheck,
+  SystemCheckStatus,
+  SystemStatus,
+} from '#/types'
+
+const CHECK_TIMEOUT_MS = 3_000
+const CACHE_TTL_MS = 5_000
+
+const requiredSchema = {
+  users: ['id', 'email', 'password_hash', 'created_at'],
+  conversations: ['id', 'user_id', 'title', 'created_at', 'updated_at'],
+  messages: ['id', 'conversation_id', 'role', 'content', 'reasoning_content', 'metadata', 'created_at'],
+  prompt_templates: [
+    'id',
+    'input_type',
+    'title',
+    'placeholder',
+    'prompt',
+    'display_order',
+    'enabled',
+    'created_at',
+    'updated_at',
+  ],
+} as const
+
+type CheckOutcome = Pick<SystemCheck, 'status' | 'reason'>
+type SystemStatusEnv = Pick<
+  Env,
+  | 'DATABASE_URL'
+  | 'FILE_SERVER_URL'
+  | 'FILE_SERVER_PUBLIC_URL'
+  | 'FILE_SERVER_ADMIN_USERNAME'
+  | 'FILE_SERVER_ADMIN_PASSWORD'
+>
+
+type CachedStatus = {
+  expiresAt: number
+  value: SystemStatus
+}
+
+class CheckTimeoutError extends Error {}
+
+const statusCache = new Map<string, CachedStatus>()
+const inFlightChecks = new Map<string, Promise<SystemStatus>>()
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function getRows(value: unknown): Array<Record<string, unknown>> {
+  if (Array.isArray(value)) {
+    return value.filter(isRecord)
+  }
+
+  if (isRecord(value) && Array.isArray(value.rows)) {
+    return value.rows.filter(isRecord)
+  }
+
+  return []
+}
+
+function outcome(status: SystemCheckStatus, reason: string): CheckOutcome {
+  return { status, reason }
+}
+
+function okOutcome(): CheckOutcome {
+  return outcome('ok', 'ok')
+}
+
+function notConfiguredOutcome(): CheckOutcome {
+  return outcome('not-configured', 'not-configured')
+}
+
+function failedOutcome(error: unknown, fallbackReason: string): CheckOutcome {
+  return outcome('error', error instanceof CheckTimeoutError ? 'timeout' : fallbackReason)
+}
+
+function toCheck(value: CheckOutcome, checkedAt: string): SystemCheck {
+  return { ...value, checkedAt }
+}
+
+async function withCheckTimeout<T>(operation: (signal: AbortSignal) => Promise<T>): Promise<T> {
+  const controller = new AbortController()
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => {
+      controller.abort()
+      reject(new CheckTimeoutError('system status check timed out'))
+    }, CHECK_TIMEOUT_MS)
+  })
+
+  try {
+    return await Promise.race([operation(controller.signal), timeout])
+  } finally {
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId)
+    }
+  }
+}
+
+async function runCheck(
+  operation: (signal: AbortSignal) => Promise<void>,
+  fallbackReason: string
+): Promise<CheckOutcome> {
+  try {
+    await withCheckTimeout(operation)
+    return okOutcome()
+  } catch (error) {
+    return failedOutcome(error, fallbackReason)
+  }
+}
+
+function aggregateOutcome(children: CheckOutcome[], fallbackReason: string): CheckOutcome {
+  const failed = children.find((child) => child.status === 'error')
+  if (failed) {
+    return outcome('error', failed.reason || fallbackReason)
+  }
+
+  if (children.some((child) => child.status === 'not-configured')) {
+    return notConfiguredOutcome()
+  }
+
+  return okOutcome()
+}
+
+async function checkDatabase(databaseUrl: string | undefined, checkedAt: string): Promise<DatabaseSystemStatus> {
+  if (!databaseUrl?.trim()) {
+    const connection = toCheck(notConfiguredOutcome(), checkedAt)
+    const schema = toCheck(notConfiguredOutcome(), checkedAt)
+    return {
+      ...toCheck(notConfiguredOutcome(), checkedAt),
+      connection,
+      schema,
+    }
+  }
+
+  let database: ReturnType<typeof getDatabase>
+  try {
+    database = getDatabase(databaseUrl)
+  } catch {
+    const connection = toCheck(outcome('error', 'connection-failed'), checkedAt)
+    const schema = toCheck(outcome('error', 'schema-check-failed'), checkedAt)
+    return {
+      ...toCheck(outcome('error', 'connection-failed'), checkedAt),
+      connection,
+      schema,
+    }
+  }
+
+  const [connectionOutcome, schemaOutcome] = await Promise.all([
+    runCheck(async () => {
+      await database.execute(sql`SELECT 1`)
+    }, 'connection-failed'),
+    runCheck(async () => {
+      const result = await database.execute(sql`
+        SELECT table_name, column_name
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+      `)
+      const columns = new Map<string, Set<string>>()
+
+      for (const row of getRows(result)) {
+        const tableName = typeof row.table_name === 'string' ? row.table_name : null
+        const columnName = typeof row.column_name === 'string' ? row.column_name : null
+        if (!tableName || !columnName) {
+          continue
+        }
+
+        const tableColumns = columns.get(tableName) ?? new Set<string>()
+        tableColumns.add(columnName)
+        columns.set(tableName, tableColumns)
+      }
+
+      const schemaIsComplete = Object.entries(requiredSchema).every(([tableName, requiredColumns]) => {
+        const tableColumns = columns.get(tableName)
+        return tableColumns && requiredColumns.every((columnName) => tableColumns.has(columnName))
+      })
+
+      if (!schemaIsComplete) {
+        throw new Error('database schema is incomplete')
+      }
+    }, 'schema-check-failed'),
+  ])
+
+  const connection = toCheck(connectionOutcome, checkedAt)
+  const schema = toCheck(schemaOutcome, checkedAt)
+  return {
+    ...toCheck(aggregateOutcome([connectionOutcome, schemaOutcome], 'database-unavailable'), checkedAt),
+    connection,
+    schema,
+  }
+}
+
+function resolveFileServerApiConfig(env: SystemStatusEnv): FileServerConfig | null {
+  const baseUrl = resolveFileServerBaseUrl(env)
+  const username = (env.FILE_SERVER_ADMIN_USERNAME ?? '').trim()
+  const password = env.FILE_SERVER_ADMIN_PASSWORD ?? ''
+
+  if (!baseUrl || !username || !password) {
+    return null
+  }
+
+  return {
+    baseUrl,
+    publicBaseUrl: resolveFileServerPublicBaseUrl(env) ?? '',
+    credentials: { username, password },
+  }
+}
+
+async function checkFileServerHealth(baseUrl: string | null, checkedAt: string): Promise<SystemCheck> {
+  if (!baseUrl) {
+    return toCheck(notConfiguredOutcome(), checkedAt)
+  }
+
+  const result = await runCheck(async (signal) => {
+    const response = await fetch(`${baseUrl}/healthz`, {
+      method: 'GET',
+      headers: { accept: 'application/json' },
+      signal,
+    })
+
+    if (!response.ok) {
+      throw new Error(`file-server healthz returned ${response.status}`)
+    }
+  }, 'healthz-unavailable')
+
+  return toCheck(result, checkedAt)
+}
+
+async function checkFileServerApi(env: SystemStatusEnv, checkedAt: string): Promise<FileServerApiSystemStatus> {
+  const config = resolveFileServerApiConfig(env)
+  if (!config) {
+    const login = toCheck(notConfiguredOutcome(), checkedAt)
+    const read = toCheck(notConfiguredOutcome(), checkedAt)
+    return {
+      ...toCheck(notConfiguredOutcome(), checkedAt),
+      login,
+      read,
+    }
+  }
+
+  let phase: 'login' | 'read' = 'login'
+  let loginOutcome: CheckOutcome = outcome('error', 'login-failed')
+  let readOutcome: CheckOutcome = outcome('error', 'login-failed')
+
+  try {
+    await withCheckTimeout(async (signal) => {
+      const session = await loginToFileServer(config, { signal })
+      loginOutcome = okOutcome()
+      phase = 'read'
+      await readFileServerApi(config, session, { signal })
+    })
+    readOutcome = okOutcome()
+  } catch (error) {
+    const reason = error instanceof CheckTimeoutError ? 'timeout' : phase === 'login' ? 'login-failed' : 'read-failed'
+    if (phase === 'login') {
+      loginOutcome = outcome('error', reason)
+      readOutcome = outcome('error', reason === 'timeout' ? 'timeout' : 'login-failed')
+    } else {
+      readOutcome = outcome('error', reason)
+    }
+  }
+
+  const login = toCheck(loginOutcome, checkedAt)
+  const read = toCheck(readOutcome, checkedAt)
+  return {
+    ...toCheck(aggregateOutcome([loginOutcome, readOutcome], 'file-server-api-unavailable'), checkedAt),
+    login,
+    read,
+  }
+}
+
+async function checkFileServerPublic(env: SystemStatusEnv, checkedAt: string): Promise<SystemCheck> {
+  const publicBaseUrl = resolveFileServerPublicBaseUrl(env)
+  if (!publicBaseUrl) {
+    return toCheck(notConfiguredOutcome(), checkedAt)
+  }
+
+  const result = await runCheck(async (signal) => {
+    const exists = await checkFileExists(publicBaseUrl, '/', { signal })
+    if (!exists) {
+      throw new Error('file-server public endpoint is unavailable')
+    }
+  }, 'public-unavailable')
+
+  return toCheck(result, checkedAt)
+}
+
+async function runSystemStatus(env: SystemStatusEnv): Promise<SystemStatus> {
+  const checkedAt = new Date().toISOString()
+  const [database, fileServerHealth, fileServerApi, fileServerPublic] = await Promise.all([
+    checkDatabase(env.DATABASE_URL, checkedAt),
+    checkFileServerHealth(resolveFileServerBaseUrl(env), checkedAt),
+    checkFileServerApi(env, checkedAt),
+    checkFileServerPublic(env, checkedAt),
+  ])
+
+  const checks = { database, fileServerHealth, fileServerApi, fileServerPublic }
+  const status = Object.values(checks).every((check) => check.status === 'ok') ? 'ok' : 'degraded'
+
+  return {
+    status,
+    checkedAt,
+    checks,
+  }
+}
+
+function buildCacheKey(env: SystemStatusEnv): string {
+  return [
+    env.DATABASE_URL ?? '',
+    env.FILE_SERVER_URL ?? '',
+    env.FILE_SERVER_PUBLIC_URL ?? '',
+    env.FILE_SERVER_ADMIN_USERNAME ?? '',
+    env.FILE_SERVER_ADMIN_PASSWORD ?? '',
+  ].join('\u0000')
+}
+
+export async function getSystemStatus(env: SystemStatusEnv, options: { force?: boolean } = {}): Promise<SystemStatus> {
+  const key = buildCacheKey(env)
+  const pending = inFlightChecks.get(key)
+  if (pending) {
+    return pending
+  }
+
+  const cached = statusCache.get(key)
+  if (!options.force && cached && cached.expiresAt > Date.now()) {
+    return cached.value
+  }
+
+  const check = runSystemStatus(env)
+  inFlightChecks.set(key, check)
+
+  try {
+    const value = await check
+    statusCache.set(key, { expiresAt: Date.now() + CACHE_TTL_MS, value })
+    return value
+  } finally {
+    inFlightChecks.delete(key)
+  }
+}
+
+export function resetSystemStatusCacheForTests(): void {
+  statusCache.clear()
+  inFlightChecks.clear()
+}

--- a/projects/portfolio/src/server/features/system-status/system-status.ts
+++ b/projects/portfolio/src/server/features/system-status/system-status.ts
@@ -1,7 +1,6 @@
 import { sql } from 'drizzle-orm'
 import { getDatabase } from '#/db'
 import {
-  checkFileExists,
   loginToFileServer,
   readFileServerApi,
   resolveFileServerBaseUrl,
@@ -18,7 +17,15 @@ import type {
 } from '#/types'
 
 const CHECK_TIMEOUT_MS = 3_000
+const DATABASE_QUERY_TIMEOUT_MS = 2_500
 const CACHE_TTL_MS = 5_000
+
+const databasePoolOptions = {
+  connectionTimeoutMillis: DATABASE_QUERY_TIMEOUT_MS,
+  query_timeout: DATABASE_QUERY_TIMEOUT_MS,
+  statement_timeout: DATABASE_QUERY_TIMEOUT_MS,
+  max: 2,
+} as const
 
 const requiredSchema = {
   users: ['id', 'email', 'password_hash', 'created_at'],
@@ -85,8 +92,21 @@ function notConfiguredOutcome(): CheckOutcome {
   return outcome('not-configured', 'not-configured')
 }
 
+function isCheckTimeoutError(error: unknown): boolean {
+  if (error instanceof CheckTimeoutError) {
+    return true
+  }
+
+  return (
+    error instanceof Error &&
+    /^(?:Query read timeout|timeout exceeded when trying to connect|Connection terminated due to connection timeout)/i.test(
+      error.message
+    )
+  )
+}
+
 function failedOutcome(error: unknown, fallbackReason: string): CheckOutcome {
-  return outcome('error', error instanceof CheckTimeoutError ? 'timeout' : fallbackReason)
+  return outcome('error', isCheckTimeoutError(error) ? 'timeout' : fallbackReason)
 }
 
 function toCheck(value: CheckOutcome, checkedAt: string): SystemCheck {
@@ -138,6 +158,13 @@ function aggregateOutcome(children: CheckOutcome[], fallbackReason: string): Che
   return okOutcome()
 }
 
+async function closeDatabase(database: ReturnType<typeof getDatabase>): Promise<void> {
+  const client = (database as unknown as { $client?: { end?: () => Promise<void> } }).$client
+  if (typeof client?.end === 'function') {
+    await client.end()
+  }
+}
+
 async function checkDatabase(databaseUrl: string | undefined, checkedAt: string): Promise<DatabaseSystemStatus> {
   if (!databaseUrl?.trim()) {
     const connection = toCheck(notConfiguredOutcome(), checkedAt)
@@ -151,7 +178,7 @@ async function checkDatabase(databaseUrl: string | undefined, checkedAt: string)
 
   let database: ReturnType<typeof getDatabase>
   try {
-    database = getDatabase(databaseUrl)
+    database = getDatabase(databaseUrl, databasePoolOptions)
   } catch {
     const connection = toCheck(outcome('error', 'connection-failed'), checkedAt)
     const schema = toCheck(outcome('error', 'schema-check-failed'), checkedAt)
@@ -162,47 +189,51 @@ async function checkDatabase(databaseUrl: string | undefined, checkedAt: string)
     }
   }
 
-  const [connectionOutcome, schemaOutcome] = await Promise.all([
-    runCheck(async () => {
-      await database.execute(sql`SELECT 1`)
-    }, 'connection-failed'),
-    runCheck(async () => {
-      const result = await database.execute(sql`
-        SELECT table_name, column_name
-        FROM information_schema.columns
-        WHERE table_schema = 'public'
-      `)
-      const columns = new Map<string, Set<string>>()
+  try {
+    const [connectionOutcome, schemaOutcome] = await Promise.all([
+      runCheck(async () => {
+        await database.execute(sql`SELECT 1`)
+      }, 'connection-failed'),
+      runCheck(async () => {
+        const result = await database.execute(sql`
+          SELECT table_name, column_name
+          FROM information_schema.columns
+          WHERE table_schema = 'public'
+        `)
+        const columns = new Map<string, Set<string>>()
 
-      for (const row of getRows(result)) {
-        const tableName = typeof row.table_name === 'string' ? row.table_name : null
-        const columnName = typeof row.column_name === 'string' ? row.column_name : null
-        if (!tableName || !columnName) {
-          continue
+        for (const row of getRows(result)) {
+          const tableName = typeof row.table_name === 'string' ? row.table_name : null
+          const columnName = typeof row.column_name === 'string' ? row.column_name : null
+          if (!tableName || !columnName) {
+            continue
+          }
+
+          const tableColumns = columns.get(tableName) ?? new Set<string>()
+          tableColumns.add(columnName)
+          columns.set(tableName, tableColumns)
         }
 
-        const tableColumns = columns.get(tableName) ?? new Set<string>()
-        tableColumns.add(columnName)
-        columns.set(tableName, tableColumns)
-      }
+        const schemaIsComplete = Object.entries(requiredSchema).every(([tableName, requiredColumns]) => {
+          const tableColumns = columns.get(tableName)
+          return tableColumns && requiredColumns.every((columnName) => tableColumns.has(columnName))
+        })
 
-      const schemaIsComplete = Object.entries(requiredSchema).every(([tableName, requiredColumns]) => {
-        const tableColumns = columns.get(tableName)
-        return tableColumns && requiredColumns.every((columnName) => tableColumns.has(columnName))
-      })
+        if (!schemaIsComplete) {
+          throw new Error('database schema is incomplete')
+        }
+      }, 'schema-check-failed'),
+    ])
 
-      if (!schemaIsComplete) {
-        throw new Error('database schema is incomplete')
-      }
-    }, 'schema-check-failed'),
-  ])
-
-  const connection = toCheck(connectionOutcome, checkedAt)
-  const schema = toCheck(schemaOutcome, checkedAt)
-  return {
-    ...toCheck(aggregateOutcome([connectionOutcome, schemaOutcome], 'database-unavailable'), checkedAt),
-    connection,
-    schema,
+    const connection = toCheck(connectionOutcome, checkedAt)
+    const schema = toCheck(schemaOutcome, checkedAt)
+    return {
+      ...toCheck(aggregateOutcome([connectionOutcome, schemaOutcome], 'database-unavailable'), checkedAt),
+      connection,
+      schema,
+    }
+  } finally {
+    await closeDatabase(database).catch(() => undefined)
   }
 }
 
@@ -292,9 +323,20 @@ async function checkFileServerPublic(env: SystemStatusEnv, checkedAt: string): P
   }
 
   const result = await runCheck(async (signal) => {
-    const exists = await checkFileExists(publicBaseUrl, '/', { signal })
-    if (!exists) {
-      throw new Error('file-server public endpoint is unavailable')
+    const response = await fetch(`${publicBaseUrl}/healthz`, {
+      method: 'GET',
+      redirect: 'manual',
+      headers: { accept: 'application/json' },
+      signal,
+    })
+
+    if (!response.ok || response.status !== 200) {
+      throw new Error(`file-server public healthz returned ${response.status}`)
+    }
+
+    const payload = (await response.json().catch(() => null)) as { status?: unknown } | null
+    if (!payload || payload.status !== 'ok') {
+      throw new Error('file-server public healthz returned an invalid response')
     }
   }, 'public-unavailable')
 

--- a/projects/portfolio/src/server/routes/system-status.ts
+++ b/projects/portfolio/src/server/routes/system-status.ts
@@ -1,0 +1,20 @@
+import { Hono } from 'hono'
+import { getSystemStatus } from '#/server/features/system-status/system-status'
+import { requireAuth } from '#/server/middleware/auth'
+import type { HonoEnv } from './shared'
+import { getServerEnv } from './shared'
+
+const systemStatusRoutes = new Hono<HonoEnv>().get('/api/system-status', requireAuth, async (c) => {
+  c.header('Cache-Control', 'no-store')
+
+  try {
+    const refresh = c.req.query('refresh') === '1' || c.req.query('refresh') === 'true'
+    const status = await getSystemStatus(getServerEnv(c), { force: refresh })
+
+    return c.json(status)
+  } catch {
+    return c.json({ error: 'System status unavailable' }, 503)
+  }
+})
+
+export { systemStatusRoutes }

--- a/projects/portfolio/src/types/index.ts
+++ b/projects/portfolio/src/types/index.ts
@@ -77,3 +77,11 @@ export {
   type ImageGenerationResponse,
   type ImageGenerationUsage,
 } from './image-generation-api.js'
+
+export type {
+  DatabaseSystemStatus,
+  FileServerApiSystemStatus,
+  SystemCheck,
+  SystemCheckStatus,
+  SystemStatus,
+} from './system-status.js'

--- a/projects/portfolio/src/types/system-status.ts
+++ b/projects/portfolio/src/types/system-status.ts
@@ -1,0 +1,28 @@
+export type SystemCheckStatus = 'ok' | 'error' | 'not-configured'
+
+export interface SystemCheck {
+  status: SystemCheckStatus
+  reason: string
+  checkedAt: string
+}
+
+export interface DatabaseSystemStatus extends SystemCheck {
+  connection: SystemCheck
+  schema: SystemCheck
+}
+
+export interface FileServerApiSystemStatus extends SystemCheck {
+  login: SystemCheck
+  read: SystemCheck
+}
+
+export interface SystemStatus {
+  status: 'ok' | 'degraded'
+  checkedAt: string
+  checks: {
+    database: DatabaseSystemStatus
+    fileServerHealth: SystemCheck
+    fileServerApi: FileServerApiSystemStatus
+    fileServerPublic: SystemCheck
+  }
+}

--- a/projects/portfolio/tests/client/features/home/system-status-widget.test.tsx
+++ b/projects/portfolio/tests/client/features/home/system-status-widget.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+const { systemStatusGetMock } = vi.hoisted(() => ({
+  systemStatusGetMock: vi.fn(),
+}))
+
+vi.mock('hono/client', () => ({
+  hc: () => ({
+    api: {
+      'system-status': {
+        $get: systemStatusGetMock,
+      },
+    },
+  }),
+}))
+
+import { SystemStatusWidget } from '#/client/features/home/system-status-widget'
+
+const responseBody = {
+  status: 'ok',
+  checkedAt: '2026-04-19T00:00:00.000Z',
+  checks: {
+    database: {
+      status: 'ok',
+      reason: 'ok',
+      checkedAt: '2026-04-19T00:00:00.000Z',
+      connection: { status: 'ok', reason: 'ok', checkedAt: '2026-04-19T00:00:00.000Z' },
+      schema: { status: 'ok', reason: 'ok', checkedAt: '2026-04-19T00:00:00.000Z' },
+    },
+    fileServerHealth: { status: 'ok', reason: 'ok', checkedAt: '2026-04-19T00:00:00.000Z' },
+    fileServerApi: {
+      status: 'ok',
+      reason: 'ok',
+      checkedAt: '2026-04-19T00:00:00.000Z',
+      login: { status: 'ok', reason: 'ok', checkedAt: '2026-04-19T00:00:00.000Z' },
+      read: { status: 'ok', reason: 'ok', checkedAt: '2026-04-19T00:00:00.000Z' },
+    },
+    fileServerPublic: { status: 'ok', reason: 'ok', checkedAt: '2026-04-19T00:00:00.000Z' },
+  },
+}
+
+describe('SystemStatusWidget', () => {
+  it('正常状態と最終確認時刻を表示し、再確認を実行する', async () => {
+    systemStatusGetMock.mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify(responseBody), { status: 200, headers: { 'content-type': 'application/json' } })
+      )
+    )
+
+    render(<SystemStatusWidget />)
+
+    await waitFor(() => expect(screen.getByText('システム正常')).toBeTruthy())
+    expect(screen.getByText(/最終確認/)).toBeTruthy()
+    expect(screen.getByText(/PostgreSQL/)).toBeTruthy()
+    expect(screen.getByText(/file-server API/)).toBeTruthy()
+    expect(screen.getByText(/公開URL/)).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: '再確認' }))
+
+    await waitFor(() => expect(systemStatusGetMock).toHaveBeenCalledTimes(2))
+    expect(systemStatusGetMock).toHaveBeenLastCalledWith({ query: { refresh: '1' } })
+  })
+})

--- a/projects/portfolio/tests/features/system-status/system-status.test.ts
+++ b/projects/portfolio/tests/features/system-status/system-status.test.ts
@@ -1,9 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { checkFileExistsMock, dbExecuteMock, getDatabaseMock, loginToFileServerMock, readFileServerApiMock } =
+const { dbEndMock, dbExecuteMock, fetchMock, getDatabaseMock, loginToFileServerMock, readFileServerApiMock } =
   vi.hoisted(() => ({
-    checkFileExistsMock: vi.fn(),
+    dbEndMock: vi.fn(),
     dbExecuteMock: vi.fn(),
+    fetchMock: vi.fn(),
     getDatabaseMock: vi.fn(),
     loginToFileServerMock: vi.fn(),
     readFileServerApiMock: vi.fn(),
@@ -20,7 +21,6 @@ vi.mock('#/server/features/chat-conversations/file-server-client', async () => {
 
   return {
     ...actual,
-    checkFileExists: checkFileExistsMock,
     loginToFileServer: loginToFileServerMock,
     readFileServerApi: readFileServerApiMock,
   }
@@ -67,18 +67,20 @@ const schemaRows = [
 describe('getSystemStatus', () => {
   beforeEach(() => {
     resetSystemStatusCacheForTests()
+    dbEndMock.mockReset()
     dbExecuteMock.mockReset()
+    fetchMock.mockReset()
     getDatabaseMock.mockReset()
     loginToFileServerMock.mockReset()
     readFileServerApiMock.mockReset()
-    checkFileExistsMock.mockReset()
 
-    getDatabaseMock.mockReturnValue({ execute: dbExecuteMock })
+    getDatabaseMock.mockReturnValue({ execute: dbExecuteMock, $client: { end: dbEndMock } })
+    dbEndMock.mockResolvedValue(undefined)
     dbExecuteMock.mockResolvedValueOnce({ rows: [] }).mockResolvedValueOnce({ rows: schemaRows })
     loginToFileServerMock.mockResolvedValue('session-value')
     readFileServerApiMock.mockResolvedValue(undefined)
-    checkFileExistsMock.mockResolvedValue(true)
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 200 })))
+    fetchMock.mockImplementation(() => Promise.resolve(new Response(JSON.stringify({ status: 'ok' }), { status: 200 })))
+    vi.stubGlobal('fetch', fetchMock)
   })
 
   it('DB・file-server API・公開URLが正常なら ok を返す', async () => {
@@ -91,6 +93,19 @@ describe('getSystemStatus', () => {
     expect(result.checks.fileServerHealth.status).toBe('ok')
     expect(result.checks.fileServerApi.status).toBe('ok')
     expect(result.checks.fileServerPublic.status).toBe('ok')
+    expect(dbEndMock).toHaveBeenCalledTimes(1)
+    expect(getDatabaseMock).toHaveBeenCalledWith(
+      env.DATABASE_URL,
+      expect.objectContaining({
+        connectionTimeoutMillis: expect.any(Number),
+        query_timeout: expect.any(Number),
+        statement_timeout: expect.any(Number),
+      })
+    )
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${env.FILE_SERVER_PUBLIC_URL}/healthz`,
+      expect.objectContaining({ method: 'GET', redirect: 'manual' })
+    )
     expect(JSON.stringify(result)).not.toContain('db.internal')
     expect(JSON.stringify(result)).not.toContain('super-secret')
     expect(JSON.stringify(result)).not.toContain('file-server:3000')
@@ -107,6 +122,7 @@ describe('getSystemStatus', () => {
     expect(result.checks.database.schema).toEqual(
       expect.objectContaining({ status: 'error', reason: 'schema-check-failed' })
     )
+    expect(dbEndMock).toHaveBeenCalledTimes(1)
   })
 
   it('file-server ログインに失敗した場合は読み取り系への影響を示す', async () => {
@@ -124,6 +140,26 @@ describe('getSystemStatus', () => {
       expect.objectContaining({ status: 'error', reason: 'login-failed' })
     )
     expect(readFileServerApiMock).not.toHaveBeenCalled()
+    expect(dbEndMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('公開URLのルートが成功しても公開healthzが失敗した場合は異常として返す', async () => {
+    fetchMock.mockImplementation(async (input: unknown) => {
+      if (String(input) === `${env.FILE_SERVER_PUBLIC_URL}/healthz`) {
+        return new Response(JSON.stringify({ status: 'unavailable' }), { status: 503 })
+      }
+
+      return new Response(JSON.stringify({ status: 'ok' }), { status: 200 })
+    })
+
+    const result = await getSystemStatus(env)
+
+    expect(result.status).toBe('degraded')
+    expect(result.checks.fileServerPublic).toEqual(
+      expect.objectContaining({ status: 'error', reason: 'public-unavailable' })
+    )
+    expect(fetchMock).not.toHaveBeenCalledWith(`${env.FILE_SERVER_PUBLIC_URL}/`, expect.anything())
+    expect(dbEndMock).toHaveBeenCalledTimes(1)
   })
 
   it('チェックが応答しない場合はタイムアウトとして返す', async () => {
@@ -138,6 +174,7 @@ describe('getSystemStatus', () => {
 
       expect(result.checks.database.connection).toEqual(expect.objectContaining({ status: 'error', reason: 'timeout' }))
       expect(result.checks.database.schema).toEqual(expect.objectContaining({ status: 'error', reason: 'timeout' }))
+      expect(dbEndMock).toHaveBeenCalledTimes(1)
     } finally {
       vi.useRealTimers()
     }
@@ -149,15 +186,17 @@ describe('getSystemStatus', () => {
 
     expect(cached).toBe(first)
     expect(dbExecuteMock).toHaveBeenCalledTimes(2)
+    expect(dbEndMock).toHaveBeenCalledTimes(1)
     expect(loginToFileServerMock).toHaveBeenCalledTimes(1)
-    expect(checkFileExistsMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
 
     dbExecuteMock.mockResolvedValueOnce({ rows: [] }).mockResolvedValueOnce({ rows: schemaRows })
     const refreshed = await getSystemStatus(env, { force: true })
 
     expect(refreshed).not.toBe(first)
     expect(dbExecuteMock).toHaveBeenCalledTimes(4)
+    expect(dbEndMock).toHaveBeenCalledTimes(2)
     expect(loginToFileServerMock).toHaveBeenCalledTimes(2)
-    expect(checkFileExistsMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock).toHaveBeenCalledTimes(4)
   })
 })

--- a/projects/portfolio/tests/features/system-status/system-status.test.ts
+++ b/projects/portfolio/tests/features/system-status/system-status.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { checkFileExistsMock, dbExecuteMock, getDatabaseMock, loginToFileServerMock, readFileServerApiMock } =
+  vi.hoisted(() => ({
+    checkFileExistsMock: vi.fn(),
+    dbExecuteMock: vi.fn(),
+    getDatabaseMock: vi.fn(),
+    loginToFileServerMock: vi.fn(),
+    readFileServerApiMock: vi.fn(),
+  }))
+
+vi.mock('#/db', () => ({
+  getDatabase: getDatabaseMock,
+}))
+
+vi.mock('#/server/features/chat-conversations/file-server-client', async () => {
+  const actual = await vi.importActual<typeof import('#/server/features/chat-conversations/file-server-client')>(
+    '#/server/features/chat-conversations/file-server-client'
+  )
+
+  return {
+    ...actual,
+    checkFileExists: checkFileExistsMock,
+    loginToFileServer: loginToFileServerMock,
+    readFileServerApi: readFileServerApiMock,
+  }
+})
+
+import { getSystemStatus, resetSystemStatusCacheForTests } from '#/server/features/system-status/system-status'
+
+const env = {
+  DATABASE_URL: 'postgresql://db.internal:5432/portfolio',
+  FILE_SERVER_URL: 'http://file-server:3000',
+  FILE_SERVER_PUBLIC_URL: 'https://files.example.com',
+  FILE_SERVER_ADMIN_USERNAME: 'admin',
+  FILE_SERVER_ADMIN_PASSWORD: 'super-secret',
+}
+
+const schemaRows = [
+  { table_name: 'users', column_name: 'id' },
+  { table_name: 'users', column_name: 'email' },
+  { table_name: 'users', column_name: 'password_hash' },
+  { table_name: 'users', column_name: 'created_at' },
+  { table_name: 'conversations', column_name: 'id' },
+  { table_name: 'conversations', column_name: 'user_id' },
+  { table_name: 'conversations', column_name: 'title' },
+  { table_name: 'conversations', column_name: 'created_at' },
+  { table_name: 'conversations', column_name: 'updated_at' },
+  { table_name: 'messages', column_name: 'id' },
+  { table_name: 'messages', column_name: 'conversation_id' },
+  { table_name: 'messages', column_name: 'role' },
+  { table_name: 'messages', column_name: 'content' },
+  { table_name: 'messages', column_name: 'reasoning_content' },
+  { table_name: 'messages', column_name: 'metadata' },
+  { table_name: 'messages', column_name: 'created_at' },
+  { table_name: 'prompt_templates', column_name: 'id' },
+  { table_name: 'prompt_templates', column_name: 'input_type' },
+  { table_name: 'prompt_templates', column_name: 'title' },
+  { table_name: 'prompt_templates', column_name: 'placeholder' },
+  { table_name: 'prompt_templates', column_name: 'prompt' },
+  { table_name: 'prompt_templates', column_name: 'display_order' },
+  { table_name: 'prompt_templates', column_name: 'enabled' },
+  { table_name: 'prompt_templates', column_name: 'created_at' },
+  { table_name: 'prompt_templates', column_name: 'updated_at' },
+]
+
+describe('getSystemStatus', () => {
+  beforeEach(() => {
+    resetSystemStatusCacheForTests()
+    dbExecuteMock.mockReset()
+    getDatabaseMock.mockReset()
+    loginToFileServerMock.mockReset()
+    readFileServerApiMock.mockReset()
+    checkFileExistsMock.mockReset()
+
+    getDatabaseMock.mockReturnValue({ execute: dbExecuteMock })
+    dbExecuteMock.mockResolvedValueOnce({ rows: [] }).mockResolvedValueOnce({ rows: schemaRows })
+    loginToFileServerMock.mockResolvedValue('session-value')
+    readFileServerApiMock.mockResolvedValue(undefined)
+    checkFileExistsMock.mockResolvedValue(true)
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 200 })))
+  })
+
+  it('DB・file-server API・公開URLが正常なら ok を返す', async () => {
+    const result = await getSystemStatus(env)
+
+    expect(result.status).toBe('ok')
+    expect(result.checks.database.status).toBe('ok')
+    expect(result.checks.database.connection.status).toBe('ok')
+    expect(result.checks.database.schema.status).toBe('ok')
+    expect(result.checks.fileServerHealth.status).toBe('ok')
+    expect(result.checks.fileServerApi.status).toBe('ok')
+    expect(result.checks.fileServerPublic.status).toBe('ok')
+    expect(JSON.stringify(result)).not.toContain('db.internal')
+    expect(JSON.stringify(result)).not.toContain('super-secret')
+    expect(JSON.stringify(result)).not.toContain('file-server:3000')
+  })
+
+  it('スキーマが不足している場合は DB のスキーマ異常として返す', async () => {
+    dbExecuteMock.mockReset()
+    dbExecuteMock.mockResolvedValueOnce({ rows: [] }).mockResolvedValueOnce({ rows: [] })
+
+    const result = await getSystemStatus(env)
+
+    expect(result.status).toBe('degraded')
+    expect(result.checks.database.connection.status).toBe('ok')
+    expect(result.checks.database.schema).toEqual(
+      expect.objectContaining({ status: 'error', reason: 'schema-check-failed' })
+    )
+  })
+
+  it('file-server ログインに失敗した場合は読み取り系への影響を示す', async () => {
+    loginToFileServerMock.mockRejectedValue(new Error('invalid credentials'))
+
+    const result = await getSystemStatus(env)
+
+    expect(result.status).toBe('degraded')
+    expect(result.checks.fileServerHealth.status).toBe('ok')
+    expect(result.checks.fileServerApi).toEqual(expect.objectContaining({ status: 'error', reason: 'login-failed' }))
+    expect(result.checks.fileServerApi.login).toEqual(
+      expect.objectContaining({ status: 'error', reason: 'login-failed' })
+    )
+    expect(result.checks.fileServerApi.read).toEqual(
+      expect.objectContaining({ status: 'error', reason: 'login-failed' })
+    )
+    expect(readFileServerApiMock).not.toHaveBeenCalled()
+  })
+
+  it('チェックが応答しない場合はタイムアウトとして返す', async () => {
+    vi.useFakeTimers()
+    dbExecuteMock.mockReset()
+    dbExecuteMock.mockImplementation(() => new Promise(() => undefined))
+
+    try {
+      const resultPromise = getSystemStatus(env)
+      await vi.advanceTimersByTimeAsync(3_000)
+      const result = await resultPromise
+
+      expect(result.checks.database.connection).toEqual(expect.objectContaining({ status: 'error', reason: 'timeout' }))
+      expect(result.checks.database.schema).toEqual(expect.objectContaining({ status: 'error', reason: 'timeout' }))
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('同じ設定では短時間キャッシュを利用し、force 時だけ再確認する', async () => {
+    const first = await getSystemStatus(env)
+    const cached = await getSystemStatus(env)
+
+    expect(cached).toBe(first)
+    expect(dbExecuteMock).toHaveBeenCalledTimes(2)
+    expect(loginToFileServerMock).toHaveBeenCalledTimes(1)
+    expect(checkFileExistsMock).toHaveBeenCalledTimes(1)
+
+    dbExecuteMock.mockResolvedValueOnce({ rows: [] }).mockResolvedValueOnce({ rows: schemaRows })
+    const refreshed = await getSystemStatus(env, { force: true })
+
+    expect(refreshed).not.toBe(first)
+    expect(dbExecuteMock).toHaveBeenCalledTimes(4)
+    expect(loginToFileServerMock).toHaveBeenCalledTimes(2)
+    expect(checkFileExistsMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/projects/portfolio/tests/routes/system-status.test.ts
+++ b/projects/portfolio/tests/routes/system-status.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { getSignedCookieMock, getSystemStatusMock } = vi.hoisted(() => ({
+  getSignedCookieMock: vi.fn(),
+  getSystemStatusMock: vi.fn(),
+}))
+
+vi.mock('hono/cookie', async () => {
+  const actual = await vi.importActual<typeof import('hono/cookie')>('hono/cookie')
+
+  return {
+    ...actual,
+    getSignedCookie: getSignedCookieMock,
+  }
+})
+
+vi.mock('#/server/features/system-status/system-status', () => ({
+  getSystemStatus: getSystemStatusMock,
+}))
+
+import { systemStatusRoutes } from '#/server/routes/system-status'
+
+const status = {
+  status: 'ok' as const,
+  checkedAt: '2026-04-19T00:00:00.000Z',
+  checks: {
+    database: {
+      status: 'ok' as const,
+      reason: 'ok',
+      checkedAt: '2026-04-19T00:00:00.000Z',
+      connection: { status: 'ok' as const, reason: 'ok', checkedAt: '2026-04-19T00:00:00.000Z' },
+      schema: { status: 'ok' as const, reason: 'ok', checkedAt: '2026-04-19T00:00:00.000Z' },
+    },
+    fileServerHealth: { status: 'ok' as const, reason: 'ok', checkedAt: '2026-04-19T00:00:00.000Z' },
+    fileServerApi: {
+      status: 'ok' as const,
+      reason: 'ok',
+      checkedAt: '2026-04-19T00:00:00.000Z',
+      login: { status: 'ok' as const, reason: 'ok', checkedAt: '2026-04-19T00:00:00.000Z' },
+      read: { status: 'ok' as const, reason: 'ok', checkedAt: '2026-04-19T00:00:00.000Z' },
+    },
+    fileServerPublic: { status: 'ok' as const, reason: 'ok', checkedAt: '2026-04-19T00:00:00.000Z' },
+  },
+}
+
+describe('systemStatusRoutes', () => {
+  beforeEach(() => {
+    getSignedCookieMock.mockReset()
+    getSystemStatusMock.mockReset()
+    vi.stubEnv('COOKIE_SECRET', 'secret')
+    vi.stubEnv('COOKIE_NAME', 'session')
+  })
+
+  it('未認証の GET は 401 を返し、system status を実行しない', async () => {
+    getSignedCookieMock.mockResolvedValue(null)
+
+    const res = await systemStatusRoutes.request('/api/system-status')
+
+    expect(res.status).toBe(401)
+    await expect(res.json()).resolves.toEqual({ error: 'Authentication error' })
+    expect(getSystemStatusMock).not.toHaveBeenCalled()
+  })
+
+  it('認証済みの GET は status と no-store を返す', async () => {
+    getSignedCookieMock.mockResolvedValue('test@example.com')
+    getSystemStatusMock.mockResolvedValue(status)
+
+    const res = await systemStatusRoutes.request('/api/system-status')
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('cache-control')).toBe('no-store')
+    await expect(res.json()).resolves.toEqual(status)
+    expect(getSystemStatusMock).toHaveBeenCalledWith(expect.objectContaining({}), { force: false })
+  })
+
+  it('予期しないエラーでも機密情報を返さず 503 にする', async () => {
+    getSignedCookieMock.mockResolvedValue('test@example.com')
+    getSystemStatusMock.mockRejectedValue(new Error('postgres://secret/internal'))
+
+    const res = await systemStatusRoutes.request('/api/system-status')
+
+    expect(res.status).toBe(503)
+    await expect(res.json()).resolves.toEqual({ error: 'System status unavailable' })
+  })
+
+  it('refresh=1 はサーバーキャッシュを bypass する', async () => {
+    getSignedCookieMock.mockResolvedValue('test@example.com')
+    getSystemStatusMock.mockResolvedValue(status)
+
+    const res = await systemStatusRoutes.request('/api/system-status?refresh=1')
+
+    expect(res.status).toBe(200)
+    expect(getSystemStatusMock).toHaveBeenCalledWith(expect.objectContaining({}), { force: true })
+  })
+})


### PR DESCRIPTION
## Issues

- closes #1169
- ref: #1167

## Why

Portfolioが依存するPostgreSQLとfile-serverの障害や設定不備を、機能利用前に確認できるようにします。

## Summary

認証済みユーザー向けのシステム状態APIと、HOME右下の状態ウィジェットを追加しました。DB、file-server API、公開URLを個別に確認できます。

## Changes

- `GET /api/system-status` を追加し、認証・短時間キャッシュ・チェックタイムアウトを適用
- PostgreSQLの接続と必要スキーマ、file-server内部URLの `/healthz`、ログイン・読み取りAPI、公開URL経由の `/healthz` を確認
- レスポンスには固定のステータスと理由のみを含め、機密情報や内部URLを除外
- HOMEのログイン済みユーザー向けに、詳細・最終確認時刻・再確認操作を備えた状態ウィジェットを追加
- APIクライアントのタイムアウト対応とテストを追加

## Verification

- `bun run typegen` ✅
- `bun run lint` ✅
- `bun run format` / `bun run format:check` ✅
- `bun run test` ✅（73 files / 406 tests）
- Docker PostgreSQL統合確認 ✅（コンテナ起動・migration後にDB正常、停止後にDB接続異常を確認）