### PR TITLE
portfolio: 未ログイン時にもシステム状態を表示する

### DIFF
--- a/projects/portfolio/.gitignore
+++ b/projects/portfolio/.gitignore
@@ -2,6 +2,7 @@
 node_modules/
 dist/
 coverage/
+.typegen/
 .env
 .tanstack
 logs/

--- a/projects/portfolio/src/client/features/home/page.tsx
+++ b/projects/portfolio/src/client/features/home/page.tsx
@@ -81,7 +81,6 @@ export function Home() {
                 Sign Out
               </button>
             </div>
-            <SystemStatusWidget />
           </>
         ) : (
           <form onSubmit={handleSubmit} className='space-y-4'>
@@ -119,6 +118,7 @@ export function Home() {
             </button>
           </form>
         )}
+        <SystemStatusWidget />
       </div>
     </div>
   )

--- a/projects/portfolio/src/client/features/home/system-status-widget.tsx
+++ b/projects/portfolio/src/client/features/home/system-status-widget.tsx
@@ -1,7 +1,7 @@
 import { hc } from 'hono/client'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { AppType } from '#/server/app.d'
-import type { SystemCheck, SystemStatus } from '#/types'
+import type { SystemCheck, SystemStatus, SystemStatusReason } from '#/types'
 
 const client = hc<AppType>('/')
 
@@ -11,19 +11,19 @@ type SystemStatusEndpoint = {
 
 const systemStatusEndpoint = (client.api as unknown as { 'system-status'?: SystemStatusEndpoint })['system-status']
 
-const reasonLabels: Record<string, string> = {
+const reasonLabels: Record<SystemStatusReason, string> = {
   ok: '応答あり',
   'not-configured': '設定なし',
+  timeout: 'タイムアウト',
   'connection-failed': '接続失敗',
   'schema-check-failed': 'スキーマ確認失敗',
-  'schema-incomplete': 'スキーマ不備',
   'database-unavailable': 'データベース利用不可',
-  timeout: 'タイムアウト',
   'healthz-unavailable': 'ヘルスチェック失敗',
   'login-failed': 'ログイン失敗',
   'read-failed': '読み取り失敗',
   'file-server-api-unavailable': 'API利用不可',
   'public-unavailable': '公開配信不可',
+  'check-failed': '確認失敗',
 }
 
 function getStatusLabel(status: SystemCheck['status']): string {
@@ -32,7 +32,7 @@ function getStatusLabel(status: SystemCheck['status']): string {
   return '異常'
 }
 
-function getReasonLabel(reason: string): string {
+function getReasonLabel(reason: SystemStatusReason): string {
   return reasonLabels[reason] ?? '確認失敗'
 }
 

--- a/projects/portfolio/src/client/features/home/system-status-widget.tsx
+++ b/projects/portfolio/src/client/features/home/system-status-widget.tsx
@@ -1,7 +1,17 @@
 import { hc } from 'hono/client'
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { IconButton } from '#/client/shared/components/icon-button/icon-button'
+import { CheckIcon } from '#/client/shared/icons/check-icon'
+import { CopyIcon } from '#/client/shared/icons/copy-icon'
+import { copyToClipboard } from '#/client/shared/lib/copy-to-clipboard'
 import type { AppType } from '#/server/app.d'
-import type { SystemCheck, SystemStatus, SystemStatusReason } from '#/types'
+import type {
+  DatabaseSystemStatus,
+  FileServerApiSystemStatus,
+  SystemCheck,
+  SystemStatus,
+  SystemStatusReason,
+} from '#/types'
 
 const client = hc<AppType>('/')
 
@@ -46,6 +56,64 @@ function formatCheckedAt(value: string): string {
   }).format(date)
 }
 
+type SystemStatusCopyInput = Omit<SystemStatus, 'checks'> & {
+  checks?: {
+    database?: Omit<DatabaseSystemStatus, 'connection' | 'schema'> & {
+      connection?: SystemCheck
+      schema?: SystemCheck
+    }
+    fileServerHealth?: SystemCheck
+    fileServerApi?: Omit<FileServerApiSystemStatus, 'login' | 'read'> & {
+      login?: SystemCheck
+      read?: SystemCheck
+    }
+    fileServerPublic?: SystemCheck
+  }
+}
+
+function formatCheckDetails(check: SystemCheck): string {
+  return [`- status: ${check.status}`, `- reason: ${check.reason}`, `- checkedAt: ${check.checkedAt}`].join('\n')
+}
+
+function formatCheckSection(
+  label: string,
+  check: SystemCheck | undefined,
+  nested: readonly [string, SystemCheck | undefined][] = []
+): string | null {
+  if (!check) return null
+
+  return [
+    `### ${label}`,
+    formatCheckDetails(check),
+    ...nested.flatMap(([nestedLabel, nestedCheck]) =>
+      nestedCheck ? [`#### ${nestedLabel}`, formatCheckDetails(nestedCheck)] : []
+    ),
+  ].join('\n\n')
+}
+
+export function formatSystemStatusForCopy(status: SystemStatusCopyInput): string {
+  const checks = status.checks
+  const sections = [
+    formatCheckSection('PostgreSQL (`checks.database`)', checks?.database, [
+      ['connection', checks?.database?.connection],
+      ['schema', checks?.database?.schema],
+    ]),
+    formatCheckSection('file-server 稼働 (`checks.fileServerHealth`)', checks?.fileServerHealth),
+    formatCheckSection('file-server API (`checks.fileServerApi`)', checks?.fileServerApi, [
+      ['login', checks?.fileServerApi?.login],
+      ['read', checks?.fileServerApi?.read],
+    ]),
+    formatCheckSection('公開URL (`checks.fileServerPublic`)', checks?.fileServerPublic),
+  ].filter((section): section is string => section !== null)
+
+  const lines = ['# System status', `- status: ${status.status}`, `- checkedAt: ${status.checkedAt}`]
+  if (sections.length > 0) {
+    lines.push('', '## Checks', '', sections.join('\n\n'))
+  }
+
+  return `${lines.join('\n')}\n`
+}
+
 function CheckRow({ label, check }: { label: string; check: SystemCheck }) {
   const isHealthy = check.status === 'ok'
   return (
@@ -60,10 +128,14 @@ function CheckRow({ label, check }: { label: string; check: SystemCheck }) {
   )
 }
 
+type CopyState = 'idle' | 'copying' | 'copied'
+
 export function SystemStatusWidget() {
   const [status, setStatus] = useState<SystemStatus | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState(false)
+  const [copyState, setCopyState] = useState<CopyState>('idle')
+  const [copyError, setCopyError] = useState(false)
   const requestRef = useRef<AbortController | null>(null)
 
   const loadStatus = useCallback(async (refresh: boolean) => {
@@ -74,6 +146,7 @@ export function SystemStatusWidget() {
     requestRef.current = controller
     setLoading(true)
     setError(false)
+    setCopyError(false)
 
     try {
       const response = await systemStatusEndpoint.$get(refresh ? { query: { refresh: '1' } } : undefined)
@@ -103,7 +176,29 @@ export function SystemStatusWidget() {
     return () => requestRef.current?.abort()
   }, [loadStatus])
 
+  useEffect(() => {
+    if (copyState !== 'copied') return
+
+    const timer = setTimeout(() => setCopyState('idle'), 2000)
+    return () => clearTimeout(timer)
+  }, [copyState])
+
+  const handleCopy = useCallback(async () => {
+    if (!status || loading || copyState !== 'idle') return
+
+    setCopyError(false)
+    setCopyState('copying')
+    try {
+      await copyToClipboard(formatSystemStatusForCopy(status))
+      setCopyState('copied')
+    } catch {
+      setCopyState('idle')
+      setCopyError(true)
+    }
+  }, [copyState, loading, status])
+
   const isHealthy = status?.status === 'ok'
+  const copyLabel = copyState === 'copied' ? 'コピー済み' : copyState === 'copying' ? 'コピー中…' : 'ステータスをコピー'
   const database = status?.checks.database
   const fileServerHealth = status?.checks.fileServerHealth
   const fileServerApi = status?.checks.fileServerApi
@@ -126,14 +221,43 @@ export function SystemStatusWidget() {
             {isHealthy ? 'システム正常' : status ? 'システム要確認' : 'システム状態'}
           </h2>
         </div>
-        <button
-          type='button'
-          onClick={() => void loadStatus(true)}
-          disabled={loading || !systemStatusEndpoint}
-          className='shrink-0 rounded border border-gray-300 px-2 py-1 text-gray-700 text-xs hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700'
-        >
-          {loading ? '確認中…' : '再確認'}
-        </button>
+        <div className='flex shrink-0 items-center gap-1'>
+          <IconButton
+            label={copyLabel}
+            onClick={() => void handleCopy()}
+            disabled={!status || loading || copyState !== 'idle'}
+            className={`relative h-8 w-8 rounded-full text-gray-500 transition-[background-color,color,transform] duration-200 ease-out dark:text-gray-300 disabled:opacity-100 ${
+              copyState === 'copied'
+                ? 'text-emerald-600 dark:text-emerald-400'
+                : 'hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-700 dark:hover:text-white'
+            }`}
+          >
+            <span
+              aria-hidden='true'
+              className={`absolute transition-[opacity,transform] duration-200 ease-out motion-reduce:transition-none ${
+                copyState === 'copied' ? '-translate-y-0.5 scale-90 opacity-0' : 'translate-y-0 scale-100 opacity-100'
+              }`}
+            >
+              <CopyIcon size={18} className='stroke-current' />
+            </span>
+            <span
+              aria-hidden='true'
+              className={`absolute transition-[opacity,transform] duration-200 ease-out motion-reduce:transition-none ${
+                copyState === 'copied' ? 'translate-y-0 scale-100 opacity-100' : 'translate-y-0.5 scale-90 opacity-0'
+              }`}
+            >
+              <CheckIcon size={18} className='stroke-current' />
+            </span>
+          </IconButton>
+          <button
+            type='button'
+            onClick={() => void loadStatus(true)}
+            disabled={loading || !systemStatusEndpoint}
+            className='shrink-0 rounded border border-gray-300 px-2 py-1 text-gray-700 text-xs hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700'
+          >
+            {loading ? '確認中…' : '再確認'}
+          </button>
+        </div>
       </div>
 
       {status ? (
@@ -145,16 +269,16 @@ export function SystemStatusWidget() {
             {database && <CheckRow label='PostgreSQL' check={database} />}
             {database && (
               <div className='ml-3 space-y-1 border-l border-gray-200 pl-2 dark:border-gray-600'>
-                <CheckRow label='接続' check={database.connection} />
-                <CheckRow label='スキーマ' check={database.schema} />
+                {database.connection && <CheckRow label='接続' check={database.connection} />}
+                {database.schema && <CheckRow label='スキーマ' check={database.schema} />}
               </div>
             )}
             {fileServerHealth && <CheckRow label='file-server 稼働' check={fileServerHealth} />}
             {fileServerApi && <CheckRow label='file-server API' check={fileServerApi} />}
             {fileServerApi && (
               <div className='ml-3 space-y-1 border-l border-gray-200 pl-2 dark:border-gray-600'>
-                <CheckRow label='ログイン' check={fileServerApi.login} />
-                <CheckRow label='読み取り' check={fileServerApi.read} />
+                {fileServerApi.login && <CheckRow label='ログイン' check={fileServerApi.login} />}
+                {fileServerApi.read && <CheckRow label='読み取り' check={fileServerApi.read} />}
               </div>
             )}
             {fileServerPublic && <CheckRow label='公開URL' check={fileServerPublic} />}
@@ -164,6 +288,11 @@ export function SystemStatusWidget() {
         <p className='mt-2 text-gray-500 text-xs dark:text-gray-400'>状態を確認しています。</p>
       )}
 
+      {copyError && (
+        <p role='alert' className='mt-2 text-red-700 text-xs dark:text-red-400'>
+          ステータスをコピーできませんでした。
+        </p>
+      )}
       {error && <p className='mt-2 text-red-700 text-xs dark:text-red-400'>状態を取得できませんでした。</p>}
     </section>
   )

--- a/projects/portfolio/src/client/features/home/system-status-widget.tsx
+++ b/projects/portfolio/src/client/features/home/system-status-widget.tsx
@@ -252,7 +252,7 @@ export function SystemStatusWidget() {
           <button
             type='button'
             onClick={() => void loadStatus(true)}
-            disabled={loading || !systemStatusEndpoint}
+            disabled={loading || !systemStatusEndpoint || copyState !== 'idle'}
             className='shrink-0 rounded border border-gray-300 px-2 py-1 text-gray-700 text-xs hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700'
           >
             {loading ? '確認中…' : '再確認'}

--- a/projects/portfolio/src/client/routes/__root.tsx
+++ b/projects/portfolio/src/client/routes/__root.tsx
@@ -46,7 +46,7 @@ function Root() {
           <Outlet />
         </Suspense>
       </AppLayout>
-      <TanStackRouterDevtoolsPanel position='bottom-right' />
+      <TanStackRouterDevtoolsPanel position='top-right' />
     </>
   )
 }

--- a/projects/portfolio/src/client/shared/lib/copy-to-clipboard.ts
+++ b/projects/portfolio/src/client/shared/lib/copy-to-clipboard.ts
@@ -5,8 +5,13 @@ export async function copyToClipboard(text: string) {
     const input = document.createElement('textarea')
     input.value = text
     document.body.appendChild(input)
-    input.select()
-    document.execCommand('copy')
-    document.body.removeChild(input)
+    try {
+      input.select()
+      if (!document.execCommand('copy')) {
+        throw new Error('Failed to copy text to clipboard')
+      }
+    } finally {
+      document.body.removeChild(input)
+    }
   }
 }

--- a/projects/portfolio/src/server/app.d.ts
+++ b/projects/portfolio/src/server/app.d.ts
@@ -1,6 +1,6 @@
-import type { HonoEnv } from './routes/shared';
-declare const app: import("hono/hono-base").HonoBase<HonoEnv, import("hono/types").BlankSchema, "/", "*">;
-declare const routes: import("hono/hono-base").HonoBase<HonoEnv, import("hono/types").BlankSchema | import("hono/types").MergeSchemaPath<{
+import { HonoEnv } from './routes/shared';
+declare const app: import('hono/hono-base').HonoBase<HonoEnv, import('hono/types').BlankSchema, "/", "*">;
+declare const routes: import('hono/hono-base').HonoBase<HonoEnv, import('hono/types').BlankSchema | import('hono/types').MergeSchemaPath<{
     "/api/signin": {
         $post: {
             input: {
@@ -25,7 +25,7 @@ declare const routes: import("hono/hono-base").HonoBase<HonoEnv, import("hono/ty
             };
             output: {};
             outputFormat: "json";
-            status: import("hono/utils/http-status").ContentfulStatusCode;
+            status: import('hono/utils/http-status').ContentfulStatusCode;
         };
     };
 } & {
@@ -34,10 +34,10 @@ declare const routes: import("hono/hono-base").HonoBase<HonoEnv, import("hono/ty
             input: {};
             output: {};
             outputFormat: "json";
-            status: import("hono/utils/http-status").ContentfulStatusCode;
+            status: import('hono/utils/http-status').ContentfulStatusCode;
         };
     };
-}, "/"> | import("hono/types").MergeSchemaPath<{
+}, "/"> | import('hono/types').MergeSchemaPath<{
     "/api/image/generations": {
         $post: {
             input: {
@@ -130,7 +130,7 @@ declare const routes: import("hono/hono-base").HonoBase<HonoEnv, import("hono/ty
                 };
             };
             outputFormat: "json";
-            status: import("hono/utils/http-status").ContentfulStatusCode;
+            status: import('hono/utils/http-status').ContentfulStatusCode;
         };
     };
 } & {
@@ -265,7 +265,7 @@ declare const routes: import("hono/hono-base").HonoBase<HonoEnv, import("hono/ty
                 } | null;
             };
             outputFormat: "json";
-            status: import("hono/utils/http-status").ContentfulStatusCode;
+            status: import('hono/utils/http-status').ContentfulStatusCode;
         };
     };
 } & {
@@ -345,7 +345,7 @@ declare const routes: import("hono/hono-base").HonoBase<HonoEnv, import("hono/ty
             };
             output: {};
             outputFormat: string;
-            status: import("hono/utils/http-status").StatusCode;
+            status: import('hono/utils/http-status').StatusCode;
         };
     };
 } & {
@@ -612,7 +612,7 @@ declare const routes: import("hono/hono-base").HonoBase<HonoEnv, import("hono/ty
                 status: "error" | "running" | "completed" | "cancelled";
             };
             outputFormat: "json";
-            status: import("hono/utils/http-status").ContentfulStatusCode;
+            status: import('hono/utils/http-status').ContentfulStatusCode;
         };
     };
 } & {
@@ -746,7 +746,7 @@ declare const routes: import("hono/hono-base").HonoBase<HonoEnv, import("hono/ty
                 };
             };
             outputFormat: "json";
-            status: import("hono/utils/http-status").ContentfulStatusCode;
+            status: import('hono/utils/http-status').ContentfulStatusCode;
         };
     };
 } & {
@@ -759,7 +759,7 @@ declare const routes: import("hono/hono-base").HonoBase<HonoEnv, import("hono/ty
             };
             output: {};
             outputFormat: string;
-            status: import("hono/utils/http-status").StatusCode;
+            status: import('hono/utils/http-status').StatusCode;
         };
     };
 } & {
@@ -787,7 +787,7 @@ declare const routes: import("hono/hono-base").HonoBase<HonoEnv, import("hono/ty
                 status: "error" | "running" | "completed" | "cancelled";
             };
             outputFormat: "json";
-            status: import("hono/utils/http-status").ContentfulStatusCode;
+            status: import('hono/utils/http-status').ContentfulStatusCode;
         };
     };
 } & {
@@ -861,10 +861,10 @@ declare const routes: import("hono/hono-base").HonoBase<HonoEnv, import("hono/ty
             };
             output: {};
             outputFormat: string;
-            status: import("hono/utils/http-status").StatusCode;
+            status: import('hono/utils/http-status').StatusCode;
         };
     };
-}, "/"> | import("hono/types").MergeSchemaPath<{
+}, "/"> | import('hono/types').MergeSchemaPath<{
     "/api/conversations": {
         $get: {
             input: {};
@@ -962,7 +962,7 @@ declare const routes: import("hono/hono-base").HonoBase<HonoEnv, import("hono/ty
                 }[];
             };
             outputFormat: "json";
-            status: import("hono/utils/http-status").ContentfulStatusCode;
+            status: import('hono/utils/http-status').ContentfulStatusCode;
         };
     };
 } & {
@@ -1166,7 +1166,7 @@ declare const routes: import("hono/hono-base").HonoBase<HonoEnv, import("hono/ty
                 conversationId: string;
             };
             outputFormat: "json";
-            status: import("hono/utils/http-status").ContentfulStatusCode;
+            status: import('hono/utils/http-status').ContentfulStatusCode;
         };
     };
 } & {
@@ -1196,7 +1196,7 @@ declare const routes: import("hono/hono-base").HonoBase<HonoEnv, import("hono/ty
                 failedIds: string[];
             };
             outputFormat: "json";
-            status: import("hono/utils/http-status").ContentfulStatusCode;
+            status: import('hono/utils/http-status').ContentfulStatusCode;
         };
     };
 } & {
@@ -1227,7 +1227,7 @@ declare const routes: import("hono/hono-base").HonoBase<HonoEnv, import("hono/ty
                 deletedConversationIds: string[];
             };
             outputFormat: "json";
-            status: import("hono/utils/http-status").ContentfulStatusCode;
+            status: import('hono/utils/http-status').ContentfulStatusCode;
         };
     };
 } & {
@@ -1483,7 +1483,7 @@ declare const routes: import("hono/hono-base").HonoBase<HonoEnv, import("hono/ty
                 };
             };
             outputFormat: "json";
-            status: import("hono/utils/http-status").ContentfulStatusCode;
+            status: import('hono/utils/http-status').ContentfulStatusCode;
         };
     };
 } & {
@@ -1610,10 +1610,10 @@ declare const routes: import("hono/hono-base").HonoBase<HonoEnv, import("hono/ty
                 alreadyExisted: boolean;
             };
             outputFormat: "json";
-            status: import("hono/utils/http-status").ContentfulStatusCode;
+            status: import('hono/utils/http-status').ContentfulStatusCode;
         };
     };
-}, "/"> | import("hono/types").MergeSchemaPath<{
+}, "/"> | import('hono/types').MergeSchemaPath<{
     "/api/fetch-models": {
         $get: {
             input: {
@@ -1636,10 +1636,10 @@ declare const routes: import("hono/hono-base").HonoBase<HonoEnv, import("hono/ty
             };
             output: string[];
             outputFormat: "json";
-            status: import("hono/utils/http-status").ContentfulStatusCode;
+            status: import('hono/utils/http-status').ContentfulStatusCode;
         };
     };
-}, "/"> | import("hono/types").MergeSchemaPath<{
+}, "/"> | import('hono/types').MergeSchemaPath<{
     "/api/prompt-templates": {
         $get: {
             input: {};
@@ -1653,10 +1653,10 @@ declare const routes: import("hono/hono-base").HonoBase<HonoEnv, import("hono/ty
                 }[];
             };
             outputFormat: "json";
-            status: import("hono/utils/http-status").ContentfulStatusCode;
+            status: import('hono/utils/http-status').ContentfulStatusCode;
         };
     };
-}, "/"> | import("hono/types").MergeSchemaPath<{
+}, "/"> | import('hono/types').MergeSchemaPath<{
     "/api/system-status": {
         $get: {
             input: {};
@@ -1665,49 +1665,49 @@ declare const routes: import("hono/hono-base").HonoBase<HonoEnv, import("hono/ty
                 checkedAt: string;
                 checks: {
                     database: {
+                        status: "error" | "ok" | "not-configured";
+                        reason: "ok" | "not-configured" | "timeout" | "connection-failed" | "schema-check-failed" | "database-unavailable" | "healthz-unavailable" | "login-failed" | "read-failed" | "file-server-api-unavailable" | "public-unavailable" | "check-failed";
+                        checkedAt: string;
                         connection: {
-                            status: import("../types").SystemCheckStatus;
-                            reason: string;
+                            status: "error" | "ok" | "not-configured";
+                            reason: "ok" | "not-configured" | "timeout" | "connection-failed" | "schema-check-failed" | "database-unavailable" | "healthz-unavailable" | "login-failed" | "read-failed" | "file-server-api-unavailable" | "public-unavailable" | "check-failed";
                             checkedAt: string;
                         };
                         schema: {
-                            status: import("../types").SystemCheckStatus;
-                            reason: string;
+                            status: "error" | "ok" | "not-configured";
+                            reason: "ok" | "not-configured" | "timeout" | "connection-failed" | "schema-check-failed" | "database-unavailable" | "healthz-unavailable" | "login-failed" | "read-failed" | "file-server-api-unavailable" | "public-unavailable" | "check-failed";
                             checkedAt: string;
                         };
-                        status: import("../types").SystemCheckStatus;
-                        reason: string;
-                        checkedAt: string;
                     };
                     fileServerHealth: {
-                        status: import("../types").SystemCheckStatus;
-                        reason: string;
+                        status: "error" | "ok" | "not-configured";
+                        reason: "ok" | "not-configured" | "timeout" | "connection-failed" | "schema-check-failed" | "database-unavailable" | "healthz-unavailable" | "login-failed" | "read-failed" | "file-server-api-unavailable" | "public-unavailable" | "check-failed";
                         checkedAt: string;
                     };
                     fileServerApi: {
+                        status: "error" | "ok" | "not-configured";
+                        reason: "ok" | "not-configured" | "timeout" | "connection-failed" | "schema-check-failed" | "database-unavailable" | "healthz-unavailable" | "login-failed" | "read-failed" | "file-server-api-unavailable" | "public-unavailable" | "check-failed";
+                        checkedAt: string;
                         login: {
-                            status: import("../types").SystemCheckStatus;
-                            reason: string;
+                            status: "error" | "ok" | "not-configured";
+                            reason: "ok" | "not-configured" | "timeout" | "connection-failed" | "schema-check-failed" | "database-unavailable" | "healthz-unavailable" | "login-failed" | "read-failed" | "file-server-api-unavailable" | "public-unavailable" | "check-failed";
                             checkedAt: string;
                         };
                         read: {
-                            status: import("../types").SystemCheckStatus;
-                            reason: string;
+                            status: "error" | "ok" | "not-configured";
+                            reason: "ok" | "not-configured" | "timeout" | "connection-failed" | "schema-check-failed" | "database-unavailable" | "healthz-unavailable" | "login-failed" | "read-failed" | "file-server-api-unavailable" | "public-unavailable" | "check-failed";
                             checkedAt: string;
                         };
-                        status: import("../types").SystemCheckStatus;
-                        reason: string;
-                        checkedAt: string;
                     };
                     fileServerPublic: {
-                        status: import("../types").SystemCheckStatus;
-                        reason: string;
+                        status: "error" | "ok" | "not-configured";
+                        reason: "ok" | "not-configured" | "timeout" | "connection-failed" | "schema-check-failed" | "database-unavailable" | "healthz-unavailable" | "login-failed" | "read-failed" | "file-server-api-unavailable" | "public-unavailable" | "check-failed";
                         checkedAt: string;
                     };
                 };
             };
             outputFormat: "json";
-            status: import("hono/utils/http-status").ContentfulStatusCode;
+            status: 200;
         } | {
             input: {};
             output: {
@@ -1717,13 +1717,13 @@ declare const routes: import("hono/hono-base").HonoBase<HonoEnv, import("hono/ty
             status: 503;
         };
     };
-}, "/"> | import("hono/types").MergeSchemaPath<{
+}, "/"> | import('hono/types').MergeSchemaPath<{
     "*": {
         $get: {
             input: {};
             output: {};
             outputFormat: string;
-            status: import("hono/utils/http-status").StatusCode;
+            status: import('hono/utils/http-status').StatusCode;
         };
     };
 }, "/">, "/", "*">;

--- a/projects/portfolio/src/server/features/system-status/system-status.ts
+++ b/projects/portfolio/src/server/features/system-status/system-status.ts
@@ -8,17 +8,20 @@ import {
   type FileServerConfig,
 } from '#/server/features/chat-conversations/file-server-client'
 import type { Env } from '#/server/routes/shared'
+import { SYSTEM_STATUS_REASONS } from '#/types'
 import type {
   DatabaseSystemStatus,
   FileServerApiSystemStatus,
   SystemCheck,
   SystemCheckStatus,
   SystemStatus,
+  SystemStatusReason,
 } from '#/types'
 
 const CHECK_TIMEOUT_MS = 3_000
 const DATABASE_QUERY_TIMEOUT_MS = 2_500
 const CACHE_TTL_MS = 5_000
+const SYSTEM_STATUS_UNAVAILABLE_MESSAGE = 'System status unavailable'
 
 const databasePoolOptions = {
   connectionTimeoutMillis: DATABASE_QUERY_TIMEOUT_MS,
@@ -59,10 +62,23 @@ type CachedStatus = {
   value: SystemStatus
 }
 
+type NegativeCooldown = {
+  expiresAt: number
+}
+
 class CheckTimeoutError extends Error {}
 
+class SystemStatusUnavailableError extends Error {
+  constructor() {
+    super(SYSTEM_STATUS_UNAVAILABLE_MESSAGE)
+    this.name = 'SystemStatusUnavailableError'
+  }
+}
+
 const statusCache = new Map<string, CachedStatus>()
+const negativeCooldowns = new Map<string, NegativeCooldown>()
 const inFlightChecks = new Map<string, Promise<SystemStatus>>()
+let cacheGeneration = 0
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null
@@ -80,7 +96,7 @@ function getRows(value: unknown): Array<Record<string, unknown>> {
   return []
 }
 
-function outcome(status: SystemCheckStatus, reason: string): CheckOutcome {
+function outcome(status: SystemCheckStatus, reason: SystemStatusReason): CheckOutcome {
   return { status, reason }
 }
 
@@ -105,7 +121,7 @@ function isCheckTimeoutError(error: unknown): boolean {
   )
 }
 
-function failedOutcome(error: unknown, fallbackReason: string): CheckOutcome {
+function failedOutcome(error: unknown, fallbackReason: SystemStatusReason): CheckOutcome {
   return outcome('error', isCheckTimeoutError(error) ? 'timeout' : fallbackReason)
 }
 
@@ -135,7 +151,7 @@ async function withCheckTimeout<T>(operation: (signal: AbortSignal) => Promise<T
 
 async function runCheck(
   operation: (signal: AbortSignal) => Promise<void>,
-  fallbackReason: string
+  fallbackReason: SystemStatusReason
 ): Promise<CheckOutcome> {
   try {
     await withCheckTimeout(operation)
@@ -145,7 +161,7 @@ async function runCheck(
   }
 }
 
-function aggregateOutcome(children: CheckOutcome[], fallbackReason: string): CheckOutcome {
+function aggregateOutcome(children: CheckOutcome[], fallbackReason: SystemStatusReason): CheckOutcome {
   const failed = children.find((child) => child.status === 'error')
   if (failed) {
     return outcome('error', failed.reason || fallbackReason)
@@ -372,31 +388,107 @@ function buildCacheKey(env: SystemStatusEnv): string {
   ].join('\u0000')
 }
 
-export async function getSystemStatus(env: SystemStatusEnv, options: { force?: boolean } = {}): Promise<SystemStatus> {
+function isSystemStatusReason(value: unknown): value is SystemStatusReason {
+  return typeof value === 'string' && (SYSTEM_STATUS_REASONS as readonly string[]).includes(value)
+}
+
+function toPublicCheck(check: SystemCheck): SystemCheck {
+  return {
+    status: check.status,
+    reason: isSystemStatusReason(check.reason) ? check.reason : 'check-failed',
+    checkedAt: check.checkedAt,
+  }
+}
+
+export function toPublicSystemStatus(status: SystemStatus): SystemStatus {
+  const database = status.checks.database
+  const fileServerApi = status.checks.fileServerApi
+
+  return {
+    status: status.status,
+    checkedAt: status.checkedAt,
+    checks: {
+      database: {
+        ...toPublicCheck(database),
+        connection: toPublicCheck(database.connection),
+        schema: toPublicCheck(database.schema),
+      },
+      fileServerHealth: toPublicCheck(status.checks.fileServerHealth),
+      fileServerApi: {
+        ...toPublicCheck(fileServerApi),
+        login: toPublicCheck(fileServerApi.login),
+        read: toPublicCheck(fileServerApi.read),
+      },
+      fileServerPublic: toPublicCheck(status.checks.fileServerPublic),
+    },
+  }
+}
+
+export async function getSystemStatus(env: SystemStatusEnv): Promise<SystemStatus> {
   const key = buildCacheKey(env)
   const pending = inFlightChecks.get(key)
   if (pending) {
     return pending
   }
 
+  const now = Date.now()
   const cached = statusCache.get(key)
-  if (!options.force && cached && cached.expiresAt > Date.now()) {
-    return cached.value
+  if (cached) {
+    if (now < cached.expiresAt) {
+      return cached.value
+    }
+    statusCache.delete(key)
   }
+
+  const negativeCooldown = negativeCooldowns.get(key)
+  if (negativeCooldown) {
+    if (now < negativeCooldown.expiresAt) {
+      throw new SystemStatusUnavailableError()
+    }
+    negativeCooldowns.delete(key)
+  }
+
+  const generation = cacheGeneration
+  let resolvePending!: (value: SystemStatus | PromiseLike<SystemStatus>) => void
+  let rejectPending!: (reason?: unknown) => void
+  const pendingCheck = new Promise<SystemStatus>((resolve, reject) => {
+    resolvePending = resolve
+    rejectPending = reject
+  })
+  inFlightChecks.set(key, pendingCheck)
 
   const check = runSystemStatus(env)
-  inFlightChecks.set(key, check)
+  void check
+    .then(
+      (value) => {
+        const completedAt = Date.now()
+        if (cacheGeneration === generation) {
+          statusCache.set(key, { expiresAt: completedAt + CACHE_TTL_MS, value })
+          negativeCooldowns.delete(key)
+        }
+        resolvePending(value)
+      },
+      () => {
+        const completedAt = Date.now()
+        if (cacheGeneration === generation) {
+          statusCache.delete(key)
+          negativeCooldowns.set(key, { expiresAt: completedAt + CACHE_TTL_MS })
+        }
+        rejectPending(new SystemStatusUnavailableError())
+      }
+    )
+    .finally(() => {
+      if (inFlightChecks.get(key) === pendingCheck) {
+        inFlightChecks.delete(key)
+      }
+    })
 
-  try {
-    const value = await check
-    statusCache.set(key, { expiresAt: Date.now() + CACHE_TTL_MS, value })
-    return value
-  } finally {
-    inFlightChecks.delete(key)
-  }
+  return pendingCheck
 }
 
 export function resetSystemStatusCacheForTests(): void {
+  cacheGeneration += 1
   statusCache.clear()
+  negativeCooldowns.clear()
   inFlightChecks.clear()
 }

--- a/projects/portfolio/src/server/features/system-status/system-status.ts
+++ b/projects/portfolio/src/server/features/system-status/system-status.ts
@@ -12,6 +12,8 @@ import { SYSTEM_STATUS_REASONS } from '#/types'
 import type {
   DatabaseSystemStatus,
   FileServerApiSystemStatus,
+  PublicSystemCheck,
+  PublicSystemStatus,
   SystemCheck,
   SystemCheckStatus,
   SystemStatus,
@@ -392,7 +394,7 @@ function isSystemStatusReason(value: unknown): value is SystemStatusReason {
   return typeof value === 'string' && (SYSTEM_STATUS_REASONS as readonly string[]).includes(value)
 }
 
-function toPublicCheck(check: SystemCheck): SystemCheck {
+function toPublicCheck(check: SystemCheck): PublicSystemCheck {
   return {
     status: check.status,
     reason: isSystemStatusReason(check.reason) ? check.reason : 'check-failed',
@@ -400,7 +402,7 @@ function toPublicCheck(check: SystemCheck): SystemCheck {
   }
 }
 
-export function toPublicSystemStatus(status: SystemStatus): SystemStatus {
+export function toPublicSystemStatus(status: SystemStatus): PublicSystemStatus {
   const database = status.checks.database
   const fileServerApi = status.checks.fileServerApi
 

--- a/projects/portfolio/src/server/routes/system-status.ts
+++ b/projects/portfolio/src/server/routes/system-status.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
 import { getSystemStatus, toPublicSystemStatus } from '#/server/features/system-status/system-status'
+import { PublicSystemStatusSchema } from '#/types/system-status'
 import type { HonoEnv } from './shared'
 import { getServerEnv } from './shared'
 
@@ -9,7 +10,7 @@ const systemStatusRoutes = new Hono<HonoEnv>().get('/api/system-status', async (
   try {
     const status = await getSystemStatus(getServerEnv(c))
 
-    return c.json(toPublicSystemStatus(status))
+    return c.json(PublicSystemStatusSchema.parse(toPublicSystemStatus(status)), 200)
   } catch {
     return c.json({ error: 'System status unavailable' }, 503)
   }

--- a/projects/portfolio/src/server/routes/system-status.ts
+++ b/projects/portfolio/src/server/routes/system-status.ts
@@ -1,17 +1,15 @@
 import { Hono } from 'hono'
-import { getSystemStatus } from '#/server/features/system-status/system-status'
-import { requireAuth } from '#/server/middleware/auth'
+import { getSystemStatus, toPublicSystemStatus } from '#/server/features/system-status/system-status'
 import type { HonoEnv } from './shared'
 import { getServerEnv } from './shared'
 
-const systemStatusRoutes = new Hono<HonoEnv>().get('/api/system-status', requireAuth, async (c) => {
+const systemStatusRoutes = new Hono<HonoEnv>().get('/api/system-status', async (c) => {
   c.header('Cache-Control', 'no-store')
 
   try {
-    const refresh = c.req.query('refresh') === '1' || c.req.query('refresh') === 'true'
-    const status = await getSystemStatus(getServerEnv(c), { force: refresh })
+    const status = await getSystemStatus(getServerEnv(c))
 
-    return c.json(status)
+    return c.json(toPublicSystemStatus(status))
   } catch {
     return c.json({ error: 'System status unavailable' }, 503)
   }

--- a/projects/portfolio/src/types/index.ts
+++ b/projects/portfolio/src/types/index.ts
@@ -80,8 +80,14 @@ export {
 
 export {
   SYSTEM_STATUS_REASONS,
+  PublicSystemStatusSchema,
+  SystemStatusReasonSchema,
   type DatabaseSystemStatus,
   type FileServerApiSystemStatus,
+  type PublicDatabaseSystemStatus,
+  type PublicFileServerApiSystemStatus,
+  type PublicSystemCheck,
+  type PublicSystemStatus,
   type SystemCheck,
   type SystemCheckStatus,
   type SystemStatus,

--- a/projects/portfolio/src/types/index.ts
+++ b/projects/portfolio/src/types/index.ts
@@ -78,10 +78,12 @@ export {
   type ImageGenerationUsage,
 } from './image-generation-api.js'
 
-export type {
-  DatabaseSystemStatus,
-  FileServerApiSystemStatus,
-  SystemCheck,
-  SystemCheckStatus,
-  SystemStatus,
+export {
+  SYSTEM_STATUS_REASONS,
+  type DatabaseSystemStatus,
+  type FileServerApiSystemStatus,
+  type SystemCheck,
+  type SystemCheckStatus,
+  type SystemStatus,
+  type SystemStatusReason,
 } from './system-status.js'

--- a/projects/portfolio/src/types/system-status.ts
+++ b/projects/portfolio/src/types/system-status.ts
@@ -1,8 +1,25 @@
+export const SYSTEM_STATUS_REASONS = [
+  'ok',
+  'not-configured',
+  'timeout',
+  'connection-failed',
+  'schema-check-failed',
+  'database-unavailable',
+  'healthz-unavailable',
+  'login-failed',
+  'read-failed',
+  'file-server-api-unavailable',
+  'public-unavailable',
+  'check-failed',
+] as const
+
+export type SystemStatusReason = (typeof SYSTEM_STATUS_REASONS)[number]
+
 export type SystemCheckStatus = 'ok' | 'error' | 'not-configured'
 
 export interface SystemCheck {
   status: SystemCheckStatus
-  reason: string
+  reason: SystemStatusReason
   checkedAt: string
 }
 

--- a/projects/portfolio/src/types/system-status.ts
+++ b/projects/portfolio/src/types/system-status.ts
@@ -1,4 +1,6 @@
-export const SYSTEM_STATUS_REASONS = [
+import { z } from 'zod'
+
+export const SystemStatusReasonSchema = z.enum([
   'ok',
   'not-configured',
   'timeout',
@@ -11,9 +13,9 @@ export const SYSTEM_STATUS_REASONS = [
   'file-server-api-unavailable',
   'public-unavailable',
   'check-failed',
-] as const
-
-export type SystemStatusReason = (typeof SYSTEM_STATUS_REASONS)[number]
+])
+export const SYSTEM_STATUS_REASONS = SystemStatusReasonSchema.options
+export type SystemStatusReason = z.infer<typeof SystemStatusReasonSchema>
 
 export type SystemCheckStatus = 'ok' | 'error' | 'not-configured'
 
@@ -43,3 +45,34 @@ export interface SystemStatus {
     fileServerPublic: SystemCheck
   }
 }
+
+const systemCheckStatusSchema = z.enum(['ok', 'error', 'not-configured'])
+const publicSystemCheckSchema = z.object({
+  status: systemCheckStatusSchema,
+  reason: SystemStatusReasonSchema,
+  checkedAt: z.string(),
+})
+const publicDatabaseSystemStatusSchema = publicSystemCheckSchema.extend({
+  connection: publicSystemCheckSchema,
+  schema: publicSystemCheckSchema,
+})
+const publicFileServerApiSystemStatusSchema = publicSystemCheckSchema.extend({
+  login: publicSystemCheckSchema,
+  read: publicSystemCheckSchema,
+})
+
+export const PublicSystemStatusSchema = z.object({
+  status: z.enum(['ok', 'degraded']),
+  checkedAt: z.string(),
+  checks: z.object({
+    database: publicDatabaseSystemStatusSchema,
+    fileServerHealth: publicSystemCheckSchema,
+    fileServerApi: publicFileServerApiSystemStatusSchema,
+    fileServerPublic: publicSystemCheckSchema,
+  }),
+})
+
+export type PublicSystemCheck = z.infer<typeof publicSystemCheckSchema>
+export type PublicDatabaseSystemStatus = z.infer<typeof publicDatabaseSystemStatusSchema>
+export type PublicFileServerApiSystemStatus = z.infer<typeof publicFileServerApiSystemStatusSchema>
+export type PublicSystemStatus = z.infer<typeof PublicSystemStatusSchema>

--- a/projects/portfolio/tests/client/features/home/system-status-copy.test.ts
+++ b/projects/portfolio/tests/client/features/home/system-status-copy.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest'
+import { formatSystemStatusForCopy } from '#/client/features/home/system-status-widget'
+import type { SystemStatus } from '#/types'
+
+const checkedAt = '2026-04-19T00:00:00.000Z'
+
+function createStatus(): SystemStatus {
+  return {
+    status: 'ok',
+    checkedAt,
+    checks: {
+      database: {
+        status: 'ok',
+        reason: 'ok',
+        checkedAt,
+        connection: { status: 'ok', reason: 'ok', checkedAt },
+        schema: { status: 'ok', reason: 'ok', checkedAt },
+      },
+      fileServerHealth: { status: 'ok', reason: 'ok', checkedAt },
+      fileServerApi: {
+        status: 'ok',
+        reason: 'ok',
+        checkedAt,
+        login: { status: 'ok', reason: 'ok', checkedAt },
+        read: { status: 'ok', reason: 'ok', checkedAt },
+      },
+      fileServerPublic: { status: 'ok', reason: 'ok', checkedAt },
+    },
+  }
+}
+
+describe('formatSystemStatusForCopy', () => {
+  it('正常状態の全チェックをraw値とMarkdownの階層で出力する', () => {
+    expect(formatSystemStatusForCopy(createStatus())).toBe(`# System status
+- status: ok
+- checkedAt: ${checkedAt}
+
+## Checks
+
+### PostgreSQL (\`checks.database\`)
+
+- status: ok
+- reason: ok
+- checkedAt: ${checkedAt}
+
+#### connection
+
+- status: ok
+- reason: ok
+- checkedAt: ${checkedAt}
+
+#### schema
+
+- status: ok
+- reason: ok
+- checkedAt: ${checkedAt}
+
+### file-server 稼働 (\`checks.fileServerHealth\`)
+
+- status: ok
+- reason: ok
+- checkedAt: ${checkedAt}
+
+### file-server API (\`checks.fileServerApi\`)
+
+- status: ok
+- reason: ok
+- checkedAt: ${checkedAt}
+
+#### login
+
+- status: ok
+- reason: ok
+- checkedAt: ${checkedAt}
+
+#### read
+
+- status: ok
+- reason: ok
+- checkedAt: ${checkedAt}
+
+### 公開URL (\`checks.fileServerPublic\`)
+
+- status: ok
+- reason: ok
+- checkedAt: ${checkedAt}
+`)
+  })
+
+  it('degraded状態でも親子チェックのraw statusとreasonを保持する', () => {
+    const status = createStatus()
+    status.status = 'degraded'
+    status.checks.database.status = 'error'
+    status.checks.database.reason = 'database-unavailable'
+    status.checks.database.connection.status = 'error'
+    status.checks.database.connection.reason = 'connection-failed'
+    status.checks.fileServerApi.read.status = 'error'
+    status.checks.fileServerApi.read.reason = 'read-failed'
+
+    const output = formatSystemStatusForCopy(status)
+
+    expect(output).toContain('- status: degraded')
+    expect(output).toContain('### PostgreSQL (`checks.database`)\n\n- status: error\n- reason: database-unavailable')
+    expect(output).toContain('#### connection\n\n- status: error\n- reason: connection-failed')
+    expect(output).toContain('#### read\n\n- status: error\n- reason: read-failed')
+    expect(output).toContain(`- checkedAt: ${checkedAt}`)
+  })
+
+  it('欠落したoptional checkを省略し、残ったnested checkを保持する', () => {
+    const status = createStatus()
+    const output = formatSystemStatusForCopy({
+      status: 'degraded',
+      checkedAt,
+      checks: {
+        fileServerApi: {
+          ...status.checks.fileServerApi,
+          login: undefined,
+        },
+      },
+    })
+
+    expect(output).toContain('# System status\n- status: degraded')
+    expect(output).toContain('### file-server API (`checks.fileServerApi`)')
+    expect(output).toContain('#### read')
+    expect(output).not.toContain('### PostgreSQL')
+    expect(output).not.toContain('### file-server 稼働')
+    expect(output).not.toContain('#### login')
+    expect(output).not.toContain('### 公開URL')
+  })
+})

--- a/projects/portfolio/tests/client/features/home/system-status-widget.test.tsx
+++ b/projects/portfolio/tests/client/features/home/system-status-widget.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { systemStatusGetMock } = vi.hoisted(() => ({
   systemStatusGetMock: vi.fn(),
@@ -43,6 +43,14 @@ const responseBody = {
 }
 
 describe('SystemStatusWidget', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  beforeEach(() => {
+    systemStatusGetMock.mockReset()
+  })
+
   it('正常状態と最終確認時刻を表示し、再確認を実行する', async () => {
     systemStatusGetMock.mockImplementation(() =>
       Promise.resolve(
@@ -62,5 +70,44 @@ describe('SystemStatusWidget', () => {
 
     await waitFor(() => expect(systemStatusGetMock).toHaveBeenCalledTimes(2))
     expect(systemStatusGetMock).toHaveBeenLastCalledWith({ query: { refresh: '1' } })
+  })
+
+  it('詳細状態の reason label と異常時の表示を反映する', async () => {
+    const degradedBody = structuredClone(responseBody)
+    degradedBody.status = 'degraded'
+    degradedBody.checks.database.status = 'error'
+    degradedBody.checks.database.reason = 'database-unavailable'
+    degradedBody.checks.database.connection.status = 'error'
+    degradedBody.checks.database.connection.reason = 'connection-failed'
+    degradedBody.checks.database.schema.status = 'error'
+    degradedBody.checks.database.schema.reason = 'schema-check-failed'
+    degradedBody.checks.fileServerHealth.status = 'error'
+    degradedBody.checks.fileServerHealth.reason = 'healthz-unavailable'
+    degradedBody.checks.fileServerApi.status = 'error'
+    degradedBody.checks.fileServerApi.reason = 'file-server-api-unavailable'
+    degradedBody.checks.fileServerApi.login.status = 'error'
+    degradedBody.checks.fileServerApi.login.reason = 'login-failed'
+    degradedBody.checks.fileServerApi.read.status = 'error'
+    degradedBody.checks.fileServerApi.read.reason = 'read-failed'
+    degradedBody.checks.fileServerPublic.status = 'error'
+    degradedBody.checks.fileServerPublic.reason = 'public-unavailable'
+    systemStatusGetMock
+      .mockResolvedValueOnce(new Response(JSON.stringify(responseBody), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(degradedBody), { status: 200 }))
+
+    render(<SystemStatusWidget />)
+    await waitFor(() => expect(screen.getByText('システム正常')).toBeTruthy())
+
+    fireEvent.click(screen.getByRole('button', { name: '再確認' }))
+
+    await waitFor(() => expect(screen.getByText('システム要確認')).toBeTruthy())
+    expect(screen.getByText(/データベース利用不可/)).toBeTruthy()
+    expect(screen.getByText(/接続失敗/)).toBeTruthy()
+    expect(screen.getByText(/スキーマ確認失敗/)).toBeTruthy()
+    expect(screen.getByText(/ヘルスチェック失敗/)).toBeTruthy()
+    expect(screen.getByText(/API利用不可/)).toBeTruthy()
+    expect(screen.getByText(/ログイン失敗/)).toBeTruthy()
+    expect(screen.getByText(/読み取り失敗/)).toBeTruthy()
+    expect(screen.getByText(/公開配信不可/)).toBeTruthy()
   })
 })

--- a/projects/portfolio/tests/client/features/home/system-status-widget.test.tsx
+++ b/projects/portfolio/tests/client/features/home/system-status-widget.test.tsx
@@ -127,6 +127,54 @@ describe('SystemStatusWidget', () => {
     expect((screen.getByRole('button', { name: 'コピー済み' }) as HTMLButtonElement).disabled).toBe(true)
   })
 
+  it('コピー中と成功表示中は再確認を無効化し、解除後のrefreshで古い成功表示を残さない', async () => {
+    let resolveCopy: (() => void) | undefined
+    let resolveRefresh: ((response: Response) => void) | undefined
+    const refreshedBody = structuredClone(responseBody)
+    refreshedBody.status = 'degraded'
+    systemStatusGetMock
+      .mockResolvedValueOnce(new Response(JSON.stringify(responseBody), { status: 200 }))
+      .mockImplementationOnce(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolveRefresh = resolve
+          })
+      )
+    copyToClipboardMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveCopy = resolve
+        })
+    )
+
+    render(<SystemStatusWidget />)
+    await waitFor(() => expect(screen.getByText('システム正常')).toBeTruthy())
+
+    fireEvent.click(screen.getByRole('button', { name: 'ステータスをコピー' }))
+    await waitFor(() => expect(copyToClipboardMock).toHaveBeenCalledTimes(1))
+    expect(screen.getByRole('button', { name: 'コピー中…' })).toBeTruthy()
+    expect((screen.getByRole('button', { name: '再確認' }) as HTMLButtonElement).disabled).toBe(true)
+    fireEvent.click(screen.getByRole('button', { name: '再確認' }))
+    expect(systemStatusGetMock).toHaveBeenCalledTimes(1)
+
+    expect(resolveCopy).toBeTypeOf('function')
+    resolveCopy?.()
+    await waitFor(() => expect(screen.getByRole('button', { name: 'コピー済み' })).toBeTruthy())
+    expect((screen.getByRole('button', { name: '再確認' }) as HTMLButtonElement).disabled).toBe(true)
+
+    await new Promise((resolve) => setTimeout(resolve, 2100))
+    await waitFor(() =>
+      expect((screen.getByRole('button', { name: '再確認' }) as HTMLButtonElement).disabled).toBe(false)
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: '再確認' }))
+    await waitFor(() => expect(systemStatusGetMock).toHaveBeenCalledTimes(2))
+    expect(resolveRefresh).toBeTypeOf('function')
+    resolveRefresh?.(new Response(JSON.stringify(refreshedBody), { status: 200 }))
+    await waitFor(() => expect(screen.getByText('システム要確認')).toBeTruthy())
+    expect(screen.queryByRole('button', { name: 'コピー済み' })).toBeNull()
+  })
+
   it('コピー失敗時も状態表示と再確認を維持する', async () => {
     systemStatusGetMock.mockImplementation(() =>
       Promise.resolve(

--- a/projects/portfolio/tests/client/features/home/system-status-widget.test.tsx
+++ b/projects/portfolio/tests/client/features/home/system-status-widget.test.tsx
@@ -3,7 +3,8 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { systemStatusGetMock } = vi.hoisted(() => ({
+const { copyToClipboardMock, systemStatusGetMock } = vi.hoisted(() => ({
+  copyToClipboardMock: vi.fn(),
   systemStatusGetMock: vi.fn(),
 }))
 
@@ -17,9 +18,14 @@ vi.mock('hono/client', () => ({
   }),
 }))
 
-import { SystemStatusWidget } from '#/client/features/home/system-status-widget'
+vi.mock('#/client/shared/lib/copy-to-clipboard', () => ({
+  copyToClipboard: copyToClipboardMock,
+}))
 
-const responseBody = {
+import { formatSystemStatusForCopy, SystemStatusWidget } from '#/client/features/home/system-status-widget'
+import type { SystemStatus } from '#/types'
+
+const responseBody: SystemStatus = {
   status: 'ok',
   checkedAt: '2026-04-19T00:00:00.000Z',
   checks: {
@@ -49,6 +55,8 @@ describe('SystemStatusWidget', () => {
 
   beforeEach(() => {
     systemStatusGetMock.mockReset()
+    copyToClipboardMock.mockReset()
+    copyToClipboardMock.mockResolvedValue(undefined)
   })
 
   it('正常状態と最終確認時刻を表示し、再確認を実行する', async () => {
@@ -60,16 +68,84 @@ describe('SystemStatusWidget', () => {
 
     render(<SystemStatusWidget />)
 
+    expect((screen.getByRole('button', { name: 'ステータスをコピー' }) as HTMLButtonElement).disabled).toBe(true)
     await waitFor(() => expect(screen.getByText('システム正常')).toBeTruthy())
     expect(screen.getByText(/最終確認/)).toBeTruthy()
     expect(screen.getByText(/PostgreSQL/)).toBeTruthy()
     expect(screen.getByText(/file-server API/)).toBeTruthy()
     expect(screen.getByText(/公開URL/)).toBeTruthy()
+    expect((screen.getByRole('button', { name: 'ステータスをコピー' }) as HTMLButtonElement).disabled).toBe(false)
 
     fireEvent.click(screen.getByRole('button', { name: '再確認' }))
 
     await waitFor(() => expect(systemStatusGetMock).toHaveBeenCalledTimes(2))
     expect(systemStatusGetMock).toHaveBeenLastCalledWith({ query: { refresh: '1' } })
+  })
+
+  it('公開DTOを改行と階層を保ったMarkdownとしてコピーし、成功状態を表示する', async () => {
+    systemStatusGetMock.mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify(responseBody), { status: 200, headers: { 'content-type': 'application/json' } })
+      )
+    )
+
+    render(<SystemStatusWidget />)
+    await waitFor(() => expect(screen.getByText('システム正常')).toBeTruthy())
+
+    fireEvent.click(screen.getByRole('button', { name: 'ステータスをコピー' }))
+
+    await waitFor(() => expect(copyToClipboardMock).toHaveBeenCalledWith(formatSystemStatusForCopy(responseBody)))
+    expect(screen.getByRole('button', { name: 'コピー済み' })).toBeTruthy()
+  })
+
+  it('コピー中と成功中の二重操作を無効化する', async () => {
+    let resolveCopy: (() => void) | undefined
+    systemStatusGetMock.mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify(responseBody), { status: 200, headers: { 'content-type': 'application/json' } })
+      )
+    )
+    copyToClipboardMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveCopy = resolve
+        })
+    )
+
+    render(<SystemStatusWidget />)
+    await waitFor(() => expect(screen.getByText('システム正常')).toBeTruthy())
+
+    fireEvent.click(screen.getByRole('button', { name: 'ステータスをコピー' }))
+
+    const copyingButton = screen.getByRole('button', { name: 'コピー中…' }) as HTMLButtonElement
+    expect(copyingButton.disabled).toBe(true)
+    fireEvent.click(copyingButton)
+    expect(copyToClipboardMock).toHaveBeenCalledTimes(1)
+
+    resolveCopy?.()
+    await waitFor(() => expect(screen.getByRole('button', { name: 'コピー済み' })).toBeTruthy())
+    expect((screen.getByRole('button', { name: 'コピー済み' }) as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('コピー失敗時も状態表示と再確認を維持する', async () => {
+    systemStatusGetMock.mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify(responseBody), { status: 200, headers: { 'content-type': 'application/json' } })
+      )
+    )
+    copyToClipboardMock.mockRejectedValueOnce(new Error('clipboard unavailable'))
+
+    render(<SystemStatusWidget />)
+    await waitFor(() => expect(screen.getByText('システム正常')).toBeTruthy())
+
+    fireEvent.click(screen.getByRole('button', { name: 'ステータスをコピー' }))
+
+    await waitFor(() => expect(screen.getByRole('alert').textContent).toContain('ステータスをコピーできませんでした。'))
+    expect(screen.getByText('システム正常')).toBeTruthy()
+    expect((screen.getByRole('button', { name: 'ステータスをコピー' }) as HTMLButtonElement).disabled).toBe(false)
+
+    fireEvent.click(screen.getByRole('button', { name: '再確認' }))
+    await waitFor(() => expect(systemStatusGetMock).toHaveBeenCalledTimes(2))
   })
 
   it('詳細状態の reason label と異常時の表示を反映する', async () => {

--- a/projects/portfolio/tests/client/pages/home.test.tsx
+++ b/projects/portfolio/tests/client/pages/home.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
-import { render } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('hono/client', () => ({
   hc: () => ({
@@ -19,6 +19,10 @@ vi.mock('hono/client', () => ({
 import { Home } from '#/client/features/home/page'
 
 describe('Home page', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
   it('ログイン済みの場合はログイン有効期限を表示する', () => {
     document.head.innerHTML = ''
     const meta = document.createElement('meta')
@@ -33,5 +37,16 @@ describe('Home page', () => {
 
     expect(container.textContent).toContain('test@example.com')
     expect(container.textContent).toContain('ログイン有効期限：1日')
+  })
+
+  it('未ログインの場合もログインフォームとシステム状態ウィジェットを表示する', () => {
+    document.head.innerHTML = ''
+
+    render(<Home />)
+
+    expect(screen.getByLabelText('Email')).toBeTruthy()
+    expect(screen.getByLabelText('Password')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Sign In' })).toBeTruthy()
+    expect(screen.getByRole('region', { name: 'システム状態' })).toBeTruthy()
   })
 })

--- a/projects/portfolio/tests/client/shared/lib/copy-to-clipboard.test.ts
+++ b/projects/portfolio/tests/client/shared/lib/copy-to-clipboard.test.ts
@@ -8,7 +8,17 @@ describe('copyToClipboard', () => {
     vi.restoreAllMocks()
   })
 
-  it('Clipboard APIが利用できない場合もテキストをコピーする', async () => {
+  it('Clipboard APIが利用できる場合はwriteTextを使う', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } })
+
+    await copyToClipboard('message dump')
+
+    expect(writeText).toHaveBeenCalledWith('message dump')
+    expect(document.querySelector('textarea')).toBeNull()
+  })
+
+  it('Clipboard APIが利用できない場合はexecCommandの成功を確認する', async () => {
     const execCommand = vi.fn().mockReturnValue(true)
     Object.defineProperty(navigator, 'clipboard', { configurable: true, value: undefined })
     Object.defineProperty(document, 'execCommand', { configurable: true, value: execCommand })
@@ -16,6 +26,29 @@ describe('copyToClipboard', () => {
     await copyToClipboard('message dump')
 
     expect(execCommand).toHaveBeenCalledWith('copy')
+    expect(document.querySelector('textarea')).toBeNull()
+  })
+
+  it('execCommandがfalseを返した場合は失敗し、textareaを削除する', async () => {
+    const execCommand = vi.fn().mockReturnValue(false)
+    Object.defineProperty(navigator, 'clipboard', { configurable: true, value: undefined })
+    Object.defineProperty(document, 'execCommand', { configurable: true, value: execCommand })
+
+    await expect(copyToClipboard('message dump')).rejects.toThrow('Failed to copy text to clipboard')
+
+    expect(document.querySelector('textarea')).toBeNull()
+  })
+
+  it('execCommandがthrowした場合もtextareaを削除する', async () => {
+    const error = new Error('copy command failed')
+    const execCommand = vi.fn().mockImplementation(() => {
+      throw error
+    })
+    Object.defineProperty(navigator, 'clipboard', { configurable: true, value: undefined })
+    Object.defineProperty(document, 'execCommand', { configurable: true, value: execCommand })
+
+    await expect(copyToClipboard('message dump')).rejects.toBe(error)
+
     expect(document.querySelector('textarea')).toBeNull()
   })
 })

--- a/projects/portfolio/tests/features/system-status/system-status.test.ts
+++ b/projects/portfolio/tests/features/system-status/system-status.test.ts
@@ -64,6 +64,14 @@ const schemaRows = [
   { table_name: 'prompt_templates', column_name: 'updated_at' },
 ]
 
+function createDeferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((nextResolve) => {
+    resolve = nextResolve
+  })
+  return { promise, resolve }
+}
+
 describe('getSystemStatus', () => {
   beforeEach(() => {
     resetSystemStatusCacheForTests()
@@ -180,23 +188,149 @@ describe('getSystemStatus', () => {
     }
   })
 
-  it('同じ設定では短時間キャッシュを利用し、force 時だけ再確認する', async () => {
+  it('同じ設定の逐次呼び出しでは正常・degradedの結果を5秒キャッシュする', async () => {
+    loginToFileServerMock.mockRejectedValue(new Error('invalid credentials'))
+
     const first = await getSystemStatus(env)
     const cached = await getSystemStatus(env)
 
     expect(cached).toBe(first)
+    expect(cached.status).toBe('degraded')
     expect(dbExecuteMock).toHaveBeenCalledTimes(2)
     expect(dbEndMock).toHaveBeenCalledTimes(1)
     expect(loginToFileServerMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledTimes(2)
 
-    dbExecuteMock.mockResolvedValueOnce({ rows: [] }).mockResolvedValueOnce({ rows: schemaRows })
-    const refreshed = await getSystemStatus(env, { force: true })
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(new Date('2026-04-19T00:00:00.000Z'))
+      resetSystemStatusCacheForTests()
+      loginToFileServerMock.mockResolvedValue('session-value')
+      dbExecuteMock.mockReset()
+      dbExecuteMock.mockResolvedValue({ rows: schemaRows })
 
-    expect(refreshed).not.toBe(first)
-    expect(dbExecuteMock).toHaveBeenCalledTimes(4)
+      const fresh = await getSystemStatus(env)
+      vi.advanceTimersByTime(4_999)
+      const beforeExpiry = await getSystemStatus(env)
+      vi.advanceTimersByTime(1)
+      const atExpiry = await getSystemStatus(env)
+
+      expect(beforeExpiry).toBe(fresh)
+      expect(atExpiry).not.toBe(fresh)
+      expect(dbExecuteMock).toHaveBeenCalledTimes(4)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('同時呼び出しでは依存チェックの開始を1回にまとめる', async () => {
+    const connection = createDeferred<{ rows: Array<Record<string, string>> }>()
+    const schema = createDeferred<{ rows: Array<Record<string, string>> }>()
+    dbExecuteMock.mockReset()
+    dbExecuteMock.mockImplementationOnce(() => connection.promise).mockImplementationOnce(() => schema.promise)
+
+    const firstPromise = getSystemStatus(env)
+    const secondPromise = getSystemStatus(env)
+
+    expect(getDatabaseMock).toHaveBeenCalledTimes(1)
+    expect(dbExecuteMock).toHaveBeenCalledTimes(2)
+    expect(loginToFileServerMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+
+    connection.resolve({ rows: [] })
+    schema.resolve({ rows: schemaRows })
+    const [first, second] = await Promise.all([firstPromise, secondPromise])
+
+    expect(first).toBe(second)
+    expect(dbEndMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('設定keyが異なる場合は別々にチェックする', async () => {
+    const otherEnv = { ...env, DATABASE_URL: 'postgresql://other.internal:5432/portfolio' }
+
+    await Promise.all([getSystemStatus(env), getSystemStatus(otherEnv)])
+
+    expect(getDatabaseMock).toHaveBeenCalledTimes(2)
+    expect(getDatabaseMock).toHaveBeenNthCalledWith(1, env.DATABASE_URL, expect.anything())
+    expect(getDatabaseMock).toHaveBeenNthCalledWith(2, otherEnv.DATABASE_URL, expect.anything())
     expect(dbEndMock).toHaveBeenCalledTimes(2)
-    expect(loginToFileServerMock).toHaveBeenCalledTimes(2)
-    expect(fetchMock).toHaveBeenCalledTimes(4)
+  })
+
+  it('top-level reject は固定エラーとし、完了から5秒 negative cooldown を適用する', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+    const dateError = new Error('postgres://secret/internal')
+    const toISOStringSpy = vi.spyOn(Date.prototype, 'toISOString').mockImplementation(() => {
+      throw dateError
+    })
+
+    try {
+      await expect(getSystemStatus(env)).rejects.toThrow('System status unavailable')
+      await expect(getSystemStatus(env)).rejects.toThrow('System status unavailable')
+      expect(getDatabaseMock).not.toHaveBeenCalled()
+
+      toISOStringSpy.mockRestore()
+      vi.setSystemTime(5_000)
+      dbExecuteMock.mockResolvedValue({ rows: schemaRows })
+      await expect(getSystemStatus(env)).resolves.toMatchObject({ status: 'ok' })
+      expect(getDatabaseMock).toHaveBeenCalledTimes(1)
+    } finally {
+      toISOStringSpy.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
+  it('reset は pending の古い完了結果を再投入しない', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-19T00:00:00.000Z'))
+    const firstConnection = createDeferred<{ rows: Array<Record<string, string>> }>()
+    const firstSchema = createDeferred<{ rows: Array<Record<string, string>> }>()
+    let queryCount = 0
+    dbExecuteMock.mockReset()
+    dbExecuteMock.mockImplementation(() => {
+      queryCount += 1
+      if (queryCount === 1) return firstConnection.promise
+      if (queryCount === 2) return firstSchema.promise
+      return Promise.resolve({ rows: schemaRows })
+    })
+
+    try {
+      const oldResultPromise = getSystemStatus(env)
+      resetSystemStatusCacheForTests()
+      vi.setSystemTime(new Date('2026-04-19T00:00:01.000Z'))
+      const newResult = await getSystemStatus(env)
+
+      firstConnection.resolve({ rows: [] })
+      firstSchema.resolve({ rows: schemaRows })
+      await oldResultPromise
+
+      const cached = await getSystemStatus(env)
+      expect(cached).toBe(newResult)
+      expect(cached.checkedAt).toBe('2026-04-19T00:00:01.000Z')
+      expect(queryCount).toBe(4)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('reset は正常結果と negative cooldown の両方を消去する', async () => {
+    vi.useFakeTimers()
+    const toISOStringSpy = vi.spyOn(Date.prototype, 'toISOString').mockImplementation(() => {
+      throw new Error('temporary failure')
+    })
+
+    try {
+      await expect(getSystemStatus(env)).rejects.toThrow('System status unavailable')
+      resetSystemStatusCacheForTests()
+      toISOStringSpy.mockRestore()
+      dbExecuteMock.mockResolvedValue({ rows: schemaRows })
+
+      const result = await getSystemStatus(env)
+      expect(result.status).toBe('ok')
+      expect(getDatabaseMock).toHaveBeenCalledTimes(1)
+    } finally {
+      toISOStringSpy.mockRestore()
+      vi.useRealTimers()
+    }
   })
 })

--- a/projects/portfolio/tests/routes/system-status.test.ts
+++ b/projects/portfolio/tests/routes/system-status.test.ts
@@ -1,95 +1,121 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { getSignedCookieMock, getSystemStatusMock } = vi.hoisted(() => ({
-  getSignedCookieMock: vi.fn(),
+const { getSystemStatusMock } = vi.hoisted(() => ({
   getSystemStatusMock: vi.fn(),
 }))
 
-vi.mock('hono/cookie', async () => {
-  const actual = await vi.importActual<typeof import('hono/cookie')>('hono/cookie')
+vi.mock('#/server/features/system-status/system-status', async () => {
+  const actual = await vi.importActual<typeof import('#/server/features/system-status/system-status')>(
+    '#/server/features/system-status/system-status'
+  )
 
   return {
     ...actual,
-    getSignedCookie: getSignedCookieMock,
+    getSystemStatus: getSystemStatusMock,
   }
 })
 
-vi.mock('#/server/features/system-status/system-status', () => ({
-  getSystemStatus: getSystemStatusMock,
-}))
-
 import { systemStatusRoutes } from '#/server/routes/system-status'
 
+const checkedAt = '2026-04-19T00:00:00.000Z'
 const status = {
   status: 'ok' as const,
-  checkedAt: '2026-04-19T00:00:00.000Z',
+  checkedAt,
   checks: {
     database: {
       status: 'ok' as const,
-      reason: 'ok',
-      checkedAt: '2026-04-19T00:00:00.000Z',
-      connection: { status: 'ok' as const, reason: 'ok', checkedAt: '2026-04-19T00:00:00.000Z' },
-      schema: { status: 'ok' as const, reason: 'ok', checkedAt: '2026-04-19T00:00:00.000Z' },
+      reason: 'ok' as const,
+      checkedAt,
+      connection: { status: 'ok' as const, reason: 'ok' as const, checkedAt },
+      schema: { status: 'ok' as const, reason: 'future-reason', checkedAt },
     },
-    fileServerHealth: { status: 'ok' as const, reason: 'ok', checkedAt: '2026-04-19T00:00:00.000Z' },
+    fileServerHealth: { status: 'ok' as const, reason: 'ok' as const, checkedAt },
     fileServerApi: {
       status: 'ok' as const,
-      reason: 'ok',
-      checkedAt: '2026-04-19T00:00:00.000Z',
-      login: { status: 'ok' as const, reason: 'ok', checkedAt: '2026-04-19T00:00:00.000Z' },
-      read: { status: 'ok' as const, reason: 'ok', checkedAt: '2026-04-19T00:00:00.000Z' },
+      reason: 'ok' as const,
+      checkedAt,
+      login: { status: 'ok' as const, reason: 'ok' as const, checkedAt },
+      read: { status: 'ok' as const, reason: 'ok' as const, checkedAt },
     },
-    fileServerPublic: { status: 'ok' as const, reason: 'ok', checkedAt: '2026-04-19T00:00:00.000Z' },
+    fileServerPublic: { status: 'ok' as const, reason: 'ok' as const, checkedAt },
+  },
+  secret: 'password',
+  internalUrl: 'http://file-server:3000',
+  responseBody: { token: 'token' },
+  stack: 'Error: secret',
+}
+
+const expectedPublicStatus = {
+  status: 'ok',
+  checkedAt,
+  checks: {
+    database: {
+      status: 'ok',
+      reason: 'ok',
+      checkedAt,
+      connection: { status: 'ok', reason: 'ok', checkedAt },
+      schema: { status: 'ok', reason: 'check-failed', checkedAt },
+    },
+    fileServerHealth: { status: 'ok', reason: 'ok', checkedAt },
+    fileServerApi: {
+      status: 'ok',
+      reason: 'ok',
+      checkedAt,
+      login: { status: 'ok', reason: 'ok', checkedAt },
+      read: { status: 'ok', reason: 'ok', checkedAt },
+    },
+    fileServerPublic: { status: 'ok', reason: 'ok', checkedAt },
   },
 }
 
 describe('systemStatusRoutes', () => {
   beforeEach(() => {
-    getSignedCookieMock.mockReset()
     getSystemStatusMock.mockReset()
-    vi.stubEnv('COOKIE_SECRET', 'secret')
-    vi.stubEnv('COOKIE_NAME', 'session')
   })
 
-  it('未認証の GET は 401 を返し、system status を実行しない', async () => {
-    getSignedCookieMock.mockResolvedValue(null)
-
-    const res = await systemStatusRoutes.request('/api/system-status')
-
-    expect(res.status).toBe(401)
-    await expect(res.json()).resolves.toEqual({ error: 'Authentication error' })
-    expect(getSystemStatusMock).not.toHaveBeenCalled()
-  })
-
-  it('認証済みの GET は status と no-store を返す', async () => {
-    getSignedCookieMock.mockResolvedValue('test@example.com')
+  it('Cookie の有無や内容にかかわらず公開 status を返す', async () => {
     getSystemStatusMock.mockResolvedValue(status)
 
-    const res = await systemStatusRoutes.request('/api/system-status')
+    for (const cookie of [undefined, 'session=valid', 'session=invalid']) {
+      const res = await systemStatusRoutes.request('/api/system-status', {
+        headers: cookie ? { Cookie: cookie } : undefined,
+      })
 
-    expect(res.status).toBe(200)
-    expect(res.headers.get('cache-control')).toBe('no-store')
-    await expect(res.json()).resolves.toEqual(status)
-    expect(getSystemStatusMock).toHaveBeenCalledWith(expect.objectContaining({}), { force: false })
+      expect(res.status).toBe(200)
+      expect(res.headers.get('cache-control')).toBe('no-store')
+      await expect(res.json()).resolves.toEqual(expectedPublicStatus)
+    }
+
+    expect(getSystemStatusMock).toHaveBeenCalledTimes(3)
+    expect(getSystemStatusMock).toHaveBeenCalledWith(expect.objectContaining({}))
   })
 
-  it('予期しないエラーでも機密情報を返さず 503 にする', async () => {
-    getSignedCookieMock.mockResolvedValue('test@example.com')
+  it('通常 GET と refresh query は同じ処理を実行し force を渡さない', async () => {
+    getSystemStatusMock.mockResolvedValue(status)
+
+    const normal = await systemStatusRoutes.request('/api/system-status')
+    const refreshOne = await systemStatusRoutes.request('/api/system-status?refresh=1')
+    const refreshTrue = await systemStatusRoutes.request('/api/system-status?refresh=true')
+
+    expect(normal.status).toBe(200)
+    expect(refreshOne.status).toBe(200)
+    expect(refreshTrue.status).toBe(200)
+    expect(getSystemStatusMock).toHaveBeenCalledTimes(3)
+    for (const call of getSystemStatusMock.mock.calls) {
+      expect(call).toHaveLength(1)
+      expect(call[0]).toEqual(expect.objectContaining({}))
+    }
+  })
+
+  it('予期しないエラーでも機密情報を返さず固定 503 にする', async () => {
     getSystemStatusMock.mockRejectedValue(new Error('postgres://secret/internal'))
 
     const res = await systemStatusRoutes.request('/api/system-status')
 
     expect(res.status).toBe(503)
-    await expect(res.json()).resolves.toEqual({ error: 'System status unavailable' })
-  })
-
-  it('refresh=1 はサーバーキャッシュを bypass する', async () => {
-    getSignedCookieMock.mockResolvedValue('test@example.com')
-    getSystemStatusMock.mockResolvedValue(status)
-
-    const res = await systemStatusRoutes.request('/api/system-status?refresh=1')
-
-    expect(res.status).toBe(200)
-    expect(getSystemStatusMock).toHaveBeenCalledWith(expect.objectContaining({}), { force: true })
+    expect(res.headers.get('cache-control')).toBe('no-store')
+    const body = await res.json()
+    expect(body).toEqual({ error: 'System status unavailable' })
+    expect(JSON.stringify(body)).not.toContain('postgres://secret/internal')
   })
 })

--- a/projects/portfolio/tests/types/system-status-app.test.ts
+++ b/projects/portfolio/tests/types/system-status-app.test.ts
@@ -1,0 +1,19 @@
+import { hc } from 'hono/client'
+import type { InferResponseType } from 'hono/client'
+import { describe, expectTypeOf, it } from 'vitest'
+import type { AppType } from '#/server/app.d'
+import type { SystemStatusReason } from '#/types'
+
+const client = hc<AppType>('/')
+type SystemStatusSuccessResponse = InferResponseType<(typeof client.api)['system-status']['$get'], 200>
+
+function getDatabaseReason(body: SystemStatusSuccessResponse): SystemStatusReason {
+  return body.checks.database.reason
+}
+
+describe('generated system status RPC types', () => {
+  it('keeps the public reason union in the successful response', () => {
+    expectTypeOf<SystemStatusSuccessResponse['checks']['database']['reason']>().toEqualTypeOf<SystemStatusReason>()
+    expectTypeOf<ReturnType<typeof getDatabaseReason>>().toEqualTypeOf<SystemStatusReason>()
+  })
+})

--- a/projects/portfolio/vite.config.ts
+++ b/projects/portfolio/vite.config.ts
@@ -1,13 +1,23 @@
+import { cp, rm } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import devServer from '@hono/vite-dev-server'
 import { tanstackRouter } from '@tanstack/router-plugin/vite'
-import { defineConfig } from 'vite'
+import { defineConfig, type Plugin } from 'vite'
 import dts from 'vite-plugin-dts'
 
 const rootDir = fileURLToPath(new URL('.', import.meta.url))
 const sourceAlias = {
   '#': resolve(rootDir, 'src'),
+}
+const typegenOutputDir = resolve(rootDir, '.typegen')
+
+const copyGeneratedAppDeclaration: Plugin = {
+  name: 'copy-generated-app-declaration',
+  async closeBundle() {
+    await cp(resolve(typegenOutputDir, 'server/app.d.ts'), resolve(rootDir, 'src/server/app.d.ts'))
+    await rm(typegenOutputDir, { recursive: true, force: true })
+  },
 }
 
 export default defineConfig(({ mode }) => {
@@ -16,14 +26,15 @@ export default defineConfig(({ mode }) => {
       return {
         plugins: [
           dts({
-            include: resolve(rootDir, 'src/server/app.tsx'),
-            outDirs: rootDir,
+            outDirs: resolve(rootDir, '.typegen'),
             declarationOnly: true,
             insertTypesEntry: false,
             bundleTypes: false,
             copyDtsFiles: false,
+            include: resolve(rootDir, 'src/server/app.tsx'),
             entryRoot: resolve(rootDir, 'src'),
           }),
+          copyGeneratedAppDeclaration,
         ],
         resolve: {
           alias: sourceAlias,


### PR DESCRIPTION
## Issues

- close: #1179
- ref: #1169
- ref: #1178

## Why

PostgreSQL停止時はログイン自体が失敗するため、未ログインの利用者にも依存サービスの状態を確認できるようにします。

## Summary

Issue #1179 に対応し、システム状態APIとHOMEウィジェットを未ログインでも利用できるようにしました。公開レスポンスの機密情報境界と5秒のプロセス内チェックゲートも明確化しています。

## Changes

- `GET /api/system-status` から認証要求を外し、Cookieの有無や内容にかかわらず公開
- `refresh=1/true` を含め、設定keyごとの5秒キャッシュ・in-flight共有・失敗時negative cooldownを適用
- 公開DTOをallowlist projectionし、未知のreasonを `check-failed` に正規化
- 未ログインHOMEにもシステム状態ウィジェットを表示し、ログイン済みの表示は維持
- システム状態ウィジェットに、公開DTOだけから生成した階層付きMarkdownのコピー操作を追加
- 共有clipboard fallbackのexecCommand成功確認とtextarea cleanupを追加
- コピー中・コピー成功表示中は再確認を無効化し、旧statusのcopy成功表示と新statusが競合しないようにした
- reasonの型とUIラベルを12値で網羅し、`schema-incomplete` を削除
- Hono RPCの生成型にもreasonの12値unionを伝播させ、`hc<AppType>` の型プローブを追加
- TanStack Router Devtoolsを右上へ移動

## Screenshot
<img width="1322" height="895" alt="image" src="https://github.com/user-attachments/assets/a937f155-1b5f-4e50-8f9c-d8b5e8a84ebf" />

## Verification

- `cd projects/portfolio && bun run format` ✅
- `cd projects/portfolio && bun run typegen` ✅ (生成差分なし)
- `cd projects/portfolio && bun run test -- tests/client/shared/lib/copy-to-clipboard.test.ts tests/client/features/home/system-status-copy.test.ts tests/client/features/home/system-status-widget.test.tsx` ✅ (3 files, 13 tests)
- `cd projects/portfolio && bun run lint` ✅
- `cd projects/portfolio && bun run format:check` ✅
- `cd projects/portfolio && bun run test` ✅ (75 files, 423 tests)
- `cd projects/portfolio && bun run build` ✅

## Scope / Notes

- チェック共有の保証範囲は各設定key・各replicaで最大1回/5秒です。cluster共有やIP rate limitは追加していません。
- `Cache-Control: no-store` と固定503エラーは維持しています。refresh queryはUI互換のため維持しますが、cache bypassはしません。
- Devtoolsは従来どおり非productionのみで、標準toggle buttonによる表示切り替えを変更していません。
- レビュー指摘対応で、typegenは一時出力から生成済み `src/server/app.d.ts` を更新するようにしています。
- コピー操作はバックエンド/API/cache contractを変更せず、公開 `SystemStatus` のstatus/reason/checkedAtだけをコピーします。