### PR TITLE
Dependabot自動処理ラベルを必須化

### DIFF
--- a/.agents/skills/github-dependabot-maintain/SKILL.md
+++ b/.agents/skills/github-dependabot-maintain/SKILL.md
@@ -11,7 +11,8 @@ description: >
 
 Keep `.github/dependabot.yml` in sync with the actual `projects/` layout.
 Adds missing Dependabot entries, removes stale entries, normalizes group names,
-and sorts entries alphabetically by `directory`.
+sorts entries alphabetically by `directory`, and requires the
+`dependabot-auto-process` label on every entry.
 
 ## When to Use This Skill
 
@@ -92,6 +93,8 @@ For each detected project, build an entry:
         interval: "weekly"
       open-pull-requests-limit: 1
       rebase-strategy: "disabled"
+      labels:
+        - "dependabot-auto-process"
       groups:
         {name}-minor-and-patch:
           applies-to: version-updates
@@ -113,7 +116,9 @@ When an entry already exists for a scanned directory, keep its existing values f
 - `rebase-strategy`
 - any other custom fields
 
-Only normalize the group name to `{name}-minor-and-patch` if it differs.
+Add `dependabot-auto-process` to `labels` when it is absent, preserving any
+existing labels and custom fields. Only normalize the group name to
+`{name}-minor-and-patch` if it differs.
 
 ### Step 5: Diff and Propose
 
@@ -128,6 +133,13 @@ After approval, write `.github/dependabot.yml`. Then run:
 
 Finally, rerun the scan from Step 2 and confirm every detected project has exactly one entry.
 
+Coverage validation must also confirm that every entry contains
+`dependabot-auto-process`; a missing label is a validation error.
+
+Run the skill tests with:
+
+    python3 -m unittest discover -s .agents/skills/github-dependabot-maintain/tests -p 'test_*.py'
+
 ## Quality Check
 
 - [ ] No uncommitted changes existed before editing
@@ -135,10 +147,12 @@ Finally, rerun the scan from Step 2 and confirm every detected project has exact
 - [ ] `_labs/` and `_samples/` were excluded
 - [ ] Ecosystems were detected from lockfiles
 - [ ] Existing entry settings were preserved except group names
+- [ ] `dependabot-auto-process` is present on every generated and existing entry
 - [ ] Entries are sorted alphabetically by `directory`
 - [ ] User approved the diff before writing
 - [ ] YAML syntax passes `python3 -c "import yaml; yaml.safe_load(...)"`
 - [ ] Scan results and entries are 1:1 after writing
+- [ ] Coverage validation detects a missing required label
 
 ## References
 

--- a/.agents/skills/github-dependabot-maintain/references/github-dependabot-maintain-detailed.md
+++ b/.agents/skills/github-dependabot-maintain/references/github-dependabot-maintain-detailed.md
@@ -11,6 +11,8 @@ The complete maintenance script is at:
 It loads the existing `.github/dependabot.yml`, preserves settings for
 directories that are still present, adds missing entries, removes stale entries,
 normalizes group names, and waits for explicit approval before writing the file.
+Every generated or existing entry contains the required
+`dependabot-auto-process` label while preserving any other labels.
 
 ## Running the script
 
@@ -50,3 +52,23 @@ python3 .agents/skills/github-dependabot-maintain/scripts/maintain-dependabot.py
 - If no lockfile is found, the directory is excluded from Dependabot.
 - If an existing entry points to a directory that no longer exists, it is removed.
 - If an existing entry points to a directory whose lockfile is gone, it is removed.
+
+## Required label and coverage validation
+
+The generated template includes:
+
+```yaml
+labels:
+  - "dependabot-auto-process"
+```
+
+When an existing entry already has labels, the script preserves them and adds
+the required label if necessary. After YAML parsing, coverage validation
+requires exactly one entry for every detected project and the required label
+on every entry. A missing label causes validation to fail.
+
+Run the focused tests with:
+
+```bash
+python3 -m unittest discover -s .agents/skills/github-dependabot-maintain/tests -p 'test_*.py'
+```

--- a/.agents/skills/github-dependabot-maintain/scripts/maintain-dependabot.py
+++ b/.agents/skills/github-dependabot-maintain/scripts/maintain-dependabot.py
@@ -1,15 +1,19 @@
 #!/usr/bin/env python3
 """Maintain .github/dependabot.yml based on projects/* lockfiles."""
 
+import json
 import re
 import subprocess
 import sys
+from collections import Counter
 from pathlib import Path
+from typing import Any
 
 import yaml
 
 CONFIG = Path(".github/dependabot.yml")
 PROJECTS = Path("projects")
+REQUIRED_LABEL = "dependabot-auto-process"
 
 
 def detect_ecosystem(project_dir: Path) -> str | None:
@@ -63,7 +67,7 @@ def parse_entries(text: str) -> tuple[str, dict[str, list[str]]]:
 
 
 def normalize_block(block: list[str], ecosystem: str, directory: str) -> list[str]:
-    """Update package-ecosystem, directory, and groups in an existing block."""
+    """Update an existing block while adding the required processing label."""
     name = directory.split("/")[-1]
     new_block: list[str] = []
     in_groups = False
@@ -101,7 +105,89 @@ def normalize_block(block: list[str], ecosystem: str, directory: str) -> list[st
 
         new_block.append(line)
 
-    return new_block
+    return ensure_required_label(new_block)
+
+
+def _entry_from_block(block: list[str]) -> dict[str, Any]:
+    """Parse one text entry using the same YAML rules as the final config."""
+    parsed = yaml.safe_load("updates:\n" + "\n".join(block))
+    if not isinstance(parsed, dict) or not isinstance(parsed.get("updates"), list):
+        raise ValueError("entry block is not a YAML updates entry")
+    if len(parsed["updates"]) != 1 or not isinstance(parsed["updates"][0], dict):
+        raise ValueError("entry block does not contain exactly one mapping")
+    return parsed["updates"][0]
+
+
+def _format_label(label: Any) -> str:
+    """Render a label as a YAML scalar suitable for a list item."""
+    if isinstance(label, str):
+        return json.dumps(label, ensure_ascii=False)
+    return yaml.safe_dump(label, default_flow_style=True).strip().removesuffix(
+        "\n..."
+    )
+
+
+def ensure_required_label(block: list[str]) -> list[str]:
+    """Add ``REQUIRED_LABEL`` to a block without dropping existing labels."""
+    entry = _entry_from_block(block)
+    labels = entry.get("labels")
+    if isinstance(labels, list) and REQUIRED_LABEL in labels:
+        return block
+
+    labels_match: int | None = None
+    for index, line in enumerate(block):
+        if re.match(r"^    labels:\s*", line):
+            labels_match = index
+            break
+
+    if labels_match is None:
+        insert_at = next(
+            (
+                index
+                for index, line in enumerate(block)
+                if line.startswith("    groups:")
+            ),
+            len(block),
+        )
+        while insert_at > 0 and block[insert_at - 1] == "":
+            insert_at -= 1
+        return (
+            block[:insert_at]
+            + ["    labels:", f'      - "{REQUIRED_LABEL}"']
+            + block[insert_at:]
+        )
+
+    labels_line = block[labels_match]
+    labels_value = labels_line.split(":", 1)[1].strip()
+    if labels_value:
+        # Inline labels cannot accept another indented list item. Expand the
+        # existing values while keeping their order, then append the required
+        # selector label.
+        existing_labels = labels if isinstance(labels, list) else [labels]
+        expanded = ["    labels:"] + [
+            f"      - {_format_label(label)}" for label in existing_labels
+        ]
+        expanded.append(f'      - "{REQUIRED_LABEL}"')
+        return block[:labels_match] + expanded + block[labels_match + 1 :]
+
+    # Block-style labels: insert after their nested values and before the next
+    # top-level entry field. Blank lines are kept with the following field.
+    insert_at = labels_match + 1
+    while insert_at < len(block):
+        line = block[insert_at]
+        if line == "" or line.startswith("      ") or line.startswith("\t"):
+            insert_at += 1
+            continue
+        if re.match(r"^    \S", line):
+            break
+        insert_at += 1
+    while insert_at > labels_match + 1 and block[insert_at - 1] == "":
+        insert_at -= 1
+    return (
+        block[:insert_at]
+        + [f'      - "{REQUIRED_LABEL}"']
+        + block[insert_at:]
+    )
 
 
 def build_new_block(ecosystem: str, directory: str) -> list[str]:
@@ -113,6 +199,8 @@ def build_new_block(ecosystem: str, directory: str) -> list[str]:
         '      interval: "weekly"',
         '    open-pull-requests-limit: 1',
         '    rebase-strategy: "disabled"',
+        '    labels:',
+        f'      - "{REQUIRED_LABEL}"',
         '    groups:',
         f'      {name}-minor-and-patch:',
         '        applies-to: version-updates',
@@ -122,6 +210,58 @@ def build_new_block(ecosystem: str, directory: str) -> list[str]:
         '          - "minor"',
         '          - "patch"',
     ]
+
+
+def coverage_errors(config: Any, detected: dict[str, str]) -> list[str]:
+    """Return coverage and required-label errors for a parsed config."""
+    errors: list[str] = []
+    if not isinstance(config, dict):
+        return ["configuration root must be a mapping"]
+
+    updates = config.get("updates")
+    if not isinstance(updates, list):
+        return ["configuration must contain an updates list"]
+
+    directory_counts: Counter[str] = Counter()
+    for index, entry in enumerate(updates, start=1):
+        if not isinstance(entry, dict):
+            errors.append(f"updates entry {index} must be a mapping")
+            continue
+
+        directory = entry.get("directory")
+        if isinstance(directory, str):
+            directory_counts[directory] += 1
+            entry_name = directory
+        else:
+            entry_name = f"entry {index}"
+
+        labels = entry.get("labels")
+        if not isinstance(labels, list) or REQUIRED_LABEL not in labels:
+            errors.append(
+                f"{entry_name} is missing required label {REQUIRED_LABEL!r}"
+            )
+
+    for directory in sorted(detected):
+        count = directory_counts[directory]
+        if count == 0:
+            errors.append(f"missing updates entry for {directory}")
+        elif count != 1:
+            errors.append(
+                f"{directory} must have exactly one updates entry (found {count})"
+            )
+
+    for directory in sorted(set(directory_counts) - set(detected)):
+        errors.append(f"stale updates entry for {directory}")
+
+    return errors
+
+
+def validate_coverage(config: Any, detected: dict[str, str]) -> None:
+    """Raise ``ValueError`` when entries or required labels are incomplete."""
+    errors = coverage_errors(config, detected)
+    if errors:
+        details = "\n".join(f"- {error}" for error in errors)
+        raise ValueError(f"coverage validation failed:\n{details}")
 
 
 def main() -> int:
@@ -193,23 +333,24 @@ def main() -> int:
         print("Aborted. Preview kept at:", preview_path)
         return 0
 
+    # Validate the preview before writing it. This keeps a template or future
+    # edit from silently producing an entry without the selector label.
+    try:
+        validate_coverage(yaml.safe_load(desired_text), detected)
+    except (ValueError, yaml.YAMLError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
     # 9. Apply and validate
     CONFIG.write_text(desired_text, encoding="utf-8")
     preview_path.unlink()
-    yaml.safe_load(CONFIG.read_text(encoding="utf-8"))
-    print("Updated and validated:", CONFIG)
-
-    # 10. Recheck coverage
     final = yaml.safe_load(CONFIG.read_text(encoding="utf-8"))
-    final_dirs = {entry["directory"] for entry in final.get("updates", [])}
-    missing = set(detected.keys()) - final_dirs
-    extra = final_dirs - set(detected.keys())
-    if missing or extra:
-        print(
-            f"ERROR: coverage mismatch. missing={missing}, extra={extra}",
-            file=sys.stderr,
-        )
+    try:
+        validate_coverage(final, detected)
+    except ValueError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
         return 1
+    print("Updated and validated:", CONFIG)
 
     return 0
 

--- a/.agents/skills/github-dependabot-maintain/tests/test_maintain_dependabot.py
+++ b/.agents/skills/github-dependabot-maintain/tests/test_maintain_dependabot.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Tests for the Dependabot configuration maintenance skill."""
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+import yaml
+
+
+SCRIPT = (
+    Path(__file__).resolve().parents[1] / "scripts" / "maintain-dependabot.py"
+)
+SPEC = importlib.util.spec_from_file_location("maintain_dependabot", SCRIPT)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"Unable to load {SCRIPT}")
+MAINTAIN = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MAINTAIN
+SPEC.loader.exec_module(MAINTAIN)
+
+
+class MaintainDependabotTests(unittest.TestCase):
+    def test_new_entry_contains_required_label(self) -> None:
+        block = MAINTAIN.build_new_block("bun", "/projects/example")
+        entry = MAINTAIN._entry_from_block(block)
+
+        self.assertEqual(entry["labels"], ["dependabot-auto-process"])
+
+    def test_existing_labels_are_preserved_and_required_label_is_added(self) -> None:
+        block = [
+            '  - package-ecosystem: "bun"',
+            '    directory: "/projects/example"',
+            "    labels:",
+            '      - "dependencies"',
+            "    groups:",
+            "      example-minor-and-patch:",
+            "        patterns:",
+            '          - "*"',
+        ]
+
+        normalized = MAINTAIN.normalize_block(
+            block, "bun", "/projects/example"
+        )
+        entry = MAINTAIN._entry_from_block(normalized)
+
+        self.assertEqual(
+            entry["labels"], ["dependencies", "dependabot-auto-process"]
+        )
+
+    def test_inline_labels_are_expanded_without_losing_existing_values(self) -> None:
+        block = [
+            '  - package-ecosystem: "bun"',
+            '    directory: "/projects/example"',
+            '    labels: ["dependencies", "javascript"]',
+            "    groups:",
+            "      example-minor-and-patch:",
+            '        patterns: ["*"]',
+        ]
+
+        normalized = MAINTAIN.normalize_block(
+            block, "bun", "/projects/example"
+        )
+        entry = MAINTAIN._entry_from_block(normalized)
+
+        self.assertEqual(
+            entry["labels"],
+            ["dependencies", "javascript", "dependabot-auto-process"],
+        )
+
+    def test_coverage_validation_detects_missing_required_label(self) -> None:
+        config = yaml.safe_load(
+            """
+            version: 2
+            updates:
+              - package-ecosystem: bun
+                directory: /projects/example
+                labels:
+                  - dependencies
+            """
+        )
+
+        with self.assertRaisesRegex(ValueError, "missing required label"):
+            MAINTAIN.validate_coverage(config, {"/projects/example": "bun"})
+
+    def test_coverage_validation_accepts_one_labeled_entry_per_project(self) -> None:
+        config = yaml.safe_load(
+            """
+            version: 2
+            updates:
+              - package-ecosystem: bun
+                directory: /projects/example
+                labels:
+                  - dependabot-auto-process
+            """
+        )
+
+        MAINTAIN.validate_coverage(config, {"/projects/example": "bun"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 1
     rebase-strategy: "disabled"
+    labels:
+      - "dependabot-auto-process"
     groups:
       edit-vid-minor-and-patch:
         applies-to: version-updates
@@ -21,6 +23,8 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 1
     rebase-strategy: "disabled"
+    labels:
+      - "dependabot-auto-process"
     groups:
       edit-vid2-minor-and-patch:
         applies-to: version-updates
@@ -36,6 +40,8 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 1
     rebase-strategy: "disabled"
+    labels:
+      - "dependabot-auto-process"
     groups:
       file-server-minor-and-patch:
         applies-to: version-updates
@@ -51,6 +57,8 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 1
     rebase-strategy: "disabled"
+    labels:
+      - "dependabot-auto-process"
     groups:
       portal-minor-and-patch:
         applies-to: version-updates
@@ -66,6 +74,8 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 1
     rebase-strategy: "disabled"
+    labels:
+      - "dependabot-auto-process"
     groups:
       portfolio-minor-and-patch:
         applies-to: version-updates
@@ -81,6 +91,8 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 1
     rebase-strategy: "disabled"
+    labels:
+      - "dependabot-auto-process"
     groups:
       simple-agent-poc-minor-and-patch:
         applies-to: version-updates

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,22 @@
 version: 2
 updates:
+  - package-ecosystem: "bun"
+    directory: "/projects/browser-auto"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 1
+    rebase-strategy: "disabled"
+    labels:
+      - "dependabot-auto-process"
+    groups:
+      browser-auto-minor-and-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
   - package-ecosystem: "uv"
     directory: "/projects/edit-vid"
     schedule:

--- a/docs/dependabot-guide.md
+++ b/docs/dependabot-guide.md
@@ -56,6 +56,8 @@ Dependabot PR が作成されたら、次の順に確認します。
     interval: "weekly"
   open-pull-requests-limit: 1
   rebase-strategy: "disabled"
+  labels:
+    - "dependabot-auto-process"
   groups:
     your-bun-project-minor-and-patch:
       applies-to: version-updates
@@ -75,6 +77,8 @@ Dependabot PR が作成されたら、次の順に確認します。
     interval: "weekly"
   open-pull-requests-limit: 1
   rebase-strategy: "disabled"
+  labels:
+    - "dependabot-auto-process"
   groups:
     your-uv-project-minor-and-patch:
       applies-to: version-updates
@@ -165,8 +169,12 @@ ignore:
 
 ```yaml
 labels:
-  - "dependencies"
+  - "dependabot-auto-process"
 ```
+
+`dependabot-auto-process` は一括処理の候補を選ぶためのラベルです。
+ラベルだけで信頼性を判断せず、Dependabot の作成者、base、head、CI などを
+別途確認します。既存の Dependabot PR へは設定変更だけでは遡及適用されません。
 
 ## PR が作成されないとき
 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## Issues

- close: <no>
- ref: #1188

## Why

Issue #1188 の2段階実装のうち、第1 PR（Dependabotラベル設定と既存maintain skillの更新）だけを実装します。第2 PRのroot batch skillはこのPRの対象外です。

## Summary

Dependabotの新規PRを `dependabot-auto-process` で選択できるようにし、設定保守時にも同ラベルを必須化しました。ラベル欠落を検出するcoverage validationとテストも追加しています。

## Changes

- `.github/dependabot.yml` の全7 `updates` エントリに `dependabot-auto-process` を追加
- `.agents/skills/github-dependabot-maintain/` の新規・既存エントリ向けテンプレート、既存ラベル保持、coverage validationを更新
- ラベル欠落検出、既存ラベル保持、インラインlabels展開のユニットテストを追加
- `docs/dependabot-guide.md` にラベルの用途と非遡及適用を追記
- リポジトリに `dependabot-auto-process` ラベルが存在しなかったため、色 `#6f42c1`、説明「Dependabot自動処理の対象候補」で作成

## Verification

- `python3 -m unittest discover -s .agents/skills/github-dependabot-maintain/tests -p 'test_*.py' -v`: 5 tests, OK（missing label検出を含む）
- `python3 -c "import yaml; config=yaml.safe_load(open('.github/dependabot.yml')); assert config['updates'] and all('dependabot-auto-process' in entry.get('labels', []) for entry in config['updates']); print(f\"YAML and label coverage OK: {len(config['updates'])} updates\")"`: `YAML and label coverage OK: 7 updates`
- `python3 -m py_compile ...` と `git diff --check`: pass
- `./scripts/check-licenses --validate-policy && python3 -m unittest discover scripts/tests -p 'test_check_licenses.py'`: policy PASS、26 tests OK

## 保留事項

現在openのDependabot PR #1183〜#1187は、後続のroot skill検証用に意図的に未ラベルのテストフィクスチャとして保存しています。このPRでは `dependabot-auto-process` を付与せず、処理・merge・closeも行っていません。したがってIssue #1188の設定PR完了条件「既存open Dependabot PRへのラベル付与」は未完了のままです。後続検証で、未ラベル0件の確認から1件のcanary、残り4件へ進める前提を維持します。