### PR TITLE
[aiagent] pino ベースの構造化ロギング導入（時刻絞り→grep 解析前提）

### DIFF
--- a/projects/aiagent/.env.example
+++ b/projects/aiagent/.env.example
@@ -2,3 +2,8 @@
 AIAGENT_MODEL=opencode-go/deepseek-v4-flash
 # API キー (コンテナ運用では必須。未設定なら ~/.pi/agent/auth.json が使われる)
 # OPENCODE_API_KEY=sk-...
+
+# ログレベル (default: info)。start/end/tool=info、failed=error、retry=warn、prompt preview=debug
+# LOG_LEVEL=debug
+# ログファイルパス (default: logs/aiagent-YYYYMMDD.log)。空文字でファイル出力を無効化
+# LOG_FILE=

--- a/projects/aiagent/.gitignore
+++ b/projects/aiagent/.gitignore
@@ -4,6 +4,7 @@ node_modules/
 tmp/
 tmp-test*/
 dist/
+logs/
 .env
 .env.*
 !.env.example

--- a/projects/aiagent/README.md
+++ b/projects/aiagent/README.md
@@ -23,6 +23,18 @@ curl -X POST localhost:3000/prompt \
 - 現時点は最小構成: セッションは in-memory(永続化なし)・ツール無効(会話のみ)
 - GUI・ストリーミング・ツールは今後この層に追加する
 
+## ロギング
+
+- [pino](https://getpino.io) ベースの構造化ロギング。stdout と `logs/aiagent-YYYYMMDD.log` に同内容の JSONL を出力する（ファイル出力はデフォルト ON）
+- 主用途は障害事後調査。タイムスタンプが固定幅ローカルISO（例: `2026-02-15T14:03:21.123+09:00`）のため、次の読み方で解析できる:
+
+```sh
+grep '"time":"2026-02-15T14:03' logs/aiagent-20260215.log | grep 'bash'
+```
+
+- レベル配分: start/end/tool=info、failed=error、retry=warn、prompt preview=debug
+- ローテートは起動時に日付確定・以降追記のみ。日跨ぎランタイムロールは未対応
+
 ## 開発
 
 ```sh
@@ -55,6 +67,8 @@ docker run -p 3000:3000 \
 | --- | --- | --- |
 | `AIAGENT_MODEL` | 推奨 | モデルを CLI 形式で固定する (例: `opencode-go/deepseek-v4-flash`、`:low` などの思考レベルサフィックス可)。未指定なら pi の設定・デフォルトに従う |
 | `OPENCODE_API_KEY` 等 | 要 | プロバイダ固有の API キー環境変数。Pi SDK が auth.json → 環境変数の順で自動解決する |
+| `LOG_LEVEL` | 任意 | ログレベル (default: `info`) |
+| `LOG_FILE` | 任意 | ログファイルパス (default: `logs/aiagent-YYYYMMDD.log`)。空文字でファイル出力を無効化 |
 
 コンテナ内には `~/.pi/agent/auth.json` が無いため、API キーは環境変数で渡す。
 

--- a/projects/aiagent/bun.lock
+++ b/projects/aiagent/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@earendil-works/pi-coding-agent": "^0.84.2",
         "hono": "^4.13.3",
+        "pino": "^10.3.1",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.5.9",
@@ -126,6 +127,8 @@
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
+    "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
+
     "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
 
     "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
@@ -171,6 +174,8 @@
     "@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
@@ -260,6 +265,8 @@
 
     "node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
+    "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
+
     "openai": ["openai@6.40.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"] }, "sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA=="],
 
     "p-retry": ["p-retry@4.6.2", "", { "dependencies": { "@types/retry": "0.12.0", "retry": "^0.13.1" } }, "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ=="],
@@ -270,13 +277,27 @@
 
     "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
 
+    "pino": ["pino@10.3.1", "", { "dependencies": { "@pinojs/redact": "^0.4.0", "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^3.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^4.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg=="],
+
+    "pino-abstract-transport": ["pino-abstract-transport@3.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg=="],
+
+    "pino-std-serializers": ["pino-std-serializers@7.1.0", "", {}, "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="],
+
+    "process-warning": ["process-warning@5.1.0", "", {}, "sha512-jQSaVHsPgtyw60e1rQ/A+/ArPEj/S8pS/vFnyGa/gYFXrKk/6RuDkoqVDQ5NI5MmS01698ltlAk0NoDBNLujRw=="],
+
     "proper-lockfile": ["proper-lockfile@4.1.2", "", { "dependencies": { "graceful-fs": "^4.2.4", "retry": "^0.12.0", "signal-exit": "^3.0.2" } }, "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA=="],
 
     "protobufjs": ["protobufjs@7.6.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.1", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw=="],
 
+    "quick-format-unescaped": ["quick-format-unescaped@4.0.4", "", {}, "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="],
+
+    "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
+
     "retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
 
     "semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
 
@@ -285,6 +306,12 @@
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
     "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+
+    "sonic-boom": ["sonic-boom@4.2.1", "", { "dependencies": { "atomic-sleep": "^1.0.0" } }, "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q=="],
+
+    "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
+
+    "thread-stream": ["thread-stream@4.2.0", "", { "dependencies": { "real-require": "^1.0.0" } }, "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ=="],
 
     "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
 
@@ -313,5 +340,7 @@
     "@aws-sdk/nested-clients/@smithy/node-http-handler": ["@smithy/node-http-handler@4.11.3", "", { "dependencies": { "@smithy/core": "^3.33.3", "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-2jY1tSpERfPfWqyBV2pH+iGFaghVsIJszJNsT7hxtQYhVJpWDyc0LqOWI+nXOxOAHaEfZ4PXXtp1wW1TGpHhkA=="],
 
     "p-retry/retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
+
+    "thread-stream/real-require": ["real-require@1.0.0", "", {}, "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g=="],
   }
 }

--- a/projects/aiagent/package.json
+++ b/projects/aiagent/package.json
@@ -8,7 +8,8 @@
   },
   "dependencies": {
     "@earendil-works/pi-coding-agent": "^0.84.2",
-    "hono": "^4.13.3"
+    "hono": "^4.13.3",
+    "pino": "^10.3.1"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.9",

--- a/projects/aiagent/src/logger.ts
+++ b/projects/aiagent/src/logger.ts
@@ -1,19 +1,123 @@
-// エージェント進行状況の人間可読ログ。
-// 後段で構造化ロガー (pino 等) へ置き換える前提の仮実装であり、
+// エージェント進行状況の構造化ロギング (pino)。
+// 障害調査の読み方を「タイムスタンプで絞ってから grep」に決め打ちした設計:
+//   - stdout と logs/aiagent-YYYYMMDD.log へ同内容の JSONL を出力 (ファイル出力はデフォルト ON)
+//   - タイムスタンプは固定幅ローカルISOなので、sed/awk のプレフィックス一致で時刻絞りできる
+//   - レベル配分: start/end/tool=info、failed=error、retry=warn、prompt preview=debug
+// worker transport は使わない (in-process の pino.destination + multistream のみ)。
 // 呼び出し側はこのファイルの関数経由のみとする。
+import pino from "pino"
 
-// タイムスタンプはシステムタイムゾーンのローカル時刻 (コンテナでは TZ env で制御)。
-function timestamp(): string {
-  const d = new Date()
-  const p = (n: number) => String(n).padStart(2, "0")
-  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())} ${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}`
+const pad = (value: number, width: number) => String(value).padStart(width, "0")
+
+// 例: 2026-02-15T14:03:21.123+09:00 (常に同じ文字数になるようゼロ埋め)
+export function localIsoTimestamp(date: Date = new Date()): string {
+  const offsetMinutes = -date.getTimezoneOffset()
+  const sign = offsetMinutes < 0 ? "-" : "+"
+  const absOffset = Math.abs(offsetMinutes)
+  return (
+    `${date.getFullYear()}-${pad(date.getMonth() + 1, 2)}-${pad(date.getDate(), 2)}` +
+    `T${pad(date.getHours(), 2)}:${pad(date.getMinutes(), 2)}:${pad(date.getSeconds(), 2)}` +
+    `.${pad(date.getMilliseconds(), 3)}` +
+    `${sign}${pad(Math.floor(absOffset / 60), 2)}:${pad(absOffset % 60, 2)}`
+  )
 }
 
-export function logAgent(message: string) {
-  console.log(`[agent] ${timestamp()} ${message}`)
+const localIsoTime = () => `,"time":"${localIsoTimestamp(new Date())}"`
+
+export function dailyLogFileName(date: Date): string {
+  return `aiagent-${date.getFullYear()}${pad(date.getMonth() + 1, 2)}${pad(date.getDate(), 2)}.log`
 }
 
-export function logAgentPrompt(text: string) {
+/** LOG_FILE の解釈: 未設定=デフォルトパス / 空文字=ファイル出力無効 / 非空=そのパス */
+export function resolveLogFilePath(
+  env: Record<string, string | undefined>,
+  now: Date = new Date(),
+): string | null {
+  if (env.LOG_FILE !== undefined) {
+    return env.LOG_FILE === "" ? null : env.LOG_FILE
+  }
+  return `logs/${dailyLogFileName(now)}`
+}
+
+// harness.ts のメッセージ規約からレベルを決定する (呼び出し側を変更せずにレベル配分を実現)
+export function eventLevel(message: string): "info" | "warn" | "error" {
+  if (message.startsWith("failed:")) return "error"
+  if (message.startsWith("retry")) return "warn"
+  return "info"
+}
+
+export interface CreateAgentLoggerOptions {
+  /** LOG_LEVEL 相当。未指定なら環境変数、それも未指定なら "info" */
+  level?: string
+  /** LOG_FILE 相当。null でファイル出力を無効化 */
+  logFile?: string | null
+  /** stdout 出力先 (テストでの差し替え用)。未指定なら fd 1 */
+  stdout?: pino.DestinationStream
+}
+
+export function createAgentLogger(
+  options: CreateAgentLoggerOptions = {},
+): pino.Logger {
+  const level = options.level ?? process.env.LOG_LEVEL ?? "info"
+
+  // ファイルパスは起動時に確定し、以降は追記のみ
+  // TODO: 書き込みごとの日付チェックによる日跨ぎランタイムローテートは先送り
+  const logFilePath =
+    options.logFile !== undefined
+      ? options.logFile
+      : resolveLogFilePath(process.env)
+
+  // sync: true で開くことで pino.destination の非同期 open レース
+  // (起動即 exit 時の "not ready yet") を構造的に回避する。ログ量は同期書き込みで十分
+  // 各ストリームのレベルは trace 固定にし、絞り込みはロガーのレベル一括で行う
+  // (multistream エントリのレベル未指定時は info 扱いになり debug が欠落するため)
+  const streams = [
+    {
+      level: "trace",
+      stream: options.stdout ?? pino.destination({ dest: 1, sync: true }),
+    },
+    ...(logFilePath === null
+      ? []
+      : [
+          {
+            level: "trace",
+            stream: pino.destination({
+              dest: logFilePath,
+              append: true,
+              mkdir: true,
+              sync: true,
+            }),
+          },
+        ]),
+  ]
+
+  return pino(
+    {
+      level,
+      // 出力イメージに合わせて level を文字列で出し、pid/hostname は付けない
+      base: {},
+      formatters: {
+        level: (label) => ({ level: label }),
+      },
+      timestamp: localIsoTime,
+    },
+    pino.multistream(streams),
+  )
+}
+
+const agentLogger = createAgentLogger()
+
+export function logAgent(
+  message: string,
+  logger: pino.Logger = agentLogger,
+): void {
+  logger[eventLevel(message)](message)
+}
+
+export function logAgentPrompt(
+  text: string,
+  logger: pino.Logger = agentLogger,
+): void {
   const preview = text.length > 80 ? `${text.slice(0, 80)}...` : text
-  logAgent(`prompt: "${preview}"`)
+  logger.debug(`prompt: "${preview}"`)
 }

--- a/projects/aiagent/tests/logger.test.ts
+++ b/projects/aiagent/tests/logger.test.ts
@@ -1,0 +1,351 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { mkdtemp, readFile, readdir, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import pino from "pino"
+
+import {
+  createAgentLogger,
+  dailyLogFileName,
+  logAgent,
+  logAgentPrompt,
+  resolveLogFilePath,
+} from "../src/logger"
+
+// ---------------------------------------------------------------------------
+// テスト = 生きたドキュメント
+//
+// ログの主用途は「障害事後調査 (人間 + コーディングエージェントが
+// タイムスタンプで時刻絞り → キーワード grep)」。
+// このファイルはその解析フローと LOG_FILE / LOG_LEVEL の仕様を記述する。
+// ---------------------------------------------------------------------------
+
+interface LogRecord {
+  level: string
+  time: string
+  msg: string
+}
+
+function parseJsonl(content: string): LogRecord[] {
+  return content
+    .split("\n")
+    .filter((line) => line !== "")
+    .map((line) => JSON.parse(line) as LogRecord)
+}
+
+async function readRecords(filePath: string): Promise<LogRecord[]> {
+  return parseJsonl(await readFile(filePath, "utf8"))
+}
+
+// stdout の検証が対象でないテストで、出力がテスト結果へ漏れないようにする
+function discardStdout(): pino.DestinationStream {
+  return pino.destination({
+    dest: path.join(workDir, "discarded.jsonl"),
+    sync: true,
+  })
+}
+
+// 固定幅ローカルISO。例: 2026-02-15T14:03:21.123+09:00 (常に29文字)
+const FIXED_WIDTH_LOCAL_ISO =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}[+-]\d{2}:\d{2}$/
+
+let workDir: string
+
+beforeEach(async () => {
+  workDir = await mkdtemp(path.join(tmpdir(), "aiagent-logger-"))
+})
+
+afterEach(async () => {
+  await rm(workDir, { recursive: true, force: true })
+})
+
+describe("createAgentLogger()", () => {
+  it("writes the same JSONL to stdout and the daily file", async () => {
+    const stdoutPath = path.join(workDir, "stdout.jsonl")
+    const filePath = path.join(workDir, "aiagent.log")
+    const logger = createAgentLogger({
+      logFile: filePath,
+      stdout: pino.destination({ dest: stdoutPath, sync: true }),
+    })
+
+    logAgent("start", logger)
+    logAgent("tool start: bash", logger)
+
+    // 完了条件①: stdout と日次ファイルに同内容の JSONL
+    const stdoutContent = await readFile(stdoutPath, "utf8")
+    const fileContent = await readFile(filePath, "utf8")
+    expect(stdoutContent).toBe(fileContent)
+    expect(stdoutContent.split("\n").filter((line) => line !== "")).toHaveLength(
+      2,
+    )
+  })
+
+  it("stamps every record with a fixed-width local ISO timestamp", async () => {
+    const filePath = path.join(workDir, "aiagent.log")
+    const logger = createAgentLogger({
+      level: "debug",
+      logFile: filePath,
+      stdout: discardStdout(),
+    })
+
+    logAgent("start", logger)
+    logAgent("failed: stopReason=error oops", logger)
+    logAgentPrompt("hello", logger)
+
+    const lines = (await readFile(filePath, "utf8"))
+      .split("\n")
+      .filter((line) => line !== "")
+    expect(lines).toHaveLength(3)
+
+    for (const line of lines) {
+      // 出力イメージ: {"level":"info","time":"...","msg":"..."}
+      expect(line).toMatch(/^\{"level":"[a-z]+","time":"/)
+      const record = JSON.parse(line) as LogRecord
+      expect(record.time).toMatch(FIXED_WIDTH_LOCAL_ISO)
+      // 固定幅であることが sed/awk プレフィックス一致の時刻絞りを支える
+      expect(record.time).toHaveLength(29)
+    }
+  })
+
+  it("keeps multi-line messages on a single JSONL line", async () => {
+    const filePath = path.join(workDir, "aiagent.log")
+    const logger = createAgentLogger({
+      level: "debug",
+      logFile: filePath,
+      stdout: discardStdout(),
+    })
+
+    logAgent("failed: stopReason=error\nline1\nline2", logger)
+
+    const content = await readFile(filePath, "utf8")
+    const lines = content.split("\n").filter((line) => line !== "")
+    // 1イベント=1行が機械的に保証される (改行はエスケープされる)
+    expect(lines).toHaveLength(1)
+    expect(parseJsonl(content)[0]?.msg).toBe(
+      "failed: stopReason=error\nline1\nline2",
+    )
+  })
+
+  it("creates the log directory when it does not exist", async () => {
+    const filePath = path.join(workDir, "nested/dir/aiagent.log")
+    const logger = createAgentLogger({ logFile: filePath, stdout: discardStdout() })
+
+    logAgent("start", logger)
+
+    expect(await readRecords(filePath)).toHaveLength(1)
+  })
+
+  it("appends to the same file instead of truncating it", async () => {
+    const filePath = path.join(workDir, "aiagent.log")
+
+    // ローテート方針: 起動時に日付確定・以降追記のみ
+    const first = createAgentLogger({
+      logFile: filePath,
+      stdout: discardStdout(),
+    })
+    logAgent("tool start: bash", first)
+    const second = createAgentLogger({
+      logFile: filePath,
+      stdout: discardStdout(),
+    })
+    logAgent("tool end: bash", second)
+
+    const records = await readRecords(filePath)
+    expect(records.map((record) => record.msg)).toEqual([
+      "tool start: bash",
+      "tool end: bash",
+    ])
+  })
+})
+
+describe("LOG_LEVEL", () => {
+  it("falls back to info when neither option nor env is set", () => {
+    const previous = process.env.LOG_LEVEL
+    delete process.env.LOG_LEVEL
+    try {
+      const logger = createAgentLogger({ logFile: null })
+      expect(logger.level).toBe("info")
+    } finally {
+      if (previous === undefined) delete process.env.LOG_LEVEL
+      else process.env.LOG_LEVEL = previous
+    }
+  })
+
+  it("follows the LOG_LEVEL environment variable when the option is omitted", () => {
+    const previous = process.env.LOG_LEVEL
+    process.env.LOG_LEVEL = "warn"
+    try {
+      const logger = createAgentLogger({ logFile: null })
+      expect(logger.level).toBe("warn")
+    } finally {
+      if (previous === undefined) delete process.env.LOG_LEVEL
+      else process.env.LOG_LEVEL = previous
+    }
+  })
+
+  it("suppresses records below the configured level", async () => {
+    const filePath = path.join(workDir, "aiagent.log")
+    const logger = createAgentLogger({
+      level: "warn",
+      logFile: filePath,
+      stdout: discardStdout(),
+    })
+
+    logAgent("start", logger) // info → 抑制される
+    logAgent("retry 2/5 in 250ms: rate limited", logger) // warn → 出力
+    logAgent("failed: stopReason=error boom", logger) // error → 出力
+
+    const records = await readRecords(filePath)
+    expect(records.map((record) => [record.msg, record.level])).toEqual([
+      ["retry 2/5 in 250ms: rate limited", "warn"],
+      ["failed: stopReason=error boom", "error"],
+    ])
+  })
+})
+
+describe("LOG_FILE", () => {
+  it("defaults to logs/aiagent-YYYYMMDD.log derived from the startup date", () => {
+    // 月日がゼロ埋めされた固定のファイル名になる
+    expect(resolveLogFilePath({}, new Date(2026, 1, 15, 14, 3, 21))).toBe(
+      "logs/aiagent-20260215.log",
+    )
+  })
+
+  it("disables file output when LOG_FILE is an empty string", async () => {
+    expect(resolveLogFilePath({ LOG_FILE: "" })).toBeNull()
+
+    // 無効化しても stdout へのロギング自体は生き続ける
+    const stdoutPath = path.join(workDir, "stdout.jsonl")
+    const logger = createAgentLogger({
+      logFile: "",
+      stdout: pino.destination({ dest: stdoutPath, sync: true }),
+    })
+    logAgent("start", logger)
+
+    expect(await readdir(workDir)).toEqual(["stdout.jsonl"])
+    expect(await readRecords(stdoutPath)).toHaveLength(1)
+  })
+
+  it("uses the LOG_FILE path verbatim when set", () => {
+    expect(resolveLogFilePath({ LOG_FILE: "/var/log/agent.log" })).toBe(
+      "/var/log/agent.log",
+    )
+  })
+})
+
+describe("dailyLogFileName()", () => {
+  it("pads month and day to two digits", () => {
+    expect(dailyLogFileName(new Date(2026, 0, 5))).toBe("aiagent-20260105.log")
+    expect(dailyLogFileName(new Date(2026, 11, 31))).toBe(
+      "aiagent-20261231.log",
+    )
+  })
+})
+
+describe("logAgent()", () => {
+  it("assigns levels by message convention (start/end/tool=info, failed=error, retry=warn)", async () => {
+    const filePath = path.join(workDir, "aiagent.log")
+    const logger = createAgentLogger({
+      logFile: filePath,
+      stdout: discardStdout(),
+    })
+
+    logAgent("start", logger)
+    logAgent("end", logger)
+    logAgent("tool start: bash", logger)
+    logAgent("tool end: bash (error)", logger)
+    logAgent("failed: stopReason=error oops", logger)
+    logAgent("retry 1/3 in 500ms: timeout", logger)
+
+    const records = await readRecords(filePath)
+    expect(records.map((record) => [record.msg, record.level])).toEqual([
+      ["start", "info"],
+      ["end", "info"],
+      ["tool start: bash", "info"],
+      ["tool end: bash (error)", "info"],
+      ["failed: stopReason=error oops", "error"],
+      ["retry 1/3 in 500ms: timeout", "warn"],
+    ])
+  })
+})
+
+describe("logAgentPrompt()", () => {
+  it("logs an 80-char preview at debug level", async () => {
+    const filePath = path.join(workDir, "aiagent.log")
+    const logger = createAgentLogger({
+      level: "debug",
+      logFile: filePath,
+      stdout: discardStdout(),
+    })
+
+    logAgentPrompt("x".repeat(100), logger)
+
+    const records = await readRecords(filePath)
+    expect(records.map((record) => [record.msg, record.level])).toEqual([
+      [`prompt: "${"x".repeat(80)}..."`, "debug"],
+    ])
+  })
+
+  it("keeps prompts of at most 80 chars intact", async () => {
+    const filePath = path.join(workDir, "aiagent.log")
+    const logger = createAgentLogger({
+      level: "debug",
+      logFile: filePath,
+      stdout: discardStdout(),
+    })
+
+    logAgentPrompt("x".repeat(80), logger)
+
+    const records = await readRecords(filePath)
+    expect(records[0]?.msg).toBe(`prompt: "${"x".repeat(80)}"`)
+  })
+
+  it("is hidden at the default info level", async () => {
+    const filePath = path.join(workDir, "aiagent.log")
+    const logger = createAgentLogger({ logFile: filePath, stdout: discardStdout() })
+
+    logAgent("start", logger)
+    logAgentPrompt("secret prompt body", logger)
+
+    const records = await readRecords(filePath)
+    // prompt preview は debug なので info 運用ではファイルに残らない
+    expect(records.map((record) => record.msg)).toEqual(["start"])
+  })
+})
+
+describe("analysis flow (time-prefix narrowing -> keyword grep)", () => {
+  it("narrows events by fixed-width time prefix and extracts them by keyword without parsing", async () => {
+    // 完了条件②: 「時刻プレフィックス → キーワード grep」の解析フローの実証。
+    // シェルで `grep '"time":"2026-02-15T14:03' agent.log | grep 'bash'` するのに相当
+    const filePath = path.join(workDir, "aiagent.log")
+    const logger = createAgentLogger({
+      level: "debug",
+      logFile: filePath,
+      stdout: discardStdout(),
+    })
+
+    logAgent("start", logger)
+    logAgent("tool start: bash", logger)
+    logAgent("tool end: bash", logger)
+    logAgent("retry 1/3 in 500ms: timeout", logger)
+    logAgentPrompt("unrelated prompt mentioning nothing special", logger)
+
+    const lines = (await readFile(filePath, "utf8"))
+      .split("\n")
+      .filter((line) => line !== "")
+
+    // 1) sed 的な時刻絞り: 先頭一致でプレフィックスを切り出せる (JSON パース不要)
+    const firstTime = (JSON.parse(lines[0] ?? "") as LogRecord).time
+    const minutePrefix = `"time":"${firstTime.slice(0, 16)}`
+    const narrowedToMinute = lines.filter((line) =>
+      line.includes(minutePrefix),
+    )
+
+    // 2) grep でキーワード抽出
+    const bashLines = narrowedToMinute.filter((line) => line.includes("bash"))
+
+    expect(bashLines.map((line) => (JSON.parse(line) as LogRecord).msg)).toEqual(
+      ["tool start: bash", "tool end: bash"],
+    )
+  })
+})


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## Issues

- close: #1198

## Why

`projects/aiagent` の `src/logger.ts` が console.log ベースの仮実装のため、エージェント本体を作り込む前に「タイムスタンプで時刻絞り → grep」という障害解析フローに耐える構造化ロギング (pino) を先に確立したい (#1198)。

## Summary

`src/logger.ts` を pino ベースに全面書き換えし、stdout と日次ログファイルへ同内容の JSONL を出力するようにした。worker transport (`transport.targets`) は使わず、in-process の `pino.destination` + multistream のみで Bun 互換を最優先している。

## Changes

- `src/logger.ts`
  - stdout と `logs/aiagent-YYYYMMDD.log`（デフォルト ON）へ同内容の JSONL を出力
  - タイムスタンプを固定幅ローカルISO（例: `2026-02-15T14:03:21.123+09:00`）にカスタムし、sed/awk のプレフィックス一致で時刻絞り可能に
  - `LOG_FILE` でパス上書き・空文字でファイル出力を無効化、`LOG_LEVEL` 導入（default: info）
  - レベル配分: start/end/tool=info、failed=error、retry=warn、prompt preview=debug（既存呼び出し側 `harness.ts` は無変更でメッセージ規約からレベル決定）
  - `pino.destination` の非同期 open レース（起動即 exit の "not ready yet"）対策として sync 書き込みを採用（エージェントイベント程度のログ量で十分）
  - ローテートは起動時に日付確定・以降追記のみ。日跨ぎランタイムロールは TODO 先送り
- `tests/logger.test.ts`: テスト＝生きたドキュメントとして Issue の完了条件を検証（JSONL 同一出力、固定幅タイムスタンプ、時刻プレフィックス→キーワード grep の実証、`LOG_FILE` / `LOG_LEVEL` の挙動）
- `.gitignore`: `logs/` を追加
- `README.md` / `.env.example`: ロギング仕様と `LOG_FILE` / `LOG_LEVEL` を追記
- `package.json` / `bun.lock`: pino ^10.3.1 を追加（browser-auto / portfolio と同バージョン）

## Verification

- `bun run lint`（tsc --noEmit + biome lint）: 通過
- `bun run test`: 29 tests pass / 0 fail
- 手動スモーク（TZ=Asia/Tokyo）: stdout と `logs/aiagent-YYYYMMDD.log` に同一の JSONL を確認。出力例:
  `{"level":"info","time":"2026-08-23T23:47:11.013+09:00","msg":"tool start: bash"}`
  複数行メッセージも 1 行にエスケープされ、`grep '"time":"...' | grep 'bash'` の解析フローが生文字列のまま機能することを確認