### PR TITLE
PRテンプレートの Issues コメントに close/ref の制約を追記

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,10 @@
 
 ## Issues
 
-<!-- PR のマージで解決する Issue は close、関連する Issue は ref に記載してください。不要な行は削除してください。 -->
+<!--
+- PR のマージで解決する Issue は close、関連する Issue は ref に記載してください。
+- 該当する Issue がない場合、その行は削除してください（<no> のまま残さない）。
+-->
 
 - close: <no>
 - ref: <no>


### PR DESCRIPTION
## Issues

（該当なし）

## Why

close / ref に該当する Issue がない場合でも `close: <no>` のプレースホルダーが残ったまま PR が作成されることがあるため、Issues セクションのコメントに制約を明記します。

## Summary

`.github/pull_request_template.md` の Issues セクションのコメントを、該当する Issue がない場合はその行を削除すること（`<no>` のまま残さない）が明確になるよう修正しました。

## Changes

- コメントを箇条書き形式に変更
- 「該当する Issue がない場合、その行は削除してください（<no> のまま残さない）」を追記

## Verification

- テンプレートの表示内容を目視で確認